### PR TITLE
Remove Acks Late due to Rabbit 3.8.15 conflict

### DIFF
--- a/server/dive_tasks/celeryconfig.py
+++ b/server/dive_tasks/celeryconfig.py
@@ -58,5 +58,6 @@ task_ignore_result = True
 
 # https://docs.celeryproject.org/en/stable/userguide/configuration.html#std-setting-task_reject_on_worker_lost
 # Run tasks at least once, rescheduling them if the worker crashes.
-task_reject_on_worker_lost = True
-task_acks_late = True
+# TODO: had to abandon due to https://github.com/Kitware/dive/issues/995
+# task_reject_on_worker_lost = True
+# task_acks_late = True


### PR DESCRIPTION
This is an undesirable hack.  Amazon MQ won't let us change the configuration value to bump this to something reasonable.

We should either abandon Amazon MQ or come up with another workaround.  This will get jobs working again.