### PR TITLE
fixing toggleKeyframe 500 error

### DIFF
--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -138,8 +138,14 @@ export default defineComponent({
       data.skipOnFocus = false;
     }
 
+    const keyframeDisabled = computed(() => (
+      !feature.value.real && !feature.value.shouldInterpolate)
+      || (props.track.length === 1 && frameRef.value === props.track.begin));
+
     function toggleKeyframe() {
-      props.track.toggleKeyframe(frameRef.value);
+      if (!keyframeDisabled.value) {
+        props.track.toggleKeyframe(frameRef.value);
+      }
     }
 
     function toggleInterpolation() {
@@ -183,6 +189,7 @@ export default defineComponent({
       typeInputBoxRef,
       frame: frameRef,
       allTypes: allTypesRef,
+      keyframeDisabled,
       /* methods */
       blurType,
       focusType,
@@ -314,7 +321,7 @@ export default defineComponent({
           :icon="(feature.isKeyframe)
             ? 'mdi-star'
             : 'mdi-star-outline'"
-          :disabled="!feature.real && !feature.shouldInterpolate"
+          :disabled="keyframeDisabled"
           tooltip-text="Toggle keyframe"
           @click="toggleKeyframe"
         />

--- a/client/src/track.spec.ts
+++ b/client/src/track.spec.ts
@@ -262,6 +262,21 @@ describe('Track', () => {
     expect(t.begin).toEqual(6);
     expect(t.getFeature(12)[0]?.bounds).toEqual([150, 150, 150, 150]);
     expect(t.getFeature(12)[0]?.keyframe).toEqual(true);
+    // toggleKeyframe on a single feature expect error
+    t.deleteFeature(18);
+    t.deleteFeature(12);
+    expect(t.begin).toEqual(t.end);
+    expect(() => t.toggleKeyframe(t.begin)).toThrow('This is the only keyframe in Track:1 it cannot be removed');
+    // Turn off interpolation
+    t.toggleKeyframe(12);
+    expect(t.getFeature(12)[0]?.keyframe).toEqual(true);
+    expect(t.getFeature(8)[1]?.frame).toEqual(6);
+    expect(t.getFeature(8)[2]?.frame).toEqual(12);
+    // Remove lower keyframe
+    t.toggleKeyframe(6);
+    // Now try to remove remaining keyframe
+    expect(t.begin).toEqual(t.end);
+    expect(() => t.toggleKeyframe(12)).toThrow('This is the only keyframe in Track:1 it cannot be removed');
   });
 });
 

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -286,7 +286,7 @@ export default class Track {
   toggleKeyframe(frame: number) {
     const { features } = this.canInterpolate(frame);
     const [real, lower, upper] = features;
-    if (real && real.keyframe && this.begin === this.end && frame === this.begin) {
+    if (real && this.length === 1) {
       throw new Error(`This is the only keyframe in Track:${this.trackId} it cannot be removed`);
     }
     if (real && !real.keyframe) {

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -286,6 +286,9 @@ export default class Track {
   toggleKeyframe(frame: number) {
     const { features } = this.canInterpolate(frame);
     const [real, lower, upper] = features;
+    if (real && real.keyframe && this.begin === this.end && frame === this.begin) {
+      throw new Error(`This is the only keyframe in Track:${this.trackId} it cannot be removed`);
+    }
     if (real && !real.keyframe) {
       this.setFeature({
         ...real,


### PR DESCRIPTION
Fixes #758 

- Prevents the user from toggling off the keyframe when there is only a single detection available
- Does this by disabling the keyframe button and the keyframe toggle keyboard shortcut
- This is done client side because we don't want a user assigning 
- Added to the `track.toggleKeyframe` an error thrown if it manages to togglekeyframe and the begin === end frame and the current frame is equal to one of them.
- Added some tests to make sure the error is properly functioning when toggling a keyframe on the only feature

Question:
- To prevent ghost tracks should there be an error thrown on `deleteFeature` if you are trying to delete the only feature in a track?