### PR TITLE
Fixes for location

### DIFF
--- a/client/platform/web-girder/App.vue
+++ b/client/platform/web-girder/App.vue
@@ -30,6 +30,8 @@ export default defineComponent({
       return root.$store.dispatch('Dataset/load', datasetId);
     }
 
+    root.$store.dispatch('Location/setLocationFromRoute', root.$route);
+
     provideApi({
       getPipelineList: unwrap(getPipelineList),
       runPipeline: unwrap(runPipeline),

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -20,7 +20,7 @@ async function getDatasetList(
   sortDir: number,
   shared: boolean,
 ) {
-  const response = await girderRest.get<GirderModel[]>('viame/datasets', {
+  const response = await girderRest.get<GirderModel[]>('dive_dataset', {
     params: {
       limit,
       offset,

--- a/client/platform/web-girder/router.ts
+++ b/client/platform/web-girder/router.ts
@@ -61,7 +61,7 @@ const router = new Router({
               component: DataShared,
             },
             {
-              path: ':_modelType?/:_id?',
+              path: ':routeType?/:routeId?',
               name: 'home',
               component: DataBrowser,
               beforeEnter,

--- a/client/platform/web-girder/store/Dataset.ts
+++ b/client/platform/web-girder/store/Dataset.ts
@@ -3,7 +3,9 @@ import type { GirderModelType } from '@girder/components/src';
 import type { GirderMetadata } from 'platform/web-girder/constants';
 import { getDataset, getDatasetMedia, getFolder } from 'platform/web-girder/api';
 import { MultiType } from 'dive-common/constants';
-import type { DatasetState, LocationType, RootState } from './types';
+import { getRouteFromLocation } from 'platform/web-girder/utils';
+import type { DatasetState, RootState } from './types';
+
 
 const datasetModule: Module<DatasetState, RootState> = {
   namespaced: true,
@@ -34,11 +36,10 @@ const datasetModule: Module<DatasetState, RootState> = {
       commit('set', { dataset: dsMeta });
       const { parentId, parentCollection } = folder.data;
       if (parentId && parentCollection) {
-        const newLoc: LocationType = {
+        commit('Location/setLocationFromRoute', getRouteFromLocation({
           _id: parentId,
           _modelType: parentCollection as GirderModelType,
-        };
-        commit('Location/setLocation', newLoc, { root: true });
+        }), { root: true });
       } else {
         throw new Error(`dataset ${datasetId} was not a valid girder folder`);
       }

--- a/client/platform/web-girder/store/Dataset.ts
+++ b/client/platform/web-girder/store/Dataset.ts
@@ -18,7 +18,7 @@ const datasetModule: Module<DatasetState, RootState> = {
     },
   },
   actions: {
-    async load({ commit }, datasetId: string): Promise<GirderMetadata> {
+    async load({ commit, dispatch }, datasetId: string): Promise<GirderMetadata> {
       const [folder, metaStatic, media] = await Promise.all([
         getFolder(datasetId),
         getDataset(datasetId),
@@ -36,10 +36,10 @@ const datasetModule: Module<DatasetState, RootState> = {
       commit('set', { dataset: dsMeta });
       const { parentId, parentCollection } = folder.data;
       if (parentId && parentCollection) {
-        commit('Location/setLocationFromRoute', getRouteFromLocation({
+        dispatch('Location/hydrate', {
           _id: parentId,
-          _modelType: parentCollection as GirderModelType,
-        }), { root: true });
+          _modelType: parentCollection,
+        }, { root: true });
       } else {
         throw new Error(`dataset ${datasetId} was not a valid girder folder`);
       }

--- a/client/platform/web-girder/store/Location.ts
+++ b/client/platform/web-girder/store/Location.ts
@@ -1,6 +1,8 @@
 import type { Module } from 'vuex';
 import type { GirderModel } from '@girder/components/src';
-import { getPathFromLocation } from 'platform/web-girder/utils';
+import { Route } from 'vue-router';
+import girderRest from 'platform/web-girder/plugins/girder';
+import { getLocationFromRoute, getRouteFromLocation } from 'platform/web-girder/utils';
 import { getFolder } from 'platform/web-girder/api';
 import {
   isGirderModel,
@@ -24,35 +26,68 @@ const locationModule: Module<LocationState, RootState> = {
   },
   getters: {
     locationIsViameFolder(state) {
-      if (isGirderModel(state.location)) {
+      if (state.location && isGirderModel(state.location)) {
         return !!state.location?.meta?.annotate;
       }
       return false;
     },
+    defaultLocation() {
+      return {
+        _id: girderRest.user._id,
+        _modelType: 'user',
+      };
+    },
+    locationRoute(state, getters) {
+      if (state.location) {
+        return getRouteFromLocation(state.location);
+      }
+      return getRouteFromLocation(getters.defaultLocation);
+    },
   },
   actions: {
-    async route({ commit, getters }, location: LocationType) {
-      /* Prevent navigation into auxiliary folder */
+    async setLocationFromRoute({ commit, state, getters }, route: Route) {
+      /**
+       * Update the location because the route changed.
+       * May need to fetch the full location details from server
+       */
+      const newLocation = getLocationFromRoute(route) || getters.defaultLocation;
+      if (
+        isGirderModel(newLocation)
+        && newLocation._modelType === 'folder'
+        && !newLocation.name
+      ) {
+        commit('setLocation', (await getFolder(newLocation._id)).data);
+      } else {
+        /** If the current and new location are the same, abort */
+        if (state.location) {
+          if ('type' in state.location && 'type' in newLocation) {
+            if (state.location.type === newLocation.type) return;
+          }
+          if ('_id' in state.location && '_id' in newLocation) {
+            if (state.location._id === newLocation._id) return;
+          }
+        }
+        commit('setLocation', newLocation);
+      }
+    },
+    setRouteFromLocation({ getters, commit }, location: LocationType) {
+      /**
+       * Update the current route because the location was changed,
+       * such as by navigating within the data browser
+       */
       if (
         isGirderModel(location)
         && getters.locationIsViameFolder
         && location.name === 'auxiliary'
       ) {
+        /* Prevent navigation into auxiliary folder */
         return;
       }
-      const newPath = getPathFromLocation(location);
+      const newPath = getRouteFromLocation(location);
       if (newPath !== router.currentRoute.path) {
         router.push(newPath);
       }
       commit('setLocation', location);
-      /* Hydrate full location girder model if it's not available */
-      if (
-        isGirderModel(location)
-        && location._modelType === 'folder'
-        && !location.name
-      ) {
-        commit('setLocation', (await getFolder(location._id)).data);
-      }
     },
   },
 };

--- a/client/platform/web-girder/store/index.ts
+++ b/client/platform/web-girder/store/index.ts
@@ -20,8 +20,7 @@ const store = new Vuex.Store<RootState>({
 /* Keep location state up to date with current route */
 router.beforeEach((to, from, next) => {
   if (to.name === 'home') {
-    /** to.params should be LocationType */
-    store.commit('Location/setLocation', to.params);
+    store.dispatch('Location/setLocationFromRoute', to);
   }
   next();
 });

--- a/client/platform/web-girder/store/types.ts
+++ b/client/platform/web-girder/store/types.ts
@@ -23,7 +23,7 @@ export interface DatasetState {
 }
 
 export interface BrandState {
-  brandData: null | BrandData;
+  brandData: BrandData;
 }
 
 export interface RootState {

--- a/client/platform/web-girder/store/types.ts
+++ b/client/platform/web-girder/store/types.ts
@@ -18,10 +18,6 @@ export interface LocationState {
   selected: GirderModel[];
 }
 
-export interface LocationGetters {
-  locationIsViameFolder: boolean;
-}
-
 export interface DatasetState {
   meta: GirderMetadata | null;
 }
@@ -35,11 +31,6 @@ export interface RootState {
   Dataset: DatasetState;
   Brand: BrandState;
 }
-
-// https://blog.e-mundo.de/post/vuex-with-typescript-tricks-to-improve-your-developer-experience/
-export type GettersDefinition<T, S> = {
-  [P in keyof T]: (state: S, getters: T) => T[P];
-};
 
 export function useStore(): Store<RootState> {
   const store: Store<RootState> | undefined = inject('store');

--- a/client/platform/web-girder/utils.ts
+++ b/client/platform/web-girder/utils.ts
@@ -3,21 +3,28 @@ import {
   otherImageTypes, otherVideoTypes, websafeImageTypes, websafeVideoTypes,
 } from 'dive-common/constants';
 import { DatasetType } from 'dive-common/apispec';
-import type { LocationType } from 'platform/web-girder/store/types';
+import type { LocationType, RootlessLocationType } from 'platform/web-girder/store/types';
 import { Route } from 'vue-router';
 
-function getLocationFromRoute(route: Route) {
+/**
+ * If the current route is representable by a LocationType, return it.
+ * _modelType comes from the router spec and must be converted into LocationType
+ */
+function getLocationFromRoute(route: Route): LocationType | null {
   const { params } = route;
-  if ('type' in params) {
-    return params as LocationType;
+  if (['root', 'collections', 'users'].indexOf(params.routeType) >= 0) {
+    return { type: params.routeType } as LocationType;
   }
-  if (['user', 'folder'].indexOf(params._modelType)) {
-    return params as LocationType;
+  if (['user', 'folder', 'collection'].indexOf(params.routeType) >= 0) {
+    return {
+      _modelType: params.routeType,
+      _id: params.routeId,
+    } as RootlessLocationType;
   }
   return null;
 }
 
-function getPathFromLocation(location: LocationType) {
+function getRouteFromLocation(location: LocationType): string {
   if (!location) {
     return '/';
   }
@@ -71,6 +78,6 @@ Promise<{ canceled: boolean; filePaths: string[]; fileList?: File[]}> {
 
 export {
   getLocationFromRoute,
-  getPathFromLocation,
+  getRouteFromLocation,
   openFromDisk,
 };

--- a/client/platform/web-girder/utils.ts
+++ b/client/platform/web-girder/utils.ts
@@ -1,22 +1,18 @@
-import { isRootLocation, GirderModel } from '@girder/components/src';
 import {
   calibrationFileTypes, inputAnnotationFileTypes, inputAnnotationTypes,
   otherImageTypes, otherVideoTypes, websafeImageTypes, websafeVideoTypes,
 } from 'dive-common/constants';
 import { DatasetType } from 'dive-common/apispec';
 import type { LocationType } from 'platform/web-girder/store/types';
+import { Route } from 'vue-router';
 
-function getLocationFromRoute({ params }: { params: GirderModel }) {
-  if (isRootLocation(params)) {
-    return {
-      type: params._modelType,
-    };
+function getLocationFromRoute(route: Route) {
+  const { params } = route;
+  if ('type' in params) {
+    return params as LocationType;
   }
-  if (params._modelType === 'user') {
-    return params;
-  }
-  if (params._modelType === 'folder') {
-    return params;
+  if (['user', 'folder'].indexOf(params._modelType)) {
+    return params as LocationType;
   }
   return null;
 }

--- a/client/platform/web-girder/views/DataBrowser.vue
+++ b/client/platform/web-girder/views/DataBrowser.vue
@@ -1,13 +1,12 @@
 <script lang="ts">
 import {
-  computed, defineComponent, inject, ref,
+  computed, defineComponent, ref,
 } from '@vue/composition-api';
 import {
-  GirderFileManager, getLocationType, RestClient, GirderModel,
+  GirderFileManager, getLocationType, GirderModel,
 } from '@girder/components/src';
 
 import { useStore, LocationType } from '../store/types';
-import { getLocationFromRoute } from '../utils';
 import Upload from './Upload.vue';
 
 export default defineComponent({
@@ -16,17 +15,16 @@ export default defineComponent({
     Upload,
   },
 
-  setup(_, { root }) {
+  setup() {
     const fileManager = ref();
     const store = useStore();
     const uploading = ref(false);
     const uploaderDialog = ref(false);
     const locationStore = store.state.Location;
     const { getters } = store;
-    const girderRest = inject('girderRest') as RestClient;
 
-    function setLocation(value: LocationType) {
-      store.dispatch('Location/route', value);
+    function setLocation(location: LocationType) {
+      store.dispatch('Location/setRouteFromLocation', location);
     }
 
     function handleNotification() {
@@ -48,16 +46,10 @@ export default defineComponent({
 
     const shouldShowUpload = computed(() => (
       locationStore.location
-      && !getters.locationIsViameFolder
+      && !getters['Location/locationIsViameFolder']
       && getLocationType(locationStore.location) === 'folder'
       && !locationStore.selected.length
     ));
-
-    /* Initialize the location in the store */
-    setLocation(getLocationFromRoute(root.$route) || {
-      _id: girderRest.user._id,
-      _modelType: 'user',
-    });
 
     return {
       fileManager,
@@ -81,9 +73,9 @@ export default defineComponent({
   <GirderFileManager
     ref="fileManager"
     v-model="locationStore.selected"
-    :selectable="!getters.locationIsViameFolder"
+    :selectable="!getters['Location/locationIsViameFolder']"
     :new-folder-enabled="
-      !locationStore.selected.length && !getters.locationIsViameFolder
+      !locationStore.selected.length && !getters['Location/locationIsViameFolder']
     "
     :location="locationStore.location"
     @update:location="setLocation($event)"

--- a/client/platform/web-girder/views/DataShared.vue
+++ b/client/platform/web-girder/views/DataShared.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  defineComponent, ref, reactive, computed, watch, toRefs,
+  defineComponent, ref, reactive, watch, toRefs,
 } from '@vue/composition-api';
 import type { DataOptions } from 'vuetify';
 import { GirderModel, mixins } from '@girder/components/src';
@@ -44,22 +44,17 @@ export default defineComponent({
 
       const response = await getDatasetList(limit, offset, sort, sortDir, true);
       dataList.value = response.data;
-      total.value = response.headers['girder-total-count'] as number;
+      total.value = Number.parseInt(response.headers['girder-total-count'], 10);
       dataList.value.forEach((element) => {
         // eslint-disable-next-line no-param-reassign
         element.formattedSize = fixSize.formatSize(element.size);
       });
     };
 
+    function setLocation(location: LocationType) {
+      store.dispatch('Location/setRouteFromLocation', location);
+    }
 
-    const location = computed({
-      get() {
-        return locationStore.location;
-      },
-      set(value: null | LocationType) {
-        store.dispatch('Location/route', value);
-      },
-    });
     function isAnnotationFolder(item: GirderModel) {
       return item._modelType === 'folder' && item.meta.annotate;
     }
@@ -74,8 +69,8 @@ export default defineComponent({
       dataList,
       getters,
       updateOptions,
+      setLocation,
       total,
-      location,
       locationStore,
       ...toRefs(tableOptions),
       headers,
@@ -88,8 +83,8 @@ export default defineComponent({
 <template>
   <v-data-table
     v-model="locationStore.selected"
-    :selectable="!getters.locationIsViameFolder"
-    :location.sync="location"
+    :selectable="!getters['Location/locationIsViameFolder']"
+    :location="locationStore.location"
     :headers="headers"
     :page.sync="page"
     :items-per-page.sync="itemsPerPage"
@@ -100,6 +95,7 @@ export default defineComponent({
     item-key="_id"
     show-select
     @input="$emit('input', $event)"
+    @update:location="setLocation"
   >
     <!-- eslint-disable-next-line -->
     <template v-slot:item.annotator="{item}">

--- a/client/platform/web-girder/views/DataShared.vue
+++ b/client/platform/web-girder/views/DataShared.vue
@@ -113,9 +113,3 @@ export default defineComponent({
     </template>
   </v-data-table>
 </template>
-
-<style lang='scss'>
-.theme--dark.v-data-table > .v-data-table__wrapper > table > thead > tr > th {
-    background: var(--v-secondary-darken2);
-}
-</style>

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -12,8 +12,6 @@ import RunPipelineMenu from 'dive-common/components/RunPipelineMenu.vue';
 import RunTrainingMenu from 'dive-common/components/RunTrainingMenu.vue';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 
-import { getFolder } from 'platform/web-girder/api/girder.service';
-import { getLocationFromRoute } from '../utils';
 import { deleteResources } from '../api';
 import { getMaxNSummaryUrl } from '../api/summary.service';
 import Export from './Export.vue';
@@ -87,9 +85,6 @@ export default defineComponent({
     exportTargetId() {
       return this.exportTarget?._id || null;
     },
-    locationIsViameFolder() {
-      return !!(this.location && this.location.meta && this.location.meta.annotate);
-    },
     selectedViameFolderIds() {
       return this.selected.filter(
         ({ _modelType, meta }) => _modelType === 'folder' && meta && meta.annotate,
@@ -105,18 +100,7 @@ export default defineComponent({
       return getMaxNSummaryUrl(this.locationInputs);
     },
   },
-  async created() {
-    let newLocaction = getLocationFromRoute(this.$route);
-    if (newLocaction === null) {
-      newLocaction = {
-        _id: this.girderRest.user._id,
-        _modelType: 'user',
-      };
-    }
-    this.location = newLocaction;
-    if (this.location._modelType === 'folder') {
-      this.location = (await getFolder(this.location._id)).data;
-    }
+  created() {
     this.girderRest.$on('message:job_status', this.handleNotification);
   },
   beforeDestroy() {

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -100,12 +100,6 @@ export default defineComponent({
       return getMaxNSummaryUrl(this.locationInputs);
     },
   },
-  created() {
-    this.girderRest.$on('message:job_status', this.handleNotification);
-  },
-  beforeDestroy() {
-    this.girderRest.$off('message:job_status', this.handleNotification);
-  },
   methods: {
     async deleteSelection() {
       const result = await this.prompt({
@@ -210,7 +204,7 @@ export default defineComponent({
           <v-toolbar
             dense
             class="mb-4"
-            rounded=""
+            rounded
           >
             <ShareTab
               :value="0"

--- a/client/platform/web-girder/views/JobsTab.vue
+++ b/client/platform/web-girder/views/JobsTab.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  defineComponent, onBeforeUnmount, reactive, toRefs,
+  defineComponent, onBeforeUnmount, reactive, toRefs, nextTick,
 } from '@vue/composition-api';
 import { GirderJob } from '@girder/components/src';
 import { all } from '@girder/components/src/components/Job/status';
@@ -47,7 +47,8 @@ export default defineComponent({
       girderRest.$on('message:job_status', handleNotification);
     }
 
-    onBeforeUnmount(() => {
+    onBeforeUnmount(async () => {
+      await nextTick();
       girderRest.$off('message:job_status', handleNotification);
     });
 

--- a/client/platform/web-girder/views/JobsTab.vue
+++ b/client/platform/web-girder/views/JobsTab.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  defineComponent, onBeforeUnmount, reactive, toRefs, nextTick,
+  defineComponent, onBeforeUnmount, reactive, toRefs,
 } from '@vue/composition-api';
 import { GirderJob } from '@girder/components/src';
 import { all } from '@girder/components/src/components/Job/status';
@@ -48,7 +48,6 @@ export default defineComponent({
     }
 
     onBeforeUnmount(async () => {
-      await nextTick();
       girderRest.$off('message:job_status', handleNotification);
     });
 

--- a/client/platform/web-girder/views/NavigationBar.vue
+++ b/client/platform/web-girder/views/NavigationBar.vue
@@ -1,5 +1,5 @@
 <script>
-import { mapActions, mapState } from 'vuex';
+import { mapActions, mapGetters, mapState } from 'vuex';
 
 import { GirderSearch } from '@girder/components/src';
 import NavigationTitle from 'dive-common/components/NavigationTitle.vue';
@@ -20,7 +20,7 @@ export default {
     runningJobIds: [],
   }),
   computed: {
-    ...mapState('Location', ['location']),
+    ...mapGetters('Location', ['locationRoute']),
     ...mapState('Brand', ['brandData']),
   },
   async created() {
@@ -30,7 +30,7 @@ export default {
     this.girderRest.$off('logout', this.onLogout);
   },
   methods: {
-    ...mapActions('Location', ['route']),
+    ...mapActions('Location', ['setRouteFromLocation']),
     onLogout() {
       this.$router.push({ name: 'login' });
     },
@@ -47,10 +47,11 @@ export default {
     <v-tabs
       icons-and-text
       color="accent"
+      class="mx-2"
     >
       <v-tab
         exact
-        @click="route(location)"
+        :to="locationRoute"
       >
         Data
         <v-icon>mdi-database</v-icon>
@@ -64,7 +65,7 @@ export default {
       hide-options-menu
       hide-search-icon
       class="mx-2 grow"
-      @select="route"
+      @select="setRouteFromLocation"
     />
     <v-btn
       text

--- a/client/platform/web-girder/views/ShareTab.vue
+++ b/client/platform/web-girder/views/ShareTab.vue
@@ -14,6 +14,7 @@ export default defineComponent({
   setup() {
     const store = useStore();
     const locationStore = store.state.Location;
+    const { getters } = store;
 
     const clearSelected = () => {
       locationStore.selected = [];
@@ -21,6 +22,7 @@ export default defineComponent({
 
     return {
       locationStore,
+      getters,
       clearSelected,
     };
   },
@@ -30,12 +32,20 @@ export default defineComponent({
 <template>
   <v-tabs
     right
+    dense
+    class="mx-1"
     @change="clearSelected"
   >
-    <v-tab :to="{name: 'home'}">
+    <v-tab :to="getters['Location/locationRoute']">
+      <v-icon class="mr-2">
+        mdi-folder-multiple
+      </v-icon>
       Browse Data
     </v-tab>
     <v-tab :to="{name: 'shared'}">
+      <v-icon class="mr-2">
+        mdi-share-variant
+      </v-icon>
       Shared with Me
     </v-tab>
   </v-tabs>

--- a/client/platform/web-girder/views/ShareTab.vue
+++ b/client/platform/web-girder/views/ShareTab.vue
@@ -31,9 +31,9 @@ export default defineComponent({
 
 <template>
   <v-tabs
-    right
     dense
-    class="mx-1"
+    right
+    class="px-4"
     @change="clearSelected"
   >
     <v-tab :to="getters['Location/locationRoute']">

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -1,14 +1,14 @@
 <script lang="ts">
 import {
-  defineComponent, onBeforeUnmount, onMounted, ref, toRef, computed,
+  defineComponent, onBeforeUnmount, onMounted, ref,
 } from '@vue/composition-api';
 
 import Viewer from 'dive-common/components/Viewer.vue';
 import NavigationTitle from 'dive-common/components/NavigationTitle.vue';
 import RunPipelineMenu from 'dive-common/components/RunPipelineMenu.vue';
 import ImportAnnotations from 'dive-common/components/ImportAnnotations.vue';
+import { useStore } from 'platform/web-girder/store/types';
 import JobsTab from './JobsTab.vue';
-import { getPathFromLocation } from '../utils';
 import Export from './Export.vue';
 import Clone from './Clone.vue';
 
@@ -54,11 +54,10 @@ export default defineComponent({
     }
   },
 
-  setup(props, { root }) {
+  setup() {
     const viewerRef = ref();
-    const brandData = toRef(root.$store.state.Brand, 'brandData');
-    const location = toRef(root.$store.state.Location, 'location');
-    const dataPath = computed(() => getPathFromLocation(location.value));
+    const store = useStore();
+    const { getters } = store;
 
     onMounted(() => {
       window.addEventListener('beforeunload', viewerRef.value.warnBrowserExit);
@@ -72,8 +71,7 @@ export default defineComponent({
       buttonOptions,
       menuOptions,
       viewerRef,
-      dataPath,
-      brandData,
+      getters,
     };
   },
 });
@@ -90,9 +88,10 @@ export default defineComponent({
       <v-tabs
         icons-and-text
         hide-slider
+        class="mx-2"
         style="flex-basis:0; flex-grow:0;"
       >
-        <v-tab :to="dataPath">
+        <v-tab :to="getters['Location/locationRoute']">
           Data
           <v-icon>mdi-database</v-icon>
         </v-tab>

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  defineComponent, onBeforeUnmount, onMounted, ref,
+  defineComponent, onBeforeUnmount, onMounted, ref, toRef,
 } from '@vue/composition-api';
 
 import Viewer from 'dive-common/components/Viewer.vue';
@@ -57,6 +57,7 @@ export default defineComponent({
   setup() {
     const viewerRef = ref();
     const store = useStore();
+    const brandData = toRef(store.state.Brand, 'brandData');
     const { getters } = store;
 
     onMounted(() => {
@@ -69,6 +70,7 @@ export default defineComponent({
 
     return {
       buttonOptions,
+      brandData,
       menuOptions,
       viewerRef,
       getters,


### PR DESCRIPTION
This backs out some of the nonsense I added when we worked on this the first time and simplifies things a bit.

* Remove `LocationGetters` and `GettersDefinitions`, as they were providing no additional safety whatsoever.
* Move `'auxiliary'` enforcement and hydration of full location model into `route` handler.  These things should happen no matter where the location is routed from.  The current behavior relied on lifecycle of `DataBrowser` and was therefore subject to `keep-alive`.
* Tweak getLocationFromRoute such that the argument is, as the name suggests, a route.  At that point in the execution, it has not been determined that `route.params` is actially `LocationType`, so the arguments to that function resulted in an untrue type coercion.
* Remove the somewhat obscure computed property with getter/setter and just call the store dispatch directly.