### PR TITLE
Mongo 2: Rollback API

### DIFF
--- a/server/dive_server/crud_annotation.py
+++ b/server/dive_server/crud_annotation.py
@@ -84,10 +84,11 @@ def rollback(dsFolder: types.GirderModel, revision: int):
     # TODO implement immutabble forward-rollback (like git revert)
     # Logic: delete everything created after revision
     # And erase deletions for anything deleted after revision
-    RevisionLogItem().removeWithQuery({REVISION: {'$gt': revision}})
-    AnnotationItem().removeWithQuery({REVISION_CREATED: {'$gt': revision}})
+    dsId = dsFolder['_id']
+    RevisionLogItem().removeWithQuery({DATASET: dsId, REVISION: {'$gt': revision}})
+    AnnotationItem().removeWithQuery({DATASET: dsId, REVISION_CREATED: {'$gt': revision}})
     AnnotationItem().update(
-        {REVISION_DELETED: {'$gt': revision}}, {'$unset': {REVISION_DELETED: ""}}
+        {DATASET: dsId, REVISION_DELETED: {'$gt': revision}}, {'$unset': {REVISION_DELETED: ""}}
     )
 
 

--- a/server/dive_server/views_annotation.py
+++ b/server/dive_server/views_annotation.py
@@ -29,8 +29,8 @@ class AnnotationResource(Resource):
         self.route("GET", (), self.get_annotations)
         self.route("GET", ("revision",), self.get_revisions)
         self.route("GET", ("export",), self.export)
-
         self.route("PATCH", (), self.save_annotations)
+        self.route("DELETE", (), self.rollback)
 
     @access.user
     @autoDescribeRoute(
@@ -97,7 +97,7 @@ class AnnotationResource(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description("")
+        Description("Update annotations")
         .modelParam("folderId", **DatasetModelParam, level=AccessType.WRITE)
         .jsonParam("tracks", "upsert and delete tracks", paramType="body", requireObject=True)
     )
@@ -109,3 +109,13 @@ class AnnotationResource(Resource):
         upsert = [track.dict(exclude_none=True) for track in validated.upsert]
         user = self.getCurrentUser()
         return crud_annotation.save_annotations(folder, upsert, validated.delete, user)
+
+    @access.user
+    @autoDescribeRoute(
+        Description("Rollback annotation revision")
+        .modelParam("folderId", **DatasetModelParam, level=AccessType.WRITE)
+        .param('revision', 'revision', dataType='integer')
+    )
+    def rollback(self, folder, revision):
+        crud.verify_dataset(folder)
+        crud_annotation.rollback(folder, revision)

--- a/server/dive_server/views_annotation.py
+++ b/server/dive_server/views_annotation.py
@@ -30,7 +30,7 @@ class AnnotationResource(Resource):
         self.route("GET", ("revision",), self.get_revisions)
         self.route("GET", ("export",), self.export)
         self.route("PATCH", (), self.save_annotations)
-        self.route("DELETE", (), self.rollback)
+        self.route("POST", ("rollback"), self.rollback)
 
     @access.user
     @autoDescribeRoute(
@@ -112,7 +112,7 @@ class AnnotationResource(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description("Rollback annotation revision")
+        Description("Rollback annotation revision to the specified version")
         .modelParam("folderId", **DatasetModelParam, level=AccessType.WRITE)
         .param('revision', 'revision', dataType='integer')
     )


### PR DESCRIPTION
## Reviewer notes

This could have been included in #1066 but it's a new feature, so I made it separate.  It provides a read API for rolling back to earlier versions.  

## Important

This implementation is naive and I don't want to keep it forever.  It's a true rollback such that it actually deletes rows from the DB.  I would prefer a soft rollback like `git revert` which replays changes in reverse.  But that sounded complicated and I didn't feel like writing it.