### PR TITLE
Adding Desktop Job Cancel Button

### DIFF
--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -7,6 +7,7 @@ import {
   MediaImportPayload,
 } from 'platform/desktop/constants';
 
+import { stopProcess } from 'platform/desktop/backend/native/processManager';
 import linux from './native/linux';
 import win32 from './native/windows';
 import * as common from './native/common';
@@ -126,4 +127,6 @@ export default function register() {
     };
     return currentPlatform.train(settings.get(), args, updater);
   });
+
+  ipcMain.handle('cancel-job', async (event, pid: number) => stopProcess(pid));
 }

--- a/client/platform/desktop/backend/native/mediaJobs.ts
+++ b/client/platform/desktop/backend/native/mediaJobs.ts
@@ -201,6 +201,7 @@ async function convertMedia(settings: Settings,
     workingDir: jobWorkDir,
     datasetIds: [args.meta.id],
     exitCode: job.exitCode,
+    signal: null,
     startTime: new Date(),
   };
 

--- a/client/platform/desktop/backend/native/processManager.ts
+++ b/client/platform/desktop/backend/native/processManager.ts
@@ -37,6 +37,12 @@ function close(child: ChildProcess): Promise<void> {
   return onclose;
 }
 
+async function stopProcess(pid: number): Promise<void> {
+  const job = children.find((proc) => proc.pid === pid);
+  if (job !== undefined) {
+    await close(job);
+  }
+}
 /**
  * Stop all remaining child processes
  */
@@ -49,4 +55,5 @@ export {
   observeChild,
   close,
   closeAll,
+  stopProcess,
 };

--- a/client/platform/desktop/backend/native/utils.ts
+++ b/client/platform/desktop/backend/native/utils.ts
@@ -32,7 +32,12 @@ function jobFileEchoMiddleware(
 }
 
 function spawnResult(command: string, shell: boolean | string, args: string[] = []):
-Promise<{ output: null | string; exitCode: number | null; error: string}> {
+Promise<{
+  output: null | string;
+  exitCode: number | null;
+  signal: NodeJS.Signals| null;
+  error: string;
+}> {
   return new Promise((resolve) => {
     const proc = observeChild(spawn(command, args, { shell }));
     let output = '';
@@ -45,10 +50,11 @@ Promise<{ output: null | string; exitCode: number | null; error: string}> {
       error = error.concat(chunk.toString('utf-8'));
     });
 
-    proc.on('exit', (exitCode) => {
+    proc.on('exit', (exitCode, signal) => {
       resolve({
         output,
         exitCode,
+        signal,
         error,
       });
     });
@@ -56,6 +62,7 @@ Promise<{ output: null | string; exitCode: number | null; error: string}> {
       resolve({
         output: null,
         exitCode: -1,
+        signal: null,
         error: err.message,
       });
     });

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -165,6 +165,7 @@ async function runPipeline(
     workingDir: jobWorkDir,
     datasetIds: [datasetId],
     exitCode: job.exitCode,
+    signal: null,
     startTime: new Date(),
   };
 
@@ -178,7 +179,7 @@ async function runPipeline(
   job.stdout.on('data', jobFileEchoMiddleware(jobBase, updater, joblog));
   job.stderr.on('data', jobFileEchoMiddleware(jobBase, updater, joblog));
 
-  job.on('exit', async (code) => {
+  job.on('exit', async (code, signal) => {
     if (code === 0) {
       try {
         const { attributes } = await common.processOtherAnnotationFiles(
@@ -196,6 +197,7 @@ async function runPipeline(
       ...jobBase,
       body: [''],
       exitCode: code,
+      signal,
       endTime: new Date(),
     });
   });
@@ -311,6 +313,7 @@ async function train(
     workingDir: jobWorkDir,
     datasetIds: runTrainingArgs.datasetIds,
     exitCode: job.exitCode,
+    signal: null,
     startTime: new Date(),
   };
 
@@ -323,7 +326,7 @@ async function train(
 
   job.stdout.on('data', jobFileEchoMiddleware(jobBase, updater, joblog));
   job.stderr.on('data', jobFileEchoMiddleware(jobBase, updater, joblog));
-  job.on('exit', async (code) => {
+  job.on('exit', async (code, signal) => {
     let exitCode = code;
     const bodyText = [''];
     if (code === 0) {
@@ -344,6 +347,7 @@ async function train(
       ...jobBase,
       body: bodyText,
       exitCode,
+      signal,
       endTime: new Date(),
     });
   });

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -167,6 +167,8 @@ export interface DesktopJob {
   workingDir: string;
   // exitCode if set, the job exited already
   exitCode: number | null;
+  // signal if sent to the job
+  signal: NodeJS.Signals | null;
   // startTime time of process initialization
   startTime: Date;
   // endTime time of process exit

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -115,6 +115,10 @@ function finalizeImport(args: MediaImportPayload): Promise<JsonMeta> {
   return ipcRenderer.invoke('finalize-import', args);
 }
 
+function cancelJob(pid: number): Promise<JsonMeta> {
+  return ipcRenderer.invoke('cancel-job', pid);
+}
+
 async function exportDataset(
   id: string, exclude: boolean, typeFilter: readonly string[],
 ): Promise<string> {
@@ -192,4 +196,5 @@ export {
   importMultiCam,
   openLink,
   nvidiaSmi,
+  cancelJob,
 };

--- a/client/platform/desktop/frontend/store/jobs.ts
+++ b/client/platform/desktop/frontend/store/jobs.ts
@@ -20,7 +20,9 @@ interface DesktopJobHistory {
 const truncateOutputAtLines = 500;
 const jobHistory: Ref<Record<string, DesktopJobHistory>> = ref({});
 const recentHistory = computed(() => Object.values(jobHistory.value));
-const runningJobs = computed(() => recentHistory.value.filter((v) => v.job.exitCode === null));
+const runningJobs = computed(() => recentHistory.value.filter(
+  ((v) => v.job.exitCode === null && v.job.signal === null),
+));
 
 function updateHistory(args: DesktopJobUpdate) {
   let existing = jobHistory.value[args.key];
@@ -40,6 +42,7 @@ function updateHistory(args: DesktopJobUpdate) {
   }
   existing.job.exitCode = args.exitCode;
   existing.job.endTime = args.endTime;
+  existing.job.signal = args.signal;
 }
 
 const conversionJob: Ref<Record<string, boolean>> = ref({});

--- a/client/src/@types/vue-utilities.d.ts
+++ b/client/src/@types/vue-utilities.d.ts
@@ -1,4 +1,5 @@
 import Vue2 from 'vue';
+
 declare module 'vue/types/vue' {
   interface Vue {
     $promptAttach(): Vue2;


### PR DESCRIPTION
fixes #959 

![image](https://user-images.githubusercontent.com/61746913/136818758-54912085-d020-463c-a9d9-0572e6e3076a.png)

- Utilizes existing `processManager.ts` to cancel a Job by it's PID
- A job cancelled in Node JS still retains an exitCode of `null` but will also return a `signal` to indicate how it terminated.  To determine the true state of a process as running or terminated you need both the exitCode and the signal. See: [NodeJS ChildProcess Event: 'exit'](https://nodejs.org/api/child_process.html#child_process_event_exit)
- Updated the `DesktopJob` interface to include the signal.
- This signal value gets populated on Job `'exit'` event.  
- Updates were made to `Job.vue` to handle the fact that state is now determined by a combination of `exitCode` and `signal` meaning that both need to be null to indicate a running process and that a `exitCode === null && signal === 'SIGTERM'` means that the user cancelled the process.
- Added in the Stop Job Button (Debating on adding a confirmation dialog to prevent accidental cancelling)
- Added display information to a job status, indicating that it was a success, User Canceled, or Error state.