### PR TITLE
Calculate Max N for all classes for multiple datasets

### DIFF
--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -132,6 +132,10 @@ export default defineComponent({
               >
                 Run pipeline
               </span>
+              <v-spacer />
+              <v-icon v-if="menuOptions.right">
+                mdi-chevron-right
+              </v-icon>
             </v-btn>
           </template>
           <span>Run CV algorithm pipelines on this data</span>

--- a/client/dive-common/components/RunTrainingMenu.vue
+++ b/client/dive-common/components/RunTrainingMenu.vue
@@ -117,6 +117,8 @@ export default defineComponent({
             >
               Run Training
             </span>
+            <v-spacer />
+            <v-icon>mdi-chevron-right</v-icon>
           </v-btn>
         </template>
         <span>Train a detector model on this data</span>

--- a/client/platform/web-girder/api/summary.service.ts
+++ b/client/platform/web-girder/api/summary.service.ts
@@ -12,7 +12,12 @@ async function getSummary() {
   return data;
 }
 
+function getMaxNSummaryUrl(ids: string[]) {
+  return `${girderRest.apiRoot}/viame_summary/max_n?folder_ids=${JSON.stringify(ids)}`;
+}
+
 export {
   SummaryItem,
   getSummary,
+  getMaxNSummaryUrl,
 };

--- a/client/platform/web-girder/views/Clone.vue
+++ b/client/platform/web-girder/views/Clone.vue
@@ -106,6 +106,8 @@ export default defineComponent({
             >
               Clone
             </span>
+            <v-spacer />
+            <v-icon>mdi-dock-window</v-icon>
           </v-btn>
         </template>
         <span>Create a clone of this data</span>

--- a/client/platform/web-girder/views/Export.vue
+++ b/client/platform/web-girder/views/Export.vue
@@ -119,6 +119,10 @@ export default defineComponent({
             >
               Download
             </span>
+            <v-spacer />
+            <v-icon v-if="menuOptions.right">
+              mdi-chevron-right
+            </v-icon>
           </v-btn>
         </template>
         <span>Download media and annotations</span>
@@ -185,15 +189,6 @@ export default defineComponent({
             </template>
           </v-card-text>
           <v-card-actions>
-            <v-btn
-              depressed
-              block
-              :disabled="!exportUrls.exportDetectionsUrl"
-              @click="doExport({ url: exportUrls && exportUrls.exportDetectionsUrl })"
-            >
-              <span v-if="exportUrls.exportDetectionsUrl">detections</span>
-              <span v-else>detections unavailable</span>
-            </v-btn>
             <v-btn
               depressed
               block

--- a/client/platform/web-girder/views/Export.vue
+++ b/client/platform/web-girder/views/Export.vue
@@ -185,7 +185,15 @@ export default defineComponent({
             </template>
           </v-card-text>
           <v-card-actions>
-            <v-spacer />
+            <v-btn
+              depressed
+              block
+              :disabled="!exportUrls.exportDetectionsUrl"
+              @click="doExport({ url: exportUrls && exportUrls.exportDetectionsUrl })"
+            >
+              <span v-if="exportUrls.exportDetectionsUrl">detections</span>
+              <span v-else>detections unavailable</span>
+            </v-btn>
             <v-btn
               depressed
               block

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -11,6 +11,7 @@ import RunTrainingMenu from 'dive-common/components/RunTrainingMenu.vue';
 import { getFolder } from 'platform/web-girder/api/girder.service';
 import { getLocationFromRoute } from '../utils';
 import { deleteResources } from '../api/viame.service';
+import { getMaxNSummaryUrl } from '../api/summary.service';
 import Export from './Export.vue';
 import Upload from './Upload.vue';
 import DataDetails from './DataDetails.vue';
@@ -107,7 +108,7 @@ export default Vue.extend({
       return this.location?.description;
     },
     summaryUrl() {
-      return `/api/v1/viame_summary/max_n?folder_ids=${JSON.stringify(this.locationInputs)}`;
+      return getMaxNSummaryUrl(this.locationInputs);
     },
   },
   async created() {

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -106,7 +106,9 @@ export default Vue.extend({
     selectedDescription() {
       return this.location?.description;
     },
-
+    summaryUrl() {
+      return `/api/v1/viame_summary/max_n?folder_ids=${JSON.stringify(this.locationInputs)}`;
+    },
   },
   async created() {
     let newLocaction = getLocationFromRoute(this.$route);
@@ -214,6 +216,19 @@ export default Vue.extend({
                   v-bind="{ buttonOptions, menuOptions }"
                   :dataset-id="exportTargetId"
                 />
+                <v-btn
+                  :disabled="!locationInputs.length"
+                  v-bind="{ ...buttonOptions }"
+                  :href="summaryUrl"
+                  target="_blank"
+                >
+                  <v-icon>
+                    mdi-file-chart
+                  </v-icon>
+                  <span class="pl-1">
+                    Generate Summary
+                  </span>
+                </v-btn>
                 <v-btn
                   :disabled="!selected.length"
                   v-bind="{ ...buttonOptions }"

--- a/server/dive_server/serializers/viame.py
+++ b/server/dive_server/serializers/viame.py
@@ -11,6 +11,10 @@ from typing import Dict, Generator, List, Tuple, Union
 from dive_utils.models import Attribute, Feature, Track, interpolate
 
 
+def format_timestamp(fps: int, frame: int) -> str:
+    return str(datetime.datetime.utcfromtimestamp(frame / fps).strftime(r'%H:%M:%S.%f'))
+
+
 def writeHeader(writer: '_csv._writer', metadata: Dict):
     writer.writerow(
         [
@@ -313,9 +317,7 @@ def export_tracks_as_csv(
 
                     # If FPS is set, column 2 will be video timestamp
                     if fps is not None and fps > 0:
-                        columns[1] = datetime.datetime.utcfromtimestamp(
-                            feature.frame / fps
-                        ).strftime(r'%H:%M:%S.%f')
+                        columns[1] = format_timestamp(fps, feature.frame)
                     # else if filenames is set, column 2 will be image file name
                     elif filenames and feature.frame < len(filenames):
                         columns[1] = filenames[feature.frame]

--- a/server/dive_server/viame_detection.py
+++ b/server/dive_server/viame_detection.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import List
 
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
@@ -19,7 +19,6 @@ from dive_server.utils import (
     saveTracks,
     verify_dataset,
 )
-from dive_tasks.summary import generate_max_n_summary
 from dive_utils import fromMeta, models
 from dive_utils.constants import (
     FPSMarker,
@@ -40,7 +39,6 @@ class ViameDetection(Resource):
         self.route("PUT", (), self.save_detection)
         self.route("GET", ("clip_meta",), self.get_clip_meta)
         self.route("GET", (":id", "export"), self.get_export_urls)
-        self.route("GET", ("export_summary",), self.export_summary)
         self.route("GET", (":id", "export_detections"), self.export_detections)
         self.route("GET", (":id", "export_all"), self.export_all)
 
@@ -192,24 +190,6 @@ class ViameDetection(Resource):
         filename, gen = self._generate_detections(folder, excludeBelowThreshold)
         setContentDisposition(filename)
         return gen
-
-    @access.public(scope=TokenScope.DATA_READ, cookie=True)
-    @autoDescribeRoute(
-        Description("Export summary of multiple datasets").jsonParam(
-            'folder_ids', 'dataset IDs', paramType='query', requireArray=True
-        )
-    )
-    def export_summary(self, folder_ids: List[str]):
-        user = self.getCurrentUser()
-        summary: Dict[str, Any] = {}
-        for id in folder_ids:
-            folder = Folder().load(id, level=AccessType.READ, user=user)
-            track_data = getTrackData(detections_file(folder))
-            summary[folder['name']] = {
-                "summary": generate_max_n_summary(track_data),
-                "meta": folder['meta'],
-            }
-        return summary
 
     @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -52,6 +52,9 @@ class Track(BaseModel):
             ]
         )
 
+    def __hash__(self):
+        return self.trackId
+
 
 class Attribute(BaseModel):
     belongs: Literal['track', 'detection']


### PR DESCRIPTION
![Screenshot from 2021-05-29 14-47-02](https://user-images.githubusercontent.com/4214172/120081682-ca7bd680-c08c-11eb-8c8e-3107455999d6.png)

Something to note: In order to make this fast, the actual detections (features) are not parsed, and instead the track bounds are used.  That means that a track that spans 10 frames but that has no detection on a given frame will be counted in the summary for that frame.  I believe this is correct from a stasticical perspective: the target is occluded, but exists in the frame.

If this is an incorrect way to count, the summary generator will need to be moved into a worker process and this will add some complexity.

I want to make the summary button it's own dialog with other report types, but this was the quick version.  I added some icons to the button to indicate which ones had "submenus" but I could revert this if you want.  Until now, all those buttons were "safe" -- they didn't do anything until you confirmed something in another menu.  This button immediately generates a report, which could make the user hesitant to explore buttons.

Fixes #710 