### PR TITLE
Meta File Upload

### DIFF
--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -32,9 +32,9 @@ export default defineComponent({
     const processing = ref(false);
     const menuOpen = ref(false);
     const openUpload = async () => {
-      menuOpen.value = false;
       const ret = await openFromDisk('annotation');
       if (!ret.canceled) {
+        menuOpen.value = false;
         const path = ret.filePaths[0];
         let importFile = false;
         processing.value = true;

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -30,7 +30,9 @@ export default defineComponent({
     const { reloadAnnotations } = useHandler();
     const { prompt } = usePrompt();
     const processing = ref(false);
+    const menuOpen = ref(false);
     const openUpload = async () => {
+      menuOpen.value = false;
       const ret = await openFromDisk('annotation');
       if (!ret.canceled) {
         const path = ret.filePaths[0];
@@ -61,37 +63,75 @@ export default defineComponent({
     return {
       openUpload,
       processing,
+      menuOpen,
     };
   },
 });
 </script>
 
 <template>
-  <v-tooltip bottom>
-    <template #activator="{ on }">
-      <v-btn
-        class="ma-0"
-        v-bind="buttonOptions"
-        :disabled="!datasetId || processing"
-        @click="openUpload"
-        v-on="on"
+  <v-menu
+    v-model="menuOpen"
+    :close-on-content-click="false"
+    :nudge-width="120"
+    v-bind="menuOptions"
+    max-width="280"
+  >
+    <template #activator="{ on: menuOn }">
+      <v-tooltip bottom>
+        <template #activator="{ on: tooltipOn }">
+          <v-btn
+            class="ma-0"
+            v-bind="buttonOptions"
+            :disabled="!datasetId || processing"
+            v-on="{ ...tooltipOn, ...menuOn }"
+          >
+            <div>
+              <v-icon>
+                {{ processing ? 'mdi-spin mdi-sync' : 'mdi-application-import' }}
+              </v-icon>
+              <span
+                v-show="!$vuetify.breakpoint.mdAndDown || buttonOptions.block"
+                class="pl-1"
+              >
+                Import
+              </span>
+            </div>
+          </v-btn>
+        </template>
+        <span> Import Annotation Data </span>
+      </v-tooltip>
+    </template>
+    <template>
+      <v-card
+        outlined
       >
-        <div>
-          <v-icon>
-            {{ processing ? 'mdi-spin mdi-sync' : 'mdi-application-import' }}
-          </v-icon>
-          <span
-            v-show="!$vuetify.breakpoint.mdAndDown || buttonOptions.block"
-            class="pl-1"
+        <v-card-title>
+          Import Formats
+        </v-card-title>
+        <v-card-text >
+          Multiple Data types can be imported using this menu:
+          <ul>
+            <li> Viame CSV Files </li>
+            <li> DIVE Track JSON files </li>
+            <li> DIVE meta.json configuation files </li>
+            <li> KWCOCO JSON files </li>
+          </ul>
+        </v-card-text>
+        <v-card-actions>
+          <v-btn
+            depressed
+            block
+            :disabled="!datasetId || processing"
+            @click="openUpload"
           >
             Import
-          </span>
-        </div>
-      </v-btn>
+          </v-btn>
+        </v-card-actions>
+      </v-card>
     </template>
-    <span> Import Annotation Data </span>
-  </v-tooltip>
+  </v-menu>
 </template>
 
-<style scoped lang="scss">
-</style>
+      <style scoped lang="scss">
+      </style>

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -109,14 +109,18 @@ export default defineComponent({
         <v-card-title>
           Import Formats
         </v-card-title>
-        <v-card-text >
-          Multiple Data types can be imported using this menu:
+        <v-card-text>
+          Multiple Data types can be imported:
           <ul>
             <li> Viame CSV Files </li>
-            <li> DIVE Track JSON files </li>
-            <li> DIVE meta.json configuation files </li>
+            <li> DIVE Annotation JSON </li>
+            <li> DIVE Configuation JSON</li>
             <li> KWCOCO JSON files </li>
           </ul>
+          <a
+            href="https://kitware.github.io/dive/DataFormats/"
+            target="_blank"
+          >Data Format Documentation</a>
         </v-card-text>
         <v-card-actions>
           <v-btn

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -136,6 +136,3 @@ export default defineComponent({
     </template>
   </v-menu>
 </template>
-
-      <style scoped lang="scss">
-      </style>

--- a/client/dive-common/constants.ts
+++ b/client/dive-common/constants.ts
@@ -107,6 +107,8 @@ const zipFileTypes = [
 const stereoPipelineMarker = 'measurement';
 const multiCamPipelineMarkers = ['2-cam', '3-cam'];
 
+const JsonMetaRegEx = /^.*\.?(meta|config)\.json$/;
+
 
 export {
   DefaultVideoFPS,
@@ -128,4 +130,5 @@ export {
   zipFileTypes,
   stereoPipelineMarker,
   multiCamPipelineMarkers,
+  JsonMetaRegEx,
 };

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -46,6 +46,12 @@ export default function register() {
     const ret = await common.exportDataset(settings.get(), args);
     return ret;
   });
+
+  ipcMain.handle('export-configuration', async (_, args: ExportDatasetArgs) => {
+    const ret = await common.exportConfiguration(settings.get(), args);
+    return ret;
+  });
+
   ipcMain.handle('autodiscover-data', async () => {
     const ret = await common.autodiscoverData(settings.get());
     return ret;

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -180,6 +180,12 @@ mockfs({
       'otherfile.txt': '',
       nomime: '',
     },
+    metaJsonIncluded: {
+      'video1.avi': '',
+      'video1.mp4': '',
+      'meta.json': '',
+      nomime: '',
+    },
     annotationEmptySuccess: {
       'video1.mp4': '',
       'result_foo.json': '',
@@ -560,6 +566,14 @@ describe('native.common', () => {
 
   it('importMedia empty json file success', async () => {
     const payload = await common.beginMediaImport(settings, '/home/user/data/annotationEmptySuccess/video1.mp4', checkMedia);
+    await common.finalizeMediaImport(settings, payload, updater, convertMedia);
+    const tracks = await common.loadDetections(settings, payload.jsonMeta.id);
+    expect(tracks).toEqual({});
+  });
+
+  it('importMedia include meta.json file', async () => {
+    const payload = await common.beginMediaImport(settings, '/home/user/data/metaJsonIncluded/video1.mp4', checkMedia);
+    expect(payload.metaFileAbsPath).toBe('/home/user/data/metaJsonIncluded/meta.json');
     await common.finalizeMediaImport(settings, payload, updater, convertMedia);
     const tracks = await common.loadDetections(settings, payload.jsonMeta.id);
     expect(tracks).toEqual({});

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -1043,7 +1043,7 @@ async function exportDataset(settings: Settings, args: ExportDatasetArgs) {
 async function exportConfiguration(settings: Settings, args: ExportConfigurationArgs) {
   const projectDirInfo = await getValidatedProjectDir(settings, args.id);
   const meta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
-  const output = { };
+  const output: DatasetMetaMutable & { version: number} = { version: meta.version };
   if (DatasetMetaMutableKeys.some((key) => key in meta)) {
     // DIVE Json metadata config file
     merge(output, pick(meta, DatasetMetaMutableKeys));

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -23,7 +23,7 @@ import {
 import * as viameSerializers from 'platform/desktop/backend/serializers/viame';
 import * as nistSerializers from 'platform/desktop/backend/serializers/nist';
 import {
-  websafeImageTypes, websafeVideoTypes, otherImageTypes, otherVideoTypes, MultiType,
+  websafeImageTypes, websafeVideoTypes, otherImageTypes, otherVideoTypes, MultiType, JsonMetaRegEx,
 } from 'dive-common/constants';
 import {
   JsonMeta, Settings, JsonMetaCurrentVersion, DesktopMetadata, DesktopJobUpdater,
@@ -170,7 +170,7 @@ async function _findJsonAndMetaTrackFile(basePath: string): Promise<
   {trackFileAbsPath: string; metaFileAbsPath?: string}> {
   const contents = await fs.readdir(basePath);
   const jsonFileCandidates: string[] = [];
-  let metaFileAbsPath;
+  let metaFileAbsPath: undefined | string;
   await Promise.all(contents.map(async (name) => {
     const fullPath = npath.join(basePath, name);
     if (JsonTrackFileName.test(name)) {
@@ -178,7 +178,7 @@ async function _findJsonAndMetaTrackFile(basePath: string): Promise<
       if (statResult.isFile()) {
         jsonFileCandidates.push(fullPath);
       }
-    } else if (name === JsonMetaFileName) {
+    } else if (JsonMetaRegEx.test(name)) {
       metaFileAbsPath = fullPath;
     }
   }));

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -225,11 +225,15 @@ export type ConvertMedia =
   updater: DesktopJobUpdater) => Promise<DesktopJob>;
 
 export interface ExportDatasetArgs {
-  id: string;
-  exclude: boolean;
-  path: string;
-  typeFilter: Set<string>;
-}
+    id: string;
+    exclude: boolean;
+    path: string;
+    typeFilter: Set<string>;
+  }
+export interface ExportConfigurationArgs {
+    id: string;
+   path: string;
+  }
 
 export interface CheckMediaResults {
   websafe: boolean;

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -190,6 +190,7 @@ export interface DesktopMediaImportResponse extends MediaImportResponse {
   trackFileAbsPath: string;
   multiCamTrackFiles: null | Record<string, string>;
   forceMediaTranscode: boolean;
+  metaFileAbsPath?: string;
 }
 
 export interface DesktopJobUpdate extends DesktopJob {

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -230,10 +230,11 @@ export interface ExportDatasetArgs {
     path: string;
     typeFilter: Set<string>;
   }
+
 export interface ExportConfigurationArgs {
     id: string;
    path: string;
-  }
+}
 
 export interface CheckMediaResults {
   websafe: boolean;

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -16,7 +16,7 @@ import {
 } from 'dive-common/constants';
 import {
   DesktopJob, DesktopMetadata, JsonMeta, NvidiaSmiReply,
-  RunPipeline, RunTraining, ExportDatasetArgs,
+  RunPipeline, RunTraining, ExportDatasetArgs, ExportConfigurationArgs,
   DesktopMediaImportResponse,
 } from 'platform/desktop/constants';
 
@@ -147,6 +147,18 @@ async function exportDataset(
   return '';
 }
 
+async function exportConfiguration(id: string): Promise<string> {
+  const location = await dialog.showSaveDialog({
+    title: 'Export Configuration',
+    defaultPath: npath.join(app.getPath('home'), 'meta.json'),
+  });
+  if (!location.canceled && location.filePath) {
+    const args: ExportConfigurationArgs = { id, path: location.filePath };
+    return ipcRenderer.invoke('export-configuration', args);
+  }
+  return '';
+}
+
 /**
  * REST api for larger-body messages
  */
@@ -200,6 +212,7 @@ export {
   openFromDisk,
   /* Nonstandard APIs */
   exportDataset,
+  exportConfiguration,
   finalizeImport,
   importMedia,
   deleteDataset,

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -150,7 +150,7 @@ async function exportDataset(
 async function exportConfiguration(id: string): Promise<string> {
   const location = await dialog.showSaveDialog({
     title: 'Export Configuration',
-    defaultPath: npath.join(app.getPath('home'), 'meta.json'),
+    defaultPath: npath.join(app.getPath('home'), `${id}.config.json`),
   });
   if (!location.canceled && location.filePath) {
     const args: ExportConfigurationArgs = { id, path: location.filePath };

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -221,7 +221,7 @@ export default defineComponent({
           outlined
           clearable
           prepend-inner-icon="mdi-file-table"
-          label="Meta Configuration File (Optional)"
+          label="Configuration File (Optional)"
           hint="Optional"
           @click="openUpload('meta')"
           @click:prepend-inner="openUpload('meta')"

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -62,12 +62,13 @@ export default defineComponent({
     });
 
     const { openFromDisk } = useApi();
-    const openUpload = async () => {
+    const openUpload = async (type: 'annotation' | 'meta') => {
+      const argMap = { annotation: 'trackFileAbsPath', meta: 'metaFileAbsPath' };
       const ret = await openFromDisk('annotation');
       if (!ret.canceled) {
         if (ret.filePaths?.length) {
           const path = ret.filePaths[0];
-          Vue.set(argCopy.value, 'trackFileAbsPath', path);
+          Vue.set(argCopy.value, argMap[type], path);
         }
       }
     };
@@ -215,6 +216,17 @@ export default defineComponent({
         </span>
       </p>
       <div v-if="showAdvanced">
+        <v-text-field
+          :value="argCopy.metaFileAbsPath"
+          outlined
+          clearable
+          prepend-inner-icon="mdi-file-table"
+          label="Meta Configuration File (Optional)"
+          hint="Optional"
+          @click="openUpload"
+          @click:prepend-inner="openUpload"
+          @click:clear="argCopy.metaFileAbsPath=''"
+        />
         <v-text-field
           v-if="argCopy.jsonMeta.type === 'image-sequence'"
           v-model="argCopy.globPattern"

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -185,8 +185,8 @@ export default defineComponent({
             prepend-inner-icon="mdi-file-table"
             label="Annotation File (Optional)"
             hint="Optional"
-            @click="openUpload"
-            @click:prepend-inner="openUpload"
+            @click="openUpload('annotation')"
+            @click:prepend-inner="openUpload('annotation')"
             @click:clear="argCopy.trackFileAbsPath=''"
           />
         </v-col>
@@ -223,8 +223,8 @@ export default defineComponent({
           prepend-inner-icon="mdi-file-table"
           label="Meta Configuration File (Optional)"
           hint="Optional"
-          @click="openUpload"
-          @click:prepend-inner="openUpload"
+          @click="openUpload('meta')"
+          @click:prepend-inner="openUpload('meta')"
           @click:clear="argCopy.metaFileAbsPath=''"
         />
         <v-text-field

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -6,7 +6,7 @@ import {
 import {
   ImageSequenceType, VideoType, DefaultVideoFPS, FPSOptions,
   inputAnnotationFileTypes, websafeVideoTypes, otherVideoTypes,
-  websafeImageTypes, otherImageTypes,
+  websafeImageTypes, otherImageTypes, JsonMetaRegEx,
 } from 'dive-common/constants';
 
 import ImportButton from 'dive-common/components/ImportButton.vue';
@@ -128,7 +128,7 @@ export default defineComponent({
      * Processes the imported media files to distinguish between
      * Media Files - Default files that aren't the Annotation or Meta
      * Annotation File - CSV or JSON file, or more in the future
-     * Meta File - Right now a json file which has 'meta' in the name
+     * Meta File - Right now a json file which has 'meta' or 'config in the name
      */
     const processImport = (files: {
       canceled: boolean; filePaths: string[]; fileList?: File[];
@@ -157,20 +157,20 @@ export default defineComponent({
         });
         output.mediaList = files.fileList.filter((item) => (
           item.name.indexOf('.json') === -1 && item.name.indexOf('.csv') === -1));
-        const metaIndex = jsonFiles.findIndex((item) => (item[0].indexOf('meta') !== -1));
+        const metaIndex = jsonFiles.findIndex((item) => (JsonMetaRegEx.test(item[0])));
         if (metaIndex !== -1) {
           output.metaFile = files.fileList[jsonFiles[metaIndex][1]];
         }
         if (jsonFiles.length === 1 && csvFiles.length === 0 && output.metaFile === null) {
           output.annotationFile = files.fileList[jsonFiles[0][1]];
         } else if (csvFiles.length && jsonFiles.length === 1) {
-          if (jsonFiles[0][0].indexOf('meta') !== -1) {
+          if (JsonMetaRegEx.test(jsonFiles[0][0])) {
             output.annotationFile = files.fileList[csvFiles[0][1]];
             output.metaFile = files.fileList[jsonFiles[0][1]];
           }
         } else if (jsonFiles.length > 1) {
           //Check for a meta
-          const filtered = jsonFiles.filter((item) => (item[0].indexOf('meta') === -1));
+          const filtered = jsonFiles.filter((item) => (JsonMetaRegEx.test(item[0])));
           if (filtered.length === 1) {
             output.annotationFile = files.fileList[filtered[0][1]];
           }

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -160,22 +160,17 @@ export default defineComponent({
         const metaIndex = jsonFiles.findIndex((item) => (JsonMetaRegEx.test(item[0])));
         if (metaIndex !== -1) {
           output.metaFile = files.fileList[jsonFiles[metaIndex][1]];
+          jsonFiles.splice(metaIndex, 1); //remove chosen meta from list
         }
-        if (jsonFiles.length === 1 && csvFiles.length === 0 && output.metaFile === null) {
+        if (jsonFiles.length === 1 && csvFiles.length === 0) { // only remaining json file
           output.annotationFile = files.fileList[jsonFiles[0][1]];
-        } else if (csvFiles.length && jsonFiles.length === 1) {
-          if (JsonMetaRegEx.test(jsonFiles[0][0])) {
-            output.annotationFile = files.fileList[csvFiles[0][1]];
-            output.metaFile = files.fileList[jsonFiles[0][1]];
-          }
-        } else if (jsonFiles.length > 1) {
-          //Check for a meta
-          const filtered = jsonFiles.filter((item) => (JsonMetaRegEx.test(item[0])));
-          if (filtered.length === 1) {
+        } else if (csvFiles.length) { // Prefer First CSV if both found
+          output.annotationFile = files.fileList[csvFiles[0][1]];
+        } else if (jsonFiles.length > 1) { //multiple jsons, filter out additional meta/configs
+          const filtered = jsonFiles.filter((item) => (!JsonMetaRegEx.test(item[0]) && (item[0].indexOf('.json') !== -1)));
+          if (filtered.length) { // take first filtered JSON file
             output.annotationFile = files.fileList[filtered[0][1]];
           }
-        } else if (csvFiles.length) {
-          output.annotationFile = files.fileList[csvFiles[0][1]];
         }
         output.fullList = [...output.mediaList];
         if (output.annotationFile) {
@@ -498,7 +493,7 @@ export default defineComponent({
                     v-model="pendingUpload.meta"
                     show-size
                     counter
-                    label="Meta File (Optional)"
+                    label="Configuration File (Optional)"
                     hint="Optional"
                     :disabled="pendingUpload.uploading"
                     :accept="filterFileUpload('meta')"

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -157,7 +157,7 @@ export default defineComponent({
         });
         output.mediaList = files.fileList.filter((item) => (
           item.name.indexOf('.json') === -1 && item.name.indexOf('.csv') === -1));
-        const metaIndex = jsonFiles.findIndex((item) => (item.indexOf('meta') !== -1));
+        const metaIndex = jsonFiles.findIndex((item) => (item[0].indexOf('meta') !== -1));
         if (metaIndex !== -1) {
           output.metaFile = files.fileList[jsonFiles[metaIndex][1]];
         }
@@ -170,7 +170,7 @@ export default defineComponent({
           }
         } else if (jsonFiles.length > 1) {
           //Check for a meta
-          const filtered = jsonFiles.filter((item) => (item.indexOf('meta') === -1));
+          const filtered = jsonFiles.filter((item) => (item[0].indexOf('meta') === -1));
           if (filtered.length === 1) {
             output.annotationFile = files.fileList[filtered[0][1]];
           }
@@ -459,52 +459,50 @@ export default defineComponent({
               </v-col>
             </v-row>
             <v-row v-if="!pendingUpload.createSubFolders && pendingUpload.type !== 'zip'">
-              <v-col class="py-0">
+              <v-col class="py-0 mx-2">
                 <v-row>
-                  <v-col>
-                    <v-file-input
-                      v-model="pendingUpload.mediaList"
-                      multiple
-                      show-size
-                      counter
-                      :disabled="pendingUpload.uploading"
-                      :prepend-icon="
-                        pendingUpload.type === 'image-sequence'
-                          ? 'mdi-image-multiple'
-                          : 'mdi-file-video'
-                      "
-                      :label="
-                        pendingUpload.type === 'image-sequence'
-                          ? 'Image files'
-                          : 'Video file'
-                      "
-                      :rules="[val => (val || '').length > 0 || 'Media Files are required']"
-                      :accept="filterFileUpload(pendingUpload.type)"
-                    />
-                  </v-col>
-                  <v-col>
-                    <v-file-input
-                      v-model="pendingUpload.annotationFile"
-                      show-size
-                      counter
-                      prepend-icon="mdi-file-table"
-                      label="Annotation File (Optional)"
-                      hint="Optional"
-                      :disabled="pendingUpload.uploading"
-                      :accept="filterFileUpload('annotation')"
-                    />
-                  </v-col>
-                  <v-col>
-                    <v-file-input
-                      v-model="pendingUpload.meta"
-                      show-size
-                      counter
-                      label="Meta File"
-                      hint="Optional"
-                      :disabled="pendingUpload.uploading"
-                      :accept="filterFileUpload('meta')"
-                    />
-                  </v-col>
+                  <v-file-input
+                    v-model="pendingUpload.mediaList"
+                    multiple
+                    show-size
+                    counter
+                    :disabled="pendingUpload.uploading"
+                    :prepend-icon="
+                      pendingUpload.type === 'image-sequence'
+                        ? 'mdi-image-multiple'
+                        : 'mdi-file-video'
+                    "
+                    :label="
+                      pendingUpload.type === 'image-sequence'
+                        ? 'Image files'
+                        : 'Video file'
+                    "
+                    :rules="[val => (val || '').length > 0 || 'Media Files are required']"
+                    :accept="filterFileUpload(pendingUpload.type)"
+                  />
+                </v-row>
+                <v-row>
+                  <v-file-input
+                    v-model="pendingUpload.annotationFile"
+                    show-size
+                    counter
+                    prepend-icon="mdi-file-table"
+                    label="Annotation File (Optional)"
+                    hint="Optional"
+                    :disabled="pendingUpload.uploading"
+                    :accept="filterFileUpload('annotation')"
+                  />
+                </v-row>
+                <v-row>
+                  <v-file-input
+                    v-model="pendingUpload.meta"
+                    show-size
+                    counter
+                    label="Meta File (Optional)"
+                    hint="Optional"
+                    :disabled="pendingUpload.uploading"
+                    :accept="filterFileUpload('meta')"
+                  />
                 </v-row>
               </v-col>
             </v-row>

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -57,10 +57,6 @@ export default defineComponent({
       type: Object,
       required: true,
     },
-    hideMeta: {
-      type: Boolean,
-      default: true, // TODO:  Once Meta upload is supported we can remove this
-    },
   },
   setup(_, { emit }) {
     const preUploadErrorMessage: Ref<string | null> = ref(null);
@@ -498,7 +494,7 @@ export default defineComponent({
                       :accept="filterFileUpload('annotation')"
                     />
                   </v-col>
-                  <v-col v-if="!hideMeta">
+                  <v-col>
                     <v-file-input
                       v-model="pendingUpload.meta"
                       show-size

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -313,9 +313,11 @@ def validate_files(files: List[str]):
     elif len(csvs) > 1:
         ok = False
         message = "Can only upload a single CSV Annotation per import"
-    elif len(jsons) > 1 and "meta.json" not in jsons:
+    elif len(jsons) > 2:
         ok = False
-        message = "Can only upload a single JSON Annotation per import"
+        message = (
+            "Can only upload a single JSON Annotation and single configuration JSON per import"
+        )
     elif len(csvs) == 1 and len(ymls):
         ok = False
         message = "Cannot mix annotation import types"

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -313,7 +313,7 @@ def validate_files(files: List[str]):
     elif len(csvs) > 1:
         ok = False
         message = "Can only upload a single CSV Annotation per import"
-    elif len(jsons) > 1:
+    elif len(jsons) > 1 and "meta.json" not in jsons:
         ok = False
         message = "Can only upload a single JSON Annotation per import"
     elif len(csvs) == 1 and len(ymls):

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -603,7 +603,7 @@ def extract_zip(self: Task, folderId: str, itemId: str):
                     continue
                 if folderName not in discovered_folders:
                     discovered_folders[folderName] = 'unstructured'
-                if os.path.basename(fileName) == constants.MetaFileName:
+                if constants.metaRegex.search(os.path.basename(fileName)):
                     # sub folder has a meta.json so it is an exported dataset
                     discovered_folders[folderName] = 'dataset'
                 if fileName.endswith('.zip'):

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -212,14 +212,16 @@ def upload_exported_zipped_dataset(
 ):
     """Uploads a folder that is generated from the export of a zip file and sets metadata"""
     listOfFileNames = os.listdir(working_directory)
-    if constants.MetaFileName not in listOfFileNames:
-        manager.write(f"Could not find {constants.MetaFileName} file within the subdirectroy\n")
+    potential_meta_files = list(filter(constants.metaRegex.match, listOfFileNames))
+    if len(potential_meta_files) == 0:
+        manager.write("Could not find meta.json or config.json file within the subdirectroy\n")
         return
     print(listOfFileNames)
     # load meta.json to get datatype and verify list of files
     meta = {}
-    with open(f"{working_directory}/{constants.MetaFileName}") as f:
-        meta = json.load(f)
+    for meta_name in potential_meta_files:
+        with open(f"{working_directory}/{meta_name}") as f:
+            meta = json.load(f)
     type = meta[constants.TypeMarker]
     if type == constants.ImageSequenceType:
         imageData = meta['imageData']

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -29,6 +29,7 @@ csvRegex = re.compile(r"\.csv$", re.IGNORECASE)
 jsonRegex = re.compile(r"\.json$", re.IGNORECASE)
 ymlRegex = re.compile(r"\.ya?ml$", re.IGNORECASE)
 zipRegex = re.compile(r"\.zip$", re.IGNORECASE)
+metaRegex = re.compile(r"^.*\.?(meta|config)\.json$", re.IGNORECASE)
 
 ImageMimeTypes = {
     "image/png",


### PR DESCRIPTION
fixes #1056

Just started working on it:

- [x] Clean up styling for the fields in the web uploader.  It looks horribile having images/annoations/meta side by side like that.
- [x] Confirm the text/style is intended for the v-menu for the import
- [x] test v-menu import on desktop version
- [x] Check to make sure that the desktop version allows for import of the meta file during data upload as well.
- [x] unit test for new import of meta on desktop
- [x] Export configuration file in Desktop version (could be an argument to combine/simplify with regular export?)
- [x] unit test for new export of meta on desktop as well

Always open to any and all CSS improvments.
Could see an argument for making `metaFileAbsPath: null | string` instead of `metaFileAbsPath?: string`

File Import V-Menu listing supported types and link to documentation:
![image](https://user-images.githubusercontent.com/61746913/149391646-1bcd32b6-13a0-4c29-a456-529fcc4a8de3.png)

Upload on Web Including meta.json:
![image](https://user-images.githubusercontent.com/61746913/149391984-337d4eef-5e37-4edb-8ec9-456db183cc19.png)

Upload in Desktop with Advanced meta.json section:
![image](https://user-images.githubusercontent.com/61746913/149392360-3bd2ac0f-606d-45f4-96cb-8d20f7068150.png)

Export Configuration Added to Desktop:
![image](https://user-images.githubusercontent.com/61746913/149392434-c4e8eeb0-cbad-42a4-b95f-f5ec70d8e08a.png)

