### PR TITLE
PostProcess detection creation

### DIFF
--- a/server/dive_server/utils.py
+++ b/server/dive_server/utils.py
@@ -261,6 +261,8 @@ def createSoftClone(
         )
         cloned_detection_item['meta'][DetectionMarker] = str(cloned_folder['_id'])
         Item().save(cloned_detection_item)
+    else:
+        saveTracks(cloned_folder, {}, owner)
     return cloned_folder
 
 

--- a/server/dive_server/viame.py
+++ b/server/dive_server/viame.py
@@ -46,6 +46,7 @@ from .training import ensure_csv_detections_file, training_output_folder
 from .transforms import GetPathFromItemId
 from .utils import (
     createSoftClone,
+    detections_file,
     detections_item,
     get_or_create_auxiliary_folder,
     getCloneRoot,
@@ -448,6 +449,10 @@ class Viame(Resource):
 
         process_csv(folder, user)
         process_json(folder, user)
+
+        # If no detections file exists create one
+        if detections_file(folder) is None:
+            saveTracks(folder, {}, user)
 
         return folder
 


### PR DESCRIPTION
fixes #802 

- Added check at the end of post process to ensure that if no detection file is found it will automatically create one
- Added the same check to the clone data, so that if there are existing datasets without a base detection on clone it will create an empty track file as well.