### PR TITLE
Release 1.5.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-media-annotator",
-  "version": "1.4.10",
+  "version": "1.5.0",
   "author": {
     "name": "Kitware, Inc.",
     "email": "viame-web@kitware.com"


### PR DESCRIPTION
Because 1.4.10 had already gone out to NPM, it can't be re-released.

Since this contains significant new features and some schema changes, I went for a minor version bump.