### PR TITLE
[Performance] Reduce Memory footprint for tracks

### DIFF
--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -13,6 +13,9 @@ export type ConfidencePair = [string, number];
 export type TrackId = number;
 export type TrackSupportedFeature = (
   GeoJSON.Point | GeoJSON.Polygon | GeoJSON.LineString | GeoJSON.Point);
+type TrackNotifier = (
+  { track, event, oldValue }: { track: Track; event: string; oldValue: unknown }
+) => void;
 export interface StringKeyObject {
   [key: string]: unknown;
 }
@@ -50,6 +53,7 @@ interface TrackParams {
   features?: Array<Feature>;
   confidencePairs?: Array<ConfidencePair>;
   attributes?: StringKeyObject;
+  notifier?: TrackNotifier;
 }
 
 /**
@@ -84,7 +88,8 @@ export default class Track {
    */
   revision: Ref<number>;
 
-  bus: Vue;
+  /** A callback to notify about changes to the track. */
+  notifier?: TrackNotifier;
 
   constructor(trackId: TrackId, {
     meta = {},
@@ -93,8 +98,8 @@ export default class Track {
     features = [],
     confidencePairs = [],
     attributes = {},
+    notifier = undefined,
   }: TrackParams) {
-    this.bus = new Vue();
     this.trackId = trackId;
     this.meta = meta;
     this.attributes = attributes;
@@ -106,6 +111,7 @@ export default class Track {
     this.begin = begin;
     this.end = end;
     this.confidencePairs = confidencePairs;
+    this.notifier = notifier;
   }
 
   get length() {
@@ -198,11 +204,13 @@ export default class Track {
     /* Prevent broadcast until the first feature is initialized */
     if (this.isInitialized()) {
       this.revision.value += 1;
-      this.bus.$emit('notify', {
-        track: this,
-        event: name,
-        oldValue,
-      });
+      if (this.notifier) {
+        this.notifier({
+          track: this,
+          event: name,
+          oldValue,
+        });
+      }
     }
   }
 
@@ -325,6 +333,10 @@ export default class Track {
         interpolate: !interpolate,
       });
     }
+  }
+
+  setNotifier(notifier?: TrackNotifier) {
+    this.notifier = notifier;
   }
 
   setFeature(feature: Feature, geometry: GeoJSON.Feature<TrackSupportedFeature>[] = []): Feature {

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue';
 import { Ref, ref } from '@vue/composition-api';
 import { RectBounds } from './utils';
 import {

--- a/client/src/use/useTrackStore.ts
+++ b/client/src/use/useTrackStore.ts
@@ -57,6 +57,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
   const trackIds: Ref<Array<TrackId>> = ref([]);
   const canary = ref(0);
 
+
   function _depend(): number {
     return canary.value;
   }
@@ -82,7 +83,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
   }
 
   function insertTrack(track: Track, args?: InsertArgs) {
-    track.bus.$on('notify', onChange);
+    track.setNotifier(onChange);
     trackMap.set(track.trackId, track);
     intervalTree.insert([track.begin, track.end], track.trackId.toString());
     if (args && args.afterId) {
@@ -117,7 +118,7 @@ export default function useTrackStore({ markChangesPending }: UseTrackStoreParam
     if (!intervalTree.remove(range, trackId.toString())) {
       throw new Error(`TrackId ${trackId} with range ${range} not found in tree.`);
     }
-    track.bus.$off(); // remove all event listeners
+    track.setNotifier(undefined);
     trackMap.delete(trackId);
     const listIndex = trackIds.value.findIndex((v) => v === trackId);
     if (listIndex === -1) {


### PR DESCRIPTION
Removes a Vue instance from each track instantiation, replace with a simple callback function.

## Profile results

With 100K tracks and 20 types on 20 image frames

* Before: 535-538MB (consistent) memory usage at idle, tops out at 700+ during load
* After: 305-311MB (consistent) memory usage at idle, tops out at 450 during load.

App uses 80MB of memory with no tracks at idle, so this results in about a 50% reduction in dynamic memory usage.