### PR TITLE
Updated server/setup.py and client/package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
   },
   "description": "DIVE annotation platform",
   "homepage": "https://github.com/Kitware/dive",
+  "license": "Apache-2.0",
   "scripts": {
     "serve": "vue-cli-service serve platform/web-girder/main.ts",
     "serve:electron": "vue-cli-service electron:serve",

--- a/server/setup.py
+++ b/server/setup.py
@@ -26,25 +26,27 @@ dev_requirements = [
 
 setup(
     name="dive_server",
-    version="1.5.0",
+    version="1.0.0",
     description="DIVE Data Server",
     author='Kitware, Inc.',
     author_email="viame-web@kitware.com",
     url="https://github.com/Kitware/dive",
-    license="Apache Software License 2.0",
+    license="Apache 2.0",
     keywords="DIVE, VIAME, VIAME-Web, Annotation",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
+        "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     python_requires=">=3.7",
-    packages=find_packages(exclude=["test", "test.*"]),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     package_data={
         "": ["**/*.mako"],
     },
-    include_package_data=True,
     zip_safe=False,
     entry_points={
         "girder.plugin": [


### PR DESCRIPTION
Updated `server/setup.py` to remove `include_package_data=True`. Although, it is used by other projects in girder, since this project does not use `MANIFEST.in` file, this option should not be used. _This option does not matter since it is being deployed using docker, but if the Python project were to ever be published to pypa using bdist, this would cause issues_

As discussed, changed the `version` in `server/setup.py` to 1.0.0 since this will not be updated and should be kept at a consistent number. 

Fixed the `packages=find_packages` in `server/setup.py` to include the correct directory names.

Changed the license field in `server/setup.py` to the correct Apache license name and updated the classifiers in `server/setup.py` to include all valid Python versions. This is what is used by other projects in girder.

Added the license field in `client/package.json` so yarn stops complaining.