### PR TITLE
Don't require annotations for training

### DIFF
--- a/server/dive_server/utils.py
+++ b/server/dive_server/utils.py
@@ -310,7 +310,7 @@ def get_annotation_csv_generator(
         imageFiles = [img['name'] for img in valid_images(folder, user)]
 
     thresholds = fromMeta(folder, "confidenceFilters", {})
-    annotation_file = detections_file(folder, strict=True)
+    annotation_file = detections_file(folder, strict=False)
     track_dict = getTrackData(annotation_file)
     typeFilterSet = set(typeFilter)
 


### PR DESCRIPTION
Silly change to not require strict existence of annotation file when annotation file is missing.

This will fix other bugs, like errors when you try to export from a dataset with no annotation file.  Getting a blank CSV is better than a 4XX error.