### PR TITLE
Adding in forcing transcode option

### DIFF
--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -765,6 +765,7 @@ async function beginMediaImport(
     globPattern: '',
     mediaConvertList,
     trackFileAbsPath,
+    forceMediaTranscode: false,
     multiCamTrackFiles: null,
   };
 }
@@ -931,12 +932,16 @@ async function finalizeMediaImport(
     mediaConvertList = found.mediaConvertList;
   }
 
+
   if (jsonMeta.type === 'video') {
     // Verify that the user didn't choose an FPS value higher than originalFPS
     // This shouldn't be possible in the UI, but we should still prevent it here.
     jsonMeta.fps = Math.floor(
       Math.max(1, Math.min(jsonMeta.fps, jsonMeta.originalFps)),
     );
+    if (args.forceMediaTranscode) {
+      mediaConvertList.push(npath.join(jsonMeta.originalBasePath, jsonMeta.originalVideoFile));
+    }
   }
 
   //Now we will kick off any conversions that are necessary

--- a/client/platform/desktop/backend/native/multiCamImport.ts
+++ b/client/platform/desktop/backend/native/multiCamImport.ts
@@ -228,6 +228,7 @@ async function beginMultiCamImport(
     globPattern: '',
     mediaConvertList,
     trackFileAbsPath: '',
+    forceMediaTranscode: false,
     multiCamTrackFiles,
   };
 }

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -179,6 +179,7 @@ export interface MediaImportPayload {
   mediaConvertList: string[];
   trackFileAbsPath: string;
   multiCamTrackFiles: null | Record<string, string>;
+  forceMediaTranscode: boolean;
 }
 
 export interface DesktopJobUpdate extends DesktopJob {

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -53,6 +53,15 @@ export default defineComponent({
       }
     };
 
+    const forceMediaTranscode = (event: boolean) => {
+      if (event) {
+        const mediaFile = `${argCopy.value.jsonMeta.originalBasePath}/${argCopy.value.jsonMeta.originalVideoFile}`;
+        Vue.set(argCopy.value, 'mediaConvertList', [mediaFile]);
+      } else {
+        Vue.set(argCopy.value, 'mediaConvertList', []);
+      }
+    };
+
     return {
       argCopy,
       duplicates,
@@ -62,6 +71,7 @@ export default defineComponent({
       MediaTypes,
       FPSOptions,
       openUpload,
+      forceMediaTranscode,
     };
   },
 });
@@ -98,13 +108,22 @@ export default defineComponent({
         to ignore the warning and create a new dataset.
       </v-alert>
       <v-alert
-        v-if="argCopy.mediaConvertList.length"
+        v-if="importData.mediaConvertList.length"
         type="info"
         outlined
         dense
       >
         Found {{ argCopy.mediaConvertList.length }}
         item(s) in this dataset that will be automatically transcoded on import.
+        Dataset will not be available until transcoding is complete.
+      </v-alert>
+      <v-alert
+        v-if="importData.mediaConvertList.length === 0 && argCopy.mediaConvertList.length"
+        type="info"
+        outlined
+        dense
+      >
+        Forcing Transcoding on video.
         Dataset will not be available until transcoding is complete.
       </v-alert>
       <v-row class="d-flex my-2 mt-7">
@@ -202,6 +221,12 @@ export default defineComponent({
           "{{ argCopy.globPattern }}" matches {{ filteredImages.length }}
           out of {{ argCopy.jsonMeta.originalImageFiles.length }} images
         </v-chip>
+        <v-switch
+          v-if="argCopy.jsonMeta.type === 'video'"
+          :disabled="importData.mediaConvertList.length !== 0"
+          label="Force Transcoding"
+          @change="forceMediaTranscode"
+        />
         <p class="my-3">
           New Dataset Properties
         </p>

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -224,7 +224,7 @@ export default defineComponent({
         <v-switch
           v-if="argCopy.jsonMeta.type === 'video'"
           :disabled="importData.mediaConvertList.length !== 0"
-          label="Force Transcoding"
+          label="Force Media Transcoding"
           @change="forceMediaTranscode"
         />
         <p class="my-3">

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -107,7 +107,7 @@ export default defineComponent({
         Dataset will not be available until transcoding is complete.
       </v-alert>
       <v-alert
-        v-if="importData.mediaConvertList.length === 0 && argCopy.mediaConvertList.length"
+        v-if="argCopy.forceMediaTranscode"
         type="info"
         outlined
         dense
@@ -215,6 +215,9 @@ export default defineComponent({
           v-model="argCopy.forceMediaTranscode"
           :disabled="importData.mediaConvertList.length !== 0"
           label="Force Media Transcoding"
+          hint="Transcode media to correct display and
+            frame timing errors"
+          persistent-hint
         />
         <p class="my-3">
           New Dataset Properties

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -52,16 +52,6 @@ export default defineComponent({
         }
       }
     };
-
-    const forceMediaTranscode = (event: boolean) => {
-      if (event) {
-        const mediaFile = `${argCopy.value.jsonMeta.originalBasePath}/${argCopy.value.jsonMeta.originalVideoFile}`;
-        Vue.set(argCopy.value, 'mediaConvertList', [mediaFile]);
-      } else {
-        Vue.set(argCopy.value, 'mediaConvertList', []);
-      }
-    };
-
     return {
       argCopy,
       duplicates,
@@ -71,7 +61,6 @@ export default defineComponent({
       MediaTypes,
       FPSOptions,
       openUpload,
-      forceMediaTranscode,
     };
   },
 });
@@ -223,9 +212,9 @@ export default defineComponent({
         </v-chip>
         <v-switch
           v-if="argCopy.jsonMeta.type === 'video'"
+          v-model="argCopy.forceMediaTranscode"
           :disabled="importData.mediaConvertList.length !== 0"
           label="Force Media Transcoding"
-          @change="forceMediaTranscode"
         />
         <p class="my-3">
           New Dataset Properties


### PR DESCRIPTION
fixes #922 

Added in new Transcode option under the advanced import options.
Transcode will add the video to the `mediaConvertList` (The list that will determine if items are not web safe and should be transcoded, or transcoded for non-square pixels/ frame misalignment).
![Selection_354](https://user-images.githubusercontent.com/61746913/133439980-6faad9ff-546c-423c-b51d-84bea05e1c31.png)

![Selection_355](https://user-images.githubusercontent.com/61746913/133440024-09cea94d-cc9e-4af7-a207-716d97aec751.png)

![Selection_356](https://user-images.githubusercontent.com/61746913/133440041-2d5c96b5-25f8-4e4b-ac70-6ebdc4bd5b0a.png)
