### PR TITLE
Updates for docker compose

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -2,6 +2,7 @@ version: "2.4"
 services:
 
   traefik:
+    restart: always
     command: >
       --log.level=${LOG_LEVEL:-DEBUG}
       --providers.docker=true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ x-worker: &base-worker
     - "com.centurylinklabs.watchtower.enable=true" 
   depends_on:
     girder:
-      condition: service_healthy
+      condition: service_started
     rabbit:
       condition: service_started
 
@@ -55,11 +55,6 @@ services:
       context: ../
       dockerfile: docker/girder.Dockerfile
     image: kitware/viame-web:${TAG:-latest}
-    healthcheck:
-        test: ["CMD", "curl", "-f", "http://localhost:8080"]
-        interval: 5s
-        timeout: 5s
-        retries: 5
     depends_on:
       - mongo
       - traefik


### PR DESCRIPTION
* The girder health check is worthless and spams the access log with 90% empty noise, making logs rather hard to look at.
* Traefik was missing restart:always, so the service doesn't come back up when the server restarts, which was an issue today.