### PR TITLE
Speed Control for Videos

### DIFF
--- a/client/dive-common/components/ControlsContainer.vue
+++ b/client/dive-common/components/ControlsContainer.vue
@@ -41,6 +41,8 @@ export default defineComponent({
     const currentView = ref('Detections');
     const collapsed = ref(false);
 
+    const ticks = ref([0.25, 0.5, 0.75, 1.0, 2.0, 4.0, 8.0]);
+
     /**
      * Toggles on and off the individual timeline views
      * Resizing is handled by the Annator itself.
@@ -50,7 +52,7 @@ export default defineComponent({
       collapsed.value = false;
     }
     const {
-      maxFrame, frame, seek, volume, setVolume,
+      maxFrame, frame, seek, volume, setVolume, setSpeed, speed,
     } = injectMediaController();
 
     return {
@@ -62,6 +64,9 @@ export default defineComponent({
       seek,
       volume,
       setVolume,
+      speed,
+      setSpeed,
+      ticks,
     };
   },
 });
@@ -148,8 +153,51 @@ export default defineComponent({
               </v-card>
             </v-menu>
           </span>
+          <span class="mr-2">
+            <v-menu
+              :close-on-content-click="false"
+              top
+              offset-y
+              nudge-left="3"
+              open-on-hover
+              close-delay="500"
+              open-delay="250"
+              rounded="lg"
+            >
+              <template v-slot:activator="{ on }">
+                <v-badge
+                  :value="speed != 1.0"
+                  color="#0277bd88"
+                  :content="`${speed}X`"
+                  offset-y="5px"
+                  overlap
+                >
+                  <v-icon
+                    v-on="on"
+                    @click="setSpeed(1)"
+                  > mdi-speedometer
+                  </v-icon>
+                </v-badge>
+              </template>
+              <v-card style="overflow:hidden; width:90px;">
+                <v-slider
+                  :value="ticks.indexOf(speed)"
+                  min="0"
+                  max="6"
+                  step="1"
+                  :tick-labels="ticks"
+                  ticks="always"
+                  :tick-size="4"
+                  style="font-size:0.75em;"
+                  vertical
+                  @change="setSpeed(ticks[$event])"
+                />
+
+              </v-card>
+            </v-menu>
+          </span>
           <file-name-time-display
-            class="text-middle"
+            class="text-middle pl-2"
             display-type="time"
           />
         </span>

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -102,12 +102,17 @@ export default defineComponent({
       data.volume = video.volume;
     }
 
+    function setSpeed(level: number) {
+      video.playbackRate = level;
+      data.speed = video.playbackRate;
+    }
+
     const {
       cursorHandler,
       initializeViewer,
       mediaController,
     } = commonMedia.initialize({
-      seek, play, pause, setVolume,
+      seek, play, pause, setVolume, setSpeed,
     });
 
     /**
@@ -138,6 +143,7 @@ export default defineComponent({
       seek(0);
       data.ready = true;
       data.volume = video.volume;
+      data.speed = video.playbackRate;
       data.currentTime = video.currentTime;
       data.duration = video.duration;
     }

--- a/client/src/components/annotators/mediaControllerType.ts
+++ b/client/src/components/annotators/mediaControllerType.ts
@@ -16,6 +16,7 @@ export interface MediaController {
   currentTime: Ref<number>;
   duration: Ref<number>;
   volume: Ref<number>;
+  speed: Ref<number>;
   maxFrame: Ref<number>;
   /** @deprecated may be removed in a future release */
   syncedFrame: Ref<number>;
@@ -30,4 +31,5 @@ export interface MediaController {
   setCursor(c: string): void;
   setImageCursor(c: string): void;
   setVolume(v: number): void;
+  setSpeed(v: number): void;
 }

--- a/client/src/components/annotators/useMediaController.ts
+++ b/client/src/components/annotators/useMediaController.ts
@@ -32,6 +32,7 @@ export default function useMediaController({ emit }: {
     currentTime: 0,
     duration: 0,
     volume: 0,
+    speed: 1.0,
     maxFrame: 0,
     syncedFrame: 0,
     observer: null,
@@ -125,12 +126,13 @@ export default function useMediaController({ emit }: {
    * the state above to construct the dependencies for the methods below.
    */
   function initialize({
-    seek, play, pause, setVolume,
+    seek, play, pause, setVolume, setSpeed,
   }: {
     seek(frame: number): void;
     play(): void;
     pause(): void;
     setVolume?(level: number): void;
+    setSpeed?(level: number): void;
   }) {
     function setCursor(newCursor: string) {
       data.cursor = `${newCursor}`;
@@ -239,6 +241,7 @@ export default function useMediaController({ emit }: {
       duration: toRef(data, 'duration'),
       volume: toRef(data, 'volume'),
       maxFrame: toRef(data, 'maxFrame'),
+      speed: toRef(data, 'speed'),
       syncedFrame: toRef(data, 'syncedFrame'),
       prevFrame,
       nextFrame,
@@ -251,6 +254,7 @@ export default function useMediaController({ emit }: {
       setCursor,
       setImageCursor,
       setVolume,
+      setSpeed,
     } as MediaController;
 
     provide(MediaControllerSymbol, mediaController);


### PR DESCRIPTION
Added in a speed control for video playback.

- Badge displays if the playback is value other than the default (1.0)
- Clicking on the icon will reset it back to 1.0 immediately
- Hovering will open the slider like the audio and then the user can choose from 0.25X to 8X for the speed setting

I didn't add support for the image-sequence playback (I don't know if it is necessary because the seeking for that is much faster for scrubbing.

Feel free to adjust and modify anything you want to (CSS, Icons, values, structure), I just did a sort of quick implementation.
![image](https://user-images.githubusercontent.com/61746913/117742319-7a6acc00-b1d2-11eb-842d-99264a3b66a2.png)



![image](https://user-images.githubusercontent.com/61746913/117742325-7f2f8000-b1d2-11eb-9a0a-d6f907b22fe1.png)

