### PR TITLE
Upgrade pipelines with worker job

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -21,6 +21,10 @@ services:
     volumes:
       - ../server:/home/viame_girder
 
+  girder_worker_default:
+    volumes:
+      - ../server:/home/viame_girder
+
   mc:
     image: mongo
     command: ["mongo", "mongodb://mongo:27017/girder"]


### PR DESCRIPTION
@BryonLewis what do you think about something like this?

Naturally the lack of worker management means other jobs couldn't be allowed to run while this was running, or you'd get pipe missing errors.   I don't think stalling the queue using celery controller is reliable.

I think just adding a `dive.pipelines_stalled` bool setting while the job runs such that trying to start a pipeline while it's true throws a 409 conflict, and then requiring an empty queue and idle runners as a pre-condition to starting the upgrade.

It's sort of a coarse lock, but I think it's easier to understand than trying to drain the queue and stall jobs using celery controller.