### PR TITLE
Added population counters for selected types

### DIFF
--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -116,7 +116,7 @@ export default defineComponent({
       Vue.nextTick(() => scrollToTrack(selectedTrackIdRef.value));
     }
 
-    //If we mount with selected we scroll to it automatically
+    // If we mount with selected we scroll to it automatically
     scrollToSelectedTrack();
 
     function scrollPreventDefault(
@@ -135,8 +135,10 @@ export default defineComponent({
     }
 
     function getItemProps(item: VirtualListItem) {
-      const type = item.filteredTrack.track.getType(item.filteredTrack.context.confidencePairIndex);
-      const trackType = type ? type[0] : '';
+      const confidencePair = item.filteredTrack.track.getType(
+        item.filteredTrack.context.confidencePairIndex,
+      );
+      const trackType = confidencePair[0];
       const selected = item.selectedTrackId === item.filteredTrack.track.trackId;
       return {
         trackType,

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -128,8 +128,8 @@ export default defineComponent({
     }
 
     const typeCounts = computed(() => filteredTracksRef.value.reduce((acc, filteredTrack) => {
-      const type = filteredTrack.track.getType(filteredTrack.context.confidencePairIndex);
-      const trackType = type ? type[0] : '';
+      const confidencePair = filteredTrack.track.getType(filteredTrack.context.confidencePairIndex);
+      const trackType = confidencePair[0];
       acc.set(trackType, (acc.get(trackType) || 0) + 1);
 
       return acc;
@@ -241,7 +241,7 @@ export default defineComponent({
               :input-value="checkedTypesRef"
               :value="type"
               :color="typeStylingRef.color(type)"
-              :label="`${type} ${typeCounts.has(type) ? `(${typeCounts.get(type)})` : ''}`"
+              :label="`${type} (${typeCounts.get(type) || 0})`"
               dense
               shrink
               hide-details

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { computed, defineComponent, reactive } from '@vue/composition-api';
 import {
-  useCheckedTypes, useAllTypes, useTypeStyling, useHandler, useUsedTypes,
+  useCheckedTypes, useAllTypes, useTypeStyling, useHandler, useUsedTypes, useFilteredTracks,
 } from '../provides';
 
 
@@ -33,6 +33,7 @@ export default defineComponent({
     const allTypesRef = useAllTypes();
     const usedTypesRef = useUsedTypes();
     const typeStylingRef = useTypeStyling();
+    const filteredTracksRef = useFilteredTracks();
     const {
       updateTypeName,
       updateTypeStyle,
@@ -126,6 +127,14 @@ export default defineComponent({
       setCheckedTypes([]);
     }
 
+    const typeCounts = computed(() => filteredTracksRef.value.reduce((acc, filteredTrack) => {
+      const type = filteredTrack.track.getType(filteredTrack.context.confidencePairIndex);
+      const trackType = type ? type[0] : '';
+      acc.set(trackType, (acc.get(trackType) || 0) + 1);
+
+      return acc;
+    }, new Map<string, number>()));
+
 
     return {
       visibleTypes,
@@ -141,6 +150,7 @@ export default defineComponent({
       headCheckState,
       headCheckClicked,
       setCheckedTypes,
+      typeCounts,
     };
   },
 });
@@ -231,7 +241,7 @@ export default defineComponent({
               :input-value="checkedTypesRef"
               :value="type"
               :color="typeStylingRef.color(type)"
-              :label="type"
+              :label="`${type} ${typeCounts.has(type) ? `(${typeCounts.get(type)})` : ''}`"
               dense
               shrink
               hide-details


### PR DESCRIPTION
fixes #645 

Displays counter in parentheses next to selected type. Literal count of all tracks in track list grouped by type. When the type is unchecked, the counter disappears. Counter updates automatically as the confidence filter slider is changed. 
![image](https://user-images.githubusercontent.com/30541973/120861124-cd773b00-c554-11eb-9b5d-1b3e68b5b8c9.png)

Still need some tests on performance and efficiency. 
