### PR TITLE
Remove forbid on CustomStyle

### DIFF
--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -88,9 +88,6 @@ class CustomStyle(BaseModel):
     opacity: Optional[float]
     fill: Optional[bool]
 
-    class Config:
-        extra = 'forbid'
-
 
 class MetadataMutable(BaseModel):
     customTypeStyling: Optional[Dict[str, CustomStyle]]


### PR DESCRIPTION
Some of the customTypeStyling values in my directory have `type`
Example https://viame.kitware.com/girder/#user/5e56c7d778ed364cd0fd30a2/folder/5f3c78e0531f8b4f23542d3f

This causes a 500 error when the data loads.  Rather than forbid, we should just ignore the extra value.

Apparently from an old version of the interface: https://github.com/Kitware/dive/pull/192/files#diff-e7e29d171278c9dd2b7a6351646365c7ad7f38aabc1f0b5c5f6ec487acf95177R35-R41
