### PR TITLE
Fix annotator creation mode bugs

### DIFF
--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -115,7 +115,14 @@ export default function useModeManager({
 
   function handleSelectTrack(trackId: TrackId | null, edit = false) {
     selectTrack(trackId, edit);
-    creating = false;
+    /**
+     * If creating mode and editing and selectedTrackId is the same,
+     * don't kick out of creating mode.  This happens when moving between
+     * rect/poly/line during continuous creation.
+     */
+    if (!(creating && edit && trackId === selectedTrackId.value)) {
+      creating = false;
+    }
   }
 
   //Handles deselection or hitting escape including while editing
@@ -161,8 +168,6 @@ export default function useModeManager({
           if (newTrackSettings.modeSettings.Detection.continuous) {
             handleAddTrackOrDetection();
             newCreatingValue = true; // don't disable creating mode
-          } else { //Exit editing mode for the added track
-            selectTrack(addedTrack.trackId, false);
           }
         }
       }

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -113,7 +113,7 @@ export default defineComponent({
             throw new Error(`TrackID ${trackId} not found in map`);
           }
           const enabledIndex = enabledTracks.findIndex(
-            (trackWithContext) => trackWithContext.track.trackId === track.trackId,
+            (trackWithContext) => trackWithContext.track.trackId === trackId,
           );
           if (enabledIndex !== -1) {
             const [features] = track.getFeature(frame);
@@ -128,7 +128,7 @@ export default defineComponent({
               confidencePairs: track.confidencePairs,
             };
             frameData.push(trackFrame);
-            if (frameData[frameData.length - 1].selected && (editingTrack)) {
+            if (trackFrame.selected && (editingTrack)) {
               editingTracks.push(trackFrame);
             }
           }
@@ -187,7 +187,6 @@ export default defineComponent({
         }
         if (editingTracks.length) {
           if (editingTrack) {
-            editAnnotationLayer.checkCreationIncomplete(editingTrack, selectedKey);
             editAnnotationLayer.setType(editingTrack);
             editAnnotationLayer.setKey(selectedKey);
             editAnnotationLayer.changeData(editingTracks);

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -117,7 +117,10 @@ export default defineComponent({
       if (data.trackTypeValue.trim() === '') {
         data.trackTypeValue = props.trackType;
       } else if (data.trackTypeValue !== props.trackType) {
-        handler.trackTypeChange(props.track.trackId, data.trackTypeValue);
+        /* horrendous hack to prevent race. https://github.com/Kitware/dive/issues/475 */
+        window.setTimeout(() => {
+          handler.trackTypeChange(props.track.trackId, data.trackTypeValue);
+        }, 100);
       }
       if (props.lockTypes) {
         blurType(e);

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -117,10 +117,7 @@ export default defineComponent({
       if (data.trackTypeValue.trim() === '') {
         data.trackTypeValue = props.trackType;
       } else if (data.trackTypeValue !== props.trackType) {
-        /* horrendous hack to prevent race. https://github.com/Kitware/dive/issues/475 */
-        window.setTimeout(() => {
-          handler.trackTypeChange(props.track.trackId, data.trackTypeValue);
-        }, 100);
+        handler.trackTypeChange(props.track.trackId, data.trackTypeValue);
       }
       if (props.lockTypes) {
         blurType(e);

--- a/client/src/layers/EditAnnotationLayer.ts
+++ b/client/src/layers/EditAnnotationLayer.ts
@@ -250,20 +250,6 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
   }
 
   /**
-   * Provides an indicator that the system is still waiting for creation
-   * geoJSON data.  This is relevant which switching focus while in creation mode
-   */
-  checkCreationIncomplete(editingType: EditAnnotationTypes, key: string) {
-    if (editingType !== this.type || key !== this.selectedKey) {
-      this.skipNextExternalUpdate = false;
-      return;
-    }
-    const features = this.featureLayer.annotations();
-    this.skipNextExternalUpdate = this.getMode() === 'creation'
-    && (!features.length || (features[0] && !features[0].coordinates().length));
-  }
-
-  /**
    * Change the layer mode
    */
   setMode(

--- a/client/src/layers/TextLayer.ts
+++ b/client/src/layers/TextLayer.ts
@@ -107,7 +107,7 @@ export default class TextLayer extends BaseLayer<TextData> {
             }
             return this.typeStyling.value.color(data.type);
           }
-          if (data.currentPair) {
+          if (data.selected && data.currentPair) {
             return this.stateStyling.selected.color;
           }
           return this.typeStyling.value.color(data.type);

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -205,6 +205,7 @@ export default class Track {
   }
 
   private notify(name: string, oldValue: unknown) {
+    /* Prevent broadcast until the first feature is initialized */
     if (this.isInitialized()) {
       this.revision.value += 1;
       this.bus.$emit('notify', {

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -123,6 +123,13 @@ export default class Track {
   }
 
   /**
+   * True after at least 1 feature has been added
+   */
+  private isInitialized() {
+    return this.featureIndex.length > 0;
+  }
+
+  /**
    * Test the first element in the feature array.  Its index should match
    * its frame number.  Otherwise, the constructor was called with a
    * dense array, which is incorrect.
@@ -198,12 +205,14 @@ export default class Track {
   }
 
   private notify(name: string, oldValue: unknown) {
-    this.revision.value += 1;
-    this.bus.$emit('notify', {
-      track: this,
-      event: name,
-      oldValue,
-    });
+    if (this.isInitialized()) {
+      this.revision.value += 1;
+      this.bus.$emit('notify', {
+        track: this,
+        event: name,
+        oldValue,
+      });
+    }
   }
 
   /** Determine if track can be split at frame */


### PR DESCRIPTION
Several issues.  

* [minor] Reverted `checkCreationIncomplete` because I still don't know what it does (#475)
* [important] Fixed issue where, during bbox creation, in editing mode, if you move away a frame then come back, you'd be kicked out of editing mode.
* [important] Fixed issue where newly created bounding boxes didn't go directly to editing mode 
* [minor] Fixed issue where, during continuous creation, moving between annotation types (rect, poly, back to rect) caused you to get kicked out of continuous mode.
* [important] fixed text styling issue where all colors changed when track entered editing mode (rather than just the text for a single track)

Noticed mostly during demo recording.  **Still no fix for continuous head/tail creation**