### PR TITLE
Allow flicks to persist server-side

### DIFF
--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -25,6 +25,7 @@ class Feature(BaseModel):
     """Feature represents a single detection in a track."""
 
     frame: int
+    flick: Optional[int]
     bounds: List[int]
     attributes: Optional[Dict[str, Union[bool, float, str]]]
     geometry: Optional[GeoJSONFeatureCollection] = None


### PR DESCRIPTION
Silly mistake.

Pydantic's default mode is to `extra.ignore`, or to drop extra unknown fields.  Because we validate on save, the flick wasn't getting saved.

This allows the flick to be saved, but is not otherwise used. 

fixes #828 