### PR TITLE
Trained pipes missing in desktop

### DIFF
--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -281,7 +281,7 @@ async function getPipelineList(settings: Settings): Promise<Pipelines> {
     pipesInFolder = pipesInFolder.filter(
       (p: string) => p.match(allowedTrainedPatterns) && !p.match(disallowedPatterns),
     );
-    if (pipesInFolder.length >= 2) {
+    if (pipesInFolder.length >= 1) {
       const pipeName = pipesInFolder.find((pipe) => pipe && pipe.indexOf('.pipe') !== -1);
       if (pipeName) {
         const pipeInfo = {


### PR DESCRIPTION
Not sure why this used to be "2"

The contents of a directory looks like this:

```
~$ ll /home/brandon/VIAME_DATA/DIVE_Pipelines/sample_detector
.rw-rw-r--   92 brandon 27 May 15:00 custom_cfrnn.lbl
.rw-rw-r-- 8.2k brandon 27 May 15:00 custom_cfrnn.py
.rw-rw-r-- 4.1k brandon 27 May 15:00 detector.pipe
```