### PR TITLE
Possible changes to Virtual Type List

### DIFF
--- a/client/dive-common/components/Sidebar.vue
+++ b/client/dive-common/components/Sidebar.vue
@@ -126,6 +126,7 @@ export default defineComponent({
         <TypeList
           :show-empty-types="typeSettings.showEmptyTypes"
           :height="data.typeHeight"
+          :width="width"
           class="flex-shrink-1 flex-grow-1"
         >
           <template slot="settings">

--- a/client/dive-common/components/Sidebar.vue
+++ b/client/dive-common/components/Sidebar.vue
@@ -2,8 +2,8 @@
 import {
   defineComponent,
   reactive,
-  toRefs,
   toRef,
+  watch,
 } from '@vue/composition-api';
 
 import { TypeList, TrackList } from 'vue-media-annotator/components';
@@ -15,11 +15,19 @@ import TrackSettingsPanel from 'dive-common/components/TrackSettingsPanel.vue';
 import TypeSettingsPanel from 'dive-common/components/TypeSettingsPanel.vue';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 
+/* Magic numbers used in height calculations */
+const toolbarHeight = 112;
+const confidenceThresholdHeight = 52;
+
 export default defineComponent({
   props: {
     width: {
       type: Number,
       default: 300,
+    },
+    enableSlot: {
+      type: Boolean,
+      default: false,
     },
   },
 
@@ -31,7 +39,7 @@ export default defineComponent({
     TypeSettingsPanel,
   },
 
-  setup() {
+  setup(props) {
     const allTypesRef = useAllTypes();
     const { toggleMerge, commitMerge } = useHandler();
     const { visible } = usePrompt();
@@ -40,6 +48,8 @@ export default defineComponent({
 
     const data = reactive({
       currentTab: 'tracks' as 'tracks' | 'attributes',
+      typeHeight: 0,
+      trackHeight: 0,
     });
 
     function swapTabs() {
@@ -55,15 +65,30 @@ export default defineComponent({
         data.currentTab = 'attributes';
       }
     }
+
+    function onResize() {
+      const totalHeight = window.innerHeight - toolbarHeight;
+      data.typeHeight = Math.floor(totalHeight * 0.45);
+      data.trackHeight = Math.floor(totalHeight * 0.55);
+      if (props.enableSlot) {
+        data.typeHeight -= confidenceThresholdHeight;
+      }
+    }
+    onResize();
+    watch(toRef(props, 'enableSlot'), onResize);
+
     return {
+      /* data */
       allTypesRef,
+      commitMerge,
+      data,
       trackSettings,
       typeSettings,
-      swapTabs,
-      doToggleMerge,
-      commitMerge,
-      ...toRefs(data),
       visible,
+      /* methods */
+      doToggleMerge,
+      onResize,
+      swapTabs,
     };
   },
 });
@@ -71,6 +96,7 @@ export default defineComponent({
 
 <template>
   <v-card
+    v-resize="onResize"
     :width="width"
     tile
     outlined
@@ -93,13 +119,13 @@ export default defineComponent({
     </v-btn>
     <v-slide-x-transition>
       <div
-        v-if="currentTab === 'tracks'"
+        v-if="data.currentTab === 'tracks'"
         key="type-tracks"
         class="wrapper d-flex flex-column"
       >
         <TypeList
-          id="typelist"
           :show-empty-types="typeSettings.showEmptyTypes"
+          :height="data.typeHeight"
           class="flex-shrink-1 flex-grow-1"
         >
           <template slot="settings">
@@ -109,7 +135,7 @@ export default defineComponent({
             />
           </template>
         </TypeList>
-        <slot />
+        <slot v-if="enableSlot" />
         <v-divider />
         <TrackList
           class="flex-grow-0 flex-shrink-0"
@@ -117,6 +143,7 @@ export default defineComponent({
           :new-track-type="trackSettings.newTrackSettings.type"
           :lock-types="typeSettings.lockTypes"
           :hotkeys-disabled="visible()"
+          :height="data.trackHeight"
           @track-seek="$emit('track-seek', $event)"
         >
           <template slot="settings">
@@ -127,7 +154,7 @@ export default defineComponent({
         </TrackList>
       </div>
       <track-details-panel
-        v-else-if="currentTab === 'attributes'"
+        v-else-if="data.currentTab === 'attributes'"
         :lock-types="typeSettings.lockTypes"
         :hotkeys-disabled="visible()"
         :width="width"
@@ -141,10 +168,6 @@ export default defineComponent({
 </template>
 
 <style scoped>
-#typelist {
-  min-height: 310px;
-}
-
 .sidebar {
   max-height: calc(100vh - 112px);
 }

--- a/client/dive-common/components/TrackSettingsPanel.vue
+++ b/client/dive-common/components/TrackSettingsPanel.vue
@@ -47,52 +47,12 @@ export default defineComponent({
 </script>
 
 <template>
-  <div class="TrackSettings mb-2">
+  <div class="TrackSettings">
     <v-card
       outlined
-      class="pa-2 pb-0 mt-3"
-    >
-      <div class="subheading">
-        Deletion Settings
-      </div>
-      <v-row
-        align="end"
-        dense
-      >
-        <v-col class="py-1">
-          <v-switch
-            v-model="clientSettings.trackSettings.deletionSettings.promptUser"
-            class="my-0 ml-1 pt-0"
-            dense
-            label="Prompt User"
-            hide-details
-          />
-        </v-col>
-        <v-col
-          cols="2"
-          class="py-1"
-          align="right"
-        >
-          <v-tooltip
-            open-delay="200"
-            bottom
-          >
-            <template #activator="{ on }">
-              <v-icon
-                small
-                v-on="on"
-              >
-                mdi-help
-              </v-icon>
-            </template>
-            <span>{{ help.prompt }}</span>
-          </v-tooltip>
-        </v-col>
-      </v-row>
-    </v-card>
-    <v-card
-      outlined
-      class="pa-2 pb-0 mt-3"
+      class="pa-2"
+      width="300"
+      color="blue-grey darken-3"
     >
       <div class="subheading">
         New Annotation Settings
@@ -143,6 +103,7 @@ export default defineComponent({
       <v-row
         align="end"
         dense
+        class="mb-2"
       >
         <v-col
           class="mx-2"
@@ -180,74 +141,74 @@ export default defineComponent({
           </v-tooltip>
         </v-col>
       </v-row>
-      <v-row
-        v-if="clientSettings.trackSettings.newTrackSettings.mode === 'Track'"
-      >
-        <v-col class="py-1">
-          <v-switch
-            v-model="
-              clientSettings.trackSettings.newTrackSettings.modeSettings.Track.autoAdvanceFrame"
-            class="my-0 ml-1 pt-0"
-            dense
-            label="Advance Frame"
-            hide-details
-          />
-        </v-col>
-        <v-col
-          cols="2"
-          class="py-1"
-          align="right"
-        >
-          <v-tooltip
-            open-delay="200"
-            bottom
+      <template v-if="clientSettings.trackSettings.newTrackSettings.mode === 'Track'">
+        <v-row>
+          <v-col class="py-1">
+            <v-switch
+              v-model="
+                clientSettings.trackSettings.newTrackSettings.modeSettings.Track.autoAdvanceFrame"
+              class="my-0 ml-1 pt-0"
+              dense
+              label="Advance Frame"
+              hide-details
+            />
+          </v-col>
+          <v-col
+            class="py-1 shrink"
+            align="right"
           >
-            <template #activator="{ on }">
-              <v-icon
-                small
-                v-on="on"
-              >
-                mdi-help
-              </v-icon>
-            </template>
-            <span>{{ help.autoAdvanceFrame }}</span>
-          </v-tooltip>
-        </v-col>
-        <v-col class="py-1">
-          <v-switch
-            v-model="
-              clientSettings.trackSettings.newTrackSettings.modeSettings.Track.interpolate"
-            class="my-0 ml-1 pt-0"
-            dense
-            label="Interpolate"
-            hide-details
-          />
-        </v-col>
-        <v-col
-          cols="2"
-          class="py-1"
-          align="right"
-        >
-          <v-tooltip
-            open-delay="200"
-            bottom
+            <v-tooltip
+              open-delay="200"
+              bottom
+            >
+              <template #activator="{ on }">
+                <v-icon
+                  small
+                  v-on="on"
+                >
+                  mdi-help
+                </v-icon>
+              </template>
+              <span>{{ help.autoAdvanceFrame }}</span>
+            </v-tooltip>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col class="py-1">
+            <v-switch
+              v-model="
+                clientSettings.trackSettings.newTrackSettings.modeSettings.Track.interpolate"
+              class="my-0 ml-1 pt-0"
+              dense
+              label="Interpolate"
+              hide-details
+            />
+          </v-col>
+          <v-col
+            class="py-1 shrink"
+            align="right"
           >
-            <template #activator="{ on }">
-              <v-icon
-                small
-                v-on="on"
-              >
-                mdi-help
-              </v-icon>
-            </template>
-            <span>{{ help.interpolate }}</span>
-          </v-tooltip>
-        </v-col>
-      </v-row>
+            <v-tooltip
+              open-delay="200"
+              bottom
+            >
+              <template #activator="{ on }">
+                <v-icon
+                  small
+                  v-on="on"
+                >
+                  mdi-help
+                </v-icon>
+              </template>
+              <span>{{ help.interpolate }}</span>
+            </v-tooltip>
+          </v-col>
+        </v-row>
+      </template>
       <v-row
         v-if="clientSettings.trackSettings.newTrackSettings.mode === 'Detection'"
       >
-        <v-col>
+        <v-col class="py-1">
           <v-switch
             v-model="
               clientSettings.trackSettings.newTrackSettings.modeSettings.Detection.continuous"
@@ -257,7 +218,10 @@ export default defineComponent({
             hide-details
           />
         </v-col>
-        <v-col cols="2">
+        <v-col
+          class="py-1 shrink"
+          align="right"
+        >
           <v-tooltip
             open-delay="200"
             bottom
@@ -271,6 +235,44 @@ export default defineComponent({
               </v-icon>
             </template>
             <span>{{ help.continuous }}</span>
+          </v-tooltip>
+        </v-col>
+      </v-row>
+      <v-divider class="my-2" />
+      <div class="subheading">
+        Deletion Settings
+      </div>
+      <v-row
+        align="end"
+        dense
+      >
+        <v-col class="py-1">
+          <v-switch
+            v-model="clientSettings.trackSettings.deletionSettings.promptUser"
+            class="my-0 ml-1 pt-0"
+            dense
+            label="Prompt User"
+            hide-details
+          />
+        </v-col>
+        <v-col
+          cols="2"
+          class="py-1"
+          align="right"
+        >
+          <v-tooltip
+            open-delay="200"
+            bottom
+          >
+            <template #activator="{ on }">
+              <v-icon
+                small
+                v-on="on"
+              >
+                mdi-help
+              </v-icon>
+            </template>
+            <span>{{ help.prompt }}</span>
           </v-tooltip>
         </v-col>
       </v-row>

--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -52,7 +52,7 @@ export default defineComponent({
   <div>
     <v-card
       outlined
-      class="pa-2 pr-4 type-settings"
+      class="pa-2 pr-4"
       color="blue-grey darken-3"
     >
       <div>
@@ -223,9 +223,3 @@ export default defineComponent({
     </v-dialog>
   </div>
 </template>
-
-<style scoped lang='scss'>
-.type-settings {
- font-size: 0.875rem !important;
-}
-</style>

--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -49,10 +49,11 @@ export default defineComponent({
 </script>
 
 <template>
-  <v-container class="px-1">
+  <div>
     <v-card
       outlined
-      class="px-2 pb-0 mx-0 mt-3 type-settings"
+      class="pa-2 pr-4 type-settings"
+      color="blue-grey darken-3"
     >
       <div>
         Type Settings
@@ -220,13 +221,11 @@ export default defineComponent({
         </v-card>
       </div>
     </v-dialog>
-  </v-container>
+  </div>
 </template>
 
 <style scoped lang='scss'>
 .type-settings {
  font-size: 0.875rem !important;
 }
-
-
 </style>

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -561,23 +561,25 @@ export default defineComponent({
       style="min-width: 700px;"
     >
       <sidebar
+        :enable-slot="context.state.active !== 'TypeThreshold'"
         @import-types="importTypes($event)"
         @track-seek="mediaController.seek($event)"
       >
-        <v-divider />
-        <ConfidenceFilter
-          v-if="context.state.active !== 'TypeThreshold'"
-          class="ma-2 mb-0"
-          :confidence.sync="confidenceFilters.default"
-          @end="saveThreshold"
-        >
-          <a
-            style="text-decoration: underline; color: white;"
-            @click="context.toggle('TypeThreshold')"
+        <template v-if="context.state.active !== 'TypeThreshold'">
+          <v-divider />
+          <ConfidenceFilter
+            class="ma-2 mb-0"
+            :confidence.sync="confidenceFilters.default"
+            @end="saveThreshold"
           >
-            Advanced
-          </a>
-        </ConfidenceFilter>
+            <a
+              style="text-decoration: underline; color: white;"
+              @click="context.toggle('TypeThreshold')"
+            >
+              Advanced
+            </a>
+          </ConfidenceFilter>
+        </template>
       </sidebar>
       <v-col style="position: relative">
         <component

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -221,6 +221,8 @@ export default defineComponent({
       ];
     });
 
+    const virtualHeight = computed(() => props.height - 52);
+
     return {
       allTypes: allTypesRef,
       data,
@@ -229,6 +231,7 @@ export default defineComponent({
       newTrackColor,
       filteredTracks: filteredTracksRef,
       trackAdd,
+      virtualHeight,
       virtualListItems,
       virtualList,
       multiDelete,
@@ -239,78 +242,82 @@ export default defineComponent({
 
 <template>
   <div class="d-flex flex-column">
-    <v-subheader class="flex-grow-1 trackHeader px-1">
-      <v-container>
+    <v-subheader class="flex-grow-1 trackHeader px-2">
+      <v-container class="py-2">
         <v-row align="center">
           Tracks ({{ filteredTracks.length }})
           <v-spacer />
-          <div>
-            <v-btn
-              icon
-              small
-              class="mr-2"
-              @click="data.settingsActive = !data.settingsActive"
-            >
-              <v-icon
+          <v-menu
+            v-model="data.settingsActive"
+            :close-on-content-click="false"
+            :nudge-bottom="28"
+          >
+            <template #activator="{ on, attrs }">
+              <v-btn
+                icon
                 small
-                :color="data.settingsActive ? 'accent' : 'default'"
+                class="mr-2"
+                v-bind="attrs"
+                v-on="on"
               >
-                mdi-cog
-              </v-icon>
-            </v-btn> <v-tooltip
-              open-delay="100"
-              bottom
-            >
-              <template #activator="{ on }">
-                <v-btn
-                  :disabled="filteredTracks.length === 0"
-                  icon
+                <v-icon
                   small
-                  class="mr-2"
-                  v-on="on"
-                  @click="multiDelete()"
+                  :color="data.settingsActive ? 'accent' : 'default'"
                 >
-                  <v-icon
-                    small
-                    color="error"
-                  >
-                    mdi-delete
-                  </v-icon>
-                </v-btn>
-              </template>
-              <span>Delete visible items</span>
-            </v-tooltip>
-            <v-tooltip
-              open-delay="200"
-              bottom
-              max-width="200"
-            >
-              <template #activator="{ on }">
-                <v-btn
-                  outlined
-                  x-small
-                  class="mr-2"
-                  :color="newTrackColor"
-                  v-on="on"
-                  @click="trackAdd"
-                >
-                  <v-icon small>
-                    mdi-plus
-                  </v-icon>
-                  {{ newTrackMode }}
-                </v-btn>
-              </template>
-              <span>Default Type: {{ newTrackType }}</span>
-            </v-tooltip>
-          </div>
-        </v-row>
-        <v-row>
-          <v-expand-transition>
+                  mdi-cog
+                </v-icon>
+              </v-btn>
+            </template>
             <slot
               v-if="data.settingsActive"
               name="settings"
             />
-          </v-expand-transition>
+          </v-menu>
+          <v-tooltip
+            open-delay="100"
+            bottom
+          >
+            <template #activator="{ on }">
+              <v-btn
+                :disabled="filteredTracks.length === 0"
+                icon
+                small
+                class="mr-2"
+                v-on="on"
+                @click="multiDelete()"
+              >
+                <v-icon
+                  small
+                  color="error"
+                >
+                  mdi-delete
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>Delete visible items</span>
+          </v-tooltip>
+          <v-tooltip
+            open-delay="200"
+            bottom
+            max-width="200"
+          >
+            <template #activator="{ on }">
+              <v-btn
+                outlined
+                x-small
+                class="mr-2"
+                :color="newTrackColor"
+                v-on="on"
+                @click="trackAdd"
+              >
+                <v-icon small>
+                  mdi-plus
+                </v-icon>
+                {{ newTrackMode }}
+              </v-btn>
+            </template>
+            <span>Default Type: {{ newTrackType }}</span>
+          </v-tooltip>
         </v-row>
       </v-container>
     </v-subheader>
@@ -329,7 +336,7 @@ export default defineComponent({
       class="tracks"
       :items="virtualListItems"
       :item-height="data.itemHeight"
-      :height="height"
+      :height="virtualHeight"
       bench="1"
     >
       <template #default="{ item }">

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -29,6 +29,9 @@ interface VirtualListItem {
   allTypes: readonly string[];
 }
 
+/* Magic numbers involved in height calculation */
+const TrackListHeaderHeight = 52;
+
 export default defineComponent({
   name: 'TrackList',
 
@@ -221,7 +224,7 @@ export default defineComponent({
       ];
     });
 
-    const virtualHeight = computed(() => props.height - 52);
+    const virtualHeight = computed(() => props.height - TrackListHeaderHeight);
 
     return {
       allTypes: allTypesRef,

--- a/client/src/components/TypeItem.vue
+++ b/client/src/components/TypeItem.vue
@@ -1,6 +1,9 @@
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { computed, defineComponent } from '@vue/composition-api';
 import TooltipBtn from './TooltipButton.vue';
+
+/* Horizontal padding is the width of checkbox, scrollbar, and edit button */
+const HorizontalPadding = 42 + 14 + 20;
 
 export default defineComponent({
   name: 'TypeItem',
@@ -28,12 +31,21 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
+    width: {
+      type: Number,
+      default: 300,
+    },
   },
+
+  setup: (props) => ({
+    cssVars: computed(() => ({ '--content-width': `${props.width - HorizontalPadding}px` })),
+  }),
 });
 </script>
 
 <template>
   <v-row
+    :style="cssVars"
     align="center"
     class="hover-show-parent"
   >
@@ -44,7 +56,7 @@ export default defineComponent({
         dense
         shrink
         hide-details
-        class="my-1 pl-2 type-checkbox"
+        class="my-1 pl-2"
         @change="$emit('setCheckedTypes', $event)"
       >
         <template #label>
@@ -55,7 +67,7 @@ export default defineComponent({
             >
               <template #activator="{ on }">
                 <span
-                  :class="{ 'nowrap-text': true, 'nowrap-text-narrow': confidenceFilterNum }"
+                  class="nowrap"
                   v-on="on"
                 >
                   {{ displayText }}
@@ -110,23 +122,11 @@ export default defineComponent({
 </template>
 
 <style lang="scss" scoped>
-.type-checkbox {
-  max-width: 90%;
-}
-
 .nowrap {
-  max-width: 100%;
   white-space: nowrap;
   overflow: hidden;
-
-  .nowrap-text {
-    max-width: 224px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .nowrap-text-narrow {
-    max-width: 180px;
-  }
+  max-width: var(--content-width);
+  text-overflow: ellipsis;
 }
 
 .hover-show-parent {

--- a/client/src/components/TypeItem.vue
+++ b/client/src/components/TypeItem.vue
@@ -1,8 +1,5 @@
 <script lang="ts">
-import {
-  computed,
-  defineComponent,
-} from '@vue/composition-api';
+import { defineComponent } from '@vue/composition-api';
 import TooltipBtn from './TooltipButton.vue';
 
 export default defineComponent({
@@ -32,17 +29,6 @@ export default defineComponent({
       required: true,
     },
   },
-  setup(props) {
-    const displayTooltip = computed(() => {
-      if (props.displayText.length > 20) {
-        return `${props.displayText.slice(0, 20)}...`;
-      }
-      return '';
-    });
-    return {
-      displayTooltip,
-    };
-  },
 });
 </script>
 
@@ -62,39 +48,34 @@ export default defineComponent({
         @change="$emit('setCheckedTypes', $event)"
       >
         <template #label>
-          <div class="text-body-2 grey--text text--lighten-1">
+          <div class="text-body-2 grey--text text--lighten-1 d-flex flex-row nowrap">
             <v-tooltip
-              v-if="displayTooltip"
               open-delay="200"
               bottom
             >
               <template #activator="{ on }">
                 <span
+                  :class="{ 'nowrap-text': true, 'nowrap-text-narrow': confidenceFilterNum }"
                   v-on="on"
                 >
-                  <span>
-                    {{ displayTooltip }}
-                  </span>
+                  {{ displayText }}
                 </span>
               </template>
               <span>{{ displayText }} </span>
             </v-tooltip>
-            <span v-else>
-              {{ displayText }}
-            </span>
             <v-tooltip
               v-if="confidenceFilterNum"
-              open-delay="100"
+              open-delay="200"
               bottom
+              class="align-self-end"
             >
-              <template #activator="{ on }">
+              <template #activator="{ on, attrs }">
                 <span
                   class="outlined"
+                  v-bind="attrs"
                   v-on="on"
                 >
-                  <span>
-                    {{ `>${confidenceFilterNum}` }}
-                  </span>
+                  {{ `>${confidenceFilterNum}` }}
                 </span>
               </template>
               <span>Type has threshold set individually</span>
@@ -131,6 +112,21 @@ export default defineComponent({
 <style lang="scss" scoped>
 .type-checkbox {
   max-width: 90%;
+}
+
+.nowrap {
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+
+  .nowrap-text {
+    max-width: 224px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .nowrap-text-narrow {
+    max-width: 180px;
+  }
 }
 
 .hover-show-parent {

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -21,6 +21,8 @@ interface VirtualTypeItem {
   checked: boolean;
 }
 
+/* Magic numbers involved in height calculation */
+const TypeListHeaderHeight = 80;
 
 export default defineComponent({
   name: 'TypeList',
@@ -33,6 +35,10 @@ export default defineComponent({
     height: {
       type: Number,
       default: 200,
+    },
+    width: {
+      type: Number,
+      default: 300,
     },
   },
 
@@ -177,11 +183,7 @@ export default defineComponent({
       }
     }
 
-    const virtualHeight = computed(() => {
-      // the combined height of the header and search bar lines.
-      const headerHeight = 80;
-      return props.height - headerHeight;
-    });
+    const virtualHeight = computed(() => props.height - TypeListHeaderHeight);
 
     return {
       data,
@@ -313,6 +315,7 @@ export default defineComponent({
             :color="item.color"
             :display-text="item.displayText"
             :confidence-filter-num="item.confidenceFilterNum"
+            :width="width"
             @setCheckedTypes="updateCheckedType($event, item.type)"
             @clickEdit="clickEdit"
           />


### PR DESCRIPTION
## Summary of changes

NOTE: this change is significantly easier to read if you ignore template changes, since those are mostly just reorganization.

Changes to height calculation

* Remove expansion panels, really simplified things.
* Move height measurement into `Sidebar.vue`, v-resize, and add a prop to sub-elements telling them how tall they're allowed to be. Sub-components are responsible for figuring out the heights of their header and virtual list section.  I've hard-coded these because IMO it's simpler and no worse than tagging and measuring the DOM.
* Had to do something about the threshold bar since it's dynamic.  I added a prop to the sidebar to indicate that the threshold bar is or is not there, and another hardcoded height I'm not happy about.  But again, it's simple code, so /shrug/

Changes to type list item rows.

* I think what I did is behaviorally correct (screenshots attached), but I'm unhappy with the implementation.
* There probably just needs to be a width prop on the list row item and each part of the row needs to have a fixed with.
* I don't think you can rely on character widths (20 chars) to make this work, you need fixed width and `text-overflow: ellipsis;`

Other minor changes

Moved deletion menu settings below the creation settings, it just seemed like the right ordering.

# Before

|  Issue with row widths | Issue with resize: box should expand | Issue with resize: box has no scrollbar but overflows |
|---|---|---|
![Screenshot from 2021-11-12 09-47-05](https://user-images.githubusercontent.com/4214172/141800913-bafd40ef-9e8c-45cb-9941-fb64884acca2.png) | ![Screenshot from 2021-11-12 11-12-37](https://user-images.githubusercontent.com/4214172/141800916-7c0629bf-6afa-417a-a953-cb24f8f0b4a6.png)  | ![Screenshot from 2021-11-12 11-14-43](https://user-images.githubusercontent.com/4214172/141800962-f86c563f-3ac1-4b35-928c-5220188e24d3.png)

# After
| Type settings | Track Settings | Width fixes: Share row width between confidence indicator and type text if both exist. |
|---|---|---|
![Screenshot from 2021-11-12 13-39-49](https://user-images.githubusercontent.com/4214172/141801115-b557cdee-4dc8-4282-a846-23b41aea4eb2.png) | ![Screenshot from 2021-11-12 13-40-00](https://user-images.githubusercontent.com/4214172/141801119-4ab52a8d-84a0-4ed0-8e9e-0475e8ec7c83.png) | ![Screenshot from 2021-11-12 16-16-32](https://user-images.githubusercontent.com/4214172/141801142-74a9ed90-755c-4361-a7e0-52a2ac143bb1.png)
