### PR TITLE
Release 1.4.4

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-media-annotator",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "author": {
     "name": "Kitware, Inc.",
     "email": "viame-web@kitware.com"

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,7 +8,6 @@
     "moduleResolution": "node",
     "allowJs": true,
     "outDir": "./dist",
-    // "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": false,

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -45,7 +45,7 @@ module.exports = {
           // https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/188
           // https://github.com/electron-userland/electron-builder/issues/2592
           main: 'background.js',
-          version: '1.4.3',
+          version: '1.4.4',
         },
         linux: {
           target: ['AppImage', 'snap', 'tar.gz'],

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -45,7 +45,6 @@ module.exports = {
           // https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/188
           // https://github.com/electron-userland/electron-builder/issues/2592
           main: 'background.js',
-          version: '1.4.4',
         },
         linux: {
           target: ['AppImage', 'snap', 'tar.gz'],


### PR DESCRIPTION
* The tsconfig comment will cause an error during release.  It's not part of the build step.
* At some point we had to release differnt versions of electron and vue-media-annotator, but now they're on track and it's easier to just release both under the same version number.  It's not like we have enough users that strict semver matters