### PR TITLE
Mongo 3: Utilize new endpoints in celery

### DIFF
--- a/server/dive_server/crud_annotation.py
+++ b/server/dive_server/crud_annotation.py
@@ -163,9 +163,11 @@ def save_annotations(
 
     if overwrite:
         query = {DATASET: datasetId, REVISION_DELETED: {'$exists': False}}
-        expire_result = AnnotationItem().collection.bulk_write(
-            [pymongo.UpdateMany(query, delete_annotation_update)]
-        ).bulk_api_result
+        expire_result = (
+            AnnotationItem()
+            .collection.bulk_write([pymongo.UpdateMany(query, delete_annotation_update)])
+            .bulk_api_result
+        )
 
     for track_id in delete_list:
         filter = {TRACKID: track_id, DATASET: datasetId, REVISION_DELETED: {'$exists': False}}
@@ -187,9 +189,13 @@ def save_annotations(
 
     # Ordered=false allows fast parallel writes
     if len(expire_operations):
-        expire_result = AnnotationItem().collection.bulk_write(expire_operations, ordered=False).bulk_api_result
+        expire_result = (
+            AnnotationItem().collection.bulk_write(expire_operations, ordered=False).bulk_api_result
+        )
     if len(insert_operations):
-        insert_result = AnnotationItem().collection.bulk_write(insert_operations, ordered=False).bulk_api_result
+        insert_result = (
+            AnnotationItem().collection.bulk_write(insert_operations, ordered=False).bulk_api_result
+        )
 
     additions = insert_result.get('nInserted', 0)
     deletions = expire_result.get('nModified', 0)

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -250,7 +250,7 @@ def run_training(
         kwargs=dict(
             params=params,
             girder_client_token=str(token["_id"]),
-            girder_job_title=(f"Running training on {len(folderIds)} datasets"),
+            girder_job_title=(f"Running training on {len(bodyParams.folderIds)} datasets"),
             girder_job_type="private" if job_is_private else "training",
         ),
     )

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -327,7 +327,7 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
     )
     auxiliary = crud.get_or_create_auxiliary_folder(folder, user)
     for item in unprocessed_items:
-        file = next(Item().childFiles(item), None)
+        file: Optional[types.GirderModel] = next(Item().childFiles(item), None)
         if file is None:
             raise RestException('Item had no associated files')
 
@@ -344,7 +344,7 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
                 [],
                 user,
                 overwrite=True,
-                description=f"Import from {filetype.name}",
+                description=f'Import {filetype.name} from {file["name"]}',
             )
             crud.saveImportAttributes(folder, attrs, user)
             item['meta'][constants.ProcessedMarker] = True
@@ -372,12 +372,12 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
                 [],
                 user,
                 overwrite=True,
-                description=f"Import from {filetype.value}"
+                description=f"Import from {filetype.value}",
             )
             item['meta'][constants.ProcessedMarker] = True
             Item().move(item, auxiliary)
         else:
-            raise RestException(f'Unknown file type {filetype.name}')
+            raise RestException(f'Unknown file type for {file["name"]}')
 
 
 def postprocess(

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -3,20 +3,19 @@ from typing import Dict, List, Optional, Tuple
 
 from girder.constants import AccessType
 from girder.exceptions import RestException
-from girder.models.assetstore import Assetstore
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
 from girder.models.setting import Setting
 from girder.models.token import Token
-from girder.models.upload import Upload
-from girder_jobs.models.job import Job
+from girder_jobs.models.job import Job, JobStatus
+from girder_worker.girder_plugin.status import CustomJobStatus
 from pydantic import BaseModel
 import pymongo
 
 from dive_server import crud, crud_annotation
 from dive_tasks import tasks
-from dive_utils import TRUTHY_META_VALUES, asbool, constants, fromMeta, models, slugify, types
+from dive_utils import TRUTHY_META_VALUES, asbool, constants, fromMeta, models, types
 from dive_utils.serializers import kwcoco, meva, viame
 
 from . import crud_dataset
@@ -31,6 +30,31 @@ def _get_queue_name(user: types.GirderUserModel, default="celery") -> str:
     if user.get(constants.UserPrivateQueueEnabledMarker, False):
         return f'{user["login"]}@private'
     return default
+
+
+def _check_running_jobs(folder_id_str: str):
+    """Find running jobs associated with the given folder"""
+    return (
+        Job().findOne(
+            {
+                constants.JOBCONST_DATASET_ID: folder_id_str,
+                'status': {
+                    '$in': [
+                        # All possible states for an incomplete job
+                        JobStatus.INACTIVE,
+                        JobStatus.QUEUED,
+                        JobStatus.RUNNING,
+                        CustomJobStatus.CANCELING,
+                        CustomJobStatus.CONVERTING_OUTPUT,
+                        CustomJobStatus.CONVERTING_INPUT,
+                        CustomJobStatus.FETCHING_INPUT,
+                        CustomJobStatus.PUSHING_OUTPUT,
+                    ],
+                },
+            }
+        )
+        is not None
+    )
 
 
 def _load_dynamic_pipelines(user: types.GirderUserModel) -> Dict[str, types.PipelineCategory]:
@@ -112,20 +136,9 @@ def run_pipeline(
     """
     verify_pipe(user, pipeline)
     crud.getCloneRoot(user, folder)
-
     folder_id_str = str(folder["_id"])
     # First, verify that no other outstanding jobs are running on this dataset
-    existing_jobs = Job().findOne(
-        {
-            constants.JOBCONST_DATASET_ID: folder_id_str,
-            'status': {
-                # Find jobs that are inactive, queued, or running
-                # https://github.com/girder/girder/blob/main/plugins/jobs/girder_jobs/constants.py
-                '$in': [0, 1, 2]
-            },
-        }
-    )
-    if existing_jobs is not None:
+    if _check_running_jobs(folder_id_str):
         raise RestException(
             (
                 f"A pipeline for {folder_id_str} is already running. "
@@ -136,23 +149,24 @@ def run_pipeline(
 
     token = Token().createToken(user=user, days=14)
 
-    requires_input = False  # include CSV input for pipe
+    input_revision = None  # include CSV input for pipe
     if pipeline["type"] == constants.TrainedPipelineCategory:
         # Verify that the user has READ access to the pipe they want to run
         pipeFolder = Folder().load(pipeline["folderId"], level=AccessType.READ, user=user)
-        requires_input = asbool(fromMeta(pipeFolder, "requires_input"))
+        if asbool(fromMeta(pipeFolder, "requires_input")):
+            input_revision = crud_annotation.get_last_revision(folder)
     elif pipeline["pipe"].startswith('utility_'):
         # TODO Temporary inclusion of utility pipes which take csv input
-        requires_input = True
+        input_revision = crud_annotation.get_last_revision(folder)
 
     job_is_private = user.get(constants.UserPrivateQueueEnabledMarker, False)
 
     params: types.PipelineJob = {
+        "pipeline": pipeline,
         "input_folder": folder_id_str,
         "input_type": fromMeta(folder, "type", required=True),
         "output_folder": folder_id_str,
-        "pipeline": pipeline,
-        "requires_input": requires_input,
+        "input_revision": input_revision,
     }
     newjob = tasks.run_pipeline.apply_async(
         queue=_get_queue_name(user, "pipelines"),
@@ -165,8 +179,8 @@ def run_pipeline(
     )
     newjob.job[constants.JOBCONST_PRIVATE_QUEUE] = job_is_private
     newjob.job[constants.JOBCONST_DATASET_ID] = folder_id_str
-    newjob.job[constants.JOBCONST_RESULTS_FOLDER_ID] = folder_id_str
-    newjob.job[constants.JOBCONST_PIPELINE_NAME] = pipeline['name']
+    newjob.job[constants.JOBCONST_PARAMS] = params
+    newjob.job[constants.JOBCONST_CREATOR] = str(user['_id'])
     # Allow any users with accecss to the input data to also
     # see and possibly manage the job
     Job().copyAccessPolicies(folder, newjob.job)
@@ -204,7 +218,7 @@ def run_training(
     config: str,
     annotatedFramesOnly: bool,
 ) -> types.GirderModel:
-    folder_list = []
+    dataset_input_list: List[Tuple[str, int]] = []
     if len(bodyParams.folderIds) == 0:
         raise RestException("No folderIds in param")
 
@@ -213,46 +227,36 @@ def run_training(
         if folder is None:
             raise RestException(f"Cannot access folder {folderId}")
         crud.getCloneRoot(user, folder)
-        folder_list.append(folder)
+        dataset_input_list.append((folderId, crud_annotation.get_last_revision(folder)))
 
     # Ensure the folder to upload results to exists
     results_folder = training_output_folder(user)
-    output_folders = list(
-        Folder().find(
-            query={
-                'parentId': results_folder['_id'],
-                'name': pipelineName,
-            },
-            user=user,
-            limit=1,
-        )
-    )
-    if len(output_folders):
+    if Folder().findOne({'parentId': results_folder['_id'], 'name': pipelineName}):
         raise RestException(
             f'Output pipeline "{pipelineName}" already exists, please choose a different name'
         )
+
+    params: types.TrainingJob = {
+        'results_folder_id': results_folder['_id'],
+        'dataset_input_list': dataset_input_list,
+        'pipeline_name': pipelineName,
+        'config': config,
+        'annotated_frames_only': annotatedFramesOnly,
+        'label_txt': bodyParams.labelText,
+    }
     job_is_private = user.get(constants.UserPrivateQueueEnabledMarker, False)
     newjob = tasks.train_pipeline.apply_async(
         queue=_get_queue_name(user, "training"),
         kwargs=dict(
-            results_folder=results_folder,
-            source_folder_list=folder_list,
-            pipeline_name=pipelineName,
-            config=config,
-            annotated_frames_only=annotatedFramesOnly,
-            label_text=bodyParams.labelText,
+            params=params,
             girder_client_token=str(token["_id"]),
-            girder_job_title=(f"Running training on {len(folder_list)} datasets"),
+            girder_job_title=(f"Running training on {len(folderIds)} datasets"),
             girder_job_type="private" if job_is_private else "training",
         ),
     )
     newjob.job[constants.JOBCONST_PRIVATE_QUEUE] = job_is_private
-    newjob.job[constants.JOBCONST_TRAINING_INPUT_IDS] = bodyParams.folderIds
-    newjob.job[constants.JOBCONST_RESULTS_FOLDER_ID] = str(results_folder['_id'])
-    newjob.job[constants.JOBCONST_TRAINING_CONFIG] = config
-    newjob.job[constants.JOBCONST_PIPELINE_NAME] = pipelineName
-    newjob.job[constants.JOBCONST_LABEL_TEXT] = bodyParams.labelText
-
+    newjob.job[constants.JOBCONST_PARAMS] = params
+    newjob.job[constants.JOBCONST_CREATOR] = str(user['_id'])
     Job().save(newjob.job)
     return newjob.job
 
@@ -343,11 +347,13 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
                 description=f"Import from {filetype.name}",
             )
             crud.saveImportAttributes(folder, attrs, user)
+            item['meta'][constants.ProcessedMarker] = True
             Item().move(item, auxiliary)
 
         elif filetype == crud.FileType.DIVE_CONF:
             crud_dataset.update_metadata(folder, data)
-            Item().remove(item)
+            item['meta'][constants.ProcessedMarker] = True
+            Item().move(item, auxiliary)
 
         elif filetype == crud.FileType.DIVE_JSON:
             for track in data.values():
@@ -366,8 +372,9 @@ def process_items(folder: types.GirderModel, user: types.GirderUserModel):
                 [],
                 user,
                 overwrite=True,
-                description=f"Import from {filetype.value}",
+                description=f"Import from {filetype.value}"
             )
+            item['meta'][constants.ProcessedMarker] = True
             Item().move(item, auxiliary)
         else:
             raise RestException(f'Unknown file type {filetype.name}')

--- a/server/dive_server/event.py
+++ b/server/dive_server/event.py
@@ -20,7 +20,6 @@ from dive_utils.constants import (
     ImageSequenceType,
     TypeMarker,
     VideoType,
-    csvRegex,
     imageRegex,
     videoRegex,
 )

--- a/server/dive_server/views_annotation.py
+++ b/server/dive_server/views_annotation.py
@@ -30,7 +30,7 @@ class AnnotationResource(Resource):
         self.route("GET", ("revision",), self.get_revisions)
         self.route("GET", ("export",), self.export)
         self.route("PATCH", (), self.save_annotations)
-        self.route("POST", ("rollback"), self.rollback)
+        self.route("POST", ("rollback",), self.rollback)
 
     @access.user
     @autoDescribeRoute(

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -74,6 +74,7 @@ class DatasetResource(Resource):
             paramType="query",
             dataType="integer",
             default=None,
+            required=False,
         )
     )
     def create_dataset(self, cloneSource, parentFolder, name, revision):

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -301,7 +301,7 @@ def train_pipeline(self: Task, params: TrainingJob):
         output_path = utils.make_directory(_working_directory_path / 'output')
 
         for source_folder_id, revision in dataset_input_list:
-            download_path = input_path / source_folder_id
+            download_path = utils.make_directory(input_path / source_folder_id)
             groundtruth_path = download_path / 'groundtruth.csv'
             # Download groundtruth item
             utils.download_revision_csv(gc, source_folder_id, revision, groundtruth_path)

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import shlex
 import shutil
 import tempfile
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 from urllib import request
 from urllib.parse import urlparse
 import zipfile

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -21,7 +21,7 @@ from dive_tasks.frame_alignment import check_and_fix_frame_alignment
 from dive_tasks.manager import patch_manager
 from dive_tasks.pipeline_discovery import discover_configs
 from dive_utils import constants, fromMeta
-from dive_utils.types import AvailableJobSchema, GirderModel, PipelineJob
+from dive_utils.types import AvailableJobSchema, GirderModel, PipelineJob, TrainingJob
 
 EMPTY_JOB_SCHEMA: AvailableJobSchema = {
     'pipelines': {},
@@ -173,6 +173,7 @@ def run_pipeline(self: Task, params: PipelineJob):
         return
 
     gc: GirderClient = self.girder_client
+    utils.authenticate_urllib(gc)
     manager.updateStatus(JobStatus.FETCHING_INPUT)
 
     # Extract params
@@ -180,7 +181,7 @@ def run_pipeline(self: Task, params: PipelineJob):
     input_folder_id = str(params["input_folder"])
     input_type = params["input_type"]
     output_folder_id = str(params["output_folder"])
-    pipeline_input = params["pipeline_input"]
+    input_revision = params["input_revision"]
 
     with tempfile.TemporaryDirectory() as _working_directory, suppress(utils.CanceledError):
         _working_directory_path = Path(_working_directory)
@@ -206,7 +207,7 @@ def run_pipeline(self: Task, params: PipelineJob):
 
         # Download source media
         input_folder: GirderModel = gc.getFolder(input_folder_id)
-        input_media_list = utils.download_source_media(gc, input_folder_id, input_path)
+        input_media_list, _ = utils.download_source_media(gc, input_folder_id, input_path)
 
         if input_type == constants.VideoType:
             input_fps = fromMeta(input_folder, constants.FPSMarker)
@@ -238,11 +239,10 @@ def run_pipeline(self: Task, params: PipelineJob):
             raise ValueError('Unknown input type: {}'.format(input_type))
 
         # Include input detections
-        if pipeline_input is not None:
-            pipeline_input_id = str(pipeline_input['_id'])
-            pipeline_input_file = str(input_path / pipeline_input["name"])
-            self.girder_client.downloadFile(pipeline_input_id, pipeline_input_file)
-            quoted_input_file = shlex.quote(pipeline_input_file)
+        if input_revision is not None:
+            pipeline_input_file = input_path / 'groundtruth.csv'
+            utils.download_revision_csv(gc, input_folder_id, input_revision, pipeline_input_file)
+            quoted_input_file = shlex.quote(str(pipeline_input_file))
             command.append(f'-s detection_reader:file_name={quoted_input_file}')
             command.append(f'-s track_reader:file_name={quoted_input_file}')
 
@@ -269,28 +269,8 @@ def run_pipeline(self: Task, params: PipelineJob):
 
 
 @app.task(bind=True, acks_late=True, ignore_result=True)
-def train_pipeline(
-    self: Task,
-    results_folder: GirderModel,
-    source_folder_list: List[GirderModel],
-    groundtruth_list: List[GirderModel],
-    pipeline_name: str,
-    config: str,
-    annotated_frames_only: bool = False,
-    label_text: Optional[str] = None,
-):
-    """
-    Train a pipeline by making a call to viame_train_detector
-
-    :param results_folder: The Girder Folder to place the results of training into
-    :param source_folder_list: The Girder Folders to pull training data from
-    :param groundtruth_list: A list of relative paths to either a file containing detections,
-        or a folder containing that file.
-    :param pipeline_name: The base name of the resulting pipeline.
-    :param config: string name of the input configuration
-    :param annotated_frames_only: Only use annotated frames for training
-    :param label_text: string value of label.txt file contents
-    """
+def train_pipeline(self: Task, params: TrainingJob):
+    """Train a pipeline by making a call to viame_train_detector"""
     conf = Config()
     context: dict = {}
     manager: JobManager = patch_manager(self.job_manager)
@@ -299,17 +279,20 @@ def train_pipeline(
         return
 
     gc: GirderClient = self.girder_client
+    utils.authenticate_urllib(gc)
     manager.updateStatus(JobStatus.FETCHING_INPUT)
+
+    # Extract params
+    results_folder_id = params['results_folder_id']
+    dataset_input_list = params['dataset_input_list']
+    pipeline_name = params['pipeline_name']
+    config = params['config']
+    annotated_frames_only = params['annotated_frames_only']
+    label_text = params['label_txt']
 
     pipeline_base_path = Path(conf.get_extracted_pipeline_path())
     config_file = pipeline_base_path / config
-
-    if len(source_folder_list) != len(groundtruth_list):
-        raise Exception("Ground truth doesn't exist for all folders")
-
-    # List of folderIds used for training
-    trained_on_list: List[str] = []
-    # List of[input folder / ground truth file] pairs for creating input lists
+    # List of (input folder, ground truth file) pairs for creating input lists
     input_groundtruth_list: List[Tuple[Path, Path]] = []
     # root_data_dir is the directory passed to `viame_train_detector`
     with tempfile.TemporaryDirectory() as _working_directory, suppress(utils.CanceledError):
@@ -317,27 +300,16 @@ def train_pipeline(
         input_path = utils.make_directory(_working_directory_path / 'input')
         output_path = utils.make_directory(_working_directory_path / 'output')
 
-        if label_text:
-            labels_path = input_path / "labels.txt"
-            with open(labels_path, "w+") as labels_file:
-                labels_file.write(label_text)
-
-        for index in range(len(source_folder_list)):
-            source_folder = source_folder_list[index]
-            groundtruth = groundtruth_list[index]
-            download_path = input_path / source_folder['name']
-            trained_on_list.append(str(source_folder["_id"]))
+        for source_folder_id, revision in dataset_input_list:
+            download_path = input_path / source_folder_id
+            groundtruth_path = download_path / 'groundtruth.csv'
             # Download groundtruth item
-            gc.downloadItem(str(groundtruth["_id"]), download_path)
-            # Rename groundtruth csv file
-            groundtruth_path = utils.organize_folder_for_training(
-                download_path, download_path / groundtruth["name"]
-            )
+            utils.download_revision_csv(gc, source_folder_id, revision, groundtruth_path)
             # Download input media
-            input_media_list = utils.download_source_media(
-                gc, str(source_folder["_id"]), download_path
+            input_media_list, input_type = utils.download_source_media(
+                gc, source_folder_id, download_path
             )
-            if fromMeta(source_folder, constants.TypeMarker) == constants.VideoType:
+            if input_type == constants.VideoType:
                 download_path = Path(input_media_list[0])
             # Set media source location
             input_groundtruth_list.append((download_path, groundtruth_path))
@@ -370,6 +342,9 @@ def train_pipeline(
             command.append("--gt-frames-only")
 
         if label_text:
+            labels_path = input_path / "labels.txt"
+            with open(labels_path, "w+") as labels_file:
+                labels_file.write(label_text)
             command.append("--labels")
             command.append(shlex.quote(str(labels_path)))
 
@@ -391,11 +366,11 @@ def train_pipeline(
         # This is the name of the folder that is uploaded to the
         # "Training Results" girder folder
         girder_output_folder = gc.createFolder(
-            results_folder["_id"],
+            results_folder_id,
             pipeline_name,
             metadata={
                 constants.TrainedPipelineMarker: True,
-                "trained_on": trained_on_list,
+                "trained_on": dataset_input_list,
             },
         )
         gc.upload(f"{training_results_path}/*", girder_output_folder["_id"])

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -65,6 +65,7 @@ VideoMimeTypes = {
 DatasetMarker = "annotate"
 PublishedMarker = "published"
 SharedMarker = "shared"
+ProcessedMarker = "processed"
 ForeignMediaIdMarker = "foreign_media_id"
 TrainedPipelineMarker = "trained_pipeline"
 TypeMarker = "type"
@@ -86,12 +87,9 @@ TrainingOutputFolderName = "VIAME Training Results"
 
 # job constants
 JOBCONST_DATASET_ID = 'datset_id'
-JOBCONST_TRAINING_INPUT_IDS = 'training_input_ids'
-JOBCONST_TRAINING_CONFIG = 'training_config'
-JOBCONST_LABEL_TEXT = 'label_text'
-JOBCONST_RESULTS_FOLDER_ID = 'results_folder_id'
-JOBCONST_PIPELINE_NAME = 'pipeline_name'
+JOBCONST_PARAMS = 'params'
 JOBCONST_PRIVATE_QUEUE = 'private_queue'
+JOBCONST_CREATOR = 'creator'
 
 # User queue constants
 UserPrivateQueueEnabledMarker = 'user_private_queue_enabled'

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from bson.objectid import ObjectId

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from bson.objectid import ObjectId

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from typing_extensions import TypedDict
 
@@ -54,10 +54,21 @@ class PipelineJob(TypedDict):
     """Describes the parameters for running a pipeline on a dataset."""
 
     pipeline: PipelineDescription
-    input_folder: str
-    input_type: str
-    output_folder: str
-    requires_input: bool
+    input_folder: str  # dataset folder id
+    input_type: str  # video, image-sequence, etc.
+    input_revision: Optional[int]  # A revision ID is included if the pipeline needs input
+    output_folder: str  # Where to upload results
+
+
+class TrainingJob(TypedDict):
+    """Describes the paramteers for running training"""
+
+    results_folder_id: str  # Where to upload the outputs
+    dataset_input_list: List[Tuple[str, int]]  # Tuples of (dataset_id, revision_id)
+    pipeline_name: str  # Name of the new pipeline to train
+    config: str  # Name of the training configuration file to use.
+    annotated_frames_only: bool  # Train on only the annotated frames
+    label_txt: Optional[str]  # Contents of a labels.txt to include in training
 
 
 class TrainingConfigurationSummary(TypedDict):

--- a/server/scripts/migrations.py
+++ b/server/scripts/migrations.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 import click
 from girder.models.file import File

--- a/server/tests/integration/test_dataset_download.py
+++ b/server/tests/integration/test_dataset_download.py
@@ -13,7 +13,7 @@ def test_download_annotation(user: dict):
         downloaded = client.get(f'dive_annotation/?folderId={dataset["_id"]}')
         if 'clone' not in dataset['name']:
             expected = match_user_server_data(user, dataset)
-            assert len(downloaded.keys()) == expected[0]['trackCount']
+            assert len(downloaded) == expected[0]['trackCount']
 
 
 @pytest.mark.integration
@@ -50,11 +50,16 @@ def test_upload_json_detections(user: dict):
     client = getClient(user['login'])
     privateFolder = getTestFolder(client)
     for dataset in client.listFolder(privateFolder['_id']):
-        old_tracks = client.get(f'dive_annotation?folderId={dataset["_id"]}')
-        newfile = client.uploadFileToFolder(dataset['_id'], '../testutils/tracks.json')
-        client.post(f'dive_rpc/postprocess/{dataset["_id"]}', data={"skipJobs": True})
-        new_tracks = client.get(f'dive_annotation?folderId={dataset["_id"]}')
+        old_tracks_list = client.get(f'dive_annotation?folderId={dataset["_id"]}')
+        old_tracks = {str(track['trackId']): track for track in old_tracks_list}
         assert '999999' not in old_tracks, "Tracks should have updated"
+        old_revision = client.get(f'dive_annotation/revision?folderId={dataset["_id"]}')[0][
+            'revision'
+        ]
+        client.uploadFileToFolder(dataset['_id'], '../testutils/tracks.json')
+        client.post(f'dive_rpc/postprocess/{dataset["_id"]}', data={"skipJobs": True})
+        new_tracks_list = client.get(f'dive_annotation?folderId={dataset["_id"]}')
+        new_tracks = {str(track['trackId']): track for track in new_tracks_list}
         assert '999999' in new_tracks, "Should have one track, 999999"
-        assert len(new_tracks.keys()) == 1, "Should have a single track"
-        client.delete(f'item/{newfile["itemId"]}')  # Remove the uploaded detections
+        assert len(new_tracks_list) == 1, "Should have a single track"
+        client.delete(f'dive_annotation?folderId={dataset["_id"]}&revision={old_revision}')

--- a/server/tests/integration/test_dataset_download.py
+++ b/server/tests/integration/test_dataset_download.py
@@ -62,4 +62,4 @@ def test_upload_json_detections(user: dict):
         new_tracks = {str(track['trackId']): track for track in new_tracks_list}
         assert '999999' in new_tracks, "Should have one track, 999999"
         assert len(new_tracks_list) == 1, "Should have a single track"
-        client.delete(f'dive_annotation?folderId={dataset["_id"]}&revision={old_revision}')
+        client.post(f'dive_annotation/rollback?folderId={dataset["_id"]}&revision={old_revision}')

--- a/server/tests/integration/test_pipelines.py
+++ b/server/tests/integration/test_pipelines.py
@@ -9,10 +9,12 @@ from .conftest import getClient, getTestFolder, match_user_server_data, users, w
 
 
 @pytest.mark.integration
-@pytest.mark.run(order=7)
+@pytest.mark.run(order=3)
 def test_reset_job_logs(admin_client: GirderClient):
     # remove any failed jobs.
-    for job in admin_client.get('job', parameters={"statuses": json.dumps([0, 1, 2, 4, 5, 824])}):
+    for job in admin_client.get(
+        'job/all', parameters={"statuses": json.dumps([0, 1, 2, 4, 5, 824])}
+    ):
         admin_client.delete(f'job/{job["_id"]}')
 
 

--- a/server/tests/test_attributes_processor.py
+++ b/server/tests/test_attributes_processor.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List
+from typing import Dict
 
 import pytest
 
@@ -11,7 +11,7 @@ with open('../testutils/attributes.spec.json', 'r') as fp:
 
 @pytest.mark.parametrize("input,expected_tracks,expected_attributes", test_tuple)
 def test_read_viame_attributes(
-    input: List[str],
+    input: Dict[str, dict],
     expected_tracks: Dict[str, dict],
     expected_attributes: Dict[str, dict],
 ):
@@ -19,7 +19,7 @@ def test_read_viame_attributes(
     text = ''
     for _i, line in enumerate(
         export_tracks_as_csv(
-            input,
+            input.values(),
         )
     ):
         print(line)

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -277,12 +277,14 @@ test_tuple: List[Tuple[list, dict, dict]] = [
             "0,3.png,3,884.66,510,1219.66,737.66,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value1",
             "0,4.png,4,111,222,3333,444,1,-1,typestring,1,(atr) DetectionPredefinedValue value2",
             "0,5.png,5,747,457,1039,633,1,-1,typestring,1,(atr) DetectionPredefinedValue value3",
+            "#comment line",
             "1,1.png,0,884.66,510,1219.66,737.66,1,-1,typestring,1,(atr) DetectionNumber 2.002,(atr) DetectionPredefinedValue value1",
             "1,2.png,1,111,222,3333,444,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value2",
             "1,3.png,2,747,457,1039,633,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value3",
             "1,3.png,3,884.66,510,1219.66,737.66,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value1",
             "1,4.png,4,111,222,3333,444,1,-1,typestring,1,(atr) DetectionPredefinedValue value2",
             "1,5.png,5,747,457,1039,633,1,-1,typestring,1,(atr) DetectionPredefinedValue value3",
+            "",
         ],
         {
             "0": {
@@ -442,6 +444,7 @@ test_tuple: List[Tuple[list, dict, dict]] = [
             "0,1.png,0,884,510,1219,737,1.0,-1,",
             "0,2.png,1,111,222,3333,444,1.0,-1,,",
             "1,1.png,0,747,457,1039,633,0.8,-1",
+            "",
         ],
         {
             "0": {

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -51,6 +51,7 @@ test_tuple: List[Tuple[dict, list, list]] = [
             "0,1.png,0,884,510,1219,737,1.0,-1,typestring,1.0",
             "0,2.png,1,111,222,3333,444,1.0,-1,typestring,1.0",
             "1,1.png,0,747,457,1039,633,1.0,-1,type2,1.0",
+            "",
         ],
         [],
     ),
@@ -81,6 +82,7 @@ test_tuple: List[Tuple[dict, list, list]] = [
             "0,2.png,1,2,2,4,4,0.9,-1,bar,0.9,foo,0.2,baz,0.1",
             "0,3.png,2,3,3,6,6,0.9,-1,bar,0.9,foo,0.2,baz,0.1",
             "0,4.png,3,4,4,8,8,0.9,-1,bar,0.9,foo,0.2,baz,0.1",
+            "",
         ],
         [],
     ),
@@ -165,6 +167,7 @@ test_tuple: List[Tuple[dict, list, list]] = [
             "0,2.png,1,2,2,4,4,0.9,-1,bar,0.9,foo,0.2,baz,0.1,(kp) head 22 46,(kp) tail 55 22",
             "0,3.png,2,3,3,6,6,0.9,-1,bar,0.9,foo,0.2,baz,0.1",
             "0,4.png,3,4,4,8,8,0.9,-1,bar,0.9,foo,0.2,baz,0.1,(poly) 1 2 3 4 5 6 7 8 9 10",
+            "",
         ],
         [],
     ),
@@ -199,6 +202,7 @@ test_tuple: List[Tuple[dict, list, list]] = [
         [
             "0,1.png,0,884,510,1219,737,1.0,-1,typestring,1.0,(atr) detectionAttr frame 0 attr,(trk-atr) trackATTR TestTrack ATTR With Space",
             "0,2.png,1,111,222,3333,444,1.0,-1,typestring,1.0,(atr) detectionAttr frame 1 attr,(trk-atr) trackATTR TestTrack ATTR With Space",
+            "",
         ],
         [],
     ),
@@ -244,6 +248,7 @@ test_tuple: List[Tuple[dict, list, list]] = [
         },
         [
             "1,1.png,0,747,457,1039,633,1.0,-1,type2,1.0",
+            "",
         ],
         ['type2'],
     ),
@@ -289,6 +294,7 @@ test_tuple: List[Tuple[dict, list, list]] = [
         [
             "0,1.png,0,884,510,1219,737,1.0,-1,typestring,1.0",
             "0,2.png,1,111,222,3333,444,1.0,-1,typestring,1.0",
+            "",
         ],
         ['typestring', 'type3', 'type4'],
     ),
@@ -299,7 +305,15 @@ test_tuple: List[Tuple[dict, list, list]] = [
 def test_write_viame_csv(input: Dict[str, dict], expected: List[str], typeFilter: List[str]):
     for i, line in enumerate(
         viame.export_tracks_as_csv(
-            input, filenames=filenames, header=False, typeFilter=set(typeFilter)
+            input.values(), filenames=filenames, header=False, typeFilter=set(typeFilter)
         )
     ):
         assert line.strip(' ').rstrip() == expected[i]
+
+
+def test_empty_header():
+    for chunk in viame.export_tracks_as_csv([], header=True):
+        lines = chunk.splitlines()
+        for line in lines:
+            assert line.startswith('#')
+        assert len(lines) == 2

--- a/testutils/tracks.json
+++ b/testutils/tracks.json
@@ -1,1 +1,1 @@
-{"999999": {"begin": 0, "end": 0, "trackId": 0, "features": [{"frame": 0, "bounds": [670, 183, 968, 433], "interpolate": false, "keyframe": true}], "confidencePairs": [["motion_signature", 0.996269]], "attributes": {}}}
+{"999999": {"begin": 0, "end": 0, "trackId": 999999, "features": [{"frame": 0, "bounds": [670, 183, 968, 433], "interpolate": false, "keyframe": true}], "confidencePairs": [["motion_signature", 0.996269]], "attributes": {}}}


### PR DESCRIPTION
## Reviewer notes

I think this one is pretty straightforward.

* Switches to TypedDict params for training so that pipelines and training jobs match.
* Generates exports using input revision ID and `urllib.urlretrieve`