### PR TITLE
Upgrade to compose 1.28, switch to device requests

### DIFF
--- a/docker/.env.default
+++ b/docker/.env.default
@@ -10,10 +10,6 @@ PUBLIC_DATA_PATH=./girder_data
 GIRDER_ADMIN_USER=admin
 GIRDER_ADMIN_PASS=letmein
 
-# Docker runtime used for worker containers
-# Comment out this line to use default runtime
-WORKER_RUNTIME=nvidia
-
 # Celery connection information
 RABBITMQ_DEFAULT_USER=guest
 RABBITMQ_DEFAULT_PASS=guest

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: "2.4"
+version: "3.8"
 services:
 
   rabbit:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,4 +1,4 @@
-version: "2.4"
+version: "3.8"
 services:
 
   traefik:

--- a/docker/docker-compose.workers.yml
+++ b/docker/docker-compose.workers.yml
@@ -1,8 +1,7 @@
-version: "2.4"
+version: "3.8"
 services:
   # Worker for misc non gpu-bound tasks
   worker:
-    runtime: ${WORKER_RUNTIME}
     ipc: host
     image: kitware/viame-worker:${TAG:-latest}
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,11 @@
 
 # Use YAML anchors for the common config between both workers
 x-worker: &base-worker
-  runtime: ${WORKER_RUNTIME}
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - capabilities: [gpu]
   ipc: host
   build:
     context: ../
@@ -18,7 +22,7 @@ x-worker: &base-worker
     rabbit:
       condition: service_started
 
-version: "2.4"
+version: "3.8"
 services:
 
   traefik:

--- a/docs/Deployment-Docker-Compose.md
+++ b/docs/Deployment-Docker-Compose.md
@@ -26,8 +26,9 @@ SSH into the target server and install these system dependencies.
     You can skip this section if you used Ansible to configure your server, as it already installed all necessary dependencies.
 
 * Install NVIDIA drivers: `sudo ubuntu-drivers install`
-* Install [docker and docker-compose](https://docs.docker.com/engine/install/ubuntu/)
-* Install [nvidia-docker2](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
+* Install `docker` version **19.03+** [guide](https://docs.docker.com/engine/install/ubuntu/)
+* Install `docker-compose` version **1.28.0+** [guide](https://docs.docker.com/compose/install/)
+* Install [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 
 ## Basic deployment
 

--- a/docs/Deployment-Provision.md
+++ b/docs/Deployment-Provision.md
@@ -149,7 +149,7 @@ Once provisioning is complete, jobs should begin processing from the job queue. 
 ssh -i ~/.ssh/gcloud_key viame@ip-address
 
 # Test nvidia docker installation
-docker run --runtime=nvidia --rm nvidia/cuda nvidia-smi
+docker run --gpus=all --rm nvidia/cuda nvidia-smi
 
 # Test regular nvidia runtime
 nvidia-smi


### PR DESCRIPTION
* Compose 1.28+ supports device requests
* So we no longer need to specify a runtime
* We just have to ask for GPUs

This will require an update to the version of compose running in prod