### PR TITLE
Arbitrary depth support for zip imports

### DIFF
--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -374,7 +374,6 @@ def postprocess(
         Conversion of CSV annotations into track JSON
     """
     job_is_private = user.get(constants.UserPrivateQueueEnabledMarker, False)
-    auxiliary = crud.get_or_create_auxiliary_folder(dsFolder, user)
     isClone = fromMeta(dsFolder, constants.ForeignMediaIdMarker, None) is not None
     # add default confidence filter threshold to folder metadata
     dsFolder['meta'][constants.ConfidenceFiltersMarker] = {'default': 0.1}
@@ -413,6 +412,7 @@ def postprocess(
             )
             newjob.job[constants.JOBCONST_PRIVATE_QUEUE] = job_is_private
             Job().save(newjob.job)
+            return dsFolder
 
         # transcode VIDEO if necessary
         videoItems = Folder().childItems(
@@ -470,6 +470,7 @@ def postprocess(
             allFiles = [make_file_generator(item) for item in ymlItems]
             crud.saveTracks(dsFolder, meva.load_kpf_as_tracks(allFiles), user)
             ymlItems.rewind()
+            auxiliary = crud.get_or_create_auxiliary_folder(dsFolder, user)
             for item in ymlItems:
                 Item().move(item, auxiliary)
 

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -125,7 +125,7 @@ def upgrade_pipelines(
     addons_to_update_update: List[Path] = []
 
     for addon in urls:
-        download_name = urlparse(addon).path.replace('/', '_')
+        download_name = urlparse(addon).path.replace(os.path.sep, '_')
         zipfile_path = conf.addon_zip_path / f'{download_name}.zip'
         if not zipfile_path.exists() or force:
             # Update the zipfile if force option set or file not exists
@@ -560,6 +560,12 @@ def convert_images(self: Task, folderId):
 
 @app.task(bind=True, acks_late=True, ignore_result=True)
 def extract_zip(self: Task, folderId: str, itemId: str):
+    """
+    Discovery logic:
+    * Find all folders that have at least one child file (potential datasets)
+    * Exclude folders which are sub-folders of previously discovered folders
+      because datasets cannot be nested in other datasets
+    """
     context: dict = {}
     gc: GirderClient = self.girder_client
     manager: JobManager = patch_manager(self.job_manager)
@@ -573,7 +579,7 @@ def extract_zip(self: Task, folderId: str, itemId: str):
         file_name = str(_working_directory_path / item['name'])
         manager.write(f'Fetching input from {itemId} to {file_name}...\n')
         gc.downloadItem(itemId, _working_directory, item["name"])
-        top_level_folders = {}
+        discovered_folders = {}
         with zipfile.ZipFile(file_name, 'r') as zipObj:
             listOfFileNames = zipObj.namelist()
             sum_file_size = sum([data.file_size for data in zipObj.filelist])
@@ -585,19 +591,25 @@ def extract_zip(self: Task, folderId: str, itemId: str):
                     Please contact an admin at viame-web@kitware.com if this is a valid zip file"
                 )
                 raise Exception("High Compression Ratio for Zip File")
+
             for fileName in listOfFileNames:
-                # contains a sub folder
-                if fileName.endswith('/') and fileName.count('/') == 1:
-                    top_level_folders[fileName.replace('/', '')] = 'flat'
-                # sub folder has a meta.json so it is imported
-                if fileName.endswith(constants.MetaFileName):
-                    root_folder = fileName.replace(f'/{constants.MetaFileName}', '')
-                    top_level_folders[root_folder] = 'dataset'
+                folderName = os.path.dirname(fileName)
+                parentName = os.path.dirname(folderName)
+                if parentName in discovered_folders and folderName != '':
+                    discovered_folders[folderName] = 'ignored'
+                    continue
+                if fileName.endswith(os.path.sep):
+                    continue
+                if folderName not in discovered_folders:
+                    discovered_folders[folderName] = 'unstructured'
+                if os.path.basename(fileName) == constants.MetaFileName:
+                    # sub folder has a meta.json so it is an exported dataset
+                    discovered_folders[folderName] = 'dataset'
                 if fileName.endswith('.zip'):
-                    manager.write("Nested Zip files are invalid\n")
                     raise Exception("Nested Zip Files are invalid")
                 manager.write(f"Extracting: {fileName}\n")
                 zipObj.extract(fileName, f'{_working_directory}')
+
         # remove the zip file so it isn't uploaded back to the folder
         os.remove(file_name)
         # Create source folder and move zip file there
@@ -611,46 +623,23 @@ def extract_zip(self: Task, folderId: str, itemId: str):
             f"/item/{str(item['_id'])}?folderId={str(created_folder['_id'])}",
         )
 
-        if len(top_level_folders) > 0:
-            for top_folder in top_level_folders.keys():
-                base_folder = ''  # default for no subfolder
-                # single flat/dataset import
-                if len(top_level_folders) != 1:
-                    base_folder = top_folder
-                # multiple flat/dataset import
-                if top_level_folders[top_folder] == 'flat':
-                    utils.upload_zipped_flat_media_files(
-                        gc,
-                        manager,
-                        folderId,
-                        Path(f"{_working_directory}/{top_folder}"),
-                        base_folder,
-                    )
-                # multiple flat file exports combined
-                elif top_level_folders[top_folder] == 'dataset':
-                    utils.upload_exported_zipped_dataset(
-                        gc,
-                        manager,
-                        folderId,
-                        Path(f"{_working_directory}/{top_folder}"),
-                        base_folder,
-                    )
-
-        else:  # flat zip file with media and/or annotation data inside
-            utils.upload_zipped_flat_media_files(gc, manager, folderId, Path(_working_directory))
-
-        # remove auxilary folder and metadata if there are sub folders
-        if len(top_level_folders) > 1:
-            sub_folders = list(gc.listFolder(folderId))
-            aux_folders = list(
-                (x for x in sub_folders if x['name'] == constants.AuxiliaryFolderName)
-            )
-            if len(aux_folders) > 0:
-                gc.delete(f"folder/{aux_folders[0]['_id']}")
-            # remove metadata
-            metdata = [constants.TypeMarker, constants.FPSMarker, constants.DatasetMarker]
-            gc.sendRestRequest(
-                "DELETE",
-                f"folder/{folderId}/metadata",
-                json=metdata,
-            )
+        for folderName, folderType in discovered_folders.items():
+            subFolderName = folderName if len(discovered_folders) > 1 else ''
+            if folderType == 'unstructured':
+                utils.upload_zipped_flat_media_files(
+                    gc,
+                    manager,
+                    folderId,
+                    _working_directory_path / folderName,
+                    subFolderName,
+                )
+            elif folderType == 'dataset':
+                utils.upload_exported_zipped_dataset(
+                    gc,
+                    manager,
+                    folderId,
+                    _working_directory_path / folderName,
+                    subFolderName,
+                )
+            else:
+                manager.write(f'Ignoring {folderName}\n')

--- a/server/tests/integration/conftest.py
+++ b/server/tests/integration/conftest.py
@@ -14,7 +14,7 @@ Alice and Bobby have different types of data (images and video)
 Most tests run operations on a single dataset for each user, so keeping
 each user constrained to a single data type will help ensure robustness
 """
-users: Dict[str, Dict[str, Any]] = {
+users = {
     'alice': {
         'login': 'alice',
         'email': 'alice@locahost.lan',
@@ -147,99 +147,97 @@ users: Dict[str, Dict[str, Any]] = {
     },
 }
 
-zipUser: Dict[str, Dict[str, Any]] = {
-    "zipUser": {
-        'login': 'zipUser',
-        'email': 'zipUser@locahost.lan',
-        'firstName': 'zip',
-        'lastName': 'User',
-        'password': 'zipUserPass',
-        'data': [
-            {
-                'name': 'testImageZip',
-                'path': 'zipTestFiles/testImageZip.zip',
-                'fps': 1,
-                'type': 'image-sequence',
-                'trackCount': 197,
-                'job_status': JobStatus.SUCCESS,
-            },
-            {
-                'name': 'testVideoZip',
-                'path': 'zipTestFiles/testVideoZip.zip',
-                'fps': 29.97002997002997,
-                'originalFps': 30000 / 1001,
-                'type': 'video',
-                'job_status': JobStatus.SUCCESS,
-            },
-            {
-                'name': 'singleDatasetImport',
-                'path': 'zipTestFiles/singleDatasetImport.zip',
-                'fps': 29.97002997002997,
-                'originalFps': 30000 / 1001,
-                'type': 'video',
-                'job_status': JobStatus.SUCCESS,
-            },
-            {
-                'name': 'flatMultiImport',
-                'path': 'zipTestFiles/flatMultiImport.zip',
-                'fps': -1,
-                'type': 'zip',
-                'subDatasets': [
-                    {
-                        'name': 'testVideoZip',
-                        'type': 'video',
-                        'fps': 29.97002997002997,
-                    },
-                    {
-                        'name': 'testImageZip',
-                        'type': 'image-sequence',
-                        'fps': 1,
-                    },
-                ],
-                'job_status': JobStatus.SUCCESS,
-            },
-            {
-                'name': 'MultiDatasetImport',
-                'path': 'zipTestFiles/MultiDatasetImport.zip',
-                'fps': -1,
-                'type': 'zip',
-                'subDatasets': [
-                    {
-                        'name': 'video1_train_mp4',
-                        'type': 'video',
-                        'fps': 29.97002997002997,
-                    },
-                    {
-                        'name': 'testtrain1_imagelist',
-                        'type': 'image-sequence',
-                        'fps': 1,
-                    },
-                ],
-                'job_status': JobStatus.SUCCESS,
-            },
-            {
-                'name': 'badFormatZip',
-                'path': 'zipTestFiles/badFormatZip.zip',
-                'fps': 1,
-                'type': 'image-sequence',
-                'job_status': JobStatus.ERROR,
-            },
-            {
-                'name': 'nestedZip',
-                'path': 'zipTestFiles/nestedZip.zip',
-                'fps': 1,
-                'type': 'image-sequence',
-                'job_status': JobStatus.ERROR,
-            },
-            {
-                'name': 'zipBomb',
-                'path': 'zipTestFiles/zipBomb.zip',
-                'fps': 1,
-                'type': 'image-sequence',
-                'job_status': JobStatus.ERROR,
-            },
-        ],
-    }
+zipUser = {
+    'login': 'zipUser',
+    'email': 'zipUser@locahost.lan',
+    'firstName': 'zip',
+    'lastName': 'User',
+    'password': 'zipUserPass',
+    'data': [
+        {
+            'name': 'testImageZip',
+            'path': 'zipTestFiles/testImageZip.zip',
+            'fps': 1,
+            'type': 'image-sequence',
+            'trackCount': 197,
+            'job_status': JobStatus.SUCCESS,
+        },
+        {
+            'name': 'testVideoZip',
+            'path': 'zipTestFiles/testVideoZip.zip',
+            'fps': 29.97002997002997,
+            'originalFps': 30000 / 1001,
+            'type': 'video',
+            'job_status': JobStatus.SUCCESS,
+        },
+        {
+            'name': 'singleDatasetImport',
+            'path': 'zipTestFiles/singleDatasetImport.zip',
+            'fps': 29.97002997002997,
+            'originalFps': 30000 / 1001,
+            'type': 'video',
+            'job_status': JobStatus.SUCCESS,
+        },
+        {
+            'name': 'flatMultiImport',
+            'path': 'zipTestFiles/flatMultiImport.zip',
+            'fps': -1,
+            'type': 'zip',
+            'subDatasets': [
+                {
+                    'name': 'testVideoZip',
+                    'type': 'video',
+                    'fps': 29.97002997002997,
+                },
+                {
+                    'name': 'testImageZip',
+                    'type': 'image-sequence',
+                    'fps': 1,
+                },
+            ],
+            'job_status': JobStatus.SUCCESS,
+        },
+        {
+            'name': 'MultiDatasetImport',
+            'path': 'zipTestFiles/MultiDatasetImport.zip',
+            'fps': -1,
+            'type': 'zip',
+            'subDatasets': [
+                {
+                    'name': 'video1_train_mp4',
+                    'type': 'video',
+                    'fps': 29.97002997002997,
+                },
+                {
+                    'name': 'testtrain1_imagelist',
+                    'type': 'image-sequence',
+                    'fps': 1,
+                },
+            ],
+            'job_status': JobStatus.SUCCESS,
+        },
+        {
+            'name': 'badFormatZip',
+            'path': 'zipTestFiles/badFormatZip.zip',
+            'fps': 1,
+            'type': 'image-sequence',
+            'job_status': JobStatus.ERROR,
+        },
+        {
+            'name': 'nestedZip',
+            'path': 'zipTestFiles/nestedZip.zip',
+            'fps': 1,
+            'type': 'image-sequence',
+            'job_status': JobStatus.ERROR,
+        },
+        {
+            'name': 'zipBomb',
+            'path': 'zipTestFiles/zipBomb.zip',
+            'fps': 1,
+            'type': 'image-sequence',
+            'job_status': JobStatus.ERROR,
+        },
+    ],
 }
 
 

--- a/server/tests/integration/conftest.py
+++ b/server/tests/integration/conftest.py
@@ -171,8 +171,8 @@ zipUser = {
             'job_status': JobStatus.SUCCESS,
         },
         {
-            'name': 'singleDatasetImport',
-            'path': 'zipTestFiles/singleDatasetImport.zip',
+            'name': 'SingleDatasetImport',
+            'path': 'zipTestFiles/SingleDatasetImport.zip',
             'fps': 29.97002997002997,
             'originalFps': 30000 / 1001,
             'type': 'video',

--- a/server/tests/integration/test_zip_uploads.py
+++ b/server/tests/integration/test_zip_uploads.py
@@ -1,14 +1,13 @@
 from pathlib import Path
 
 from girder_client import GirderClient, HttpError
-from girder_worker.utils import JobStatus
 import pytest
 
 from .conftest import getTestFolder, localDataRoot, wait_for_jobs, zipUser
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("user", zipUser.values())
+@pytest.mark.parametrize("user", [zipUser])
 @pytest.mark.run(order=2)
 def test_user_creation(admin_client: GirderClient, user: dict):
     try:
@@ -25,7 +24,7 @@ def test_user_creation(admin_client: GirderClient, user: dict):
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("user", zipUser.values())
+@pytest.mark.parametrize("user", [zipUser])
 @pytest.mark.run(order=3)
 def test_reset_integration_env(user: dict):
     client = GirderClient(apiUrl='http://localhost:8010/api/v1')
@@ -35,40 +34,34 @@ def test_reset_integration_env(user: dict):
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("user", zipUser.values())
+@pytest.mark.parametrize("dataset", zipUser['data'])
 @pytest.mark.run(order=4)
-def test_upload_zip_data(user: dict):
+def test_upload_zip_data(dataset: dict):
+    user = zipUser
     client = GirderClient(apiUrl='http://localhost:8010/api/v1')
     client.authenticate(username=user['login'], password=user['password'])
 
-    createdDatasets = []
-    for dataset in user['data']:
-        dsPath = localDataRoot / str(dataset['path'])
-        privateFolder = getTestFolder(client)
-        newDatasetFolder = client.createFolder(
-            privateFolder['_id'],
-            dataset['name'],
-            metadata={
-                'fps': dataset['fps'],
-                'type': dataset['type'],
-            },
-        )
-        createdDatasets.append(newDatasetFolder)
-        if Path(dsPath).is_file():
-            client.uploadFileToFolder(newDatasetFolder['_id'], str(dsPath))
-        client.post(f'dive_rpc/postprocess/{newDatasetFolder["_id"]}')
-        try:
-            wait_for_jobs(client, max_wait_timeout=30, expected_status=dataset['job_status'])
-        except Exception as ex:
-            if dataset['job_status'] == JobStatus.ERROR:
-                continue
-            raise ex
-        # verify sub datasets if they exist
-        if dataset.get('subDatasets', False):
-            folders = list(client.listFolder(newDatasetFolder['_id']))
-            for item in dataset["subDatasets"]:
-                matches = [x for x in folders if x["name"] == item["name"]]
-                if len(matches) > 0:
-                    meta = matches[0].get("meta", {})
-                    assert meta.get("fps", -1) == item["fps"]
-                    assert meta.get("type", "") == item["type"]
+    dsPath = localDataRoot / str(dataset['path'])
+    privateFolder = getTestFolder(client)
+    newDatasetFolder = client.createFolder(
+        privateFolder['_id'],
+        dataset['name'],
+        metadata={
+            'fps': dataset['fps'],
+            'type': dataset['type'],
+        },
+    )
+    if Path(dsPath).is_file():
+        client.uploadFileToFolder(newDatasetFolder['_id'], str(dsPath))
+    client.post(f'dive_rpc/postprocess/{newDatasetFolder["_id"]}')
+    wait_for_jobs(client, max_wait_timeout=30, expected_status=dataset['job_status'])
+
+    # verify sub datasets if they exist
+    if dataset.get('subDatasets', False):
+        folders = list(client.listFolder(newDatasetFolder['_id']))
+        for item in dataset["subDatasets"]:
+            matches = [x for x in folders if x["name"] == item["name"]]
+            if len(matches) > 0:
+                meta = matches[0].get("meta", {})
+                assert meta.get("fps", -1) == item["fps"]
+                assert meta.get("type", "") == item["type"]


### PR DESCRIPTION
* Changes a bit of code related to import dataset folder discovery to support arbitrary depths and cases where the zipfile is constructed in an unusual way.  Sometimes `filenames` doesn't list the directory as its own item, which was breaking stuff.  See this comment for a better description of what was broken: https://github.com/Kitware/dive/pull/1062#pullrequestreview-836459161
* Changes the integration test to parameterize the dataset rather than the user, so it's immediately clear what test case failed.
* Replaces the early return statement in `postprocess` because it makes things easier and you can leave off the "cleanup" routine in the celery task.  The server should be smart enough to detect a zip upload and not go around creating empty annotation files and aux folders when it knows that it's about to perform an import.


Now, even if there's an upload where a zip file contains multiple datasets at `a/b/c/d` and `a/1/2`, things should work out properly.