### PR TITLE
Import annotations

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -105,7 +105,7 @@ interface Api {
   saveMetadata(datasetId: string, metadata: DatasetMetaMutable): Promise<unknown>;
   saveAttributes(datasetId: string, args: SaveAttributeArgs): Promise<unknown>;
   // Non-Endpoint shared functions
-  openFromDisk(datasetType: DatasetType | 'calibration', directory?: boolean):
+  openFromDisk(datasetType: DatasetType | 'calibration' | 'annotation', directory?: boolean):
     Promise<{canceled?: boolean; filePaths: string[]; fileList?: File[]; root?: string}>;}
 
 const ApiSymbol = Symbol('api');

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -1,0 +1,65 @@
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api';
+import { useApi } from 'dive-common/apispec';
+
+export default defineComponent({
+  name: 'ImportAnnotations',
+  props: {
+    datasetId: {
+      type: String,
+      default: null,
+    },
+    blockOnUnsaved: {
+      type: Boolean,
+      default: false,
+    },
+    buttonOptions: {
+      type: Object,
+      default: () => ({}),
+    },
+    menuOptions: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  setup(props, { emit }) {
+    const { openFromDisk } = useApi();
+    const openUpload = async () => {
+      const ret = await openFromDisk('annotation');
+      if (!ret.canceled) {
+        const path = ret.filePaths[0];
+        if (ret.fileList?.length) {
+          emit('import-annotation-file', props.datasetId, ret.fileList[0]);
+        } else {
+          emit('import-annotation-file', props.datasetId, path);
+        }
+      }
+    };
+    return {
+      openUpload,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-btn
+    class="ma-0"
+    v-bind="buttonOptions"
+    :disabled="!datasetId"
+    @click="openUpload"
+  >
+    <v-icon>
+      mdi-application-import
+    </v-icon>
+    <span
+      v-show="!$vuetify.breakpoint.mdAndDown || buttonOptions.block"
+      class="pl-1"
+    >
+      Import
+    </span>
+  </v-btn>
+</template>
+
+<style scoped lang="scss">
+</style>

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -75,6 +75,13 @@ export default function register() {
     return ret;
   });
 
+  ipcMain.handle('import-annotation', async (event, { id, path }: { id: string; path: string }) => {
+    const ret = await common.annotationImport(
+      settings.get(), id, path,
+    );
+    return ret;
+  });
+
 
   ipcMain.handle('finalize-import', async (event, args: MediaImportPayload) => {
     const updater = (update: DesktopJobUpdate) => {

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -9,7 +9,7 @@ import type {
   Pipe, Pipelines, SaveAttributeArgs, SaveDetectionsArgs, TrainingConfigs,
 } from 'dive-common/apispec';
 
-import { fileVideoTypes, calibrationFileTypes } from 'dive-common/constants';
+import { fileVideoTypes, calibrationFileTypes, inputAnnotationFileTypes } from 'dive-common/constants';
 import {
   DesktopJob, DesktopMetadata, JsonMeta, NvidiaSmiReply,
   RunPipeline, RunTraining, ExportDatasetArgs,
@@ -21,7 +21,7 @@ import {
  * Native functions that run entirely in the renderer
  */
 
-async function openFromDisk(datasetType: DatasetType | 'calibration', directory = false) {
+async function openFromDisk(datasetType: DatasetType | 'calibration' | 'annotation', directory = false) {
   let filters: FileFilter[] = [];
   if (datasetType === 'video') {
     filters = [
@@ -32,6 +32,12 @@ async function openFromDisk(datasetType: DatasetType | 'calibration', directory 
   if (datasetType === 'calibration') {
     filters = [
       { name: 'calibration', extensions: calibrationFileTypes },
+      { name: 'All Files', extensions: ['*'] },
+    ];
+  }
+  if (datasetType === 'annotation') {
+    filters = [
+      { name: 'annotation', extensions: inputAnnotationFileTypes },
       { name: 'All Files', extensions: ['*'] },
     ];
   }
@@ -89,6 +95,10 @@ function importMedia(path: string): Promise<MediaImportPayload> {
 function importMultiCam(args: MultiCamImportArgs):
    Promise<MediaImportPayload> {
   return ipcRenderer.invoke('import-multicam-media', { args });
+}
+
+function importAnnotation(id: string, path: string): Promise<boolean> {
+  return ipcRenderer.invoke('import-annotation', { id, path });
 }
 
 function finalizeImport(args: MediaImportPayload): Promise<JsonMeta> {
@@ -165,6 +175,7 @@ export {
   finalizeImport,
   importMedia,
   importMultiCam,
+  importAnnotation,
   openLink,
   nvidiaSmi,
 };

--- a/client/src/use/useTrackStore.ts
+++ b/client/src/use/useTrackStore.ts
@@ -107,7 +107,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
     return track;
   }
 
-  function removeTrack(trackId: TrackId | null): void {
+  function removeTrack(trackId: TrackId | null, disableNotifications = false): void {
     if (trackId === null) {
       return;
     }
@@ -123,9 +123,17 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
       throw new Error(`TrackId ${trackId} not found in trackIds.`);
     }
     trackIds.value.splice(listIndex, 1);
-    markChangesPending({ action: 'delete', track });
+    if (!disableNotifications) {
+      markChangesPending({ action: 'delete', track });
+    }
   }
 
+  function clearAllTracks() {
+    trackIds.value.forEach((track) => {
+      removeTrack(track, true);
+    });
+    trackIds.value = [];
+  }
   /*
    * Discard tracks whose highest confidencePair value
    * is lower than specified.
@@ -156,5 +164,6 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
     getNewTrackId,
     removeTrack,
     removeTracksBelowConfidence,
+    clearAllTracks,
   };
 }


### PR DESCRIPTION
Support for importing annotations after dataset has been uploaded already.
This is based of the stereo backend support PR because of some changes to how `openFromDisk` works.



https://user-images.githubusercontent.com/61746913/119048804-bbf73600-b98d-11eb-8507-445238c5ebe8.mp4


Questions/Unknowns:
- For web I'm using direct girder endpoints for uploading of a single chunk.  Should I really be using the mixins and have support for larger annotation files?
- Should upload be a place where we allow the user to change the Annotation FPS at the same time? (as an aside it may be nice to have pipelines when writting the CSV include the FPS so we could adjust it in postprocess)
- I encapsulated the load function inside of `Viewer.vue` to be able to reload the data.  Part of this was creating a function inside of track called `clearAll` which removes all of the current tracks.  There is probably a better a way to do this.

fixes #686 
fixes #656 