### PR TITLE
Updates to import-failures

### DIFF
--- a/client/platform/desktop/backend/native/attributeProcessor.ts
+++ b/client/platform/desktop/backend/native/attributeProcessor.ts
@@ -78,6 +78,9 @@ function processTrackAttributes(tracks: TrackData[]):
   }
 
   tracks.forEach((t) => {
+    if (t.trackId === undefined) {
+      throw new Error('The Track JSON file contains no valid trackIds.');
+    }
     trackMap[t.trackId.toString()] = t;
     processTrackforAttributes(t);
   });

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -16,7 +16,6 @@ import { validateUploadGroup } from 'platform/web-girder/api';
 import { openFromDisk } from 'platform/web-girder/utils';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { getResponseError } from 'vue-media-annotator/utils';
-import { AxiosError } from 'axios';
 import UploadGirder from './UploadGirder.vue';
 
 export interface InteralFiles {
@@ -293,7 +292,8 @@ export default defineComponent({
         disabled: uploading.value,
       };
     });
-    const errorHandler = async ({ err, name }: {err: AxiosError; name: string}) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const errorHandler = async ({ err, name }: {err: any; name: string}) => {
       const text = getResponseError(err);
       await prompt({
         title: `${name}: Import Error`,

--- a/client/platform/web-girder/views/UploadGirder.vue
+++ b/client/platform/web-girder/views/UploadGirder.vue
@@ -148,7 +148,11 @@ export default Vue.extend({
           folder,
           results: data.results,
         });
-        await postProcess(folder._id);
+        try {
+          await postProcess(folder._id);
+        } catch (err) {
+          this.$emit('error', { err, name });
+        }
       };
       // Sets the files used by the fileUploader mixin
       this.setFiles(files);

--- a/server/dive_server/crud.py
+++ b/server/dive_server/crud.py
@@ -233,6 +233,7 @@ def process_json(folder: GirderModel, user: GirderUserModel):
                 raise RestException('Expected exactly 1 file')
             for track in getTrackData(possible_annotation_files[0]).values():
                 if not isinstance(track, dict):
+                    Item().remove(item)  # remove the bad JSON from dataset
                     raise RestException(
                         (
                             'Invalid JSON file provided.'


### PR DESCRIPTION
Feel free to take what you want or reject the merge.

- The standard upload UI would fail non-gracefully when selecting an incorrect JSON file so I added a prompt and error handling to the postprocess request.
- I felt like the offending JSON file should be removed from the dataset folder if it is found to not be a compatible type.  Otherwise we have a bunch of orphaned json files sitting there on export.
- Small error throwing message on desktop-electron to make it clearer why there was a failure.  There was a failure processing attributes which could cause an error in the import.  Alternative would be to check for some basic schema in the `loadJSONTracks`, there is a TODO there for that.