### PR TITLE
Quick Fix for ResizeObserver Error

### DIFF
--- a/client/src/components/annotators/useMediaController.ts
+++ b/client/src/components/annotators/useMediaController.ts
@@ -57,7 +57,9 @@ export default function useMediaController({ emit }: {
     const size = containerRef.value.getBoundingClientRect();
     const mapSize = geoViewerRef.value.size();
     if (size.width !== mapSize.width || size.height !== mapSize.height) {
-      geoViewerRef.value.size(size);
+      window.requestAnimationFrame(() => {
+        geoViewerRef.value.size(size);
+      });
     }
   }
 


### PR DESCRIPTION
Fixes #808 

Quick fix for the resizeObserver Error.  My understanding is that this is an error in chrome/firefox that isn't typically logged but can be shown if you subscribe to all errors on the window object : `window.onerror = (e) => console.log(e)` that should show it.

It looks like it is a true infinite call error that the browser handles gracefully so that is why it isn't shown in console.log by default.  The act of resizing the geoJS area during a resize event creates I think a cascading call to resize which the browser interprets and handles.  Throwing a `requestAnimationFrame` around it will delay the setting and hopefully prevent recursive updates.

You can  test it by using the console.log for the window.onerror and loading data and resizing the window while monitoring the console window.  Without the animation frame request you'll get the error.  I need to test for other instances where this may occur.

Some background support:

- https://github.com/chromium/chromium/blob/d7da0240cae77824d1eda25745c4022757499131/third_party/blink/renderer/core/resize_observer/README.md - Readme about the chromimium implementation of ResizeObserver.  Within deliver observations is where the loop limit exceed error can occur.
- That is defined by this : https://github.com/chromium/chromium/blob/d7da0240cae77824d1eda25745c4022757499131/third_party/blink/renderer/core/resize_observer/resize_observer_controller.h#L49
- Which flows into https://github.com/chromium/chromium/blob/d7da0240cae77824d1eda25745c4022757499131/third_party/blink/renderer/core/frame/local_frame_view.cc#L2381-L2396
- And finally by looking at the tests you can see that this exception is hidden https://github.com/chromium/chromium/blob/d7da0240cae77824d1eda25745c4022757499131/third_party/blink/web_tests/resize-observer/device-pixel-notification.html#L10-L11