### PR TITLE
Release to NPM last, allow it to fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,6 @@ jobs:
     - run: yarn build:cli
     - run: chmod +x bin/platform/desktop/backend/cli.js
 
-    - name: Publish to NPM
-      run: yarn publish --new-version ${{ github.event.release.tag_name }}
-      if: ${{ matrix.config.os == 'ubuntu-latest' }}
-      env:
-        # Use a token to publish to NPM.  Must configure this!
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
     # push the version changes to GitHub
     - name: Upload Release Asset
       uses: alexellis/upload-assets@0.2.3
@@ -57,6 +50,14 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         asset_paths: '["./client/dist_electron/DIVE-Desktop*"]'
+
+    - name: Publish to NPM
+      run: yarn publish --new-version ${{ github.event.release.tag_name }}
+      if: ${{ matrix.config.os == 'ubuntu-latest' }}
+      continue-on-error: true
+      env:
+        # Use a token to publish to NPM.  Must configure this!
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   docs:
     name: Deploy docs


### PR DESCRIPTION
In a pickle where NPM release succeded, then windows build failed.

It's not possible to unpublish from NPM (because the release was done in CI, so the SHA is lost) so I need to allow publish to fail to let the rerun complete everything else.