### PR TITLE
Fix #1028

### DIFF
--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -127,9 +127,7 @@ interface ValidationResponse {
 }
 
 function validateUploadGroup(names: string[]) {
-  return girderRest.get<ValidationResponse>('dive_dataset/validate_files', {
-    params: { files: JSON.stringify(names) },
-  });
+  return girderRest.post<ValidationResponse>('dive_dataset/validate_files', names);
 }
 
 

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -33,7 +33,7 @@ class DatasetResource(Resource):
         self.route("GET", (":id", "media"), self.get_media)
         self.route("GET", (":id", "export"), self.export)
         self.route("GET", (":id", "configuration"), self.get_configuration)
-        self.route("GET", ("validate_files",), self.validate_files)
+        self.route("POST", ("validate_files",), self.validate_files)
 
         self.route("PATCH", (":id",), self.patch_metadata)
 
@@ -204,7 +204,7 @@ class DatasetResource(Resource):
     @access.user
     @autoDescribeRoute(
         Description("Test whether or not a set of files are safe to upload").jsonParam(
-            "files", "", paramType="query", requireArray=True
+            "files", "", paramType="body", requireArray=True
         )
     )
     def validate_files(self, files):

--- a/server/tests/integration/test_dataset_upload.py
+++ b/server/tests/integration/test_dataset_upload.py
@@ -30,6 +30,10 @@ def test_upload_user_data(user: dict):
             },
         )
         createdDatasets.append(newDatasetFolder)
+        # Validate the fileset
+        filenames = [file.name for file in dsPath.iterdir()]
+        valid = client.post('dive_dataset/validate_files', json=filenames)
+        assert valid['ok'], f'File validation failed'
         for file in dsPath.iterdir():
             if file.is_file():
                 client.uploadFileToFolder(newDatasetFolder['_id'], str(file))

--- a/server/tests/integration/test_dataset_upload.py
+++ b/server/tests/integration/test_dataset_upload.py
@@ -33,7 +33,7 @@ def test_upload_user_data(user: dict):
         # Validate the fileset
         filenames = [file.name for file in dsPath.iterdir()]
         valid = client.post('dive_dataset/validate_files', json=filenames)
-        assert valid['ok'], f'File validation failed'
+        assert valid['ok'], 'File validation failed'
         for file in dsPath.iterdir():
             if file.is_file():
                 client.uploadFileToFolder(newDatasetFolder['_id'], str(file))


### PR DESCRIPTION
Switch to POST for file validation so that params can be sent as json body.  

Read https://stackoverflow.com/questions/978061/http-get-with-request-body

Apparently elastic search uses GET with body, but cherrypy didn't like this, and it's not totally good with the HTTP spec.  POST is harmless here.

fixes #1028