### PR TITLE
Replace all uses of `vue-media-annotator` alias under src/ with relative imports

### DIFF
--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { defineComponent, watch, PropType } from '@vue/composition-api';
 
-import { TrackWithContext } from 'vue-media-annotator/use/useTrackFilters';
+import { TrackWithContext } from '../use/useTrackFilters';
 import { injectMediaController } from './annotators/useMediaController';
 import RectangleLayer from '../layers/AnnotationLayers/RectangleLayer';
 import PolygonLayer from '../layers/AnnotationLayers/PolygonLayer';

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -4,8 +4,8 @@ import {
   defineComponent, reactive, computed, ref, Ref, watch,
 } from '@vue/composition-api';
 
-import { TrackWithContext } from 'vue-media-annotator/use/useTrackFilters';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
+import { TrackWithContext } from '../use/useTrackFilters';
 
 import { TrackId } from '../track';
 import {

--- a/client/src/components/TypeEditor.vue
+++ b/client/src/components/TypeEditor.vue
@@ -3,7 +3,7 @@ import {
   defineComponent, reactive, toRef, watch,
 } from '@vue/composition-api';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
-import { useHandler, useTypeStyling, useUsedTypes } from 'vue-media-annotator/provides';
+import { useHandler, useTypeStyling, useUsedTypes } from '../provides';
 
 export default defineComponent({
   name: 'TypeEditor',

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -3,11 +3,11 @@ import {
   computed, defineComponent, reactive, Ref,
 } from '@vue/composition-api';
 
+import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import {
   useCheckedTypes, useAllTypes, useTypeStyling, useHandler,
   useUsedTypes, useFilteredTracks, useConfidenceFilters,
-} from 'vue-media-annotator/provides';
-import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
+} from '../provides';
 import TooltipBtn from './TooltipButton.vue';
 import TypeEditor from './TypeEditor.vue';
 

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -2,7 +2,7 @@
 import {
   defineComponent, ref, onUnmounted, PropType, toRef, watch,
 } from '@vue/composition-api';
-import { SetTimeFunc } from 'vue-media-annotator/use/useTimeObserver';
+import { SetTimeFunc } from '../../use/useTimeObserver';
 import useMediaController from './useMediaController';
 
 export interface ImageDataItem {

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -3,7 +3,7 @@ import {
   defineComponent, onBeforeUnmount, PropType, toRef, watch,
 } from '@vue/composition-api';
 
-import { Flick, SetTimeFunc } from 'vue-media-annotator/use/useTimeObserver';
+import { Flick, SetTimeFunc } from '../../use/useTimeObserver';
 import useMediaController from './useMediaController';
 
 /**

--- a/client/src/components/annotators/useMediaController.ts
+++ b/client/src/components/annotators/useMediaController.ts
@@ -4,8 +4,8 @@ import geo from 'geojs';
 import {
   ref, reactive, onMounted, onBeforeUnmount, provide, toRef, Ref,
 } from '@vue/composition-api';
-import { use } from 'vue-media-annotator/provides';
 
+import { use } from '../../provides';
 import type { MediaController } from './mediaControllerType';
 
 const MediaControllerSymbol = Symbol('media-controller');

--- a/client/src/layers/TextLayer.ts
+++ b/client/src/layers/TextLayer.ts
@@ -1,4 +1,4 @@
-import { TypeStyling } from 'vue-media-annotator/use/useStyling';
+import { TypeStyling } from '../use/useStyling';
 import BaseLayer, { BaseLayerParams, LayerStyle } from './BaseLayer';
 import { FrameDataTrack } from './LayerTypes';
 

--- a/client/src/use/useEventChart.ts
+++ b/client/src/use/useEventChart.ts
@@ -1,6 +1,6 @@
 
 import { computed, Ref } from '@vue/composition-api';
-import { TrackWithContext } from 'vue-media-annotator/use/useTrackFilters';
+import { TrackWithContext } from './useTrackFilters';
 import { TrackId } from '../track';
 import { TypeStyling } from './useStyling';
 

--- a/client/src/use/useLineChart.ts
+++ b/client/src/use/useLineChart.ts
@@ -1,5 +1,5 @@
 import { computed, Ref } from '@vue/composition-api';
-import { TrackWithContext } from 'vue-media-annotator/use/useTrackFilters';
+import { TrackWithContext } from './useTrackFilters';
 import { TypeStyling } from './useStyling';
 
 interface UseLineChartParams {

--- a/client/src/use/useTrackSelectionControls.ts
+++ b/client/src/use/useTrackSelectionControls.ts
@@ -1,5 +1,5 @@
 import { computed, ref, Ref } from '@vue/composition-api';
-import { TrackWithContext } from 'vue-media-annotator/use/useTrackFilters';
+import { TrackWithContext } from './useTrackFilters';
 import { TrackId } from '../track';
 /* Maintain references to the selected Track, selected detection,
  * editing state, etc.


### PR DESCRIPTION
When using `vue-media-annotator` externally, attempting to import anything from `src/layers/TextLayer.ts` (in my case the `TextData` type), the following error is thrown:

```
1:29 Cannot find module 'vue-media-annotator/use/useStyling' or its corresponding type declarations.
  > 1 | import { TypeStyling } from 'vue-media-annotator/use/useStyling';
      |                             ^
    2 | import BaseLayer, { BaseLayerParams, LayerStyle } from './BaseLayer';
    3 | import { FrameDataTrack } from './LayerTypes';
    4 | 
```

I suspect this is due to the fact that in the project itself, `vue-media-annotator` is an alias to the `src` directory.
This PR just replaces that with the use of a relative path.