### PR TITLE
Checkbox to use annotated frames only when training

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -105,7 +105,9 @@ interface Api {
   runPipeline(itemId: string, pipeline: Pipe): Promise<unknown>;
 
   getTrainingConfigurations(): Promise<TrainingConfigs>;
-  runTraining(folderIds: string[], pipelineName: string, config: string): Promise<unknown>;
+  runTraining(
+    folderIds: string[], pipelineName: string, config: string, annotatedFramesOnly: boolean
+  ): Promise<unknown>;
 
   loadMetadata(datasetId: string): Promise<DatasetMeta>;
   loadDetections(datasetId: string): Promise<MultiTrackRecord>;

--- a/client/dive-common/components/RunTrainingMenu.vue
+++ b/client/dive-common/components/RunTrainingMenu.vue
@@ -29,6 +29,7 @@ export default defineComponent({
 
     const trainingConfigurations = ref<TrainingConfigs | null>(null);
     const selectedTrainingConfig = ref<string | null>(null);
+    const annotatedFramesOnly = ref<boolean>(true);
 
     onBeforeMount(async () => {
       const resp = await getTrainingConfigurations();
@@ -54,6 +55,7 @@ export default defineComponent({
           props.selectedDatasetIds,
           trainingOutputName.value,
           selectedTrainingConfig.value,
+          annotatedFramesOnly.value,
         );
 
         menuOpen.value = false;
@@ -83,6 +85,7 @@ export default defineComponent({
     return {
       trainingConfigurations,
       selectedTrainingConfig,
+      annotatedFramesOnly,
       trainingOutputName,
       menuOpen,
       trainingDisabled,
@@ -164,6 +167,14 @@ export default defineComponent({
             class="my-4"
             label="Configuration File"
             :items="trainingConfigurations.configs"
+          />
+          <v-checkbox
+            v-model="annotatedFramesOnly"
+            label="Use annotated frames only"
+            dense
+            hint="Train only on frames with groundtruth and ignore frames without annotations"
+            persistent-hint
+            class="pt-0"
           />
           <v-btn
             depressed

--- a/client/dive-common/components/RunTrainingMenu.vue
+++ b/client/dive-common/components/RunTrainingMenu.vue
@@ -29,7 +29,7 @@ export default defineComponent({
 
     const trainingConfigurations = ref<TrainingConfigs | null>(null);
     const selectedTrainingConfig = ref<string | null>(null);
-    const annotatedFramesOnly = ref<boolean>(true);
+    const annotatedFramesOnly = ref<boolean>(false);
 
     onBeforeMount(async () => {
       const resp = await getTrainingConfigurations();

--- a/client/platform/desktop/backend/cli.ts
+++ b/client/platform/desktop/backend/cli.ts
@@ -111,6 +111,11 @@ const { argv } = yargs
     yargs.option('name', {
       describe: 'New pipeline name created by training',
     });
+    yargs.option('annotatedFramesOnly', {
+      describe: 'Train only on annotated frames',
+      type: 'boolean',
+      default: false,
+    });
     yargs.demandOption(['id', 'config', 'name']);
   })
   .command('stats', 'Show stats on existing data', () => {
@@ -165,6 +170,7 @@ if (argv._.includes('viame2json')) {
     datasetIds: argv.id as string[],
     trainingConfig: argv.config as string,
     pipelineName: argv.name as string,
+    annotatedFramesOnly: argv.annotatedFramesOnly as boolean,
   };
   const run = async () => {
     const job = await settings.platform.train(settings, trainargs, updater);

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -416,6 +416,7 @@ describe('native.common', () => {
       datasetIds: ['randomID'],
       pipelineName: 'trainedPipelineName',
       trainingConfig: 'trainingConfig',
+      annotatedFramesOnly: false,
     };
     const contents = await common.processTrainedPipeline(settings, trainingArgs, '/home/user/viamedata/DIVE_Jobs/goodTrainingJob/');
     expect(contents).toEqual(['detector.pipe', 'trained_detector.zip']);
@@ -435,6 +436,7 @@ describe('native.common', () => {
       datasetIds: ['randomID'],
       pipelineName: 'trainedBadPipelineName',
       trainingConfig: 'trainingConfig',
+      annotatedFramesOnly: false,
     };
     expect(common.processTrainedPipeline(settings, trainingArgs, '/home/user/viamedata/DIVE_Jobs/badTrainingJob/')).rejects.toThrow(
       'Path: /home/user/viamedata/DIVE_Jobs/badTrainingJob/category_models does not exist',

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -292,6 +292,10 @@ async function train(
     '--no-embedded-pipe',
   ];
 
+  if (runTrainingArgs.annotatedFramesOnly) {
+    command.push('--gt-frames-only');
+  }
+
   const job = observeChild(spawn(command.join(' '), {
     shell: viameConstants.shell,
     cwd: jobWorkDir,

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -130,6 +130,8 @@ export interface RunTraining {
   pipelineName: string;
   // training configuration file name
   trainingConfig: string;
+  // train only on annotated frames
+  annotatedFramesOnly: boolean;
 }
 
 export interface ConversionArgs {

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -79,12 +79,13 @@ async function runPipeline(itemId: string, pipeline: Pipe): Promise<DesktopJob> 
 }
 
 async function runTraining(
-  folderIds: string[], pipelineName: string, config: string,
+  folderIds: string[], pipelineName: string, config: string, annotatedFramesOnly: boolean,
 ): Promise<DesktopJob> {
   const args: RunTraining = {
     datasetIds: folderIds,
     pipelineName,
     trainingConfig: config,
+    annotatedFramesOnly,
   };
   return ipcRenderer.invoke('run-training', args);
 }

--- a/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
+++ b/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
@@ -40,6 +40,7 @@ export default defineComponent({
         configs: [],
         default: '',
       } as TrainingConfigs,
+      annotatedFramesOnly: true,
     });
 
     const headersTmpl: DataTableHeader[] = [
@@ -97,6 +98,7 @@ export default defineComponent({
           stagedItems.value.map(({ id }) => id),
           data.trainingOutputName,
           data.selectedTrainingConfig,
+          data.annotatedFramesOnly,
         );
         root.$router.push({ name: 'jobs' });
       } catch (err) {
@@ -157,7 +159,7 @@ export default defineComponent({
       <v-card-text>
         Add datasets to the staging area and choose a training configuration.
       </v-card-text>
-      <v-row class="my-4">
+      <v-row class="mt-4 pt-0">
         <v-col sm="5">
           <v-text-field
             v-model="data.trainingOutputName"
@@ -198,6 +200,14 @@ export default defineComponent({
         </template>
       </v-data-table>
       <div class="d-flex flex-row mt-7">
+        <v-checkbox
+          v-model="data.annotatedFramesOnly"
+          label="Use annotated frames only"
+          dense
+          hint="Train only on frames with groundtruth and ignore frames without annotations"
+          persistent-hint
+          class="py-0 my-0"
+        />
         <v-spacer />
         <v-btn
           :disabled="!isReadyToTrain"

--- a/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
+++ b/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
@@ -40,7 +40,7 @@ export default defineComponent({
         configs: [],
         default: '',
       } as TrainingConfigs,
-      annotatedFramesOnly: true,
+      annotatedFramesOnly: false,
     });
 
     const headersTmpl: DataTableHeader[] = [

--- a/client/platform/web-girder/api/viame.service.ts
+++ b/client/platform/web-girder/api/viame.service.ts
@@ -106,8 +106,12 @@ async function getTrainingConfigurations(): Promise<TrainingConfigs> {
   return data;
 }
 
-function runTraining(folderIds: string[], pipelineName: string, config: string) {
-  return girderRest.post('/viame/train', folderIds, { params: { pipelineName, config } });
+function runTraining(
+  folderIds: string[], pipelineName: string, config: string, annotatedFramesOnly: boolean,
+) {
+  return girderRest.post('/viame/train', folderIds, {
+    params: { pipelineName, config, annotatedFramesOnly },
+  });
 }
 
 function saveMetadata(folderId: string, metadata: DatasetMetaMutable) {

--- a/docs/Pipeline-Documentation.md
+++ b/docs/Pipeline-Documentation.md
@@ -68,7 +68,13 @@ Run model training on ground truth annotations.  Currently, training configurati
 * [NetHarn](https://gitlab.kitware.com/computer-vision/netharn) is a pytorch deep learning framework that requires more input data: on the order of thousands of target examples.  There are two architectures used.  Netharn models can take up to several days to train.
     * Cascade Faster R-CNN (cfrnn) for training box detectors
     * Mask R-CNN for training pixel classification and box detection
-    * ResNet (Residual Network) for training full frame or secondary object classifiers 
+    * ResNet (Residual Network) for training full frame or secondary object classifiers
+
+### Options
+
+* Output Name - a recognizeable name for the pipeline that results from the training run.
+* Configuration File - chosen from the options below
+* Use anootation Frames Only - by default, training runs include all frames from the chosen input datasets, and frames without annotations are considered negatives examples.  If you choose to use annotated frames only, frames or images with zero annotations will be discarded.  This option is useful for trying to train on datasets that are only partially annotated.
 
 ### Configurations
 

--- a/server/dive_server/viame.py
+++ b/server/dive_server/viame.py
@@ -296,7 +296,7 @@ class Viame(Resource):
                 groundtruth_list=detection_list,
                 pipeline_name=pipelineName,
                 config=config,
-                annotatedFramesOnly=annotatedFramesOnly,
+                annotated_frames_only=annotatedFramesOnly,
                 girder_client_token=str(token["_id"]),
                 girder_job_title=(f"Running training on {len(folder_list)} datasets"),
                 girder_job_type="private" if job_is_private else "training",

--- a/server/dive_server/viame.py
+++ b/server/dive_server/viame.py
@@ -253,8 +253,16 @@ class Viame(Resource):
             paramType="query",
             required=True,
         )
+        .param(
+            "annotatedFramesOnly",
+            description="Train only using frames with annotations",
+            paramType="query",
+            dataType="boolean",
+            default=False,
+            required=False,
+        )
     )
-    def run_training(self, folderIds, pipelineName, config):
+    def run_training(self, folderIds, pipelineName, config, annotatedFramesOnly):
         user = self.getCurrentUser()
         token = Token().createToken(user=user, days=14)
 
@@ -288,6 +296,7 @@ class Viame(Resource):
                 groundtruth_list=detection_list,
                 pipeline_name=pipelineName,
                 config=config,
+                annotatedFramesOnly=annotatedFramesOnly,
                 girder_client_token=str(token["_id"]),
                 girder_job_title=(f"Running training on {len(folder_list)} datasets"),
                 girder_job_type="private" if job_is_private else "training",

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -316,6 +316,7 @@ def train_pipeline(
     groundtruth_list: List[GirderModel],
     pipeline_name: str,
     config: str,
+    annotatedFramesOnly: bool = False,
 ):
     """
     Train a pipeline by making a call to viame_train_detector

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -316,7 +316,7 @@ def train_pipeline(
     groundtruth_list: List[GirderModel],
     pipeline_name: str,
     config: str,
-    annotatedFramesOnly: bool = False,
+    annotated_frames_only: bool = False,
 ):
     """
     Train a pipeline by making a call to viame_train_detector
@@ -327,6 +327,7 @@ def train_pipeline(
         or a folder containing that file.
     :param pipeline_name: The base name of the resulting pipeline.
     :param config: string name of the input configuration
+    :param annotated_frames_only: Only use annotated frames for training
     """
     conf = Config()
     context: dict = {}
@@ -398,6 +399,9 @@ def train_pipeline(
                 "--no-query",
                 "--no-embedded-pipe",
             ]
+
+            if annotated_frames_only:
+                command.append("--gt-frames-only")
 
             manager.updateStatus(JobStatus.RUNNING)
             cmd = " ".join(command)


### PR DESCRIPTION
resolves #771

Checkbox added in training menu to choose option to only train on annotated frames and ignore frames that are not annotated. This is enabled by default for both web and desktop. This checkbox is passed as an additional parameter to the kwiver call.

Web:
![Screenshot from 2021-07-08 16-50-42](https://user-images.githubusercontent.com/30541973/124989005-b1136600-e00c-11eb-9000-323a1cd6bd92.png)

Desktop:
![Screenshot from 2021-07-08 16-45-17](https://user-images.githubusercontent.com/30541973/124989027-b670b080-e00c-11eb-9aa8-24b164bf7fdf.png)

Also modified CLI to incorporate this new change by adding the `--annotatedFramesOnly` flag which is false by default.
