### PR TITLE
Try settings singleton

### DIFF
--- a/client/dive-common/components/Sidebar.vue
+++ b/client/dive-common/components/Sidebar.vue
@@ -3,25 +3,20 @@ import {
   defineComponent,
   reactive,
   toRefs,
-  PropType,
   toRef,
 } from '@vue/composition-api';
 
 import { TypeList, TrackList } from 'vue-media-annotator/components';
 import { useAllTypes, useHandler } from 'vue-media-annotator/provides';
 
+import { clientSettings } from 'dive-common/store/settings';
 import TrackDetailsPanel from 'dive-common/components/TrackDetailsPanel.vue';
 import TrackSettingsPanel from 'dive-common/components/TrackSettingsPanel.vue';
 import TypeSettingsPanel from 'dive-common/components/TypeSettingsPanel.vue';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
-import { AnnotationSettings } from 'dive-common/use/useSettings';
 
 export default defineComponent({
   props: {
-    clientSettings: {
-      type: Object as PropType<AnnotationSettings>,
-      required: true,
-    },
     width: {
       type: Number,
       default: 300,
@@ -36,12 +31,12 @@ export default defineComponent({
     TypeSettingsPanel,
   },
 
-  setup(props) {
+  setup() {
     const allTypesRef = useAllTypes();
     const { toggleMerge, commitMerge } = useHandler();
     const { visible } = usePrompt();
-    const trackSettings = toRef(props.clientSettings, 'trackSettings');
-    const typeSettings = toRef(props.clientSettings, 'typeSettings');
+    const trackSettings = toRef(clientSettings, 'trackSettings');
+    const typeSettings = toRef(clientSettings, 'typeSettings');
 
     const data = reactive({
       currentTab: 'tracks' as 'tracks' | 'attributes',
@@ -107,8 +102,6 @@ export default defineComponent({
           <template slot="settings">
             <type-settings-panel
               :all-types="allTypesRef"
-              :client-settings="clientSettings"
-              @update-settings="$emit('update-settings',$event)"
               @import-types="$emit('import-types',$event)"
             />
           </template>
@@ -127,8 +120,6 @@ export default defineComponent({
           <template slot="settings">
             <track-settings-panel
               :all-types="allTypesRef"
-              :client-settings="clientSettings"
-              @update-settings="$emit('update-settings',$event)"
             />
           </template>
         </track-list>

--- a/client/dive-common/components/TrackSettingsPanel.vue
+++ b/client/dive-common/components/TrackSettingsPanel.vue
@@ -250,7 +250,7 @@ export default defineComponent({
         v-if="clientSettings.trackSettings.newTrackSettings.mode === 'Detection'"
       >
         <v-col>
-          <v-text-field
+          <v-switch
             v-model="
               clientSettings.trackSettings.newTrackSettings.modeSettings.Detection.continuous"
             class="my-0 ml-1 pt-0"

--- a/client/dive-common/components/TrackSettingsPanel.vue
+++ b/client/dive-common/components/TrackSettingsPanel.vue
@@ -250,8 +250,8 @@ export default defineComponent({
         v-if="clientSettings.trackSettings.newTrackSettings.mode === 'Detection'"
       >
         <v-col>
-          <v-switch
-            :input-value="
+          <v-text-field
+            v-model="
               clientSettings.trackSettings.newTrackSettings.modeSettings.Detection.continuous"
             class="my-0 ml-1 pt-0"
             dense

--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -3,12 +3,9 @@ import {
   defineComponent,
   reactive,
   PropType,
-  toRef,
   ref,
 } from '@vue/composition-api';
-
-import { cloneDeep } from 'lodash';
-import { AnnotationSettings } from 'dive-common/use/useSettings';
+import { clientSettings } from 'dive-common/store/settings';
 
 export default defineComponent({
   name: 'TypeSettingsPanel',
@@ -18,14 +15,9 @@ export default defineComponent({
       type: Array as PropType<Array<string>>,
       required: true,
     },
-    clientSettings: {
-      type: Object as PropType<AnnotationSettings>,
-      required: true,
-    },
   },
   setup(props, { emit }) {
-    const typeSettings = toRef(props.clientSettings, 'typeSettings');
-    const itemHeight = ref(45);
+    const itemHeight = 45; // in pixels
     const help = reactive({
       import: 'Import multiple Types',
       showEmptyTypes: 'View types that are not used currently.',
@@ -35,12 +27,6 @@ export default defineComponent({
     const importDialog = ref(false);
     const importTypes = ref('');
 
-    /** Reduces the number of update functions utilizing Vuex by indicating the target type */
-    const saveTypeSettings = (event: boolean, target: 'showEmptyTypes' | 'lockTypes') => {
-      const copy = cloneDeep(props.clientSettings);
-      copy.typeSettings[target] = event; // Modify the value
-      emit('update-settings', copy);
-    };
     const confirmImport = () => {
       // Go through the importTypes and create types for importing
       const types = importTypes.value.split('\n').filter((item) => item.length);
@@ -48,14 +34,14 @@ export default defineComponent({
       importDialog.value = false;
       importTypes.value = '';
     };
+
     return {
-      typeSettings,
+      clientSettings,
       itemHeight,
       help,
       importInstructions,
       importDialog,
       importTypes,
-      saveTypeSettings,
       confirmImport,
     };
   },
@@ -111,12 +97,11 @@ export default defineComponent({
       <v-row>
         <v-col class="py-1">
           <v-switch
-            v-model="typeSettings.showEmptyTypes"
+            v-model="clientSettings.typeSettings.showEmptyTypes"
             class="my-0 ml-1 pt-0"
             dense
             label="Show Empty"
             hide-details
-            @change="saveTypeSettings($event, 'showEmptyTypes')"
           />
         </v-col>
         <v-col
@@ -144,12 +129,11 @@ export default defineComponent({
       <v-row>
         <v-col class="py-1">
           <v-switch
-            v-model="typeSettings.lockTypes"
+            v-model="clientSettings.typeSettings.lockTypes"
             label="Lock Types"
             class="my-0 ml-1 pt-0"
             dense
             hide-details
-            @change="saveTypeSettings($event, 'lockTypes')"
           />
         </v-col>
         <v-col

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -35,7 +35,7 @@ import DeleteControls from 'dive-common/components/DeleteControls.vue';
 import ControlsContainer from 'dive-common/components/ControlsContainer.vue';
 import Sidebar from 'dive-common/components/Sidebar.vue';
 import { useModeManager, useSave } from 'dive-common/use';
-import clientSettingsSetup, { clientSettings } from 'dive-common/store/settings';
+import clientSettingsSetup from 'dive-common/store/settings';
 import { useApi, FrameImage, DatasetType } from 'dive-common/apispec';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { cloneDeep } from 'lodash';
@@ -196,7 +196,6 @@ export default defineComponent({
       editingTrack,
       trackMap,
       mediaController,
-      clientSettings,
       selectTrack,
       selectNextTrack,
       addTrack,
@@ -434,7 +433,6 @@ export default defineComponent({
       loadError,
       mediaController,
       mergeMode: mergeInProgress,
-      clientSettings,
       pendingSaveCount,
       progress,
       progressValue,

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -34,11 +34,8 @@ import UserGuideButton from 'dive-common/components/UserGuideButton.vue';
 import DeleteControls from 'dive-common/components/DeleteControls.vue';
 import ControlsContainer from 'dive-common/components/ControlsContainer.vue';
 import Sidebar from 'dive-common/components/Sidebar.vue';
-import {
-  useModeManager,
-  useSave,
-  useSettings,
-} from 'dive-common/use';
+import { useModeManager, useSave } from 'dive-common/use';
+import clientSettingsSetup, { clientSettings } from 'dive-common/store/settings';
 import { useApi, FrameImage, DatasetType } from 'dive-common/apispec';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { cloneDeep } from 'lodash';
@@ -182,10 +179,7 @@ export default defineComponent({
       filteredTracks,
     });
 
-    const {
-      clientSettings,
-      updateSettings,
-    } = useSettings(allTypes);
+    clientSettingsSetup(allTypes);
 
     // Provides wrappers for actions to integrate with settings
     const {
@@ -459,7 +453,6 @@ export default defineComponent({
       save,
       saveThreshold,
       updateTime,
-      updateSettings,
       updateTypeStyle,
       updateTypeName,
       removeTypeTracks,
@@ -563,8 +556,6 @@ export default defineComponent({
       style="min-width: 700px;"
     >
       <sidebar
-        v-bind="{ clientSettings }"
-        @update-settings="updateSettings($event)"
         @import-types="importTypes($event)"
         @track-seek="mediaController.seek($event)"
       >

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -65,7 +65,6 @@ const storedSettings = JSON.parse(localStorage.getItem('Settings') || '{}');
 const clientSettings = reactive(hydrate(storedSettings));
 
 function saveSettings() {
-  console.log(JSON.stringify(clientSettings));
   localStorage.setItem('Settings', JSON.stringify(clientSettings));
 }
 

--- a/client/dive-common/use/index.ts
+++ b/client/dive-common/use/index.ts
@@ -1,11 +1,9 @@
 import useModeManager from './useModeManager';
 import useSave from './useSave';
-import useSettings from './useSettings';
 import useRequest from './useRequest';
 
 export {
   useModeManager,
   useRequest,
   useSave,
-  useSettings,
 };

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -10,7 +10,7 @@ import { MediaController } from 'vue-media-annotator/components/annotators/media
 
 import Recipe from 'vue-media-annotator/recipe';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
-import { AnnotationSettings } from './useSettings';
+import { clientSettings } from 'dive-common/store/settings';
 
 type SupportedFeature = GeoJSON.Feature<GeoJSON.Point | GeoJSON.Polygon | GeoJSON.LineString>;
 
@@ -32,7 +32,6 @@ export default function useModeManager({
   editingTrack,
   trackMap,
   mediaController,
-  clientSettings,
   recipes,
   selectTrack,
   selectNextTrack,
@@ -43,7 +42,6 @@ export default function useModeManager({
   editingTrack: Ref<boolean>;
   trackMap: Map<TrackId, Track>;
   mediaController: Ref<MediaController>;
-  clientSettings: AnnotationSettings;
   recipes: Recipe[];
   selectTrack: (trackId: TrackId | null, edit: boolean) => void;
   selectNextTrack: (delta?: number) => TrackId | null;


### PR DESCRIPTION
@BryonLewis while reviewing #891 I had an idea to try something.

I think I've abused the composition function pattern in `dive-common` somewhat by representing singleton modules like settings, useSave, and modemanager as composeable when they're really just state and mutation functions.  In desktop, we have the `store/` folder for these, but there are no singleton stores in `dive-common`.

The idea is that anyone who wants to use settings can just `v-model` the imported reactive object, and a watcher inside the store persists changes into localstorage when the settings object updates.

It drops about 100 lines of code and makes settings much more straightforward to use from anywhere in the app, but I'd like to know what you think.  Are there risks to doing it this way?