### PR TITLE
Updating training configurations

### DIFF
--- a/client/dive-common/constants.ts
+++ b/client/dive-common/constants.ts
@@ -109,6 +109,10 @@ const multiCamPipelineMarkers = ['2-cam', '3-cam'];
 
 const JsonMetaRegEx = /^.*\.?(meta|config)\.json$/;
 
+function simplifyTrainingName(item: string) {
+  return item.replace('.viame_csv.conf', '');
+}
+
 
 export {
   DefaultVideoFPS,
@@ -131,4 +135,5 @@ export {
   stereoPipelineMarker,
   multiCamPipelineMarkers,
   JsonMetaRegEx,
+  simplifyTrainingName,
 };

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -423,8 +423,9 @@ async function getPipelineList(settings: Settings): Promise<Pipelines> {
  */
 async function getTrainingConfigs(settings: Settings): Promise<TrainingConfigs> {
   const pipelinePath = npath.join(settings.viamePath, 'configs/pipelines');
+  const defaultTrainingConfiguration = 'train_detector_default.viame_csv.conf';
   const allowedPatterns = /\.viame_csv\.conf$/;
-  const disallowedPatterns = /.*_nf\.viame_csv\.conf$/;
+  const disallowedPatterns = /.(.*_nf|.*\.continue)\.viame_csv\.conf$/;
   const exists = await fs.pathExists(pipelinePath);
   if (!exists) {
     throw new Error('Path does not exist');
@@ -432,7 +433,7 @@ async function getTrainingConfigs(settings: Settings): Promise<TrainingConfigs> 
   let configs = await fs.readdir(pipelinePath);
   configs = configs
     .filter((p) => (p.match(allowedPatterns) && !p.match(disallowedPatterns)))
-    .sort((a, b) => a.localeCompare(b));
+    .sort((a, b) => (a === defaultTrainingConfiguration ? -1 : a.localeCompare(b)));
   return {
     default: configs[0],
     configs,

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -430,7 +430,7 @@ async function getTrainingConfigs(settings: Settings): Promise<TrainingConfigs> 
   const pipelinePath = npath.join(settings.viamePath, 'configs/pipelines');
   const defaultTrainingConfiguration = 'train_detector_default.viame_csv.conf';
   const allowedPatterns = /\.viame_csv\.conf$/;
-  const disallowedPatterns = /.(.*_nf|.*\.continue)\.viame_csv\.conf$/;
+  const disallowedPatterns = /.*(_nf|\.continue)\.viame_csv\.conf$/;
   const exists = await fs.pathExists(pipelinePath);
   if (!exists) {
     throw new Error('Path does not exist');

--- a/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
+++ b/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
@@ -79,6 +79,10 @@ export default defineComponent({
       }
     }
 
+    function stripTrainingName(item: string) {
+      return item.replace('.viame_csv.conf', '');
+    }
+
     const availableItems = computed(() => Object.values(datasets.value)
       .filter((item) => item.subType === null)
       .map((item) => ({
@@ -119,6 +123,7 @@ export default defineComponent({
     return {
       data,
       toggleStaged,
+      stripTrainingName,
       isReadyToTrain,
       runTrainingOnFolder,
       nameRules,
@@ -179,10 +184,18 @@ export default defineComponent({
             v-model="data.selectedTrainingConfig"
             outlined
             dense
-            hide-details
             label="Configuration File (Required)"
             :items="data.trainingConfigurations.configs"
-          />
+            :hint="data.selectedTrainingConfig"
+            persistent-hint
+          >
+            <template v-slot:item="row">
+              {{ stripTrainingName(row.item) }}
+            </template>
+            <template v-slot:selection="{ item}">
+              {{ stripTrainingName(item) }}
+            </template>
+          </v-select>
         </v-col>
       </v-row>
       <v-data-table

--- a/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
+++ b/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
@@ -8,7 +8,7 @@ import {
   DatasetMeta, Pipelines, TrainingConfigs, useApi,
 } from 'dive-common/apispec';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
-import { itemsPerPageOptions } from 'dive-common/constants';
+import { itemsPerPageOptions, simplifyTrainingName } from 'dive-common/constants';
 import { clientSettings } from 'dive-common/store/settings';
 
 import { datasets } from '../store/dataset';
@@ -78,11 +78,6 @@ export default defineComponent({
         set(data.stagedItems, meta.id, meta);
       }
     }
-
-    function stripTrainingName(item: string) {
-      return item.replace('.viame_csv.conf', '');
-    }
-
     const availableItems = computed(() => Object.values(datasets.value)
       .filter((item) => item.subType === null)
       .map((item) => ({
@@ -123,7 +118,7 @@ export default defineComponent({
     return {
       data,
       toggleStaged,
-      stripTrainingName,
+      simplifyTrainingName,
       isReadyToTrain,
       runTrainingOnFolder,
       nameRules,
@@ -190,10 +185,10 @@ export default defineComponent({
             persistent-hint
           >
             <template v-slot:item="row">
-              {{ stripTrainingName(row.item) }}
+              {{ simplifyTrainingName(row.item) }}
             </template>
-            <template v-slot:selection="{ item}">
-              {{ stripTrainingName(item) }}
+            <template v-slot:selection="{ item }">
+              {{ simplifyTrainingName(item) }}
             </template>
           </v-select>
         </v-col>

--- a/client/platform/web-girder/views/RunTrainingMenu.vue
+++ b/client/platform/web-girder/views/RunTrainingMenu.vue
@@ -7,6 +7,7 @@ import { useApi, TrainingConfigs } from 'dive-common/apispec';
 import JobLaunchDialog from 'dive-common/components/JobLaunchDialog.vue';
 import ImportButton from 'dive-common/components/ImportButton.vue';
 import { useRequest } from 'dive-common/use';
+import { simplifyTrainingName } from 'dive-common/constants';
 
 
 export default defineComponent({
@@ -98,10 +99,6 @@ export default defineComponent({
       labelText.value = '';
     };
 
-    function stripTrainingName(item: string) {
-      return item.replace('.viame_csv.conf', '');
-    }
-
     return {
       trainingConfigurations,
       selectedTrainingConfig,
@@ -115,7 +112,7 @@ export default defineComponent({
       runTrainingOnFolder,
       labelFile,
       clearLabelText,
-      stripTrainingName,
+      simplifyTrainingName,
     };
   },
 });
@@ -203,10 +200,10 @@ export default defineComponent({
               persistent-hint
             >
               <template v-slot:item="row">
-                {{ stripTrainingName(row.item) }}
+                {{ simplifyTrainingName(row.item) }}
               </template>
               <template v-slot:selection="{ item}">
-                {{ stripTrainingName(item) }}
+                {{ simplifyTrainingName(item) }}
               </template>
             </v-select>
             <v-file-input

--- a/client/platform/web-girder/views/RunTrainingMenu.vue
+++ b/client/platform/web-girder/views/RunTrainingMenu.vue
@@ -98,6 +98,9 @@ export default defineComponent({
       labelText.value = '';
     };
 
+    function stripTrainingName(item: string) {
+      return item.replace('.viame_csv.conf', '');
+    }
 
     return {
       trainingConfigurations,
@@ -112,6 +115,7 @@ export default defineComponent({
       runTrainingOnFolder,
       labelFile,
       clearLabelText,
+      stripTrainingName,
     };
   },
 });
@@ -192,11 +196,19 @@ export default defineComponent({
             <v-select
               v-model="selectedTrainingConfig"
               outlined
-              hide-details
               class="my-4"
               label="Configuration File"
               :items="trainingConfigurations.configs"
-            />
+              :hint="selectedTrainingConfig"
+              persistent-hint
+            >
+              <template v-slot:item="row">
+                {{ stripTrainingName(row.item) }}
+              </template>
+              <template v-slot:selection="{ item}">
+                {{ stripTrainingName(item) }}
+              </template>
+            </v-select>
             <v-file-input
               v-model="labelFile"
               icon="mdi-folder-open"

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -11,7 +11,7 @@ from dive_utils.types import (
 
 DefaultTrainingConfiguration = "train_detector_default.viame_csv.conf"
 AllowedTrainingConfigs = r".*\.viame_csv\.conf$"
-DisallowedTrainingConfigs = r"(.*_nf|.*\.continue)\.viame_csv\.conf$"
+DisallowedTrainingConfigs = r".*(_nf|\.continue)\.viame_csv\.conf$"
 AllowedStaticPipelines = r"^detector_.+|^tracker_.+|^utility_.+|^generate_.+"
 DisallowedStaticPipelines = (
     # Remove utilities pipes which hold no meaning in web

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -11,7 +11,7 @@ from dive_utils.types import (
 
 DefaultTrainingConfiguration = "train_detector_default.viame_csv.conf"
 AllowedTrainingConfigs = r".*\.viame_csv\.conf$"
-DisallowedTrainingConfigs = r".*_nf\.viame_csv\.conf$"
+DisallowedTrainingConfigs = r"(.*_nf|.*\.continue)\.viame_csv\.conf$"
 AllowedStaticPipelines = r"^detector_.+|^tracker_.+|^utility_.+|^generate_.+"
 DisallowedStaticPipelines = (
     # Remove utilities pipes which hold no meaning in web


### PR DESCRIPTION
fixes #1122 
fixes #1123 
fixes #1121 

- Adds in `.continue` to the filter to dissallowed training configurations.
- Sets the default pipeline in the Desktop version to "train_detector_default"
- Strips the `viame_csv.pipe` name from all of the training configurations in desktop/web
- Adds a persistent hint to the `v-select` which displays the full filename.

I could also but didn't want to modify the `getTrainingConfigs` endpoint.  That could be modified instead of doing all the stripping work on the client.  Instead just a small function (`simplifyTrainingName`) added to constants.ts (I think it's okay because it's a relatively simple function used across desktop/web).  I like that it just provides a list of files and client takes care of the presentation of the names.  If it was modified server side it would still have to be modified for the desktop request to that endpoint as well as the girder one.

Web:
![image](https://user-images.githubusercontent.com/61746913/150402110-8cfead6e-bbba-42d7-8df3-9417f87177a5.png)

Desktop:
![image](https://user-images.githubusercontent.com/61746913/150402936-8f0fd571-3dcb-4d0a-acee-e84757b593ff.png)
