### PR TITLE
markChangesPending update for typeGuards

### DIFF
--- a/client/src/use/useAttributes.ts
+++ b/client/src/use/useAttributes.ts
@@ -30,11 +30,9 @@ export type Attributes = Record<string, Attribute>;
 interface UseAttributesParams {
   markChangesPending: (
     {
-      type,
       action,
       data,
     }: {
-      type: 'attribute';
       action: 'upsert' | 'delete';
       data: Attribute;
     }
@@ -62,7 +60,7 @@ export default function UseAttributes({ markChangesPending }: UseAttributesParam
         oldAttribute = attributes.value[data._id];
         // Name change should delete the old attribute and create a new one with the updated id
         VueDel(attributes.value, data._id);
-        markChangesPending({ type: 'attribute', action: 'delete', data: { ...attributes.value[data._id] } });
+        markChangesPending({ action: 'delete', data: { ...attributes.value[data._id] } });
         // Create a new attribute to replace it
         // eslint-disable-next-line no-param-reassign
         data._id = `${data.belongs}_${data.name}`;
@@ -72,13 +70,13 @@ export default function UseAttributes({ markChangesPending }: UseAttributesParam
       // TODO: Lengthy track/detection attribute updating function
     }
     VueSet(attributes.value, data._id, data);
-    markChangesPending({ type: 'attribute', action: 'upsert', data: attributes.value[data._id] });
+    markChangesPending({ action: 'upsert', data: attributes.value[data._id] });
   }
 
 
   function deleteAttribute(attributeId: string, removeFromTracks = false) {
     if (attributes.value[attributeId] !== undefined) {
-      markChangesPending({ type: 'attribute', action: 'delete', data: { ...attributes.value[attributeId] } });
+      markChangesPending({ action: 'delete', data: { ...attributes.value[attributeId] } });
       VueDel(attributes.value, attributeId);
     }
     if (removeFromTracks) {

--- a/client/src/use/useTrackStore.ts
+++ b/client/src/use/useTrackStore.ts
@@ -5,12 +5,10 @@ import Track, { TrackId } from '../track';
 interface UseTrackStoreParams {
   markChangesPending: (
     {
-      type,
       action,
       data,
     }:
     {
-      type: 'track';
       action: 'upsert' | 'delete';
       data: Track;
     }) => void;
@@ -74,7 +72,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
       intervalTree.insert([track.begin, track.end], track.trackId.toString());
     }
     canary.value += 1;
-    markChangesPending({ type: 'track', action: 'upsert', data: track });
+    markChangesPending({ action: 'upsert', data: track });
   }
 
   function insertTrack(track: Track, afterId?: TrackId) {
@@ -97,7 +95,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
       confidencePairs: [[defaultType, 1]],
     });
     insertTrack(track, afterId);
-    markChangesPending({ type: 'track', action: 'upsert', data: track });
+    markChangesPending({ action: 'upsert', data: track });
     return track;
   }
 
@@ -117,7 +115,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
       throw new Error(`TrackId ${trackId} not found in trackIds.`);
     }
     trackIds.value.splice(listIndex, 1);
-    markChangesPending({ type: 'track', action: 'delete', data: track });
+    markChangesPending({ action: 'delete', data: track });
   }
 
   /*


### PR DESCRIPTION
Just updating the types in `useAttributes` and `useStyling`  for `markChangesPending` to be compatible with the newer style, it just had extraneous information before.  We could export the markChangesPending type and use that, but this forces  each `use` item to using the data and structure specifically associated with it. 