### PR TITLE
Catch connection reset exception

### DIFF
--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -34,7 +34,7 @@ def check_canceled(task: Task, context: dict, force=True):
         context[TIMEOUT_LAST_CHECKED] = now
         try:
             return task.canceled
-        except TimeoutError as err:
+        except (TimeoutError, ConnectionError) as err:
             context[TIMEOUT_COUNT] += 1
             print(
                 f"Timeout N={context[TIMEOUT_COUNT]} for this task when checking for cancellation. {err}"


### PR DESCRIPTION
This would have fixed https://viame.kitware.com/girder/#job/60a27a583753b80a81e13e55

I'm not sure if this is a fluke, a band-aid fix, or caused by network unreliability inside KHQ.  