### PR TITLE
AV1 Transcoding Support, CRF=22

### DIFF
--- a/client/platform/desktop/backend/cli.ts
+++ b/client/platform/desktop/backend/cli.ts
@@ -86,6 +86,12 @@ const { argv } = yargs
     });
     yargs.demandOption(['file', 'meta']);
   })
+  .command('checkmedia [file]', 'Run checkMedia', () => {
+    yargs.positional('file', {
+      description: 'The video to check',
+      type: 'string',
+    }).demandOption('file');
+  })
   .command('list-config', 'List viame pipeline configuration', settingsArgs)
   .command('run-pipeline', 'Run a pipeline', () => {
     settingsArgs();
@@ -138,6 +144,13 @@ if (argv._.includes('viame2json')) {
   parseViameFile(argv.file as string);
 } else if (argv._.includes('json2viame')) {
   parseJsonFile(argv.file as string, argv.meta as string);
+} else if (argv._.includes('checkmedia')) {
+  const settings = getSettings();
+  const run = async () => {
+    const out = await settings.platform.checkMedia(settings, argv.file as string);
+    console.log(out);
+  };
+  run();
 } else if (argv._.includes('list-config')) {
   const settings = getSettings();
   const run = async () => {

--- a/client/platform/desktop/backend/native/linux.ts
+++ b/client/platform/desktop/backend/native/linux.ts
@@ -54,7 +54,8 @@ const ViameLinuxConstants = {
     videoArgs: [
       '-c:v libx264',
       '-preset slow',
-      '-crf 26',
+      // https://github.com/Kitware/dive/issues/855
+      '-crf 22',
       // https://askubuntu.com/questions/1315697/could-not-find-tag-for-codec-pcm-s16le-in-stream-1-codec-not-currently-support
       '-c:a aac',
       /**

--- a/client/platform/desktop/backend/native/windows.ts
+++ b/client/platform/desktop/backend/native/windows.ts
@@ -50,7 +50,8 @@ const ViameWindowsConstants = {
     videoArgs: [
       '-c:v libx264',
       '-preset slow',
-      '-crf 26',
+      // https://github.com/Kitware/dive/issues/855
+      '-crf 22',
       // https://askubuntu.com/questions/1315697/could-not-find-tag-for-codec-pcm-s16le-in-stream-1-codec-not-currently-support
       '-c:a aac',
       // https://video.stackexchange.com/questions/20871/how-do-i-convert-anamorphic-hdv-video-to-normal-h-264-video-with-ffmpeg-how-to

--- a/client/platform/desktop/frontend/components/Recent.vue
+++ b/client/platform/desktop/frontend/components/Recent.vue
@@ -384,7 +384,7 @@ export default defineComponent({
               <template #[`item.name`]="{ item }">
                 <span :key="item.id">
                   <div v-if="setOrGetConversionJob(item.id)">
-                    <span class="primary--text text--darken-1 text-decoration-none">
+                    <span class="primary--text text--darken-1 text-subtitle-1 pt-1">
                       {{ item.name }}
                     </span>
                     <span class="pl-4">

--- a/docker/girder_worker.Dockerfile
+++ b/docker/girder_worker.Dockerfile
@@ -12,6 +12,9 @@ WORKDIR /home/viame_girder
 
 # BEGIN: Porting girder worker install from girder/girder_worker Dockerfile.py3
 RUN apt-get update && \
+  apt-get install -qy software-properties-common && \
+  add-apt-repository ppa:savoury1/ffmpeg4 && \
+  apt-get update && \
 	export DEBIAN_FRONTEND=noninteractive && \
   apt-get install -qy software-properties-common python3-software-properties && \
   apt-get update && apt-get install -qy \

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -501,8 +501,9 @@ def convert_video(self: Task, path, folderId, auxiliaryFolderId, itemId):
             "libx264",
             "-preset",
             "slow",
+            # https://github.com/Kitware/dive/issues/855
             "-crf",
-            "26",
+            "22",
             # https://askubuntu.com/questions/1315697/could-not-find-tag-for-codec-pcm-s16le-in-stream-1-codec-not-currently-support
             "-c:a",
             "aac",


### PR DESCRIPTION
Tested AV1 using this video from https://github.com/SPBTV/video_av1_samples/blob/master/spbtv_sample_bipbop_av1_960x540_25fps.mp4

Verified that browser will play av1 without transcoding, but that web and desktop are still choosing to transcode anyway because of VIAME support.

fixes #750 
fixes #855 