### PR TITLE
Fixing loading within 1.4.10

### DIFF
--- a/client/platform/desktop/backend/native/migrations.ts
+++ b/client/platform/desktop/backend/native/migrations.ts
@@ -11,6 +11,9 @@ function upgrade(meta: JsonMeta) {
     if (meta.multiCam === undefined) {
       meta.multiCam = null;
     }
+    if (meta.subType === undefined) {
+      meta.subType = null;
+    }
   } else if (meta.version < JsonMetaCurrentVersion) {
     /* Perform major version upgrade */
     console.error('Impossible schema', meta);

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -38,7 +38,7 @@ export default defineComponent({
   },
   setup(props) {
     const viewerRef = ref();
-    const subTypeList = computed(() => [datasets.value[props.id]?.subType] || []);
+    const subTypeList = computed(() => [datasets.value[props.id]?.subType || null]);
     return {
       datasets,
       viewerRef,

--- a/client/platform/desktop/frontend/store/dataset.ts
+++ b/client/platform/desktop/frontend/store/dataset.ts
@@ -63,6 +63,8 @@ function load(): JsonMetaCache[] {
         maybeArr.forEach((meta: JsonMetaCache) => (
           Vue.set(datasets.value, meta.id, hydrateJsonMetaCacheValue(meta))
         ));
+        const values = Object.values(datasets.value);
+        window.localStorage.setItem(RecentsKey, JSON.stringify(values));
         return maybeArr;
       }
     }

--- a/client/platform/desktop/frontend/store/dataset.ts
+++ b/client/platform/desktop/frontend/store/dataset.ts
@@ -63,8 +63,6 @@ function load(): JsonMetaCache[] {
         maybeArr.forEach((meta: JsonMetaCache) => (
           Vue.set(datasets.value, meta.id, hydrateJsonMetaCacheValue(meta))
         ));
-        const values = Object.values(datasets.value);
-        window.localStorage.setItem(RecentsKey, JSON.stringify(values));
         return maybeArr;
       }
     }


### PR DESCRIPTION

- Updated the viewer loader so that it will default to standard data instead of an undefined value.
- Updated the `upgrade` function for `meta.json` so it will properly set the subType if not available.