### PR TITLE
Example without fetching metadata

### DIFF
--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -47,6 +47,7 @@ export default defineComponent({
     const viewerRef = ref();
     const compoundId = ref(props.id);
     const subTypeList = computed(() => [datasets.value[props.id]?.subType || null]);
+    const camNumbers = computed(() => [datasets.value[props.id]?.cameraNumber || 1]);
     const readonlyMode = computed(() => settings.value?.readonlyMode || false);
 
     watch(runningJobs, async (_previous, current) => {
@@ -73,6 +74,7 @@ export default defineComponent({
       buttonOptions,
       menuOptions,
       subTypeList,
+      camNumbers,
       readonlyMode,
     };
   },
@@ -108,6 +110,7 @@ export default defineComponent({
       <RunPipelineMenu
         :selected-dataset-ids="[id]"
         :sub-type-list="subTypeList"
+        :camera-numbers="camNumbers"
         v-bind="{ buttonOptions, menuOptions }"
       />
       <ImportAnnotations

--- a/client/platform/desktop/frontend/store/dataset.ts
+++ b/client/platform/desktop/frontend/store/dataset.ts
@@ -28,6 +28,7 @@ export interface JsonMetaCache {
   imageListPath: string;
   transcodedVideoFile?: string;
   subType: SubType;
+  cameraNumber: number;
 }
 
 /**
@@ -40,6 +41,7 @@ function hydrateJsonMetaCacheValue(input: any): JsonMetaCache {
     transcodedVideoFile: '',
     accessedAt: input.createdAt,
     subType: null,
+    cameraNumber: 1,
     ...input,
   };
 }
@@ -62,6 +64,7 @@ function setRecents(meta: JsonMeta, accessTime?: string) {
     imageListPath: meta.imageListPath,
     transcodedVideoFile: meta.transcodedVideoFile,
     subType: meta.subType,
+    cameraNumber: Object.keys(meta.multiCam || {}).length,
   } as JsonMetaCache);
   const values = Object.values(datasets.value);
   window.localStorage.setItem(RecentsKey, JSON.stringify(values));


### PR DESCRIPTION
I was still struggling with how this worked, and I went back and looked at the change when `subType` was added as a prop.

https://github.com/Kitware/dive/pull/803

The point of that change was to make it so that this component didn't need to `loadMetadata`: it should be provided with all the filtering information required.  

**Bug**: There was also a bug in the previous behavior where only the first dataset's camera count was checked, so if a 2-cam and 3-cam mult-camera dataset were provided as selected, only the 2-cam option would show up.  In reality, there are no pipelines that accept both those types, so nothing should show up yet.

This change makes `cameraNumbers` a new prop to `RunPipeineMenu` consistent with `subTypeList`, and then adds `cameraCount` to the cache so that it can be provided.

The really nice thing here is that `setRecents` is called when the viewer is loaded, so the new value will be populated correctly before it ever gets used.