### PR TITLE
Minor worker fixes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -100,6 +100,7 @@ This image contains a celery worker to run VIAME pipelines and transcoding jobs.
 | WORKER_CONCURRENCY | `# of CPU cores` | max concurrnet jobs. **Change this if you run training** |
 | WORKER_GPU_UUID | null | leave empty to use all GPUs.  Specify UUID to use specific device |
 | CELERY_BROKER_URL | null | rabbitmq connection string |
+| KWIVER_DEFAULT_LOG_LEVEL | `warn` | kwiver log level |
 | DIVE_USERNAME | null | Username to start private queue processor |
 | DIVE_PASSWORD | null | Password for private queue processor |
 | DIVE_API_URL  | `https://viame.kitware.com/api/v1` | Remote URL to authenticate against |

--- a/docker/provision/girder_worker_entrypoint.sh
+++ b/docker/provision/girder_worker_entrypoint.sh
@@ -18,5 +18,5 @@ fi
 exec python3.7 \
     -m dive_tasks \
     -l info \
-    --without-gossip --without-heartbeat --without-mingle \
+    --without-gossip --without-mingle \
     $QUEUE_ARGUMENT $CONCURRENCY_ARGUMENT

--- a/server/dive_tasks/celeryconfig.py
+++ b/server/dive_tasks/celeryconfig.py
@@ -44,12 +44,11 @@ if dive_username and dive_password:
 if broker_url is None:
     raise RuntimeError('CELERY_BROKER_URL must be set')
 
-broker_heartbeat = False
 worker_send_task_events = False
 # https://docs.celeryproject.org/en/stable/userguide/configuration.html#std-setting-worker_prefetch_multiplier
 worker_prefetch_multiplier = 1
 # https://docs.celeryproject.org/en/v4.4.6/userguide/configuration.html#broker-connection-timeout
-broker_connection_timeout = 12
+broker_connection_timeout = 6
 # Remote control is necessary to handle cancellation
 # Needs celery.pidbox, reply.celery.pidbox, uuid.reply.celery.pidbox, celery@uuid.celery.pidbox
 worker_enable_remote_control = True

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -81,6 +81,10 @@ class Config:
             'ADDON_ROOT_DIR',
             '/tmp/addons',
         )
+        self.kwiver_log_level = os.environ.get(
+            'KWIVER_DEFAULT_LOG_LEVEL',
+            'warn',
+        )
 
         self.viame_install_path = Path(self.viame_install_directory)
         assert self.viame_install_path.exists(), "VIAME Base install directory missing."
@@ -236,6 +240,7 @@ def run_pipeline(self: Task, params: PipelineJob):
         assert len(input_media_list) == 1, "Expected exactly 1 video"
         command = [
             f". {shlex.quote(str(conf.viame_setup_script))} &&",
+            f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
             "kwiver runner",
             "-s input:video_reader:type=vidl_ffmpeg",
             f"-p {shlex.quote(str(pipeline_path))}",
@@ -249,6 +254,7 @@ def run_pipeline(self: Task, params: PipelineJob):
             img_list_file.write('\n'.join(input_media_list))
         command = [
             f". {shlex.quote(str(conf.viame_setup_script))} &&",
+            f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
             "kwiver runner",
             f"-p {shlex.quote(str(pipeline_path))}",
             f"-s input:video_filename={shlex.quote(str(img_list_path))}",
@@ -376,6 +382,7 @@ def train_pipeline(
 
             command = [
                 f". {shlex.quote(str(conf.viame_setup_script))} &&",
+                f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
                 shlex.quote(str(conf.viame_training_executable)),
                 "-il",
                 shlex.quote(str(input_folder_file_list)),


### PR DESCRIPTION
* Turns out heartbeat was useful. I'm learning lots of stuff about celery.  I was trying to test the behavior more robustly by running a worker and turning my VPN on/off, pulling out my ethernet cable, etc.  Without the heartbeat, the rabbit server doesn't know when a connection has been lost.  Mailbox reservation gets stuck and messages start to flow into a mailbox for a worker that is no longer listening.  With heartbeat, the mailbox will eventually be cleared and the job with get rescheduled on another worker.
* Add `KWIVER_DEFAULT_LOG_LEVEL`.  Some processes don't respect this variable, but that's not dive's concern.
* I've experimentally found that the timeout error handling works well, so I've dropped the timeout to a more reasonable value.

Our cancellation error handling means that mingle isn't needed.  Without mingle, you get scary errors about invalid state transitions, but girder enforces job state integrity and the revoked job gets removed from the queue after it errors. Gossip doesn't apply to our deployment configuration at all.