### PR TITLE
Desktop Fixes

### DIFF
--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -462,6 +462,7 @@ export default defineComponent({
       // For Navigation Guarding
       navigateAwayGuard,
       warnBrowserExit,
+      reloadAnnotations,
     };
   },
 });

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -182,7 +182,7 @@ async function runPipeline(
     if (code === 0) {
       try {
         const { attributes } = await common.processOtherAnnotationFiles(
-          settings, datasetId, [trackOutput, detectorOutput], multiOutFiles,
+          settings, datasetId, [detectorOutput, trackOutput], multiOutFiles,
         );
         if (attributes) {
           meta.attributes = attributes;

--- a/client/platform/desktop/frontend/components/Jobs.vue
+++ b/client/platform/desktop/frontend/components/Jobs.vue
@@ -120,7 +120,17 @@ export default defineComponent({
                       <tr>
                         <td>datasets</td>
                         <td>
-                          {{ job.job.datasetIds.join(', ') }}
+                          <span
+                            v-for="dataset in job.job.datasetIds"
+                            :key="dataset"
+                          >
+                            <router-link
+                              class="mr-1"
+                              :to="{ name: 'viewer', params: { id: dataset } }"
+                            >
+                              {{ dataset }}
+                            </router-link>
+                          </span>
                         </td>
                       </tr>
                       <tr>

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -51,7 +51,7 @@ export default defineComponent({
 
     watch(runningJobs, async (_previous, current) => {
       const index = current.findIndex((item) => item.job.datasetIds.includes(props.id));
-      if (index !== -1 && current[index] && current[index].job.exitCode !== -1) {
+      if (index !== -1 && current[index] && current[index].job.exitCode !== -1 && current[index].job.jobType === 'pipeline') {
         const result = await prompt({
           title: 'Pipeline Finished',
           text: [`Pipeline: ${current[index].job.title}`,

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -50,11 +50,11 @@ export default defineComponent({
     const readonlyMode = computed(() => settings.value?.readonlyMode || false);
 
     watch(runningJobs, async (_previous, current) => {
-      const index = current.findIndex((item) => item.job.datasetIds.includes(props.id));
-      if (index !== -1 && current[index] && current[index].job.exitCode !== -1 && current[index].job.jobType === 'pipeline') {
+      const currentJob = current.find((item) => item.job.datasetIds.includes(props.id));
+      if (currentJob && currentJob.job.exitCode !== -1 && currentJob.job.jobType === 'pipeline') {
         const result = await prompt({
           title: 'Pipeline Finished',
-          text: [`Pipeline: ${current[index].job.title}`,
+          text: [`Pipeline: ${currentJob.job.title}`,
             'finished running sucesffully on the current dataset.  Click reload to load the annotations.  The current annotations will be replaced with the pipeline output.',
           ],
           confirm: true,

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -1,15 +1,20 @@
 <script lang="ts">
-import { computed, defineComponent, ref } from '@vue/composition-api';
+import {
+  computed, defineComponent, ref, watch,
+} from '@vue/composition-api';
 
 import Viewer from 'dive-common/components/Viewer.vue';
 import RunPipelineMenu from 'dive-common/components/RunPipelineMenu.vue';
 import ImportAnnotations from 'dive-common//components/ImportAnnotations.vue';
 
+import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import Export from './Export.vue';
 import JobTab from './JobTab.vue';
 
 import { datasets } from '../store/dataset';
 import { settings } from '../store/settings';
+
+import { runningJobs } from '../store/jobs';
 
 const buttonOptions = {
   outlined: true,
@@ -38,11 +43,29 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const { prompt } = usePrompt();
     const viewerRef = ref();
     const compoundId = ref(props.id);
     const subTypeList = computed(() => [datasets.value[props.id]?.subType || null]);
     const readonlyMode = computed(() => settings.value?.readonlyMode || false);
 
+    watch(runningJobs, async (_previous, current) => {
+      const index = current.findIndex((item) => item.job.datasetIds.includes(props.id));
+      if (index !== -1 && current[index] && current[index].job.exitCode !== -1) {
+        const result = await prompt({
+          title: 'Pipeline Finished',
+          text: [`Pipeline: ${current[index].job.title}`,
+            'finished running sucesffully on the current dataset.  Click reload to load the annotations.  The current annotations will be replaced with the pipeline output.',
+          ],
+          confirm: true,
+          positiveButton: 'Reload',
+          negativeButton: 'Cancel',
+        });
+        if (result) {
+          viewerRef.value.reloadAnnotations();
+        }
+      }
+    });
     return {
       datasets,
       compoundId,
@@ -60,7 +83,7 @@ export default defineComponent({
   <Viewer
     :id.sync="compoundId"
     ref="viewerRef"
-    :read-only-mode="readonlyMode"
+    :readonly-mode="readonlyMode"
   >
     <template #title>
       <v-tabs


### PR DESCRIPTION
fixes #939 
Was fixed by swapping the order of the `detectorOutput, trackOutput` in the `processOtherAnnotationFiles` to cause it to load them in sequence where if the `trackOutput` exists it is the final result.

fixes #937
Simple fix with a text error on the attribute.  Swapped `read-only-mode` to  `readonly-mode`

fixes #924 
In the `ViewerLoader.vue` placed a watcher on the jobs queue.  Will check to see if a job with which contains the same ID as the currently loaded one if it has completed successfully and if the jobType is a pipeline.  If all those conditions are met it will prompt the user telling that it is complete and if they want to reload the annotation.  Then it calls the standard reloadAnnotation function used for stereo and importing.
![image](https://user-images.githubusercontent.com/61746913/134908385-ed67b431-0837-44d4-a1a4-a2ccb90f5581.png)

fixes #940 
Changed the list in the jobs panel to include links to the datasets used in the job.  Currently there was a list of jobIds that represented datasets being used.  Clicking on them now will take the user to that dataset and open it up.
![image](https://user-images.githubusercontent.com/61746913/134909022-f56bc5e2-115c-434f-a25c-16fa17a20e45.png)
