### PR TITLE
Fixes #903 Import annotation error handling

### DIFF
--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -3,6 +3,7 @@ import { defineComponent, ref } from '@vue/composition-api';
 import { useApi } from 'dive-common/apispec';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { useHandler } from 'vue-media-annotator/provides';
+import { getResponseError } from 'vue-media-annotator/utils';
 
 export default defineComponent({
   name: 'ImportAnnotations',
@@ -42,7 +43,7 @@ export default defineComponent({
             importFile = await importAnnotationFile(props.datasetId, path);
           }
         } catch (error) {
-          const text = [`Import of File ${path} failed`, error];
+          const text = [`Import of File ${path} failed`, getResponseError(error)];
           prompt({
             title: 'Import Failed',
             text,

--- a/client/platform/desktop/backend/native/attributeProcessor.ts
+++ b/client/platform/desktop/backend/native/attributeProcessor.ts
@@ -78,6 +78,9 @@ function processTrackAttributes(tracks: TrackData[]):
   }
 
   tracks.forEach((t) => {
+    if (t.trackId === undefined) {
+      throw new Error('The Track JSON file contains no valid trackIds.');
+    }
     trackMap[t.trackId.toString()] = t;
     processTrackforAttributes(t);
   });

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -3,6 +3,7 @@ import type { GirderModel } from '@girder/components/src';
 import { DatasetMetaMutable, FrameImage, SaveAttributeArgs } from 'dive-common/apispec';
 import { GirderMetadataStatic } from 'platform/web-girder/constants';
 import girderRest from 'platform/web-girder/plugins/girder';
+import { postProcess } from './rpc.service';
 
 interface HTMLFile extends File {
   webkitRelativePath?: string;
@@ -77,14 +78,8 @@ async function importAnnotationFile(parentId: string, path: string, file?: HTMLF
       headers: { 'Content-Type': 'application/octet-stream' },
     });
     if (uploadResponse.status === 200) {
-      const final = await girderRest.post(`viame/postprocess/${parentId}`, null, {
-        params: {
-          skipJobs: true,
-        },
-      });
-      if (final.status === 200) {
-        return true;
-      }
+      const final = await postProcess(parentId, true);
+      return final.status === 200;
     }
   }
   return false;

--- a/client/platform/web-girder/api/rpc.service.ts
+++ b/client/platform/web-girder/api/rpc.service.ts
@@ -1,8 +1,10 @@
 import girderRest from 'platform/web-girder/plugins/girder';
 import { Pipe } from 'dive-common/apispec';
 
-function postProcess(folderId: string) {
-  return girderRest.post(`dive_rpc/postprocess/${folderId}`);
+function postProcess(folderId: string, skipJobs = false) {
+  return girderRest.post(`dive_rpc/postprocess/${folderId}`, null, {
+    params: { skipJobs },
+  });
 }
 
 function runPipeline(itemId: string, pipeline: Pipe) {

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -14,6 +14,8 @@ import ImportMultiCamDialog from 'dive-common/components/ImportMultiCamDialog.vu
 import { DatasetType, MultiCamImportArgs } from 'dive-common/apispec';
 import { validateUploadGroup } from 'platform/web-girder/api';
 import { openFromDisk } from 'platform/web-girder/utils';
+import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
+import { getResponseError } from 'vue-media-annotator/utils';
 import UploadGirder from './UploadGirder.vue';
 
 export interface InteralFiles {
@@ -66,6 +68,7 @@ export default defineComponent({
     const multiCamOpenType = ref('image-sequence');
     const importMultiCamDialog = ref(false);
     const girderUpload: Ref<null | GirderUpload> = ref(null);
+    const { prompt } = usePrompt();
     /**
      * Initial opening of file dialog
      */
@@ -289,6 +292,15 @@ export default defineComponent({
         disabled: uploading.value,
       };
     });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const errorHandler = async ({ err, name }: {err: any; name: string}) => {
+      const text = getResponseError(err);
+      await prompt({
+        title: `${name}: Import Error`,
+        text,
+        positiveButton: 'OK',
+      });
+    };
     return {
       buttonAttrs,
       FPSOptions,
@@ -314,6 +326,7 @@ export default defineComponent({
       addPendingUpload,
       remove,
       abort,
+      errorHandler,
     };
   },
 });
@@ -368,6 +381,7 @@ export default defineComponent({
         @remove-upload="remove"
         @update:uploading="$emit('update:uploading', $event)"
         @abort="abort"
+        @error="errorHandler"
       >
         <template #default="{ upload }">
           <v-card

--- a/client/platform/web-girder/views/UploadGirder.vue
+++ b/client/platform/web-girder/views/UploadGirder.vue
@@ -148,7 +148,11 @@ export default Vue.extend({
           folder,
           results: data.results,
         });
-        await postProcess(folder._id);
+        try {
+          await postProcess(folder._id);
+        } catch (err) {
+          this.$emit('error', { err, name });
+        }
       };
       // Sets the files used by the fileUploader mixin
       this.setFiles(files);

--- a/server/dive_server/crud.py
+++ b/server/dive_server/crud.py
@@ -227,6 +227,19 @@ def process_json(folder: GirderModel, user: GirderUserModel):
             saveImportAttributes(folder, attributes, user)
             Item().move(item, auxiliary)
         else:  # dive json
+            # Perform validation of JSON file input
+            possible_annotation_files = list(Item().childFiles(item))
+            if len(possible_annotation_files) != 1:
+                raise RestException('Expected exactly 1 file')
+            for track in getTrackData(possible_annotation_files[0]).values():
+                if not isinstance(track, dict):
+                    raise RestException(
+                        (
+                            'Invalid JSON file provided.'
+                            ' Please upload a COCO, KWCOCO, VIAME CSV, or DIVE JSON file.'
+                        )
+                    )
+                get_validated_model(models.Track, **track)
             item['meta'][constants.DetectionMarker] = str(folder['_id'])
             Item().save(item)
     if len(jsonItems) > 0:

--- a/server/dive_server/crud.py
+++ b/server/dive_server/crud.py
@@ -233,6 +233,7 @@ def process_json(folder: GirderModel, user: GirderUserModel):
                 raise RestException('Expected exactly 1 file')
             for track in getTrackData(possible_annotation_files[0]).values():
                 if not isinstance(track, dict):
+                    Item().remove(item)  # remove the bad JSON from dataset
                     raise RestException(
                         (
                             'Invalid JSON file provided.'


### PR DESCRIPTION
fixes #903

Until now, apparently the client would let you upload whatever json you wanted and postprocess would tag it as an annotation file without checking the formatting.  Now, it's forced through a pydantic schema validation same as if you `save`.

Also fixes a bug where `api.importAnnotationFile` was not updated to use the new postprocessing endpoint.