### PR TITLE
updating GPU-less running instructions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -33,6 +33,7 @@ docker-compose up
 VIAME server will be running at http://localhost:8010/
 
 You can run the data viewer without needing GPU support as well
+> **Note:** Video import is unsupported in this mode.
 
 ``` bash
 docker-compose up girder

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -62,6 +62,7 @@ services:
         retries: 5
     depends_on:
       - mongo
+      - traefik
     volumes:
       # Bind mount assetstore from local directory
       # - ${DIVE_GIRDER_ASSETSTORE:-girder_data/assetstore}:/home/assetstore


### PR DESCRIPTION
Just fixing because without traefik started you need to reference your local Docker IP and port 8080.  The previous instructions of `docker-compose up girder` would have left the server in that state.
Also noted that you won't have video import working in this mode (the worker container won't be up, so upload hangs).
