### PR TITLE
Fix Cancellation

### DIFF
--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -17,6 +17,10 @@ TIMEOUT_LAST_CHECKED = 'last_checked'
 TIMEOUT_CHECK_INTERVAL = 30
 
 
+class CanceledError(RuntimeError):
+    pass
+
+
 def check_canceled(task: Task, context: dict, force=True):
     """
     Only check for canceled task every interval unless force is true (default).
@@ -88,7 +92,7 @@ def stream_subprocess(
         stderr_file.close()
         if cleanup:
             cleanup()
-        return stdout
+        raise CanceledError('Job was canceled')
 
     if code > 0:
         stderr_file.seek(0)


### PR DESCRIPTION
While reviewing on friday, I noticed there were some unhandled cancellation conditions, most notably in `check_and_fix_frame_alignment()`.  I implemented cancellation poorly to begin with such that any function call that could interrupt the function has to be checked on return (in the same way that golang error handling works) so you have to check all the way down the call stack.

This is the whole purpose of built-in error handling language features (throw early/catch late).  This gets rid of most instances of `check_canceled` so that forgetting handle the cancel somewhere won't introduce bugs.

It also replaces `self` with `task` in some functions.  Self shouldn't be the name of an argument in a function that isn't an instance method (celery tasks are a special case)

This is untested (I wasn't done with it) but I wanted to go ahead and let you know about the possible change because it looks like you were doing stuff.