### PR TITLE
Grouped minor fixes

### DIFF
--- a/client/dive-common/components/UserGuideDialog.vue
+++ b/client/dive-common/components/UserGuideDialog.vue
@@ -60,6 +60,16 @@ export default {
             {
               name: 'Edit Type', icon: 'mdi-keyboard', actions: ['Shift + Enter'], description: 'Choose/Edit track type',
             },
+            {
+              name: 'Toggle Keyframe', icon: 'mdi-keyboard', actions: ['K'], description: 'Toggle Keyframe',
+            },
+            {
+              name: 'Split Track', icon: 'mdi-keyboard', actions: ['X'], description: 'Split Track',
+            },
+            {
+              name: 'Merge Mode', icon: 'mdi-keyboard', actions: ['M'], description: 'Enter Merge Mode, commit with Shift+M',
+            },
+
           ],
         },
         {

--- a/client/dive-common/components/UserGuideDialog.vue
+++ b/client/dive-common/components/UserGuideDialog.vue
@@ -35,24 +35,10 @@ export default {
           ],
         },
         {
-          name: 'Editing Mode',
-          data: [
-            {
-              name: 'New Track', icon: 'mdi-keyboard', actions: ['N Key'], description: 'Create a new Track/Detection',
-            },
-            {
-              name: 'Edit Track', icon: 'mdi-mouse', actions: ['Right Click Mouse'], description: 'Right click a track to enter Edit Mode',
-            },
-            {
-              name: 'Add Head/Tail', icon: 'mdi-keyboard', actions: ['H Key - Head', 'T Key - Tail'], description: 'While a track is selected add head/tail annotations',
-            },
-          ],
-        },
-        {
           name: 'Selected Mode',
           data: [
             {
-              name: 'First Frame', icon: 'mdi-keyboard', actions: ['Enter'], description: 'Go to first frame of selected track',
+              name: 'First/Last Frame', icon: 'mdi-keyboard', actions: ['Home or End'], description: 'Go to first or last frame of selected track',
             },
             {
               name: 'Delete', icon: 'mdi-keyboard', actions: ['Delete'], description: 'Delete selected track',
@@ -61,8 +47,12 @@ export default {
               name: 'Edit Type', icon: 'mdi-keyboard', actions: ['Shift + Enter'], description: 'Choose/Edit track type',
             },
             {
-              name: 'Toggle Keyframe', icon: 'mdi-keyboard', actions: ['K'], description: 'Toggle Keyframe',
+              name: 'Toggle Keyframe', icon: 'mdi-keyboard', actions: ['K'], description: 'Toggle Current Frame Keyframe',
             },
+            {
+              name: 'Toggle Interpolation', icon: 'mdi-keyboard', actions: ['I'], description: 'Toggle Interpolation On/Off',
+            },
+
             {
               name: 'Split Track', icon: 'mdi-keyboard', actions: ['X'], description: 'Split Track',
             },
@@ -83,6 +73,20 @@ export default {
             },
             {
               name: 'Next Frame', icon: 'mdi-keyboard', actions: ['F Key', 'Right Arrow'], description: 'skip ahead 1 frame',
+            },
+          ],
+        },
+        {
+          name: 'Editing Mode',
+          data: [
+            {
+              name: 'New Track', icon: 'mdi-keyboard', actions: ['N Key'], description: 'Create a new Track/Detection',
+            },
+            {
+              name: 'Edit Track', icon: 'mdi-mouse', actions: ['Right Click Mouse'], description: 'Right click a track to enter Edit Mode',
+            },
+            {
+              name: 'Add Head/Tail', icon: 'mdi-keyboard', actions: ['H Key - Head', 'T Key - Tail'], description: 'While a track is selected add head/tail annotations',
             },
           ],
         },

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -80,6 +80,7 @@ export default defineComponent({
     const imageData = ref([] as FrameImage[]);
     const datasetType: Ref<DatasetType> = ref('image-sequence');
     const datasetName = ref('');
+    const saveInProgress = ref(false);
     const videoUrl = ref(undefined as undefined | string);
     const frame = ref(0); // the currently displayed frame number
     const { loadDetections, loadMetadata, saveMetadata } = useApi();
@@ -230,6 +231,7 @@ export default defineComponent({
 
     async function save() {
       // If editing the track, disable editing mode before save
+      saveInProgress.value = true;
       if (editingTrack.value) {
         handler.trackSelect(selectedTrackId.value, false);
       }
@@ -249,6 +251,7 @@ export default defineComponent({
         });
         throw err;
       }
+      saveInProgress.value = false;
     }
 
     function saveThreshold() {
@@ -378,6 +381,7 @@ export default defineComponent({
       newTrackSettings: clientSettings.newTrackSettings,
       typeSettings: clientSettings.typeSettings,
       pendingSaveCount,
+      saveInProgress,
       playbackComponent,
       recipes,
       selectedFeatureHandle,
@@ -440,7 +444,7 @@ export default defineComponent({
       >
         <v-btn
           icon
-          :disabled="pendingSaveCount === 0"
+          :disabled="pendingSaveCount === 0 || saveInProgress"
           @click="save"
         >
           <v-icon>mdi-content-save</v-icon>

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -249,6 +249,7 @@ export default defineComponent({
           text,
           positiveButton: 'OK',
         });
+        saveInProgress.value = false;
         throw err;
       }
       saveInProgress.value = false;

--- a/client/platform/desktop/backend/server.ts
+++ b/client/platform/desktop/backend/server.ts
@@ -14,6 +14,7 @@ import settings from './state/settings';
 import * as common from './native/common';
 
 const app = express();
+app.use(express.json({ limit: '250MB' }));
 const apirouter = express.Router();
 let server: http.Server;
 

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -139,40 +139,11 @@ export default defineComponent({
     }
 
     function toggleKeyframe() {
-      const f = feature.value;
-      if (f.real && !f.isKeyframe) {
-        props.track.setFeature({
-          ...f.real,
-          frame: frameRef.value,
-          keyframe: true,
-        });
-      } else if ((f.lower || f.upper) && !f.isKeyframe) {
-        let interFeature: Feature | null = null;
-        if (f.upper && frameRef.value > f.upper.frame) {
-          interFeature = f.upper;
-        } else if (f.lower && frameRef.value < f.lower.frame) {
-          interFeature = f.lower;
-        }
-        if (interFeature) {
-          props.track.setFeature({
-            ...interFeature,
-            frame: frameRef.value,
-            keyframe: true,
-          });
-        }
-      } else if (f.isKeyframe) {
-        props.track.deleteFeature(frameRef.value);
-      }
+      props.track.toggleKeyframe(frameRef.value);
     }
 
     function toggleInterpolation() {
-      const f = feature.value;
-      if (f.targetKeyframe) {
-        props.track.setFeature({
-          ...f.targetKeyframe,
-          interpolate: !f.shouldInterpolate,
-        });
-      }
+      props.track.toggleInterpolation(frameRef.value);
     }
 
     function gotoNext() {

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -104,7 +104,6 @@ export default defineComponent({
     watch(trackTypeRef, (val) => { data.trackTypeValue = val; });
 
     function focusType() {
-      console.log('focusTypeCalled');
       if (props.selected && typeInputBoxRef.value !== undefined) {
         data.skipOnFocus = true;
         typeInputBoxRef.value.focus();
@@ -318,6 +317,7 @@ export default defineComponent({
           v-mousetrap="[
             { bind: 'shift+enter', handler: focusType },
             { bind: 'k', handler:toggleKeyframe},
+            { bind: 'i', handler:toggleInterpolation},
             { bind: 'home', handler: () => $emit('seek', track.begin)},
             { bind: 'end', handler: () => $emit('seek', track.end)},
           ]"

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -218,6 +218,7 @@ export default defineComponent({
   <div
     v-mousetrap="[
       { bind: 'shift+enter', handler: focusType },
+      { bind: 'k', handler:toggleKeyframe}
     ]"
     class="track-item d-flex flex-column align-start hover-show-parent px-1"
     :style="style"

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -104,6 +104,7 @@ export default defineComponent({
     watch(trackTypeRef, (val) => { data.trackTypeValue = val; });
 
     function focusType() {
+      console.log('focusTypeCalled');
       if (props.selected && typeInputBoxRef.value !== undefined) {
         data.skipOnFocus = true;
         typeInputBoxRef.value.focus();
@@ -230,10 +231,6 @@ export default defineComponent({
 
 <template>
   <div
-    v-mousetrap="[
-      { bind: 'shift+enter', handler: focusType },
-      { bind: 'k', handler: () => selected && toggleKeyframe()}
-    ]"
     class="track-item d-flex flex-column align-start hover-show-parent px-1"
     :style="style"
   >
@@ -316,6 +313,15 @@ export default defineComponent({
     >
       <v-spacer v-if="!isTrack" />
       <template v-if="selected">
+        <span
+          v-show="false"
+          v-mousetrap="[
+            { bind: 'shift+enter', handler: focusType },
+            { bind: 'k', handler:toggleKeyframe},
+            { bind: 'home', handler: () => $emit('seek', track.begin)},
+            { bind: 'end', handler: () => $emit('seek', track.end)},
+          ]"
+        />
         <tooltip-btn
           color="error"
           icon="mdi-delete"

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -55,7 +55,7 @@ export default defineComponent({
 
   components: { TrackItem },
 
-  setup(props, { emit }) {
+  setup(props) {
     const { prompt } = usePrompt();
     const allTypesRef = useAllTypes();
     const checkedTrackIdsRef = useCheckedTrackIds();

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -55,7 +55,7 @@ export default defineComponent({
 
   components: { TrackItem },
 
-  setup(props) {
+  setup(props, { emit }) {
     const { prompt } = usePrompt();
     const allTypesRef = useAllTypes();
     const checkedTrackIdsRef = useCheckedTrackIds();

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -283,6 +283,46 @@ export default class Track {
     });
   }
 
+  toggleKeyframe(frame: number) {
+    const { features } = this.canInterpolate(frame);
+    const [real, lower, upper] = features;
+    if (real && !real.keyframe) {
+      this.setFeature({
+        ...real,
+        frame,
+        keyframe: true,
+      });
+    } else if ((lower || upper) && !real?.keyframe) {
+      let interFeature: Feature | null = null;
+      if (upper && frame > upper.frame) {
+        interFeature = upper;
+      } else if (lower && frame < lower.frame) {
+        interFeature = lower;
+      }
+      if (interFeature) {
+        this.setFeature({
+          ...interFeature,
+          frame,
+          keyframe: true,
+        });
+      }
+    } else if (real?.keyframe) {
+      this.deleteFeature(frame);
+    }
+  }
+
+  toggleInterpolation(frame: number) {
+    const { features, interpolate } = this.canInterpolate(frame);
+    const [real, lower, upper] = features;
+    const targetKeyframe = real?.keyframe ? real : (lower || upper);
+    if (targetKeyframe) {
+      this.setFeature({
+        ...targetKeyframe,
+        interpolate: !interpolate,
+      });
+    }
+  }
+
   setFeature(feature: Feature, geometry: GeoJSON.Feature<TrackSupportedFeature>[] = []): Feature {
     const f = this.features[feature.frame] || {};
     this.features[feature.frame] = {

--- a/docs/Mouse-Keyboard-Shortcuts.md
+++ b/docs/Mouse-Keyboard-Shortcuts.md
@@ -31,13 +31,15 @@ Most editing controls are available when a track or detection is selected.
 | ---------- | ------------|
 | `delete` | delete entire track or detection |
 | `n` | create new track or detection |
-| `enter` | go to first frame of selected |
+| `Home` or `End` | go to first or last frame of selected |
 | `1` | Enter **bounding-box** edit mode on selection |
 | `2` | Enter **polygon** edit mode on selection  |
 | `3` | Enter **head/tail/line** edit mode on selection |
 | `h` or `g` | while in line mode, place head point next |
 | `t` or `y` | while in line mode, place tail point next |
 | `escape` | unselect, exit edit mode, exit merge mode |
+| `k` | toggle keyframe for the current frame and selected track |
+| `i` | toggle interpolation for the current range of the selected track |
 | `m` | enter merge mode for on selection |
 | `shift` + `m` | commit (finalize) merge for selected tracks. |
 | `shift` + `enter` | focus class select/text box on selected track in track list.  Press `Down Arrow` to open all options.  Pres `enter` twice to accept an option.  Press `escape` to unfocus. |


### PR DESCRIPTION
Some minor bugfixes
Fixes #762 - disabling button while save is in progress
Fixes #765 - expressJS setting of JSON limit to 250MB from the default of 100KB
Fixes #728 :  
- Added in 'K' for toggle keyframe as well as updated the shortcuts in the help for split/merge/keyframe.
- Modified v-mousetrap to hidden div only visible when the item is selected.  Before the shift+enter focus call was added and called on all visible items in the virtual scroll list.  This will limit it to only the selected one having keyboard shortcuts applied.
- Keyframes should be added and removed while in edit mode by pressing K
- Added in toggle interpolation shortcut "I"
- "Enter" no longer went to first frame, modified for "Home" or "End" going to the first/last frame of the currently selected track
- Updated the keyboard control list to reflect the update keyboard commands and reordered it to fit better.