### PR TITLE
Fix #1052 import json and meta json

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -89,6 +89,7 @@ interface DatasetMetaMutable {
   confidenceFilters?: Record<string, number>;
   attributes?: Readonly<Record<string, Attribute>>;
 }
+const DatasetMetaMutableKeys = ['attributes', 'confidenceFilters', 'customTypeStyles'];
 
 interface DatasetMeta extends DatasetMetaMutable {
   id: Readonly<string>;
@@ -144,10 +145,11 @@ export {
   useApi,
 };
 
-export type {
+export {
   Api,
   DatasetMeta,
   DatasetMetaMutable,
+  DatasetMetaMutableKeys,
   DatasetType,
   SubType,
   FrameImage,

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -94,9 +94,7 @@ export default function register() {
   });
 
   ipcMain.handle('import-annotation', async (event, { id, path }: { id: string; path: string }) => {
-    const ret = await common.annotationImport(
-      settings.get(), id, path,
-    );
+    const ret = await common.dataFileImport(settings.get(), id, path);
     return ret;
   });
 

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -105,7 +105,7 @@ const convertMedia = async (settingsVal: Settings, args: ConversionArgs,
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const console = new Console(process.stdout, process.stderr);
 
-const emptyCsvString = '# comment line\n# metadata,fps: 32,"whateever"\n#comment line';
+const emptyCsvString = '# comment line\n# metadata,fps: 32,"whatever"\n#comment line';
 
 mockfs({
   '/opt/viame': {

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -120,7 +120,7 @@ mockfs({
   '/home/user/data': {
     annotationImport: {
       'viame.csv': emptyCsvString,
-      'foreign.meta.json': '{ "confidenceFilters": {"default": 0.8} }',
+      'foreign.meta.json': '{ "confidenceFilters": {"default": 0.8}, "type": "invalidtype" }',
       'dive.json': '{ "0": { "trackId": 0 } }', // fake track file
     },
     imageSuccess: {
@@ -516,6 +516,7 @@ describe('native.common', () => {
     await common.dataFileImport(settings, final.id, '/home/user/data/annotationImport/foreign.meta.json');
     const meta2 = await common.loadMetadata(settings, final.id, urlMapper);
     expect(meta2.confidenceFilters).toStrictEqual({ "default": 0.8 });
+    expect(meta2.type).toBe("image-sequence"); // Ensure meta import cannot change immutable fields.
   });
 
   it('import with CSV annotations without specifying track file', async () => {

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -8,6 +8,9 @@ import { shell } from 'electron';
 import mime from 'mime-types';
 import moment from 'moment';
 import lockfile from 'proper-lockfile';
+import {
+  cloneDeep, merge, uniq, pick,
+} from 'lodash';
 
 import { DefaultConfidence } from 'vue-media-annotator/use/useTrackFilters';
 import { TrackData } from 'vue-media-annotator/track';
@@ -29,7 +32,7 @@ import {
 import {
   cleanString, filterByGlob, makeid, strNumericCompare,
 } from 'platform/desktop/sharedUtils';
-import { cloneDeep, merge, uniq } from 'lodash';
+
 import processTrackAttributes from './attributeProcessor';
 import { upgrade } from './migrations';
 import { getMultiCamUrls, transcodeMultiCam } from './multiCamUtils';
@@ -573,7 +576,7 @@ async function _ingestFilePath(
       meta.fps = data.fps;
     } else if (DatasetMetaMutableKeys.some((key) => key in jsonObject)) {
       // DIVE Json metadata config file
-      merge(meta, jsonObject);
+      merge(meta, pick(jsonObject, DatasetMetaMutableKeys));
     } else {
       // Regular dive json
       tracks = Object.values(await loadJsonTracks(path));

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -181,11 +181,11 @@ async function runPipeline(
   job.on('exit', async (code) => {
     if (code === 0) {
       try {
-        const { attributes } = await common.processOtherAnnotationFiles(
+        const { meta: newMeta } = await common.ingestDataFiles(
           settings, datasetId, [detectorOutput, trackOutput], multiOutFiles,
         );
-        if (attributes) {
-          meta.attributes = attributes;
+        if (newMeta) {
+          meta.attributes = newMeta.attributes;
           await common.saveMetadata(settings, datasetId, meta);
         }
       } catch (err) {

--- a/client/platform/desktop/backend/serializers/nist.ts
+++ b/client/platform/desktop/backend/serializers/nist.ts
@@ -66,19 +66,6 @@ interface NistActivity {
 function confirmNistFormat(data: any): data is NistFile {
   return Array.isArray(data?.activities) && Array.isArray(data?.filesProcessed);
 }
-async function confirmNistFile(filename: string) {
-  const rawBuffer = await fs.readFile(filename, 'utf-8');
-  let nistJson;
-  if (rawBuffer.length === 0) {
-    return false;
-  }
-  try {
-    nistJson = JSON.parse(rawBuffer);
-  } catch (err) {
-    throw new Error(`Unable to parse ${filename}: ${err}`);
-  }
-  return confirmNistFormat(nistJson);
-}
 
 function loadObjects(
   objects: NistObject[],
@@ -392,5 +379,4 @@ export {
   convertNisttoJSON,
   exportNist,
   confirmNistFormat,
-  confirmNistFile,
 };


### PR DESCRIPTION
## Changes

* Fixes bug where every json file was being parsed as a NIST file and failing.
* Adds feature to import meta json on desktop for parity with web.

## Notes

* Removes 2 large blocks of code that were inline-copies of other existing functions.
* Replace `annotationImport` with `dataFileImport` agnostic to the kind of data being ingested to match web logic
* Add tests.

## Testing

Tested with json tracks, meta files, and CSV.  I don't have any NIST data, but if you tell me where to find some, I can check that too.

fixes #1052 