### PR TITLE
Dedupe detection generation code, fix clone training bug

### DIFF
--- a/server/dive_server/utils.py
+++ b/server/dive_server/utils.py
@@ -302,7 +302,7 @@ def get_annotation_csv_generator(
     if source_type == VideoType:
         fps = fromMeta(folder, FPSMarker)
     elif source_type == ImageSequenceType:
-        imageFiles = valid_images(folder, user)
+        imageFiles = [img['name'] for img in valid_images(folder, user)]
 
     thresholds = fromMeta(folder, "confidenceFilters", {})
     annotation_file = detections_file(folder, strict=True)

--- a/server/dive_server/viame.py
+++ b/server/dive_server/viame.py
@@ -1,7 +1,5 @@
-import functools
 from typing import List
 
-import pymongo
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute, describeRoute
 from girder.api.rest import Resource
@@ -21,7 +19,7 @@ from dive_tasks.tasks import (
     train_pipeline,
     upgrade_pipelines,
 )
-from dive_utils import TRUTHY_META_VALUES, fromMeta, models, strNumericCompare
+from dive_utils import TRUTHY_META_VALUES, fromMeta, models
 from dive_utils.constants import (
     JOBCONST_PIPELINE_NAME,
     JOBCONST_PRIVATE_QUEUE,
@@ -54,6 +52,7 @@ from .utils import (
     process_csv,
     process_json,
     saveTracks,
+    valid_images,
     verify_dataset,
 )
 
@@ -530,18 +529,7 @@ class Viame(Resource):
         )
     )
     def get_valid_images(self, folder):
-        images = Folder().childItems(
-            getCloneRoot(self.getCurrentUser(), folder),
-            filters={"lowerName": {"$regex": safeImageRegex}},
-        )
-
-        def unwrapItem(item1, item2):
-            return strNumericCompare(item1['name'], item2['name'])
-
-        return sorted(
-            images,
-            key=functools.cmp_to_key(unwrapItem),
-        )
+        return valid_images(folder, self.getCurrentUser())
 
     @access.user
     @autoDescribeRoute(


### PR DESCRIPTION
Fixes a somewhat nuanced bug with training with clones.

Biggest issue was `new_file = File().findOne({"name": filename}) or File().createFile(`

* Obviously identifying files to generate groundtruth by name is a real bad plan.  However, since `ensure_csv_detections_file()` and `_generate_detections()` were almost identical functions and that code is complicated enough that copy/paste is a bad idea, I refactored into `get_annotation_csv_generator()`.  There were bugs in both variants that needed to be fixed.
* This fixes a related bug where the generator fails to call clone root to populate the list of input images, causing the CSV to be missing that column.
* This fixes an unrelated bug where advanced image ordering was not applied to the CSV export image listing.


This has been a lesson in DRY (Don't Repeat Yourself).

## Testing

Use `ldc dev up girder` to run the server in development mode.

- [ ] Please test training on cloned data
- [ ] Please test training when multiple clones of the same data exist (the problem today)
- [ ] Please test csv export on regular data and clones