### PR TITLE
Transcode audio to AAC to prevent incompatible container formats

### DIFF
--- a/client/platform/desktop/backend/native/linux.ts
+++ b/client/platform/desktop/backend/native/linux.ts
@@ -43,7 +43,8 @@ const ViameLinuxConstants = {
       '-c:v libx264',
       '-preset slow',
       '-crf 26',
-      '-c:a copy',
+      // https://askubuntu.com/questions/1315697/could-not-find-tag-for-codec-pcm-s16le-in-stream-1-codec-not-currently-support
+      '-c:a aac',
       /**
        * TODO: Upgrade to ffmpeg 4, use `round` instead of `ceil`
        * 3.4 is part of 18.04LTS, so we should support it

--- a/client/platform/desktop/backend/native/windows.ts
+++ b/client/platform/desktop/backend/native/windows.ts
@@ -39,7 +39,8 @@ const ViameWindowsConstants = {
       '-c:v libx264',
       '-preset slow',
       '-crf 26',
-      '-c:a copy',
+      // https://askubuntu.com/questions/1315697/could-not-find-tag-for-codec-pcm-s16le-in-stream-1-codec-not-currently-support
+      '-c:a aac',
       // https://video.stackexchange.com/questions/20871/how-do-i-convert-anamorphic-hdv-video-to-normal-h-264-video-with-ffmpeg-how-to
       '-vf "scale=ceil(iw*sar/2)*2:ceil(ih/2)*2,setsar=1"',
     ].join(' '),

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -472,8 +472,9 @@ def convert_video(self: Task, path, folderId, auxiliaryFolderId, itemId):
             "slow",
             "-crf",
             "26",
+            # https://askubuntu.com/questions/1315697/could-not-find-tag-for-codec-pcm-s16le-in-stream-1-codec-not-currently-support
             "-c:a",
-            "copy",
+            "aac",
             # see native/<platform> code for a discussion of this option
             "-vf",
             "scale=ceil(iw*sar/2)*2:ceil(ih/2)*2,setsar=1",


### PR DESCRIPTION
Note that this fixes one of the only failures I could find related to video where the sample data had not been removed.  This may not  be the cause of every transcoding issue.

fixes #353

