### PR TITLE
COCO Import Fix

### DIFF
--- a/server/dive_server/crud.py
+++ b/server/dive_server/crud.py
@@ -139,11 +139,12 @@ def get_data_by_type(
                 raise RestException('No array-type json objects are supported')
             if kwcoco.is_coco_json(data_dict):
                 as_type = FileType.COCO_JSON
-            try:
-                data_dict = models.MetadataMutable(**data_dict).dict(exclude_none=True)
-                as_type = FileType.DIVE_CONF
-            except pydantic.ValidationError:
-                as_type = FileType.DIVE_JSON
+            else:
+                try:
+                    data_dict = models.MetadataMutable(**data_dict).dict(exclude_none=True)
+                    as_type = FileType.DIVE_CONF
+                except pydantic.ValidationError:
+                    as_type = FileType.DIVE_JSON
         else:
             raise RestException('Got file of unknown and unusable type')
 

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -12,7 +12,7 @@ from . import viame
 
 def is_coco_json(coco: Dict[str, Any]):
     # Required COCO fields according to https://cocodataset.org/#format-data
-    keys = ['info', 'images', 'annotations', 'licenses', 'categories']
+    keys = ['info', 'images', 'annotations', 'categories']
     return all(key in coco for key in keys)
 
 


### PR DESCRIPTION
Fixes #981

COCO import was failing because it was interpreted as metadata instead of COCO.
The user who brought this to our attention also had data that didn't have a `licenses` field in their COCO.

https://viame.kitware.com/girder#user/5e71179478ed364cd0fd30e3/folder/6160b9a724bf0e97a9e05e8b
You can test using this dataset downloaded from here.