### PR TITLE
Use Pydantic for validation

### DIFF
--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -100,10 +100,12 @@ export default defineComponent({
       }
       updateTypeStyle({
         type: data.editingType,
-        color: data.editingColor,
-        strokeWidth: data.editingThickness,
-        fill: data.editingFill,
-        opacity: data.editingOpacity,
+        value: {
+          color: data.editingColor,
+          strokeWidth: data.editingThickness,
+          fill: data.editingFill,
+          opacity: data.editingOpacity,
+        },
       });
     }
 

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -3,7 +3,7 @@ import {
   provide, inject, ref, Ref,
 } from '@vue/composition-api';
 
-import { StateStyles, TypeStyling } from './use/useStyling';
+import { CustomStyle, StateStyles, TypeStyling } from './use/useStyling';
 import { EditAnnotationTypes } from './layers/EditAnnotationLayer';
 import Track, { TrackId } from './track';
 import { VisibleAnnotationTypes } from './layers';
@@ -120,10 +120,7 @@ export interface Handler {
   /* change styles */
   updateTypeStyle(args: {
     type: string;
-    color?: string;
-    strokeWidth?: number;
-    opacity?: number;
-    fill?: boolean;
+    value: CustomStyle;
   }): void;
   /* set an Attribute in the metaData */
   setAttribute({ data, oldAttribute }:

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -4,7 +4,7 @@ import {
   inject, ref, Ref, computed, set as VueSet,
 } from '@vue/composition-api';
 import * as d3 from 'd3';
-import { noop } from 'lodash';
+import { noop, merge } from 'lodash';
 
 interface Style {
   strokeWidth: number;
@@ -122,20 +122,11 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
 
   function updateTypeStyle(args: {
     type: string;
-    color?: string;
-    strokeWidth?: number;
-    opacity?: number;
-    fill?: boolean;
+    value: CustomStyle;
   }) {
-    const { type } = args;
-    if (!customStyles.value[type]) {
-      VueSet(customStyles.value, type, {});
-    }
-    Object.entries(args).forEach(([key, value]) => {
-      if (value !== undefined) {
-        VueSet(customStyles.value[type], key, value);
-      }
-    });
+    const { type, value } = args;
+    const oldValue = customStyles.value[type] || {};
+    VueSet(customStyles.value, type, merge(oldValue, value));
     customStylesRevisionCounter.value += 1;
     markChangesPending();
   }

--- a/server/dive_server/constants.py
+++ b/server/dive_server/constants.py
@@ -42,14 +42,3 @@ TrainedPipelineCategory = "trained"
 # The name of the folder where any user specific data should be stored
 # (created as a folder of that user)
 ViameDataFolderName = "VIAME"
-
-metadataMutable = ['customTypeStyling', 'confidenceFilters']
-metadataReserved = [
-    'attributes',
-    'fps',
-    'type',
-    'ffprobe_info',
-    'annotate',
-    'codec',
-    'source_video',
-]

--- a/server/dive_server/serializers/models.py
+++ b/server/dive_server/serializers/models.py
@@ -61,6 +61,23 @@ class Attribute(BaseModel):
     key: str
 
 
+class CustomStyle(BaseModel):
+    color: Optional[str]
+    strokeWidth: Optional[float]
+    opacity: Optional[float]
+    fill: Optional[bool]
+
+
+class MetadataMutableUpdate(BaseModel):
+    """Update schema for mutable metadata fields"""
+
+    customTypeStyling: Optional[Dict[str, CustomStyle]]
+    confidenceFilters: Optional[Dict[str, float]]
+
+    class Config:
+        extra = 'forbid'
+
+
 # interpolate all features [a, b)
 def interpolate(a: Feature, b: Feature) -> List[Feature]:
     if a.interpolate is False:

--- a/server/dive_server/serializers/models.py
+++ b/server/dive_server/serializers/models.py
@@ -67,6 +67,9 @@ class CustomStyle(BaseModel):
     opacity: Optional[float]
     fill: Optional[bool]
 
+    class Config:
+        extra = 'forbid'
+
 
 class MetadataMutableUpdate(BaseModel):
     """Update schema for mutable metadata fields"""


### PR DESCRIPTION
I've been trying to move toward pydantic for strict valudation of incoming models, and this looked like a good place to choose pydantic over a hand-rolled version.  

`extra = 'forbid'` results in the same exclusions as `metadataReserved`, but there's a difference in behavior with expunged.

I don't really understand the value of expunged, and I think it'd be better to throw an error if the payload isn't identical to what the server expects.  The only risk I could come up with was that save failure would cause the user to lose a bunch of hard work (as the result of a client bug), but track save will still succeed even if meta save fails.  

The benefit here of course is less code and deep schema enforcement (rather than just based on key).

What do you think?  Are there considerations I missed?