### PR TITLE
Mongo 1: Server side implementation

### DIFF
--- a/client/dive-common/constants.ts
+++ b/client/dive-common/constants.ts
@@ -101,7 +101,7 @@ const listFileTypes = [
 ];
 
 const stereoPipelineMarker = 'measurement';
-const multiCamPipelineMarker = ''; //Placeholder
+const multiCamPipelineMarkers = ['2-cam', '3-cam'];
 
 
 export {
@@ -122,5 +122,5 @@ export {
   inputAnnotationFileTypes,
   listFileTypes,
   stereoPipelineMarker,
-  multiCamPipelineMarker,
+  multiCamPipelineMarkers,
 };

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -515,8 +515,8 @@ describe('native.common', () => {
 
     await common.dataFileImport(settings, final.id, '/home/user/data/annotationImport/foreign.meta.json');
     const meta2 = await common.loadMetadata(settings, final.id, urlMapper);
-    expect(meta2.confidenceFilters).toStrictEqual({ "default": 0.8 });
-    expect(meta2.type).toBe("image-sequence"); // Ensure meta import cannot change immutable fields.
+    expect(meta2.confidenceFilters).toStrictEqual({ default: 0.8 });
+    expect(meta2.type).toBe('image-sequence'); // Ensure meta import cannot change immutable fields.
   });
 
   it('import with CSV annotations without specifying track file', async () => {

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -340,7 +340,7 @@ async function autodiscoverData(settings: Settings): Promise<JsonMeta[]> {
  */
 async function getPipelineList(settings: Settings): Promise<Pipelines> {
   const pipelinePath = npath.join(settings.viamePath, 'configs/pipelines');
-  const allowedPatterns = /^detector_.+|^tracker_.+|^generate_.+|^utility_|^measurement_gmm_.+/;
+  const allowedPatterns = /^detector_.+|^tracker_.+|^generate_.+|^utility_|^measurement_gmm_.+|.*[2,3]-cam.+/;
   const disallowedPatterns = /.*local.*|detector_svm_models.pipe|tracker_svm_models.pipe/;
   const exists = await fs.pathExists(pipelinePath);
   if (!exists) return {};
@@ -351,8 +351,13 @@ async function getPipelineList(settings: Settings): Promise<Pipelines> {
   const ret: Pipelines = {};
   pipes.forEach((p) => {
     const parts = cleanString(p.replace('.pipe', '')).split('_');
-    const pipeType = parts[0];
-    const pipeName = parts.slice(1).join(' ');
+    let pipeType = parts[0];
+    let pipeName = parts.slice(1).join(' ');
+    // Extract out only 2-cam and 3-cam pipelines to own category, 1-cam remain in tracker/detector
+    if (parts.length > 1 && parts[parts.length - 1] === 'cam' && parts[parts.length - 2] !== '1') {
+      pipeType = `${parts[parts.length - 2]}-cam`;
+      pipeName = parts.join(' ');
+    }
     const pipeInfo = {
       name: pipeName,
       type: pipeType,

--- a/client/platform/desktop/backend/native/multiCamUtils.ts
+++ b/client/platform/desktop/backend/native/multiCamUtils.ts
@@ -80,7 +80,9 @@ function writeMultiCamStereoPipelineArgs(jobWorkDir: string, meta: JsonMeta) {
       const { originalBasePath } = list;
       const outputFileName = `computed_tracks_${key}.csv`;
       const outputArg = `detector_writer${i + 1}:file_name`;
+      const outputArgWriteTracks = `track_writer${i + 1}:file_name`;
       argFilePair[outputArg] = outputFileName;
+      argFilePair[outputArgWriteTracks] = outputFileName;
       outFiles[key] = outputFileName;
       const inputArg = `input${i + 1}:video_filename`;
       if (list.type === 'image-sequence') {

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -10,7 +10,7 @@ import { cleanString } from 'platform/desktop/sharedUtils';
 import { serialize } from 'platform/desktop/backend/serializers/viame';
 import { observeChild } from 'platform/desktop/backend/native/processManager';
 
-import { MultiType, stereoPipelineMarker } from 'dive-common/constants';
+import { MultiType, stereoPipelineMarker, multiCamPipelineMarkers } from 'dive-common/constants';
 import * as common from './common';
 import { jobFileEchoMiddleware } from './utils';
 import {
@@ -132,7 +132,9 @@ async function runPipeline(
   }
 
   let multiOutFiles: Record<string, string>;
-  if (meta.multiCam && pipeline.type === stereoPipelineMarker) {
+  const stereoOrMultiCam = (pipeline.type === stereoPipelineMarker
+    || multiCamPipelineMarkers.includes(pipeline.type));
+  if (meta.multiCam && stereoOrMultiCam) {
     const { argFilePair, outFiles } = writeMultiCamStereoPipelineArgs(jobWorkDir, meta);
     Object.entries(argFilePair).forEach(([arg, file]) => {
       command.push(`-s ${arg}="${file}"`);

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -47,6 +47,7 @@ export default defineComponent({
     const viewerRef = ref();
     const compoundId = ref(props.id);
     const subTypeList = computed(() => [datasets.value[props.id]?.subType || null]);
+    const camNumbers = computed(() => [datasets.value[props.id]?.cameraNumber || 1]);
     const readonlyMode = computed(() => settings.value?.readonlyMode || false);
 
     watch(runningJobs, async (_previous, current) => {
@@ -73,6 +74,7 @@ export default defineComponent({
       buttonOptions,
       menuOptions,
       subTypeList,
+      camNumbers,
       readonlyMode,
     };
   },
@@ -108,6 +110,7 @@ export default defineComponent({
       <RunPipelineMenu
         :selected-dataset-ids="[id]"
         :sub-type-list="subTypeList"
+        :camera-numbers="camNumbers"
         v-bind="{ buttonOptions, menuOptions }"
       />
       <ImportAnnotations

--- a/client/platform/desktop/frontend/store/dataset.ts
+++ b/client/platform/desktop/frontend/store/dataset.ts
@@ -28,6 +28,7 @@ export interface JsonMetaCache {
   imageListPath: string;
   transcodedVideoFile?: string;
   subType: SubType;
+  cameraNumber: number;
 }
 
 /**
@@ -40,6 +41,7 @@ function hydrateJsonMetaCacheValue(input: any): JsonMetaCache {
     transcodedVideoFile: '',
     accessedAt: input.createdAt,
     subType: null,
+    cameraNumber: 1,
     ...input,
   };
 }
@@ -62,6 +64,7 @@ function setRecents(meta: JsonMeta, accessTime?: string) {
     imageListPath: meta.imageListPath,
     transcodedVideoFile: meta.transcodedVideoFile,
     subType: meta.subType,
+    cameraNumber: Object.keys(meta.multiCam || {}).length,
   } as JsonMetaCache);
   const values = Object.values(datasets.value);
   window.localStorage.setItem(RecentsKey, JSON.stringify(values));

--- a/docker/girder.Dockerfile
+++ b/docker/girder.Dockerfile
@@ -54,7 +54,7 @@ COPY --from=server-builder /opt/dive/local/venv /opt/dive/local/venv
 # Copy the source code of the editable module
 COPY --from=server-builder /opt/dive/src /opt/dive/src
 # Copy the client code into the static source location
-COPY --from=client-builder /app/dist/ /usr/local/share/girder/static/viame/
+COPY --from=client-builder /app/dist/ /opt/dive/local/venv/share/girder/static/viame/
 # Install startup scripts
 COPY docker/entrypoint_server.sh docker/server_setup.py /
 

--- a/server/bucket_notifications/models.py
+++ b/server/bucket_notifications/models.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from dive_server.crud import PydanticModel
+from dive_server.crud import PydanticAccessControlModel
 
 
 class GCSObjectFinalizeNotification(BaseModel):
@@ -27,7 +27,7 @@ class GCSPushNotificationPayload(BaseModel):
     subscription: str
 
 
-class GCSNotificationRecord(PydanticModel):
+class GCSNotificationRecord(PydanticAccessControlModel):
     def initialize(self):
         return super().initialize("gcsnotification", GCSPushNotificationMessage)
 

--- a/server/dive_server/__init__.py
+++ b/server/dive_server/__init__.py
@@ -11,6 +11,7 @@ from girder.utility.model_importer import ModelImporter
 from dive_utils.constants import UserPrivateQueueEnabledMarker
 
 from .client_webroot import ClientWebroot
+from .crud_annotation import AnnotationItem, RevisionLogItem
 from .event import process_fs_import, process_s3_import, send_new_user_email
 from .views_annotation import AnnotationResource
 from .views_configuration import ConfigurationResource
@@ -23,6 +24,8 @@ from .views_summary import SummaryItem, SummaryResource
 class GirderPlugin(plugin.GirderPlugin):
     def load(self, info):
         ModelImporter.registerModel('summaryItem', SummaryItem, plugin='dive_server')
+        ModelImporter.registerModel('annotationItem', AnnotationItem, plugin='dive_server')
+        ModelImporter.registerModel('revisionLogItem', RevisionLogItem, plugin='dive_server')
 
         info["apiRoot"].dive_summary = SummaryResource("dive_summary")
         info["apiRoot"].dive_annotation = AnnotationResource("dive_annotation")

--- a/server/dive_server/crud.py
+++ b/server/dive_server/crud.py
@@ -1,26 +1,19 @@
 """General CRUD operations and utilities shared among views"""
-from datetime import datetime
 from enum import Enum
 import functools
-import io
-import json
 import os
 from pathlib import Path
-from typing import Callable, Dict, Generator, List, Optional, Tuple, Type
+from typing import List, Type
 
 from girder.constants import AccessType
 from girder.exceptions import RestException, ValidationException
-from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
-from girder.models.model_base import AccessControlledModel
-from girder.models.upload import Upload
+from girder.models.model_base import AccessControlledModel, Model
 import pydantic
 from pydantic.main import BaseModel
-from pymongo.cursor import Cursor
 
 from dive_utils import asbool, constants, fromMeta, models, strNumericCompare
-from dive_utils.serializers import kwcoco, viame
 from dive_utils.types import GirderModel, GirderUserModel
 
 
@@ -38,7 +31,7 @@ def get_validated_model(model: BaseModel, **kwargs):
         raise ValidationException(err)
 
 
-class PydanticModel(AccessControlledModel):
+class PydanticModel(Model):
     schema: Type[BaseModel]
 
     def initialize(self, name: str, schema: Type[BaseModel]):
@@ -54,34 +47,8 @@ class PydanticModel(AccessControlledModel):
         return self.save(item.dict())
 
 
-def all_detections_items(folder: GirderModel) -> Cursor:
-    """Caller is responsible for verifying access permissions"""
-    return (
-        Item()
-        .find({f"meta.{constants.DetectionMarker}": str(folder['_id'])})
-        .sort([("created", -1)])
-    )
-
-
-def detections_item(folder: GirderModel, strict=False) -> Optional[GirderModel]:
-    all_items = all_detections_items(folder)
-    first_item = next(all_items, None)
-    if first_item is None and strict:
-        raise RestException(f"No detections for folder {folder['name']}", code=404)
-    return first_item
-
-
-def detections_file(dsFolder: GirderModel, strict=False) -> Optional[GirderModel]:
-    """
-    Find the Girder file containing the most recent annotation revision
-    """
-    item = detections_item(dsFolder, strict)
-    if item is None and not strict:
-        return None
-    first_file = next(Item().childFiles(item), None)
-    if first_file is None and strict:
-        raise RestException(f"No file associated with detection item {item}", code=404)
-    return first_file
+class PydanticAccessControlModel(PydanticModel, AccessControlledModel):
+    pass
 
 
 def get_static_pipelines_path() -> Path:
@@ -105,91 +72,8 @@ def get_or_create_auxiliary_folder(folder, user):
     return Folder().createFolder(folder, "auxiliary", reuseExisting=True, creator=user)
 
 
-def move_existing_result_to_auxiliary_folder(folder, user):
-    auxiliary = get_or_create_auxiliary_folder(folder, user)
-    for item in all_detections_items(folder):
-        Item().move(item, auxiliary)
-
-
 def itemIsWebsafeVideo(item: Item) -> bool:
     return fromMeta(item, "codec") == "h264"
-
-
-def get_data_by_type(
-    file: Optional[GirderModel], as_type: Optional[FileType] = None
-) -> Tuple[Optional[FileType], dict, dict]:
-    """
-    Given an arbitrary Girder file model, figure out what kind of file it is and
-    parse it appropriately.
-
-    :as_type: bypass type discovery (potentially expensive) if caller is certain about type
-    """
-    if file is None:
-        return None, {}, {}
-    file_string = b"".join(list(File().download(file, headers=False)())).decode()
-    data_dict = None
-
-    # If the caller has not specified a type, try to discover it
-    if as_type is None:
-        if file['exts'][-1] == 'csv':
-            as_type = FileType.VIAME_CSV
-        elif file['exts'][-1] == 'json':
-            data_dict = json.loads(file_string)
-            if type(data_dict) is list:
-                raise RestException('No array-type json objects are supported')
-            if kwcoco.is_coco_json(data_dict):
-                as_type = FileType.COCO_JSON
-            elif models.MetadataMutable.is_dive_configuration(data_dict):
-                data_dict = models.MetadataMutable(**data_dict).dict(exclude_none=True)
-                as_type = FileType.DIVE_CONF
-            else:
-                as_type = FileType.DIVE_JSON
-        else:
-            raise RestException('Got file of unknown and unusable type')
-
-    # Parse the file as the now known type
-    if as_type == FileType.VIAME_CSV:
-        tracks, attributes = viame.load_csv_as_tracks_and_attributes(file_string.splitlines())
-        return as_type, tracks, attributes
-
-    # All filetypes below are JSON, so if as_type was specified, it needs to be loaded.
-    if data_dict is None:
-        data_dict = json.loads(file_string)
-
-    if as_type == FileType.COCO_JSON:
-        tracks, attributes = kwcoco.load_coco_as_tracks_and_attributes(data_dict)
-        return as_type, tracks, attributes
-    if as_type == FileType.DIVE_CONF or as_type == FileType.DIVE_JSON:
-        return as_type, data_dict, {}
-    return None, {}, {}
-
-
-def getTrackData(file: Optional[GirderModel]) -> Dict[str, dict]:
-    """Wrapper function to get track data if type is already known"""
-    return get_data_by_type(file, as_type=FileType.DIVE_JSON)[1]
-
-
-def saveTracks(folder, tracks, user):
-    timestamp = datetime.now().strftime("%m-%d-%Y_%H:%M:%S")
-    item_name = f"result_{timestamp}.json"
-
-    move_existing_result_to_auxiliary_folder(folder, user)
-    newResultItem = Item().createItem(item_name, user, folder)
-    Item().setMetadata(
-        newResultItem, {constants.DetectionMarker: str(folder["_id"])}, allowNull=True
-    )
-
-    json_bytes = json.dumps(tracks).encode()
-    byteIO = io.BytesIO(json_bytes)
-    Upload().uploadFromFile(
-        byteIO,
-        len(json_bytes),
-        item_name,
-        parentType="item",
-        parent=newResultItem,
-        user=user,
-        mimeType="application/json",
-    )
 
 
 def saveImportAttributes(folder, attributes, user):
@@ -261,37 +145,3 @@ def valid_images(
         images,
         key=functools.cmp_to_key(unwrapItem),
     )
-
-
-def get_annotation_csv_generator(
-    folder: GirderModel, user: GirderUserModel, excludeBelowThreshold=False, typeFilter=None
-) -> Tuple[str, Callable[[], Generator[str, None, None]]]:
-    """
-    Get the annotation generator for a folder
-    """
-    fps = None
-    imageFiles = None
-
-    source_type = fromMeta(folder, constants.TypeMarker)
-    if source_type == constants.VideoType:
-        fps = fromMeta(folder, constants.FPSMarker)
-    elif source_type == constants.ImageSequenceType:
-        imageFiles = [img['name'] for img in valid_images(folder, user)]
-
-    thresholds = fromMeta(folder, "confidenceFilters", {})
-    annotation_file = detections_file(folder)
-    track_dict = getTrackData(annotation_file)
-
-    def downloadGenerator():
-        for data in viame.export_tracks_as_csv(
-            track_dict,
-            excludeBelowThreshold,
-            thresholds=thresholds,
-            filenames=imageFiles,
-            fps=fps,
-            typeFilter=typeFilter,
-        ):
-            yield data
-
-    filename = folder["name"] + ".csv"
-    return filename, downloadGenerator

--- a/server/dive_server/crud_annotation.py
+++ b/server/dive_server/crud_annotation.py
@@ -24,7 +24,7 @@ class AnnotationItem(crud.PydanticModel):
     }
 
     def initialize(self):
-        self._indices = [[[(DATASET, 1), (TRACKID, 1), (REVISION_CREATED, 1)], {}]]
+        self._indices = [[[(DATASET, 1), (TRACKID, 1), (REVISION_CREATED, 1)], {'unique': True}]]
         super().initialize("annotationItem", models.AnnotationItemSchema)
 
 
@@ -32,7 +32,7 @@ class RevisionLogItem(crud.PydanticModel):
     PROJECT_FIELDS = {'_id': 0}
 
     def initialize(self):
-        self._indices = [[[(DATASET, 1), (REVISION, 1)], {}]]
+        self._indices = [[[(DATASET, 1), (REVISION, 1)], {'unique': True}]]
         super().initialize("revisionLogItem", models.RevisionLog)
 
 
@@ -134,6 +134,7 @@ def save_annotations(
     upsert_list: Iterable[dict],
     delete_list: Iterable[int],
     user: types.GirderUserModel,
+    description="save",
     overwrite=False,
 ):
     """
@@ -192,6 +193,7 @@ def save_annotations(
             revision=new_revision,
             additions=additions,
             deletions=deletions,
+            description=description,
         )
         RevisionLogItem().create(log_entry)
 
@@ -205,4 +207,4 @@ def clone_annotations(
     revision: Optional[int] = None,
 ):
     source_iter, _ = get_annotations(source, revision=revision)
-    save_annotations(dest, source_iter, [], user)
+    save_annotations(dest, source_iter, [], user, description="initialize clone")

--- a/server/dive_server/crud_annotation.py
+++ b/server/dive_server/crud_annotation.py
@@ -24,7 +24,7 @@ class AnnotationItem(crud.PydanticModel):
     }
 
     def initialize(self):
-        self._indices = [[[(DATASET, 1), (TRACKID, 1), (REVISION_CREATED, 1)], {'unique': True}]]
+        self._indices = [[[(DATASET, 1), (TRACKID, 1)], {}]]
         super().initialize("annotationItem", models.AnnotationItemSchema)
 
 

--- a/server/dive_server/crud_annotation.py
+++ b/server/dive_server/crud_annotation.py
@@ -1,21 +1,124 @@
-from typing import List
+from typing import Callable, Generator, Iterable, List, Optional, Tuple
 
-from girder.exceptions import RestException
-from girder.models.file import File
 from pydantic.main import BaseModel
+import pymongo
 
 from dive_server import crud
-from dive_utils import models, types
+from dive_utils import constants, fromMeta, models, types
+from dive_utils.serializers import viame
+
+DATASET = 'dataset'
+REVISION_DELETED = 'rev_deleted'
+REVISION_CREATED = 'rev_created'
+REVISION = 'revision'
+TRACKID = 'trackId'
+
+DEFAULT_ANNOTATION_SORT = [[TRACKID, 1]]
+DEFAULT_REVISION_SORT = [[REVISION, pymongo.DESCENDING]]
 
 
-def get_annotations(dsFolder: types.GirderModel):
-    crud.verify_dataset(dsFolder)
-    file = crud.detections_file(dsFolder)
-    if file is None:
-        return {}
-    if "csv" in file["exts"]:
-        raise RestException('Cannot get detections until postprocessing is complete.')
-    return File().download(file, contentDisposition="inline")
+class AnnotationItem(crud.PydanticModel):
+    PROJECT_FIELDS = {
+        **{'_id': 0},
+        **{key: 1 for key in models.Track.schema()['properties'].keys()},
+    }
+
+    def initialize(self):
+        self._indices = [[[(DATASET, 1), (TRACKID, 1), (REVISION_CREATED, 1)], {}]]
+        super().initialize("annotationItem", models.AnnotationItemSchema)
+
+
+class RevisionLogItem(crud.PydanticModel):
+    PROJECT_FIELDS = {'_id': 0}
+
+    def initialize(self):
+        self._indices = [[[(DATASET, 1), (REVISION, 1)], {}]]
+        super().initialize("revisionLogItem", models.RevisionLog)
+
+
+def get_last_revision(dsFolder: types.GirderModel):
+    query = {DATASET: dsFolder['_id']}
+    result = RevisionLogItem().findOne(query, sort=[[REVISION, pymongo.DESCENDING]]) or {}
+    return result.get(REVISION, 0)  # Revision 0 is always the empty revision
+
+
+def get_annotations(
+    dsFolder: types.GirderModel,
+    limit=0,
+    offset=0,
+    sort=DEFAULT_ANNOTATION_SORT,
+    revision: Optional[int] = None,
+):
+    head = get_last_revision(dsFolder) if revision is None else revision
+    query = {
+        DATASET: dsFolder['_id'],
+        REVISION_CREATED: {'$lte': head},
+        '$or': [{REVISION_DELETED: {'$gt': head}}, {REVISION_DELETED: {'$exists': False}}],
+    }
+    cursor = AnnotationItem().find(
+        offset=offset, limit=limit, sort=sort, query=query, fields=AnnotationItem.PROJECT_FIELDS
+    )
+    total = AnnotationItem().find(query=query).count()
+    return cursor, total
+
+
+def get_revisions(
+    dsFolder: types.GirderModel,
+    limit=0,
+    offset=0,
+    sort=DEFAULT_REVISION_SORT,
+    before: Optional[int] = None,
+):
+    query: dict = {DATASET: dsFolder['_id']}
+    if before is not None:
+        query[REVISION] = {'$lte': before}
+    cursor = RevisionLogItem().find(
+        offset=offset, limit=limit, sort=sort, query=query, fields=RevisionLogItem.PROJECT_FIELDS
+    )
+    total = RevisionLogItem().find(query=query).count()
+    return cursor, total
+
+
+def get_annotations_as_dict(dsFolder: types.GirderModel):
+    cursor, _ = get_annotations(dsFolder)
+    output = {}
+    for annotation in cursor:
+        output[annotation['trackId']] = annotation
+    return output
+
+
+def get_annotation_csv_generator(
+    folder: types.GirderModel,
+    user: types.GirderUserModel,
+    excludeBelowThreshold=False,
+    typeFilter=None,
+) -> Tuple[str, Callable[[], Generator[str, None, None]]]:
+    """Get the annotation generator for a folder"""
+    fps = None
+    imageFiles = None
+
+    source_type = fromMeta(folder, constants.TypeMarker)
+    if source_type == constants.VideoType:
+        fps = fromMeta(folder, constants.FPSMarker)
+    elif source_type == constants.ImageSequenceType:
+        imageFiles = [img['name'] for img in crud.valid_images(folder, user)]
+
+    thresholds = fromMeta(folder, "confidenceFilters", {})
+
+    def downloadGenerator():
+        datalist, _ = get_annotations(folder)
+        for data in viame.export_tracks_as_csv(
+            datalist,
+            excludeBelowThreshold,
+            thresholds=thresholds,
+            filenames=imageFiles,
+            fps=fps,
+            typeFilter=typeFilter,
+        ):
+            yield data
+
+    filename = folder["name"] + ".csv"
+    return filename, downloadGenerator
 
 
 class AnnotationUpdateArgs(BaseModel):
@@ -23,26 +126,83 @@ class AnnotationUpdateArgs(BaseModel):
     upsert: List[models.Track] = []
 
     class Config:
-        extra = 'forbid'
+        extra = 'ignore'
 
 
-def save_annotations(dsFolder: types.GirderModel, user: types.GirderUserModel, data: dict):
-    crud.verify_dataset(dsFolder)
-    track_dict = crud.getTrackData(crud.detections_file(dsFolder))
-    validated: AnnotationUpdateArgs = crud.get_validated_model(AnnotationUpdateArgs, **data)
+def save_annotations(
+    dsFolder: types.GirderModel,
+    upsert_list: Iterable[dict],
+    delete_list: Iterable[int],
+    user: types.GirderUserModel,
+    overwrite=False,
+):
+    """
+    Annotations are lazy-deleted by marking their staleness property as true.
+    """
 
-    for track_id in validated.delete:
-        track_dict.pop(str(track_id), None)
-    for track in validated.upsert:
-        track_dict[str(track.trackId)] = track.dict(exclude_none=True)
+    datasetId = dsFolder['_id']
+    update_operations = []
+    insert_operations = []
+    changes = False
+    new_revision = get_last_revision(dsFolder) + 1
+    delete_annotation_update = {'$set': {REVISION_DELETED: new_revision}}
 
-    upserted_len = len(validated.delete)
-    deleted_len = len(validated.upsert)
+    if overwrite:
+        query = {DATASET: datasetId, REVISION_DELETED: {'$exists': False}}
+        AnnotationItem().collection.bulk_write(
+            [pymongo.UpdateMany(query, delete_annotation_update)]
+        )
+        changes = True
 
-    if upserted_len or deleted_len:
-        crud.saveTracks(dsFolder, track_dict, user)
+    for track_id in delete_list:
+        filter = {TRACKID: track_id, DATASET: datasetId, REVISION_DELETED: {'$exists': False}}
+        # UpdateMany for safety, UpdateOne would also work
+        update_operations.append(pymongo.UpdateMany(filter, delete_annotation_update))
 
-    return {
-        "updated": upserted_len,
-        "deleted": deleted_len,
-    }
+    for newdict in upsert_list:
+        newdict.update({DATASET: datasetId, REVISION_CREATED: new_revision})
+        newdict.pop(REVISION_DELETED, None)
+        filter = {
+            TRACKID: newdict['trackId'],
+            DATASET: datasetId,
+            REVISION_DELETED: {'$exists': False},
+        }
+        if not overwrite:
+            # UpdateMany for safety, UpdateOne would also work
+            update_operations.append(pymongo.UpdateMany(filter, delete_annotation_update))
+        insert_operations.append(pymongo.InsertOne(newdict))
+
+    # Ordered=false allows fast parallel writes
+    if len(update_operations):
+        AnnotationItem().collection.bulk_write(update_operations, ordered=False)
+        changes = True
+    if len(insert_operations):
+        AnnotationItem().collection.bulk_write(insert_operations, ordered=False)
+        changes = True
+
+    # Write the revision to the log
+    additions = len(insert_operations)
+    deletions = len(update_operations) - additions
+
+    if changes:
+        log_entry = models.RevisionLog(
+            dataset=datasetId,
+            author_name=user['login'],
+            author_id=user['_id'],
+            revision=new_revision,
+            additions=additions,
+            deletions=deletions,
+        )
+        RevisionLogItem().create(log_entry)
+
+    return {"updated": additions, "deleted": deletions}
+
+
+def clone_annotations(
+    source: types.GirderModel,
+    dest: types.GirderModel,
+    user: types.GirderUserModel,
+    revision: Optional[int] = None,
+):
+    source_iter, _ = get_annotations(source, revision=revision)
+    save_annotations(dest, source_iter, [], user)

--- a/server/dive_server/crud_annotation.py
+++ b/server/dive_server/crud_annotation.py
@@ -153,7 +153,7 @@ def save_annotations(
         query = {DATASET: datasetId, REVISION_DELETED: {'$exists': False}}
         expire_result = AnnotationItem().collection.bulk_write(
             [pymongo.UpdateMany(query, delete_annotation_update)]
-        )
+        ).bulk_api_result
 
     for track_id in delete_list:
         filter = {TRACKID: track_id, DATASET: datasetId, REVISION_DELETED: {'$exists': False}}
@@ -175,9 +175,9 @@ def save_annotations(
 
     # Ordered=false allows fast parallel writes
     if len(expire_operations):
-        expire_result = AnnotationItem().collection.bulk_write(expire_operations, ordered=False)
+        expire_result = AnnotationItem().collection.bulk_write(expire_operations, ordered=False).bulk_api_result
     if len(insert_operations):
-        insert_result = AnnotationItem().collection.bulk_write(insert_operations, ordered=False)
+        insert_result = AnnotationItem().collection.bulk_write(insert_operations, ordered=False).bulk_api_result
 
     additions = insert_result.get('nInserted', 0)
     deletions = expire_result.get('nModified', 0)

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -332,7 +332,7 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
                 [],
                 user,
                 overwrite=True,
-                description=f"Import from {filetype.value}",
+                description=f"Import from {filetype.name}",
             )
             crud.saveImportAttributes(folder, attrs, user)
             Item().move(item, auxiliary)
@@ -362,7 +362,7 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
             )
             Item().move(item, auxiliary)
         else:
-            raise RestException(f'Unknown file type {filetype}')
+            raise RestException(f'Unknown file type {filetype.name}')
 
 
 def postprocess(

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -326,7 +326,14 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
             raise RestException(f'{file["name"]} was not valid JSON or CSV: {e}') from e
 
         if filetype == crud.FileType.VIAME_CSV or filetype == crud.FileType.COCO_JSON:
-            crud_annotation.save_annotations(folder, data.values(), [], user, overwrite=True)
+            crud_annotation.save_annotations(
+                folder,
+                data.values(),
+                [],
+                user,
+                overwrite=True,
+                description=f"Import from {filetype.value}",
+            )
             crud.saveImportAttributes(folder, attrs, user)
             Item().move(item, auxiliary)
 
@@ -345,7 +352,14 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
                         )
                     )
                 crud.get_validated_model(models.Track, **track)
-            crud_annotation.save_annotations(folder, data.values(), [], user, overwrite=True)
+            crud_annotation.save_annotations(
+                folder,
+                data.values(),
+                [],
+                user,
+                overwrite=True,
+                description=f"Import from {filetype.value}",
+            )
             Item().move(item, auxiliary)
         else:
             raise RestException(f'Unknown file type {filetype}')
@@ -434,7 +448,9 @@ def postprocess(
 
             allFiles = [make_file_generator(item) for item in ymlItems]
             data = meva.load_kpf_as_tracks(allFiles)
-            crud_annotation.save_annotations(dsFolder, data.values(), [], user, overwrite=True)
+            crud_annotation.save_annotations(
+                dsFolder, data.values(), [], user, overwrite=True, description="Import from KPF"
+            )
             ymlItems.rewind()
             for item in ymlItems:
                 Item().move(item, auxiliary)

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Optional
+import json
+from typing import Dict, List, Optional, Tuple
 
 from girder.constants import AccessType
 from girder.exceptions import RestException
@@ -12,10 +13,10 @@ from girder.models.upload import Upload
 from girder_jobs.models.job import Job
 import pymongo
 
-from dive_server import crud
+from dive_server import crud, crud_annotation
 from dive_tasks import tasks
 from dive_utils import TRUTHY_META_VALUES, asbool, constants, fromMeta, models, slugify, types
-from dive_utils.serializers import meva
+from dive_utils.serializers import kwcoco, meva, viame
 
 from . import crud_dataset
 
@@ -138,13 +139,6 @@ def run_pipeline(
         # TODO Temporary inclusion of utility pipes which take csv input
         requires_input = True
 
-    detection_csv: Optional[types.GirderModel] = None
-    if requires_input:
-        # Ensure detection has a csv detections item
-        detection = crud.detections_item(folder, strict=True)
-        detection_csv = ensure_csv_detections_file(folder, detection, user)
-
-    crud.move_existing_result_to_auxiliary_folder(folder, user)
     job_is_private = user.get(constants.UserPrivateQueueEnabledMarker, False)
 
     params: types.PipelineJob = {
@@ -152,7 +146,7 @@ def run_pipeline(
         "input_type": fromMeta(folder, "type", required=True),
         "output_folder": folder_id_str,
         "pipeline": pipeline,
-        "pipeline_input": detection_csv,
+        "requires_input": requires_input,
     }
     newjob = tasks.run_pipeline.apply_async(
         queue=_get_queue_name(user, "pipelines"),
@@ -196,33 +190,6 @@ def training_output_folder(user: types.GirderUserModel) -> types.GirderModel:
     )
 
 
-def ensure_csv_detections_file(
-    folder: types.GirderModel, detection_item: Item, user: types.GirderUserModel
-) -> types.GirderModel:
-    """
-    Ensures that the detection item has a file which is a csv.
-    Attach the newly created .csv to the existing detection_item.
-    :returns: the file document.
-
-    TODO: move this to the training job code instead of keeping it
-    in the request thread
-    """
-    filename, gen = crud.get_annotation_csv_generator(folder, user, excludeBelowThreshold=True)
-    filename = slugify(filename)
-    csv_bytes = ("".join([line for line in gen()])).encode()
-    new_file = File().createFile(
-        user,
-        detection_item,
-        filename,
-        len(csv_bytes),
-        Assetstore().getCurrent(),
-        reuseExisting=True,
-    )
-    upload = Upload().createUploadToFile(new_file, user, len(csv_bytes))
-    new_file = Upload().handleChunk(upload, csv_bytes)
-    return new_file
-
-
 def run_training(
     user: types.GirderUserModel,
     token: types.GirderModel,
@@ -231,23 +198,16 @@ def run_training(
     config: str,
     annotatedFramesOnly: bool,
 ) -> types.GirderModel:
-    detection_list = []
     folder_list = []
-    folder_names = []
     if folderIds is None or len(folderIds) == 0:
         raise RestException("No folderIds in param")
 
     for folderId in folderIds:
+        # Ensure user has read permissions to run training on every folder requested
         folder = Folder().load(folderId, level=AccessType.READ, user=user)
         if folder is None:
             raise RestException(f"Cannot access folder {folderId}")
         crud.getCloneRoot(user, folder)
-        folder_names.append(folder['name'])
-        # Ensure detection has a csv format
-        # TODO: Move this into worker job
-        train_on_detections_item = crud.detections_item(folder, strict=True)
-        ensure_csv_detections_file(folder, train_on_detections_item, user)
-        detection_list.append(train_on_detections_item)
         folder_list.append(folder)
 
     # Ensure the folder to upload results to exists
@@ -272,7 +232,6 @@ def run_training(
         kwargs=dict(
             results_folder=results_folder,
             source_folder_list=folder_list,
-            groundtruth_list=detection_list,
             pipeline_name=pipelineName,
             config=config,
             annotated_frames_only=annotatedFramesOnly,
@@ -290,23 +249,65 @@ def run_training(
     return newjob.job
 
 
-def process_items(folder: types.GirderModel, user: types.GirderModel):
+def _get_data_by_type(
+    file: Optional[types.GirderModel], as_type: Optional[crud.FileType] = None
+) -> Tuple[Optional[crud.FileType], dict, dict]:
+    """
+    Given an arbitrary Girder file model, figure out what kind of file it is and
+    parse it appropriately.
+
+    :as_type: bypass type discovery (potentially expensive) if caller is certain about type
+    """
+    if file is None:
+        return None, {}, {}
+    file_string = b"".join(list(File().download(file, headers=False)())).decode()
+    data_dict = None
+
+    # If the caller has not specified a type, try to discover it
+    if as_type is None:
+        if file['exts'][-1] == 'csv':
+            as_type = crud.FileType.VIAME_CSV
+        elif file['exts'][-1] == 'json':
+            data_dict = json.loads(file_string)
+            if type(data_dict) is list:
+                raise RestException('No array-type json objects are supported')
+            if kwcoco.is_coco_json(data_dict):
+                as_type = crud.FileType.COCO_JSON
+            elif models.MetadataMutable.is_dive_configuration(data_dict):
+                data_dict = models.MetadataMutable(**data_dict).dict(exclude_none=True)
+                as_type = crud.FileType.DIVE_CONF
+            else:
+                as_type = crud.FileType.DIVE_JSON
+        else:
+            raise RestException('Got file of unknown and unusable type')
+
+    # Parse the file as the now known type
+    if as_type == crud.FileType.VIAME_CSV:
+        tracks, attributes = viame.load_csv_as_tracks_and_attributes(file_string.splitlines())
+        return as_type, tracks, attributes
+
+    # All filetypes below are JSON, so if as_type was specified, it needs to be loaded.
+    if data_dict is None:
+        data_dict = json.loads(file_string)
+
+    if as_type == crud.FileType.COCO_JSON:
+        tracks, attributes = kwcoco.load_coco_as_tracks_and_attributes(data_dict)
+        return as_type, tracks, attributes
+    if as_type == crud.FileType.DIVE_CONF or as_type == crud.FileType.DIVE_JSON:
+        return as_type, data_dict, {}
+    return None, {}, {}
+
+
+def process_items(folder: types.GirderModel, user: types.GirderUserModel):
     """
     Discover unprocessed items in a dataset and process them by type in order of creation
     """
     unprocessed_items = Folder().childItems(
         folder,
         filters={
-            "$and": [
-                # Look for both JSON and CSV items
-                {
-                    "$or": [
-                        {"lowerName": {"$regex": constants.csvRegex}},
-                        {"lowerName": {"$regex": constants.jsonRegex}},
-                    ]
-                },
-                # Don't re-process existing annotation files
-                {f"meta.{constants.DetectionMarker}": {'$not': {"$in": TRUTHY_META_VALUES}}},
+            "$or": [
+                {"lowerName": {"$regex": constants.csvRegex}},
+                {"lowerName": {"$regex": constants.jsonRegex}},
             ]
         },
         # Processing order: oldest to newest
@@ -319,17 +320,17 @@ def process_items(folder: types.GirderModel, user: types.GirderModel):
             raise RestException('Item had no associated files')
 
         try:
-            filetype, data, attrs = crud.get_data_by_type(file)
+            filetype, data, attrs = _get_data_by_type(file)
         except Exception as e:
             Item().remove(item)
             raise RestException(f'{file["name"]} was not valid JSON or CSV: {e}') from e
 
         if filetype == crud.FileType.VIAME_CSV or filetype == crud.FileType.COCO_JSON:
-            crud.saveTracks(folder, data, user)
+            crud_annotation.save_annotations(folder, data.values(), [], user, overwrite=True)
             crud.saveImportAttributes(folder, attrs, user)
             Item().move(item, auxiliary)
 
-        if filetype == crud.FileType.DIVE_CONF:
+        elif filetype == crud.FileType.DIVE_CONF:
             crud_dataset.update_metadata(folder, data)
             Item().remove(item)
 
@@ -344,9 +345,10 @@ def process_items(folder: types.GirderModel, user: types.GirderModel):
                         )
                     )
                 crud.get_validated_model(models.Track, **track)
-            item['meta'][constants.DetectionMarker] = str(folder['_id'])
-            Item().save(item)
-    crud.move_existing_result_to_auxiliary_folder(folder, user)
+            crud_annotation.save_annotations(folder, data.values(), [], user, overwrite=True)
+            Item().move(item, auxiliary)
+        else:
+            raise RestException(f'Unknown file type {filetype}')
 
 
 def postprocess(
@@ -431,7 +433,8 @@ def postprocess(
                 return File().download(file, headers=False)()
 
             allFiles = [make_file_generator(item) for item in ymlItems]
-            crud.saveTracks(dsFolder, meva.load_kpf_as_tracks(allFiles), user)
+            data = meva.load_kpf_as_tracks(allFiles)
+            crud_annotation.save_annotations(dsFolder, data.values(), [], user, overwrite=True)
             ymlItems.rewind()
             for item in ymlItems:
                 Item().move(item, auxiliary)
@@ -439,9 +442,4 @@ def postprocess(
         Folder().save(dsFolder)
 
     process_items(dsFolder, user)
-
-    # If no detections file exists create one
-    if crud.detections_file(dsFolder) is None:
-        crud.saveTracks(dsFolder, {}, user)
-
     return dsFolder

--- a/server/dive_server/event.py
+++ b/server/dive_server/event.py
@@ -16,7 +16,6 @@ from dive_utils.constants import (
     AssetstoreSourcePathMarker,
     DatasetMarker,
     DefaultVideoFPS,
-    DetectionMarker,
     FPSMarker,
     ImageSequenceType,
     TypeMarker,
@@ -59,11 +58,9 @@ def process_assetstore_import(event, meta: dict):
         }
     )
 
-    if csvRegex.search(importPath):
-        # Update file metadata
-        item["meta"].update({DetectionMarker: str(item["folderId"])})
+    # TODO figure out what's going on here?
 
-    elif imageRegex.search(importPath):
+    if imageRegex.search(importPath):
         dataset_type = ImageSequenceType
 
     elif videoRegex.search(importPath):

--- a/server/dive_server/views_annotation.py
+++ b/server/dive_server/views_annotation.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+import cherrypy
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource, setResponseHeader
@@ -26,18 +27,33 @@ class AnnotationResource(Resource):
         self.resourceName = resourceName
 
         self.route("GET", (), self.get_annotations)
+        self.route("GET", ("revision",), self.get_revisions)
         self.route("GET", ("export",), self.export)
 
         self.route("PATCH", (), self.save_annotations)
 
     @access.user
     @autoDescribeRoute(
-        Description("Get annotations of a clip").modelParam(
-            "folderId", **DatasetModelParam, level=AccessType.READ
-        )
+        Description("Get annotations of a dataset")
+        .pagingParams("trackId", defaultLimit=0)
+        .modelParam("folderId", **DatasetModelParam, level=AccessType.READ)
+        .param('revision', 'revision', dataType='integer', required=False)
     )
-    def get_annotations(self, folder):
-        return crud_annotation.get_annotations(folder)
+    def get_annotations(self, limit: int, offset: int, sort, folder, revision):
+        cursor, total = crud_annotation.get_annotations(folder, limit, offset, sort, revision)
+        cherrypy.response.headers['Girder-Total-Count'] = total
+        return cursor
+
+    @access.user
+    @autoDescribeRoute(
+        Description("Get dataset annotation revision log")
+        .pagingParams("revision", defaultLimit=20)
+        .modelParam("folderId", **DatasetModelParam, level=AccessType.READ)
+    )
+    def get_revisions(self, limit: int, offset: int, sort, folder):
+        cursor, total = crud_annotation.get_revisions(folder, limit, offset, sort)
+        cherrypy.response.headers['Girder-Total-Count'] = total
+        return cursor
 
     @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(
@@ -61,7 +77,7 @@ class AnnotationResource(Resource):
     )
     def export(self, folder, excludeBelowThreshold: bool, typeFilter: Optional[List[str]]):
         crud.verify_dataset(folder)
-        filename, gen = crud.get_annotation_csv_generator(
+        filename, gen = crud_annotation.get_annotation_csv_generator(
             folder,
             self.getCurrentUser(),
             excludeBelowThreshold=excludeBelowThreshold,
@@ -79,4 +95,10 @@ class AnnotationResource(Resource):
         .jsonParam("tracks", "upsert and delete tracks", paramType="body", requireObject=True)
     )
     def save_annotations(self, folder, tracks):
-        return crud_annotation.save_annotations(folder, self.getCurrentUser(), tracks)
+        crud.verify_dataset(folder)
+        validated: crud_annotation.AnnotationUpdateArgs = crud.get_validated_model(
+            crud_annotation.AnnotationUpdateArgs, **tracks
+        )
+        upsert = [track.dict(exclude_none=True) for track in validated.upsert]
+        user = self.getCurrentUser()
+        return crud_annotation.save_annotations(folder, upsert, validated.delete, user)

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -68,10 +68,19 @@ class DatasetResource(Resource):
             dataType="string",
             required=True,
         )
+        .param(
+            "revision",
+            "Revision ID to use for clone source",
+            paramType="query",
+            dataType="integer",
+            default=None,
+        )
     )
-    def create_dataset(self, cloneSource, parentFolder, name):
+    def create_dataset(self, cloneSource, parentFolder, name, revision):
         # TODO: make this endpoint do regular creation and clone
-        return crud_dataset.createSoftClone(self.getCurrentUser(), cloneSource, parentFolder, name)
+        return crud_dataset.createSoftClone(
+            self.getCurrentUser(), cloneSource, parentFolder, name, revision
+        )
 
     @access.user
     @autoDescribeRoute(

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -2,11 +2,11 @@ from typing import List, Optional
 
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
-from girder.api.rest import Resource, rawResponse, setResponseHeader
-from girder.constants import AccessType, TokenScope
+from girder.api.rest import Resource, rawResponse
+from girder.constants import AccessType, SortDir, TokenScope
 from girder.models.folder import Folder
 
-from dive_utils import constants, slugify
+from dive_utils import constants, setContentDisposition
 from dive_utils.models import MetadataMutable
 
 from . import crud_dataset
@@ -85,7 +85,7 @@ class DatasetResource(Resource):
     @access.user
     @autoDescribeRoute(
         Description("List datasets in the system")
-        .pagingParams("created")
+        .pagingParams("created", defaultSortDir=SortDir.DESCENDING)
         .param(
             constants.PublishedMarker,
             'Return only published datasets',
@@ -135,9 +135,7 @@ class DatasetResource(Resource):
         )
     )
     def get_configuration(self, folder):
-        setResponseHeader('Content-Type', 'application/json')
-        filename = slugify(f'{folder["name"]}.config.json')
-        setResponseHeader('Content-Disposition', f'attachment; filename="{filename}"')
+        setContentDisposition(f'{folder["name"]}.config.json')
         # A dataset configuration consists of MetadataMutable properties.
         expose = MetadataMutable.schema()['properties'].keys()
         return crud_dataset.get_dataset(folder, self.getCurrentUser()).json(
@@ -205,9 +203,7 @@ class DatasetResource(Resource):
             excludeBelowThreshold=excludeBelowThreshold,
             typeFilter=typeFilter,
         )
-        filename = slugify(f'{folder["name"]}.zip')
-        setResponseHeader('Content-Type', 'application/zip')
-        setResponseHeader('Content-Disposition', f'attachment; filename="{filename}"')
+        setContentDisposition(f'{folder["name"]}.zip', mime='application/zip')
         return gen
 
     @access.user

--- a/server/dive_server/views_summary.py
+++ b/server/dive_server/views_summary.py
@@ -9,7 +9,8 @@ from girder.constants import AccessType, SortDir, TokenScope
 from girder.models.folder import Folder
 from girder.models.token import Token
 
-from dive_server.crud import PydanticModel, detections_file, getTrackData
+from dive_server.crud import PydanticAccessControlModel
+from dive_server.crud_annotation import get_annotations_as_dict
 from dive_tasks.summary import generate_max_n_summary, generate_summary
 from dive_utils import fromMeta, models
 from dive_utils.serializers.viame import format_timestamp
@@ -44,7 +45,7 @@ def generate_max_n_summary_csv(
 
     def gen():
         for folder in folders:
-            track_data = getTrackData(detections_file(folder))
+            track_data = get_annotations_as_dict(folder)
             annotation_fps = fromMeta(folder, 'fps')
             for detection_type, result in generate_max_n_summary(track_data).items():
                 writer.writerow(
@@ -65,7 +66,7 @@ def generate_max_n_summary_csv(
     return gen
 
 
-class SummaryItem(PydanticModel):
+class SummaryItem(PydanticAccessControlModel):
     def initialize(self):
         return super().initialize("summaryItem", models.SummaryItemSchema)
 

--- a/server/dive_utils/__init__.py
+++ b/server/dive_utils/__init__.py
@@ -4,6 +4,8 @@ import re
 from typing import Any, Dict, List, Union
 import unicodedata
 
+from girder.api.rest import setResponseHeader
+
 from dive_utils.types import GirderModel
 
 TRUTHY_META_VALUES = ['yes', '1', 1, 'true', 't', 'True', True]
@@ -82,3 +84,10 @@ def slugify(value, allow_unicode=False):
     if '.' in value and len(value.split('.')) == 1:  # all unicode stripped, gives back sample.ext
         value = f"sample{value}"
     return re.sub(r'[-\s]+', '-', value)
+
+
+def setContentDisposition(filename: str, disposition='attachment', mime='application/json'):
+    if disposition == 'attachment':
+        setResponseHeader('Content-Type', mime)
+        filename = slugify(filename)
+        setResponseHeader('Content-Disposition', f'attachment; filename={filename}')

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -63,7 +63,6 @@ VideoMimeTypes = {
 
 # Metadata markers
 DatasetMarker = "annotate"
-DetectionMarker = "detection"
 PublishedMarker = "published"
 SharedMarker = "shared"
 ForeignMediaIdMarker = "foreign_media_id"

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from bson.objectid import InvalidId, ObjectId
+from bson.objectid import ObjectId
 from pydantic import BaseModel, Field, validator
 from typing_extensions import Literal
 
@@ -89,18 +89,19 @@ class Track(BaseModel):
 
 
 class AnnotationItemSchema(Track):
-    dataset: PydanticObjectId  # Not supported by pydantic
+    dataset: PydanticObjectId
     rev_created: int = 0
     rev_deleted: Optional[int]
 
 
 class RevisionLog(BaseModel):
-    dataset: PydanticObjectId  # Not supported by pydantic
-    author_id: PydanticObjectId  # Not supported by pydantic
+    dataset: PydanticObjectId
+    author_id: PydanticObjectId
     author_name: str
     revision: int
     additions: int = 0
     deletions: int = 0
+    created: datetime = Field(default_factory=datetime.utcnow)
     description: Optional[str]
 
 

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -1,7 +1,21 @@
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from bson.objectid import InvalidId, ObjectId
 from pydantic import BaseModel, Field, validator
 from typing_extensions import Literal
+
+
+class PydanticObjectId(str):
+    """https://stackoverflow.com/a/69431643"""
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        return ObjectId(v)
 
 
 class GeoJSONGeometry(BaseModel):
@@ -72,6 +86,22 @@ class Track(BaseModel):
 
     def __hash__(self):
         return self.trackId
+
+
+class AnnotationItemSchema(Track):
+    dataset: PydanticObjectId  # Not supported by pydantic
+    rev_created: int = 0
+    rev_deleted: Optional[int]
+
+
+class RevisionLog(BaseModel):
+    dataset: PydanticObjectId  # Not supported by pydantic
+    author_id: PydanticObjectId  # Not supported by pydantic
+    author_name: str
+    revision: int
+    additions: int = 0
+    deletions: int = 0
+    description: Optional[str]
 
 
 class Attribute(BaseModel):

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -274,7 +274,7 @@ def load_csv_as_tracks_and_attributes(rows: List[str]) -> Tuple[dict, dict]:
 
 
 def export_tracks_as_csv(
-    track_dict,
+    track_iterator,
     excludeBelowThreshold=False,
     thresholds=None,
     filenames=None,
@@ -309,8 +309,8 @@ def export_tracks_as_csv(
         if fps is not None:
             metadata["fps"] = fps
         writeHeader(writer, metadata)
-    track_values = track_dict.values()
-    for t in track_values:
+
+    for t in track_iterator:
         track = Track(**t)
         if (not excludeBelowThreshold) or track.exceeds_thresholds(thresholds):
 
@@ -392,5 +392,4 @@ def export_tracks_as_csv(
                     yield csvFile.getvalue()
                     csvFile.seek(0)
                     csvFile.truncate(0)
-    if len(track_values) == 0:
-        yield csvFile.getvalue()
+    yield csvFile.getvalue()

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -57,7 +57,7 @@ class PipelineJob(TypedDict):
     input_folder: str
     input_type: str
     output_folder: str
-    pipeline_input: Optional[GirderModel]
+    requires_input: bool
 
 
 class TrainingConfigurationSummary(TypedDict):

--- a/server/scripts/migrations.py
+++ b/server/scripts/migrations.py
@@ -34,7 +34,7 @@ def migrate_server(dry_run):
                     click.echo(f'  Loading {len(tracks)} tracks into {dataset_id}')
                     total_tracks_ingested += len(tracks)
                     crud_annotation.save_annotations(
-                        dataset, tracks, [], admin_user, overwrite=True
+                        dataset, tracks, [], admin_user, overwrite=True, description="Migration"
                     )
                     annotation['meta']['migrated'] = True
                     Item().updateItem(annotation)

--- a/server/scripts/migrations.py
+++ b/server/scripts/migrations.py
@@ -1,0 +1,50 @@
+import json
+import re
+
+import click
+from girder.models.file import File
+from girder.models.folder import Folder
+from girder.models.item import Item
+from girder.models.user import User
+
+from dive_server import crud, crud_annotation
+
+
+@click.command(name="migrate")
+@click.option('--dry-run', is_flag=True, default=False)
+def migrate_server(dry_run):
+    admin_user = User().findOne({'admin': True})
+    click.echo(f'Running as user {admin_user["login"]}')
+    total_tracks_ingested = 0
+    annotation_files = Item().find(
+        {'meta.detection': {'$exists': True}, 'meta.migrated': {'$exists': False}},
+        sort=[['created', 1]],
+    )
+    for annotation in annotation_files:
+        if annotation['name'].endswith('.json'):
+            dataset_id = annotation["meta"]["detection"]
+            dataset = Folder().load(dataset_id, user=admin_user)
+            crud.verify_dataset(dataset)
+            click.echo(f'Migrating annotation file {annotation["name"]} @ {dataset_id}')
+            for file in Item().childFiles(annotation):
+                if file['name'].endswith('.json'):
+                    file_string = b"".join(list(File().download(file, headers=False)())).decode()
+                    data_dict = json.loads(file_string)
+                    tracks = list(data_dict.values())
+                    click.echo(f'  Loading {len(tracks)} tracks into {dataset_id}')
+                    total_tracks_ingested += len(tracks)
+                    crud_annotation.save_annotations(
+                        dataset, tracks, [], admin_user, overwrite=True
+                    )
+                    annotation['meta']['migrated'] = True
+                    Item().updateItem(annotation)
+                    break
+                else:
+                    click.echo(f'  Skipping {annotation["name"]}')
+        else:
+            click.echo(f'Skipping {annotation["name"]}')
+    click.echo(f'Ingested {total_tracks_ingested} tracks')
+
+
+if __name__ == "__main__":
+    migrate_server()

--- a/server/tests/integration/test_download_extract.py
+++ b/server/tests/integration/test_download_extract.py
@@ -26,3 +26,14 @@ def test_extract_download(data):
         gc.downloadFile(fileId, str(filepath))
         with zipfile.ZipFile(filepath, 'r') as zipref:
             zipref.extractall(localDataRoot)
+
+
+@pytest.mark.integration
+@pytest.mark.run(order=1)
+def test_sanity_checks():
+    gc = GirderClient(apiUrl=source_api_root)
+    resp = gc.get('/', jsonResp=False)
+    assert resp.status_code == 200
+    assert resp.headers['Content-Type'] == 'text/html;charset=utf-8'
+    resp = gc.get('system/check', jsonResp=False)
+    assert resp.status_code == 200


### PR DESCRIPTION
# Reviewer notes

* This is the largest change and will require the most discussion
* It leaves jobs (pipelines/training/summary) in a broken state fixed by #1068, but I spearated them because the changes are pretty much completely independent, and I thought it would be easier to review by breaking it apart.

## Design

This is a soft delete implementation that tolerates data duplication in favor of defending against data loss.

* By modeling the annotations with a `rev_created` and `rev_deleted`, you can check out any point in history.  This is the simplest implementation I could come up with, and should be looked at critically.  I'm open to changing it.
* There is also a revision log collection.  This collection is non-critical (doesn't need to be joined in order to reconstruct history).  It's just a convenience for attaching metadata to revisions, such as author, description, and timestamp.

## Logic - Creation

* `revision` is an increasing integer key (per dataset)
* When a track is saved, the full track is saved as a single mongo record.  `rev_created` is set as the current `revision`
* If a previous version of the track existed, its `rev_deleted` field is set, marking that previous version as lazy-deleted.

## Logic - Checkout

```python
{
        DATASET: dsFolder['_id'],
        REVISION_CREATED: {'$lte': head},
        '$or': [{REVISION_DELETED: {'$gt': head}}, {REVISION_DELETED: {'$exists': False}}],
    }
```
 "Get annotations from this dataset where revision_created is less than or equal to target and either deleted is greater than target or deleted is not set."

## Deconflicting

There's another concern we could address here: deconflicting multi-user saves.  Suppose User A loads, User B Loads, User B saves, and User A saves.  Currently, each save is an overwrite and User A might break some of B's work.

Now that we have revisions, each save could require that the user provide the ID they loaded and if the ID has changed since they loaded, the server could attempt to merge and detect a collision.   This could be considered in-scope, but I think maintaining the existing behavior for now is best.

There are even advanced options where we could utilize the notification stream to deliver notifications to all users who have a given dataset open.  This is well out of scope for this stage of changes, but interesting to think about.