### PR TITLE
import fix and some animation for importing

### DIFF
--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -2,7 +2,6 @@
 import { defineComponent, ref } from '@vue/composition-api';
 import { useApi } from 'dive-common/apispec';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
-import { stubFalse } from 'lodash';
 import { useHandler } from 'vue-media-annotator/provides';
 
 export default defineComponent({
@@ -68,7 +67,7 @@ export default defineComponent({
       <v-btn
         class="ma-0"
         v-bind="buttonOptions"
-        :disabled="!datasetId"
+        :disabled="!datasetId || processing"
         :color=" processing ? 'warning': ''"
         @click="openUpload"
         v-on="on"

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -1,7 +1,8 @@
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent, ref } from '@vue/composition-api';
 import { useApi } from 'dive-common/apispec';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
+import { stubFalse } from 'lodash';
 import { useHandler } from 'vue-media-annotator/provides';
 
 export default defineComponent({
@@ -28,17 +29,20 @@ export default defineComponent({
     const { openFromDisk, importAnnotationFile } = useApi();
     const { reloadAnnotations } = useHandler();
     const { prompt } = usePrompt();
+    const processing = ref(false);
     const openUpload = async () => {
       const ret = await openFromDisk('annotation');
       if (!ret.canceled) {
         const path = ret.filePaths[0];
         let importFile = false;
+        processing.value = true;
         if (ret.fileList?.length) {
           importFile = await importAnnotationFile(props.datasetId, path, ret.fileList[0]);
         } else {
           importFile = await importAnnotationFile(props.datasetId, path);
         }
         if (importFile) {
+          processing.value = false;
           await reloadAnnotations();
         } else {
           const text = `Import of File ${path} failed`;
@@ -52,6 +56,7 @@ export default defineComponent({
     };
     return {
       openUpload,
+      processing,
     };
   },
 });
@@ -64,18 +69,23 @@ export default defineComponent({
         class="ma-0"
         v-bind="buttonOptions"
         :disabled="!datasetId"
+        :color=" processing ? 'warning': ''"
         @click="openUpload"
         v-on="on"
       >
-        <v-icon>
-          mdi-application-import
-        </v-icon>
-        <span
-          v-show="!$vuetify.breakpoint.mdAndDown || buttonOptions.block"
-          class="pl-1"
-        >
-          Import
-        </span>
+        <div>
+          <v-icon
+            :color=" processing ? 'warning': ''"
+          >
+            {{ processing ? 'mdi-spin mdi-sync' : 'mdi-application-import' }}
+          </v-icon>
+          <span
+            v-show="!$vuetify.breakpoint.mdAndDown || buttonOptions.block"
+            class="pl-1"
+          >
+            Import
+          </span>
+        </div>
       </v-btn>
     </template>
     <span> Import Annotation Data </span>

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -68,14 +68,11 @@ export default defineComponent({
         class="ma-0"
         v-bind="buttonOptions"
         :disabled="!datasetId || processing"
-        :color=" processing ? 'warning': ''"
         @click="openUpload"
         v-on="on"
       >
         <div>
-          <v-icon
-            :color=" processing ? 'warning': ''"
-          >
+          <v-icon>
             {{ processing ? 'mdi-spin mdi-sync' : 'mdi-application-import' }}
           </v-icon>
           <span

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -816,45 +816,47 @@ async function _importTrackFile(
 ) {
   /* Look for JSON track file as first priority */
   let foundDetections = false;
-  const foundTrackFileAbsPath = await _findJsonTrackFile(jsonMeta.originalBasePath);
-  const trackFileAbsPath = userTrackFileAbsPath !== undefined
-    ? userTrackFileAbsPath : foundTrackFileAbsPath;
-  if (trackFileAbsPath !== null && !CsvFileName.test(trackFileAbsPath)) {
+  if (userTrackFileAbsPath !== null) {
+    const foundTrackFileAbsPath = await _findJsonTrackFile(jsonMeta.originalBasePath);
+    const trackFileAbsPath = userTrackFileAbsPath !== undefined
+      ? userTrackFileAbsPath : foundTrackFileAbsPath;
+    if (trackFileAbsPath && !CsvFileName.test(trackFileAbsPath)) {
     /* Move the track file into the new project directory */
-    const time = moment().format('MM-DD-YYYY_hh-mm-ss.SSS');
-    const newFileName = `result_${time}.json`;
+      const time = moment().format('MM-DD-YYYY_hh-mm-ss.SSS');
+      const newFileName = `result_${time}.json`;
 
-    const newPath = npath.join(projectDirAbsPath, npath.basename(newFileName));
+      const newPath = npath.join(projectDirAbsPath, npath.basename(newFileName));
 
-    await fs.copy(
-      trackFileAbsPath,
-      newPath,
-    );
-    //Load tracks to generate attributes
-    const tracks = await loadJsonTracks(newPath);
-    const { attributes } = processTrackAttributes(Object.values(tracks));
-    // eslint-disable-next-line no-param-reassign
-    if (attributes) jsonMeta.attributes = attributes;
-    foundDetections = true;
-  }
-  /* Look for other types of annotation files as a second priority */
-  if (!foundDetections) {
-    const contents = await fs.readdir(jsonMeta.originalBasePath);
-    let csvFileCandidates = contents
-      .filter((v) => CsvFileName.test(v))
-      .map((filename) => npath.join(jsonMeta.originalBasePath, filename));
-
-    if (userTrackFileAbsPath && CsvFileName.test(userTrackFileAbsPath)) {
-      csvFileCandidates = [userTrackFileAbsPath];
-    }
-    const { fps, processedFiles, attributes } = await processOtherAnnotationFiles(
-      settings, dsId, csvFileCandidates,
-    );
+      await fs.copy(
+        trackFileAbsPath,
+        newPath,
+      );
+      //Load tracks to generate attributes
+      const tracks = await loadJsonTracks(newPath);
+      const { attributes } = processTrackAttributes(Object.values(tracks));
       // eslint-disable-next-line no-param-reassign
-    if (fps) jsonMeta.fps = fps;
-    // eslint-disable-next-line no-param-reassign
-    if (attributes) jsonMeta.attributes = attributes;
-    foundDetections = processedFiles.length > 0;
+      if (attributes) jsonMeta.attributes = attributes;
+      foundDetections = true;
+    }
+    /* Look for other types of annotation files as a second priority */
+    if (!foundDetections) {
+      const contents = await fs.readdir(jsonMeta.originalBasePath);
+      let csvFileCandidates = contents
+        .filter((v) => CsvFileName.test(v))
+        .map((filename) => npath.join(jsonMeta.originalBasePath, filename));
+
+      if (userTrackFileAbsPath && CsvFileName.test(userTrackFileAbsPath)) {
+        csvFileCandidates = [userTrackFileAbsPath];
+      }
+      const { fps, processedFiles, attributes } = await processOtherAnnotationFiles(
+        settings, dsId, csvFileCandidates,
+      );
+      // eslint-disable-next-line no-param-reassign
+      if (fps) jsonMeta.fps = fps;
+      // eslint-disable-next-line no-param-reassign
+      if (attributes) jsonMeta.attributes = attributes;
+      foundDetections = processedFiles.length > 0;
+    }
   }
 
   /* custom image sort */

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -141,15 +141,19 @@ export default defineComponent({
         v-if="!argCopy.jsonMeta.multiCam"
         class="d-flex my-2 mt-2"
       >
-        <v-text-field
-          :value="argCopy.trackFileAbsPath"
-          show-size
-          counter
-          prepend-icon="mdi-file-table"
-          label="Annotation File (Optional)"
-          hint="Optional"
-          @click="openUpload"
-        />
+        <v-col>
+          <v-text-field
+            :value="argCopy.trackFileAbsPath"
+            outlined
+            clearable
+            prepend-inner-icon="mdi-file-table"
+            label="Annotation File (Optional)"
+            hint="Optional"
+            @click="openUpload"
+            @click:prepend-inner="openUpload"
+            @click:clear="argCopy.trackFileAbsPath=null"
+          />
+        </v-col>
       </v-row>
       <p class="mb-5">
         <span

--- a/client/src/use/useTrackStore.ts
+++ b/client/src/use/useTrackStore.ts
@@ -130,9 +130,8 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
   }
 
   function clearAllTracks() {
-    trackIds.value.forEach((track) => {
-      removeTrack(track, true);
-    });
+    trackMap.clear();
+    intervalTree.forEach((key) => intervalTree.remove(key));
     trackIds.value = [];
   }
 


### PR DESCRIPTION
Fixes #871 
Fixes #873 

871 - upated `_importTrackFile` so that it can accept a duser defined track file.  If that track file is not included it will fall back to the default operation (This is required for stereo import of folders).  If it is included and set to null/empty it will create an empty dataset.

873 - added a disabled state and spinner to the import for longer uploads.  The previous delays were actually caused by the clearing of the tracks and not the import process itself.  If modified the clearAllTracks function to remove the objects instead of iteratively calling `removeTrack`.  This sped it up so on desktop it should be relatively quick and the longest part will be reloading the data.