### PR TITLE
Phantom desktop clicking opening links

### DIFF
--- a/client/platform/desktop/frontend/components/Recent.vue
+++ b/client/platform/desktop/frontend/components/Recent.vue
@@ -66,15 +66,30 @@ export default defineComponent({
               DIVE Annotation Tool
             </h1>
             <h3>Useful Links</h3>
-            <browser-link href="https://kitware.github.io/dive/">
-              User Guide
-            </browser-link>
-            <browser-link href="https://viame.kitware.com/#/collection/5e4c256ca0fc86aa03120c34">
-              Public example data
-            </browser-link>
-            <browser-link href="https://viametoolkit.org/">
-              viametoolkit.org
-            </browser-link>
+            <div>
+              <browser-link
+                display="inline"
+                href="https://kitware.github.io/dive/"
+              >
+                User Guide
+              </browser-link>
+            </div>
+            <div>
+              <browser-link
+                display="inline"
+                href="https://viame.kitware.com/#/collection/5e4c256ca0fc86aa03120c34"
+              >
+                Public example data
+              </browser-link>
+            </div>
+            <div>
+              <browser-link
+                display="inline"
+                href="https://viametoolkit.org/"
+              >
+                viametoolkit.org
+              </browser-link>
+            </div>
           </v-col>
           <v-col
             md="4"


### PR DESCRIPTION
Sorry this happened enough times I just needed to adjust it.

Mainly did it because of the phantom link opening when I was clicking on Dive to achieve window focus.  The root of those links were in a column so they were interpreted as a row that went across the full width of the app.  About 6 different times I accidentally opened the Help/Viametoolkit.org or another link clicking in the blank space between the actual link text and the buttons on the right

![image](https://user-images.githubusercontent.com/61746913/108125571-9f89eb80-7076-11eb-9255-ddfe44f151ba.png)
