### PR TITLE
Take breaks when loading large amounts of data

### DIFF
--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -90,9 +90,16 @@ export default defineComponent({
       // like vuex is used to drive them.
       loaded: false,
       // Tracks loaded
-      progress: -1,
+      progress: 0,
       // Total tracks
-      total: -1,
+      total: 0,
+    });
+
+    const progressValue = computed(() => {
+      if (progress.total > 0 && (progress.progress !== progress.total)) {
+        return Math.round((progress.progress / progress.total) * 100);
+      }
+      return 0;
     });
 
     const {
@@ -358,8 +365,6 @@ export default defineComponent({
         }
       }),
     ]).then(() => {
-      progress.progress = -1;
-      progress.total = -1;
       progress.loaded = true;
     }).catch((err) => {
       progress.loaded = false;
@@ -398,6 +403,7 @@ export default defineComponent({
       typeSettings: clientSettings.typeSettings,
       pendingSaveCount,
       progress,
+      progressValue,
       saveInProgress,
       playbackComponent,
       recipes,
@@ -523,15 +529,16 @@ export default defineComponent({
           </v-alert>
           <v-progress-circular
             v-else
-            :indeterminate="progress.progress < 0"
-            :value="Math.round(progress.progress / progress.total * 100)"
+            :indeterminate="progressValue === 0"
+            :value="progressValue"
             size="100"
             width="15"
             color="light-blue"
             class="main-progress-linear"
+            rotate="-90"
           >
-            <span v-if="progress.progress < 0">Loading</span>
-            <span v-else>{{ Math.round(progress.progress / progress.total * 100) }}%</span>
+            <span v-if="progressValue === 0">Loading</span>
+            <span v-else>{{ progressValue }}%</span>
           </v-progress-circular>
         </div>
       </v-col>

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  defineComponent, ref, toRef, computed, Ref,
+  defineComponent, ref, toRef, computed, Ref, reactive,
 } from '@vue/composition-api';
 import type { Vue } from 'vue/types/vue';
 
@@ -84,10 +84,16 @@ export default defineComponent({
     const videoUrl = ref(undefined as undefined | string);
     const frame = ref(0); // the currently displayed frame number
     const { loadDetections, loadMetadata, saveMetadata } = useApi();
-    // Loaded flag prevents annotator window from populating
-    // with stale data from props, for example if a persistent store
-    // like vuex is used to drive them.
-    const loaded = ref(false);
+    const progress = reactive({
+      // Loaded flag prevents annotator window from populating
+      // with stale data from props, for example if a persistent store
+      // like vuex is used to drive them.
+      loaded: false,
+      // Tracks loaded
+      progress: -1,
+      // Total tracks
+      total: -1,
+    });
 
     const {
       save: saveToServer,
@@ -338,15 +344,25 @@ export default defineComponent({
         videoUrl.value = meta.videoUrl;
         datasetType.value = meta.type as DatasetType; // TODO: support for multiCam will remove this
       }),
-      loadDetections(props.id).then((tracks) => {
-        Object.values(tracks).forEach(
-          (trackData) => insertTrack(Track.fromJSON(trackData), { imported: true }),
-        );
+      loadDetections(props.id).then(async (trackData) => {
+        const tracks = Object.values(trackData);
+        progress.total = tracks.length;
+        for (let i = 0; i < tracks.length; i += 1) {
+          if (i % 4000 === 0) {
+            /* Every N tracks, yeild some cycles for other scheduled tasks */
+            progress.progress = i;
+            // eslint-disable-next-line no-await-in-loop
+            await new Promise((resolve) => window.setTimeout(resolve, 500));
+          }
+          insertTrack(Track.fromJSON(tracks[i]), { imported: true });
+        }
       }),
     ]).then(() => {
-      loaded.value = true;
+      progress.progress = -1;
+      progress.total = -1;
+      progress.loaded = true;
     }).catch((err) => {
-      loaded.value = false;
+      progress.loaded = false;
       // Cleaner displaying of interal errors for desktop
       if (err.response?.data && err.response?.status === 500 && !err.response?.data?.message) {
         const fullText = err.response.data;
@@ -375,13 +391,13 @@ export default defineComponent({
       frameRate,
       imageData,
       lineChartData,
-      loaded,
       loadError,
       mediaController,
       mergeMode: mergeInProgress,
       newTrackSettings: clientSettings.newTrackSettings,
       typeSettings: clientSettings.typeSettings,
       pendingSaveCount,
+      progress,
       saveInProgress,
       playbackComponent,
       recipes,
@@ -472,7 +488,7 @@ export default defineComponent({
       <v-col style="position: relative">
         <component
           :is="datasetType === 'image-sequence' ? 'image-annotator' : 'video-annotator'"
-          v-if="(imageData.length || videoUrl) && loaded"
+          v-if="(imageData.length || videoUrl) && progress.loaded"
           ref="playbackComponent"
           v-mousetrap="[
             { bind: 'n', handler: () => handler.trackAdd() },
@@ -507,12 +523,15 @@ export default defineComponent({
           </v-alert>
           <v-progress-circular
             v-else
-            indeterminate
+            :indeterminate="progress.progress < 0"
+            :value="Math.round(progress.progress / progress.total * 100)"
             size="100"
             width="15"
             color="light-blue"
+            class="main-progress-linear"
           >
-            Loading
+            <span v-if="progress.progress < 0">Loading</span>
+            <span v-else>{{ Math.round(progress.progress / progress.total * 100) }}%</span>
           </v-progress-circular>
         </div>
       </v-col>


### PR DESCRIPTION
This is a really obvious intermediary fix for issues where the page locks up during data load that we should have added months ago.

* Add a percentage progress bar to show how much of the dataset is loaded
* Take 500ms breaks every 4000 track loads to yeild CPU time to other scheduled tasks on the page during load time.  This will prevent the browser from trying to kill the page for "not responding" as can happen with really large amounts of data.  For absurdly large amounts of data, it also provides much better user confidence that something is happening.  

I picked the batch and sleep numbers somewhat arbitrarily because the vuetify progress spinner is kinda buggy and runs its transitions in JS land rather than in CSS.   It was implemented such that the transitions stack and can get behind, but that's a whole other thing.
