### PR TITLE
Mongo 4: Client changes to support revisions

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -119,7 +119,7 @@ interface Api {
   ): Promise<unknown>;
 
   loadMetadata(datasetId: string): Promise<DatasetMeta>;
-  loadDetections(datasetId: string): Promise<MultiTrackRecord>;
+  loadDetections(datasetId: string, revision?: number): Promise<MultiTrackRecord>;
 
   saveDetections(datasetId: string, args: SaveDetectionsArgs): Promise<unknown>;
   saveMetadata(datasetId: string, metadata: DatasetMetaMutable): Promise<unknown>;

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -63,6 +63,10 @@ export default defineComponent({
       type: String,
       required: true,
     },
+    revision: {
+      type: Number,
+      default: undefined,
+    },
     readonlyMode: {
       type: Boolean,
       default: false,
@@ -77,6 +81,7 @@ export default defineComponent({
     const defaultCamera = ref('');
     const currentCamera = ref('');
     const playbackComponent = ref(undefined as Vue | undefined);
+    const readonlyState = computed(() => props.readonlyMode || props.revision !== undefined);
     const mediaController = computed(() => {
       if (playbackComponent.value) {
         // TODO: Bug in composition-api types incorrectly organizes the static members of a Vue
@@ -117,7 +122,7 @@ export default defineComponent({
       markChangesPending,
       discardChanges,
       pendingSaveCount,
-    } = useSave(datasetId, toRef(props, 'readonlyMode'));
+    } = useSave(datasetId, readonlyState);
 
     const recipes = [
       new PolygonBase(),
@@ -341,7 +346,7 @@ export default defineComponent({
         videoUrl.value = meta.videoUrl;
         datasetType.value = meta.type as DatasetType;
 
-        const trackData = await loadDetections(datasetId.value);
+        const trackData = await loadDetections(datasetId.value, props.revision);
         const tracks = Object.values(trackData);
         progress.total = tracks.length;
         for (let i = 0; i < tracks.length; i += 1) {
@@ -452,6 +457,7 @@ export default defineComponent({
       frameRate: time.frameRate,
       originalFps: time.originalFps,
       context,
+      readonlyState,
       /* methods */
       handler: globalHandler,
       save,
@@ -527,23 +533,23 @@ export default defineComponent({
 
       <v-tooltip
         bottom
-        :disabled="!readonlyMode"
+        :disabled="!readonlyState"
       >
         <template v-slot:activator="{ on }">
           <v-badge
             overlap
             bottom
-            :color="readonlyMode ? 'warning' : undefined"
-            :icon="readonlyMode ? 'mdi-exclamation-thick' : undefined"
-            :content="!readonlyMode ? pendingSaveCount : undefined"
-            :value="readonlyMode || pendingSaveCount > 0"
+            :color="readonlyState ? 'warning' : undefined"
+            :icon="readonlyState ? 'mdi-exclamation-thick' : undefined"
+            :content="!readonlyState ? pendingSaveCount : undefined"
+            :value="readonlyState || pendingSaveCount > 0"
             offset-x="14"
             offset-y="18"
           >
             <div v-on="on">
               <v-btn
                 icon
-                :disabled="readonlyMode || pendingSaveCount === 0 || saveInProgress"
+                :disabled="readonlyState || pendingSaveCount === 0 || saveInProgress"
                 @click="save"
               >
                 <v-icon>mdi-content-save</v-icon>

--- a/client/platform/web-girder/api/annotation.service.ts
+++ b/client/platform/web-girder/api/annotation.service.ts
@@ -2,10 +2,12 @@ import { SaveDetectionsArgs } from 'dive-common/apispec';
 import { TrackData } from 'vue-media-annotator/track';
 import girderRest from 'platform/web-girder/plugins/girder';
 
-function loadDetections(folderId: string) {
-  return girderRest.get<{ [key: string]: TrackData }>('dive_annotation', {
-    params: { folderId },
-  });
+function loadDetections(folderId: string, revision?: number) {
+  const params: Record<string, unknown> = { folderId };
+  if (revision !== undefined) {
+    params.revision = revision;
+  }
+  return girderRest.get<{ [key: string]: TrackData }>('dive_annotation', { params });
 }
 
 function saveDetections(folderId: string, args: SaveDetectionsArgs) {

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -51,13 +51,18 @@ function getDatasetMedia(folderId: string) {
   return girderRest.get<DatasetSourceMedia>(`dive_dataset/${folderId}/media`);
 }
 
-function clone({ folderId, name, parentFolderId }: {
+function clone({
+  folderId, name, parentFolderId, revision,
+}: {
   folderId: string;
   parentFolderId: string;
   name: string;
+  revision?: number;
 }) {
   return girderRest.post<GirderModel>('dive_dataset', null, {
-    params: { cloneId: folderId, parentFolderId, name },
+    params: {
+      cloneId: folderId, parentFolderId, name, revision,
+    },
   });
 }
 

--- a/client/platform/web-girder/router.ts
+++ b/client/platform/web-girder/router.ts
@@ -36,6 +36,13 @@ const router = new Router({
       beforeEnter,
     },
     {
+      path: '/viewer/:id/rev/:revision',
+      name: 'viewer',
+      component: ViewerLoader,
+      props: true,
+      beforeEnter,
+    },
+    {
       path: '/',
       component: RouterPage,
       children: [

--- a/client/platform/web-girder/views/Clone.vue
+++ b/client/platform/web-girder/views/Clone.vue
@@ -19,6 +19,10 @@ export default defineComponent({
       type: String as PropType<string | null>,
       default: null,
     },
+    revision: {
+      type: Number,
+      default: undefined,
+    },
     buttonOptions: {
       type: Object,
       default: () => ({}),
@@ -45,6 +49,9 @@ export default defineComponent({
       if (props.datasetId) {
         source.value = (await getDataset(props.datasetId)).data;
         newName.value = `Clone of ${source.value.name}`;
+        if (props.revision) {
+          newName.value = `${newName.value} revision ${props.revision}`;
+        }
         open.value = true;
       }
     }
@@ -64,6 +71,7 @@ export default defineComponent({
         folderId: props.datasetId,
         name: newName.value,
         parentFolderId: location.value._id,
+        revision: props.revision,
       });
       root.$router.push({ name: 'viewer', params: { id: newDataset.data._id } });
     });

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import {
+  computed,
   defineComponent, onBeforeUnmount, onMounted, ref, toRef,
 } from '@vue/composition-api';
 
@@ -47,6 +48,10 @@ export default defineComponent({
       type: String,
       required: true,
     },
+    revision: {
+      type: String,
+      default: undefined,
+    },
   },
 
   // TODO: This will require an import from vue-router for Vue3 compatibility
@@ -56,10 +61,15 @@ export default defineComponent({
     }
   },
 
-  setup() {
+  setup(props) {
     const viewerRef = ref();
     const store = useStore();
     const brandData = toRef(store.state.Brand, 'brandData');
+    const revisionNum = computed(() => {
+      const parsed = Number.parseInt(props.revision, 10);
+      if (Number.isNaN(parsed)) return undefined;
+      return parsed;
+    });
     const { getters } = store;
 
     onMounted(() => {
@@ -74,6 +84,7 @@ export default defineComponent({
       buttonOptions,
       brandData,
       menuOptions,
+      revisionNum,
       viewerRef,
       getters,
     };
@@ -84,8 +95,9 @@ export default defineComponent({
 <template>
   <Viewer
     :id="id"
-    :key="id"
+    :key="`${id}/${revisionNum}`"
     ref="viewerRef"
+    :revision="revisionNum"
   >
     <template #title>
       <ViewerAlert />
@@ -122,6 +134,7 @@ export default defineComponent({
         v-if="$store.state.Dataset.meta"
         v-bind="{ buttonOptions, menuOptions }"
         :dataset-id="id"
+        :revision="revisionNum"
       />
     </template>
   </Viewer>


### PR DESCRIPTION
Adds optional `viewer/:datasetId/rev/:revisionId` to route which loads the dataset from a specified revision.  Whenever this optional route param is used, the UI is placed into the already implementated "read-only" state.

I think the UI needs more clear indication that a previous revision is loaded, what that means, and how to either commit the rollback or return to HEAD, but that seemed out of scope until the rest of the revision history is implemented.  For now, this is more of an easter-egg feature for us.