### PR TITLE
Server/pipelines improvements

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -50,3 +50,5 @@ jobs:
       run: black --check .
     - name: Check import linting with isort
       run: isort --check .
+    - name: Check mypy
+      run: mypy --ignore-missing-imports dive_utils/ dive_tasks/

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -26,6 +26,10 @@ services:
     restart: always
     labels:
       - "com.centurylinklabs.watchtower.enable=true" 
+    environment:
+      - WORKER_WATCHING_QUEUES=training,pipelines
+      - WORKER_CONCURRENCY=${TRAINING_WORKER_CONCURRENCY:-1}
+      - WORKER_GPU_UUID=${TRAINING_GPU_UUID}
 
   watchtower:
     image: containrrr/watchtower:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     volumes:
       - addons:/tmp/addons:ro # readonly
     environment:
-      - WORKER_WATCHING_QUEUES=training,pipelines
+      - WORKER_WATCHING_QUEUES=training
       - WORKER_CONCURRENCY=${TRAINING_WORKER_CONCURRENCY:-1}
       - WORKER_GPU_UUID=${TRAINING_GPU_UUID}
 

--- a/server/dev-requirements.txt
+++ b/server/dev-requirements.txt
@@ -3,4 +3,5 @@ flake8
 isort
 mkdocs
 mkdocs-material
+mypy
 pytest

--- a/server/dive_server/viame.py
+++ b/server/dive_server/viame.py
@@ -209,9 +209,9 @@ class Viame(Resource):
             "input_type": folder["meta"]["type"],
             "output_folder": folder_id_str,
             "pipeline": pipeline,
+            "pipeline_input": detection if requires_input else None,
         }
-        if requires_input is True:
-            params["pipeline_input"] = detection
+
         newjob = run_pipeline.apply_async(
             queue="pipelines",
             kwargs=dict(

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -13,7 +13,17 @@ DefaultTrainingConfiguration = "train_netharn_cascade.viame_csv.conf"
 AllowedTrainingConfigs = r".*\.viame_csv\.conf$"
 AllowedStaticPipelines = r"^detector_.+|^tracker_.+|^utility_.+|^generate_.+"
 DisallowedStaticPipelines = (
-    r".*local.*|detector_svm_models\.pipe|tracker_svm_models\.pipe"
+    # Remove utilities pipes which hold no meaning in web
+    r".*local.*|"
+    r".*hough.*|"
+    r".*_svm_models\.pipe|"
+    r"detector_extract_chips\.pipe|"
+    # Remove tracker pipelines which hold no meaning in web
+    r"tracker_stabilized_iou\.pipe|"
+    r"tracker_short_term\.pipe|"
+    # Remove seal and sea lion specialized pipelines un-runnable in web
+    r"detector_arctic_.*fusion.*\.pipe|"
+    r".*[2|3]-cam\.pipe"
 )
 
 
@@ -35,7 +45,7 @@ def load_static_pipelines(search_path: Path) -> Dict[str, PipelineCategory]:
             "pipe": pipe,
             "folderId": None,
         }
-
+        print(f"Discovered pipe {pipe_info}")
         if pipe_type in pipedict:
             pipedict[pipe_type]["pipes"].append(pipe_info)
         else:
@@ -51,6 +61,7 @@ def load_training_configurations(search_path: Path) -> TrainingConfigurationSumm
     for pipe in search_path.glob("./*.conf"):
         pipe_name = pipe.name
         configurations.append(pipe_name)
+        print(f"Discovered training {pipe_name}")
         if pipe_name == DefaultTrainingConfiguration:
             default_config = pipe_name
 

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -1,48 +1,86 @@
 import shutil
+import signal
+from datetime import datetime
 from pathlib import Path
-from subprocess import Popen, TimeoutExpired
+from subprocess import Popen
 from tempfile import mktemp
-from typing import IO, Optional, Tuple
+from typing import IO, Callable, Optional
 
 from girder_client import GirderClient
 from girder_worker.task import Task
+from girder_worker.utils import JobManager, JobStatus
 
 
-def read_and_close_process_outputs(
+def stream_subprocess(
     process: Popen,
     task: Task,
-    stdout_file: Optional[IO] = None,
-    stderr_file: Optional[IO] = None,
-) -> Tuple[str, str]:
-    stdout: str = ""
-    stderr: str = ""
+    manager: JobManager,
+    stderr_file: IO[bytes],
+    keep_stdout: bool = False,
+    cleanup: Optional[Callable] = None,
+) -> str:
+    """
+    Stream live results from process to job manager
 
-    while not task.canceled and process.poll() is None:
-        try:
-            process.wait(timeout=20)
-        except TimeoutExpired:
-            pass
+    :param process: Process to stream
+    :param task: task to detect cancelation
+    :param manager: job manager
+    :param stderr_file: will log stderr to manager IF nonzero exit, else will close
+    :param keep_stdout: will return stdout as a string if needed
+    :param cleanup: a function to invoke if job errors or is canceled
+    """
+    start_time = datetime.now()
+    stdout = ""
+
+    if process.stdout is None:
+        raise RuntimeError("Stdout must not be none")
+
+    # call readline until it returns empty bytes
+    for line in iter(process.stdout.readline, b''):
+        line_str = line.decode('utf-8')
+        manager.write(line_str)
+        if keep_stdout:
+            stdout += line_str
+        if task.canceled:
+            # Can never be sure what signal a process will respond to.
+            process.send_signal(signal.SIGTERM)
+            process.send_signal(signal.SIGKILL)
+            break
+
+    # flush logs
+    manager._flush()
+    # Wait for exit up to 30 seconds after kill
+    code = process.wait(30)
 
     if task.canceled:
-        process.kill()
-        return ("", "")
+        manager.write('\nCanceled during subprocess run.\n')
+        manager.updateStatus(JobStatus.CANCELED)
+        stderr_file.close()
+        if cleanup:
+            cleanup()
+        return stdout
 
-    if stdout_file is not None:
-        stdout_file.seek(0)
-        stdout = stdout_file.read().decode()
-        stdout_file.close()
-
-    if stderr_file is not None:
+    if code > 0:
         stderr_file.seek(0)
         stderr = stderr_file.read().decode()
         stderr_file.close()
+        if cleanup:
+            cleanup()
+        raise RuntimeError(
+            'Pipeline exited with nonzero status code {}: {}'.format(
+                process.returncode, stderr
+            )
+        )
+    else:
+        end_time = datetime.now()
+        manager.write(f"\nProcess completed in {str((end_time - start_time))}\n")
 
-    return (stdout, stderr)
+    stderr_file.close()
+
+    return stdout
 
 
-def organize_folder_for_training(
-    root_training_dir: Path, data_dir: Path, downloaded_groundtruth: Path
-):
+def organize_folder_for_training(data_dir: Path, downloaded_groundtruth: Path):
     """
     Organize directory downloaded from girder into a structure compatible with Viame.
 

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -3,10 +3,16 @@ from typing import Any, Dict, List, Optional
 from typing_extensions import TypedDict
 
 __all__ = [
+    "GirderModel",
     "PipelineDescription",
     "PipelineJob",
     "PipelineCategory",
 ]
+
+
+class GirderModel(TypedDict):
+    name: str
+    _id: str
 
 
 class PipelineDescription(TypedDict):
@@ -20,9 +26,6 @@ class PipelineDescription(TypedDict):
     # the ID of the folder containing the pipeline,
     folderId: Optional[str]
 
-    # If the pipeline requires input
-    requires_input: Optional[bool]
-
 
 class PipelineJob(TypedDict):
     """Describes the parameters for running a pipeline on a dataset."""
@@ -31,7 +34,7 @@ class PipelineJob(TypedDict):
     input_folder: str
     input_type: str
     output_folder: str
-    pipeline_input: Optional[str]
+    pipeline_input: Optional[GirderModel]
 
 
 class TrainingConfigurationSummary(TypedDict):


### PR DESCRIPTION
General improvements to the various failure conditions of pipelines. 

* There were some missing edge conditions, such as cleanup after cancellation or failure.
* Stream logs directly to girder rather than buffering them into a log file and then writing the whole log file at once.
  * This will enable progress reporting in the near future as well
* Refactor common error handling logic to simplify each task code.
* Fix job cancellation again, because it apparently wasn't working on kwiver.
* Fix pipeline exclusions missed in #616 to match current filter file.  

fixes #576