### PR TITLE
Large JSON file uploading fix

### DIFF
--- a/server/dive_server/utils.py
+++ b/server/dive_server/utils.py
@@ -131,11 +131,10 @@ def get_track_and_attributes_from_coco(file: GirderModel) -> Tuple[dict, dict, b
     if file is None:
         return {}, {}, False
     if 'json' in file['exts']:
-        with File().open(file) as fh:
-            coco = json.load(fh)
-            if kwcoco.is_coco_json(coco):
-                tracks, attributes = kwcoco.load_coco_as_tracks_and_attributes(coco)
-                return tracks, attributes, True
+        coco = json.loads(b"".join(list(File().download(file, headers=False)())).decode())
+        if kwcoco.is_coco_json(coco):
+            tracks, attributes = kwcoco.load_coco_as_tracks_and_attributes(coco)
+            return tracks, attributes, True
     return {}, {}, False
 
 


### PR DESCRIPTION
The coco check tries to open the file up directly which will result in this:
`{"message": "Read exceeds maximum allowed size.", "type": "girder"}`
If the file is too large.
I just switched it to use the standard `json.loads(file().download())` format instead and that seems to fix the problem.  I also did some basic testing to ensure that the coco loader still works properly.

![image](https://user-images.githubusercontent.com/61746913/127656018-bff73388-9b19-40b5-a31c-0c72cc932910.png)
