### PR TITLE
Truncate logs on fluxh 5XX error

### DIFF
--- a/server/dive_server/viame.py
+++ b/server/dive_server/viame.py
@@ -289,9 +289,7 @@ class Viame(Resource):
                 pipeline_name=pipelineName,
                 config=config,
                 girder_client_token=str(token["_id"]),
-                girder_job_title=(
-                    f"Running training on folder: {', '.join(folder_names)}"
-                ),
+                girder_job_title=(f"Running training on {len(folder_list)} datasets"),
                 girder_job_type="private" if job_is_private else "training",
             ),
         )

--- a/server/dive_tasks/manager.py
+++ b/server/dive_tasks/manager.py
@@ -1,0 +1,72 @@
+import datetime
+
+import requests
+from girder_worker.utils import JobManager
+
+
+def _flush(self):
+    """
+    If there are contents in the buffer, send them up to the server. If the
+    buffer is empty, this is a no-op.
+    """
+    if not self.url:
+        return
+
+    if (
+        len(self._buf)
+        or self._progressTotal
+        or self._progressMessage
+        or self._progressCurrent is not None
+    ):
+        data = {
+            'progressTotal': self._progressTotal,
+            'progressCurrent': self._progressCurrent,
+            'progressMessage': self._progressMessage,
+        }
+        if self._buf:
+            data['log'] = self._buf
+
+        try:
+            req = requests.request(
+                self.method.upper(),
+                self.url,
+                allow_redirects=True,
+                headers=self.headers,
+                data=data,
+            )
+            req.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            if err.response.status_code >= 500:
+                # Any 500 level error
+                # The job record size has been exceeded.  Attempt to truncate the log
+                data['overwrite'] = True
+                data[
+                    'log'
+                ] = f'Log overflowed and was truncated at {datetime.datetime.utcnow()}'
+                req_2 = requests.request(
+                    self.method.upper(),
+                    self.url,
+                    allow_redirects=True,
+                    headers=self.headers,
+                    data=data,
+                )
+                req_2.raise_for_status()
+            else:
+                raise err
+        self._buf = b""
+
+
+def patch_manager(manager):
+    """
+    This is a monkey patch for girder worker job manager logging
+    When writing logs to mongo, if the record size is exceeded,
+    girder worker will throw a 500.
+
+    This will catch the error and truncate the log so that the
+    error doesn't interrupt a job run.
+
+    This patch should be included with any celery job where the
+    job manager is used.
+    """
+    manager.flush = _flush.__get__(manager, JobManager)
+    return manager

--- a/server/dive_tasks/manager.py
+++ b/server/dive_tasks/manager.py
@@ -36,7 +36,7 @@ def _flush(self):
             )
             req.raise_for_status()
         except requests.exceptions.HTTPError as err:
-            if err.response.status_code >= 500:
+            if err.response.status_code >= 500 or err.response.status_code == 413:
                 # Any 500 level error
                 # The job record size has been exceeded.  Attempt to truncate the log
                 data['overwrite'] = True

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -19,6 +19,7 @@ from girder_worker.task import Task
 from girder_worker.utils import JobManager, JobStatus
 from GPUtil import getGPUs
 
+from dive_tasks.manager import patch_manager
 from dive_tasks.pipeline_discovery import discover_configs
 from dive_tasks.utils import (
     check_canceled,
@@ -137,7 +138,7 @@ def upgrade_pipelines(
     """Install addons from zip files over HTTP"""
     conf = Config()
     context: dict = {}
-    manager: JobManager = self.job_manager
+    manager: JobManager = patch_manager(self.job_manager)
     if check_canceled(self, context):
         manager.updateStatus(JobStatus.CANCELED)
         return
@@ -193,7 +194,7 @@ def upgrade_pipelines(
 def run_pipeline(self: Task, params: PipelineJob):
     conf = Config()
     context: dict = {}
-    manager: JobManager = self.job_manager
+    manager: JobManager = patch_manager(self.job_manager)
     if check_canceled(self, context):
         manager.updateStatus(JobStatus.CANCELED)
         return
@@ -329,7 +330,7 @@ def train_pipeline(
     conf = Config()
     context: dict = {}
     gc: GirderClient = self.girder_client
-    manager: JobManager = self.job_manager
+    manager: JobManager = patch_manager(self.job_manager)
     if check_canceled(self, context):
         manager.updateStatus(JobStatus.CANCELED)
         return
@@ -448,7 +449,7 @@ def convert_video(self: Task, path, folderId, auxiliaryFolderId, itemId):
 
     context: dict = {}
     gc: GirderClient = self.girder_client
-    manager: JobManager = self.job_manager
+    manager: JobManager = patch_manager(self.job_manager)
     if check_canceled(self, context):
         manager.updateStatus(JobStatus.CANCELED)
         return
@@ -577,7 +578,7 @@ def convert_images(self: Task, folderId):
     """
     context: dict = {}
     gc: GirderClient = self.girder_client
-    manager: JobManager = self.job_manager
+    manager: JobManager = patch_manager(self.job_manager)
     if check_canceled(self, context):
         manager.updateStatus(JobStatus.CANCELED)
         return

--- a/server/setup.py
+++ b/server/setup.py
@@ -16,6 +16,7 @@ requirements = [
     "typing_extensions",
     "gputil",
     # botocore requirement conflict
+    "requests>=2.20.0",  # Match girder_worker_utils
     "urllib3<1.26",
 ]
 

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -30,7 +30,6 @@ skip_install = true
 deps =
     mypy
 commands =
-    mypy --install-types
     mypy {posargs:.}
 
 [testenv:test]

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -30,6 +30,7 @@ skip_install = true
 deps =
     mypy
 commands =
+    mypy --install-types
     mypy {posargs:.}
 
 [testenv:test]

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -30,7 +30,7 @@ skip_install = true
 deps =
     mypy
 commands =
-    mypy {posargs:.}
+    mypy --install-types --non-interactive {posargs:.}
 
 [testenv:test]
 extra = 


### PR DESCRIPTION
monkey-patch the girder worker util manager _flush() function to drop logs on 5XX.

fixes #809 