### PR TITLE
Prevent Desktop Reload on Failed Pipeline

### DIFF
--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -51,7 +51,7 @@ export default defineComponent({
 
     watch(runningJobs, async (_previous, current) => {
       const currentJob = current.find((item) => item.job.datasetIds.includes(props.id));
-      if (currentJob && currentJob.job.exitCode !== -1 && currentJob.job.jobType === 'pipeline') {
+      if (currentJob && currentJob.job.exitCode === 0 && currentJob.job.jobType === 'pipeline') {
         const result = await prompt({
           title: 'Pipeline Finished',
           text: [`Pipeline: ${currentJob.job.title}`,


### PR DESCRIPTION
Fixes #1010 

Looks like it was mistake on my part of using not `!== -1` instead `=== 0` for success.  This update should prevent the viewer from asking to reload if the pipeline fails.

Test Methods:
Simply pick one of the faster pipelines (like `detector_fish_without_motion.pipe`) and temporary change the `include common_fish_detector_with_filter.pipe` or other specification in the file to a non-existing pipe file or setting and it should error.