### PR TITLE
Better status indicators for running jobs.

### DIFF
--- a/client/platform/web-girder/store/Jobs.ts
+++ b/client/platform/web-girder/store/Jobs.ts
@@ -1,0 +1,61 @@
+import { Store, Module } from 'vuex';
+import { GirderJob } from '@girder/components/src';
+import { all } from '@girder/components/src/components/Job/status';
+import Vue from 'vue';
+
+import eventBus from 'platform/web-girder/eventBus';
+import girderRest from 'platform/web-girder/plugins/girder';
+import { RootState, JobState } from './types';
+
+
+const JobStatus = all();
+const NonRunningStates = [
+  JobStatus.CANCELED.value,
+  JobStatus.ERROR.value,
+  JobStatus.SUCCESS.value,
+];
+
+const jobModule: Module<JobState, RootState> = {
+  namespaced: true,
+  state: {
+    jobIds: {},
+    datasetStatus: {},
+  },
+  getters: {
+    runningJobIds(state) {
+      return Object.values(state.jobIds).filter((v) => !NonRunningStates.includes(v)).length >= 1;
+    },
+    datasetRunningState: (state) => (datasetId: string) => (
+      datasetId in state.datasetStatus && !NonRunningStates.includes(state.datasetStatus[datasetId])
+    ),
+  },
+  mutations: {
+    setJobState(state, { jobId, value }: { jobId: string; value: number }) {
+      Vue.set(state.jobIds, jobId, value);
+    },
+    setDatasetStatus(state, { datasetId, value }: { datasetId: string; value: number }) {
+      Vue.set(state.datasetStatus, datasetId, value);
+    },
+  },
+};
+
+export async function init(store: Store<RootState>) {
+  const { data: runningJobs } = await girderRest.get<GirderJob[]>('/job', {
+    params: { statuses: `[${JobStatus.RUNNING.value}]` },
+  });
+
+  function updateJob(job: GirderJob) {
+    store.commit('Jobs/setJobState', { jobId: job._id, value: job.status });
+    if (typeof job.dataset_id === 'string') {
+      store.commit('Jobs/setDatasetStatus', { datasetId: job.dataset_id, value: job.status });
+    }
+  }
+
+  runningJobs.forEach(updateJob);
+  girderRest.$on('message:job_status', ({ data: job }: { data: GirderJob }) => {
+    updateJob(job);
+    eventBus.$emit('refresh-data-browser');
+  });
+}
+
+export default jobModule;

--- a/client/platform/web-girder/store/index.ts
+++ b/client/platform/web-girder/store/index.ts
@@ -6,6 +6,7 @@ import { RootState } from './types';
 import Location from './Location';
 import Dataset from './Dataset';
 import Brand from './Brand';
+import Jobs, { init as JobsInit } from './Jobs';
 
 Vue.use(Vuex);
 
@@ -14,6 +15,7 @@ const store = new Vuex.Store<RootState>({
     Brand,
     Location,
     Dataset,
+    Jobs,
   },
 });
 
@@ -24,5 +26,7 @@ router.beforeEach((to, from, next) => {
   }
   next();
 });
+
+JobsInit(store);
 
 export default store;

--- a/client/platform/web-girder/store/types.ts
+++ b/client/platform/web-girder/store/types.ts
@@ -26,6 +26,11 @@ export interface BrandState {
   brandData: BrandData;
 }
 
+export interface JobState {
+  jobIds: Record<string, number>;
+  datasetStatus: Record<string, number>;
+}
+
 export interface RootState {
   Location: LocationState;
   Dataset: DatasetState;

--- a/client/platform/web-girder/views/DataBrowser.vue
+++ b/client/platform/web-girder/views/DataBrowser.vue
@@ -5,7 +5,6 @@ import {
 import {
   GirderFileManager, getLocationType, GirderModel,
 } from '@girder/components/src';
-import { useGirderRest } from 'platform/web-girder/plugins/girder';
 import { itemsPerPageOptions } from 'dive-common/constants';
 import { clientSettings } from 'dive-common/store/settings';
 import { useStore, LocationType } from '../store/types';
@@ -25,7 +24,6 @@ export default defineComponent({
     const uploaderDialog = ref(false);
     const locationStore = store.state.Location;
     const { getters } = store;
-    const girderRest = useGirderRest();
 
     function setLocation(location: LocationType) {
       store.dispatch('Location/setRouteFromLocation', location);
@@ -55,10 +53,8 @@ export default defineComponent({
     ));
 
     eventBus.$on('refresh-data-browser', handleNotification);
-    girderRest.$on('message:job_status', handleNotification);
     onBeforeUnmount(() => {
       eventBus.$off('refresh-data-browser', handleNotification);
-      girderRest.$off('message:job_status', handleNotification);
     });
 
     return {
@@ -125,6 +121,13 @@ export default defineComponent({
       </v-dialog>
     </template>
     <template #row-widget="{item}">
+      <v-icon
+        v-if="getters['Jobs/datasetRunningState'](item._id)"
+        color="warning"
+        class="rotate"
+      >
+        mdi-autorenew
+      </v-icon>
       <v-btn
         v-if="isAnnotationFolder(item)"
         class="ml-2"

--- a/client/platform/web-girder/views/Jobs.vue
+++ b/client/platform/web-girder/views/Jobs.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, ref } from '@vue/composition-api';
-import { GirderModel, GirderJobList } from '@girder/components/src';
+import { GirderJobList } from '@girder/components/src';
 import { setUsePrivateQueue } from 'platform/web-girder/api';
 import { useGirderRest } from 'platform/web-girder/plugins/girder';
 
@@ -11,17 +11,6 @@ export default defineComponent({
     const privateQueueEnabled = ref(false);
     const loading = ref(true);
     const restClient = useGirderRest();
-
-    function getId(data: GirderModel | string) {
-      try {
-        if (typeof data === 'object') {
-          return data.folderId;
-        }
-        return JSON.parse(data).params.input_folder;
-      } catch (err) {
-        return null;
-      }
-    }
 
     async function setPrivateQueueEnabled(value: boolean) {
       loading.value = true;
@@ -40,7 +29,6 @@ export default defineComponent({
       privateQueueEnabled,
       loading,
       /* methods */
-      getId,
       setPrivateQueueEnabled,
     };
   },
@@ -52,7 +40,7 @@ export default defineComponent({
     <GirderJobList>
       <template #jobwidget="{ item }">
         <v-tooltip
-          v-if="getId(item.kwargs)"
+          v-if="item.dataset_id"
           bottom
         >
           <template #activator="{on, attrs}">
@@ -60,7 +48,7 @@ export default defineComponent({
               v-bind="attrs"
               x-small
               depressed
-              :to="{ name: 'viewer', params: { id: getId(item.kwargs) } }"
+              :to="{ name: 'viewer', params: { id: item.dataset_id } }"
               color="info"
               class="ml-0"
               v-on="on"

--- a/client/platform/web-girder/views/JobsTab.vue
+++ b/client/platform/web-girder/views/JobsTab.vue
@@ -1,59 +1,12 @@
 <script lang="ts">
-import {
-  defineComponent, onBeforeUnmount, reactive, toRefs,
-} from '@vue/composition-api';
-import { GirderJob } from '@girder/components/src';
-import { all } from '@girder/components/src/components/Job/status';
-import { useGirderRest } from 'platform/web-girder/plugins/girder';
+import { defineComponent } from '@vue/composition-api';
+import { useStore } from 'platform/web-girder/store/types';
 
 export default defineComponent({
   name: 'JobsTab',
   setup() {
-    const girderRest = useGirderRest();
-    const jobStatus = all();
-    const data = reactive({
-      runningJobIds: [] as string[],
-    });
-
-    function handleNotification({ data: job }: { data: GirderJob }) {
-      const jobId = job._id;
-      switch (job.status) {
-        case jobStatus.RUNNING.value:
-          if (data.runningJobIds.indexOf(jobId) === -1) {
-            data.runningJobIds.push(jobId);
-          }
-          break;
-        case jobStatus.CANCELED.value:
-          // fall through
-        case jobStatus.SUCCESS.value:
-          // fall through
-        case jobStatus.ERROR.value:
-          if (data.runningJobIds.indexOf(jobId) !== -1) {
-            data.runningJobIds.splice(data.runningJobIds.indexOf(jobId), 1);
-          }
-          break;
-        default:
-          break;
-      }
-    }
-
-    async function created() {
-      const { data: runningJobs } = await girderRest.get<GirderJob[]>('/job', {
-        params: {
-          statuses: `[${jobStatus.RUNNING.value}]`,
-        },
-      });
-      data.runningJobIds = runningJobs.map((job) => job._id);
-      girderRest.$on('message:job_status', handleNotification);
-    }
-
-    onBeforeUnmount(() => {
-      girderRest.$off('message:job_status', handleNotification);
-    });
-
-    created();
-
-    return toRefs(data);
+    const store = useStore();
+    return { getters: store.getters };
   },
 });
 </script>
@@ -62,7 +15,7 @@ export default defineComponent({
   <v-tab to="/jobs">
     Jobs
     <v-badge
-      :value="runningJobIds.length"
+      :value="getters['Jobs/runningJobIds']"
       overlap
       bottom
       offset-x="-6"

--- a/server/dive_server/__init__.py
+++ b/server/dive_server/__init__.py
@@ -7,8 +7,9 @@ from girder.models.setting import Setting
 from girder.models.user import User
 from girder.utility import mail_utils
 from girder.utility.model_importer import ModelImporter
+from girder_jobs.models.job import Job
 
-from dive_utils.constants import UserPrivateQueueEnabledMarker
+from dive_utils import constants
 
 from .client_webroot import ClientWebroot
 from .crud_annotation import AnnotationItem, RevisionLogItem
@@ -32,7 +33,10 @@ class GirderPlugin(plugin.GirderPlugin):
 
         # Setup route additions for exsting resources
         info["apiRoot"].user.route("PUT", (":id", "use_private_queue"), use_private_queue)
-        User().exposeFields(AccessType.READ, UserPrivateQueueEnabledMarker)
+        User().exposeFields(AccessType.READ, constants.UserPrivateQueueEnabledMarker)
+
+        # Expose Job dataset assocation
+        Job().exposeFields(AccessType.READ, constants.JOBCONST_DATASET_ID)
 
         DIVE_MAIL_TEMPLATES = Path(os.path.realpath(__file__)).parent / 'mail_templates'
         mail_utils.addTemplateDirectory(str(DIVE_MAIL_TEMPLATES))

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -453,6 +453,7 @@ def postprocess(
                 ),
             )
             newjob.job[constants.JOBCONST_PRIVATE_QUEUE] = job_is_private
+            newjob.job[constants.JOBCONST_DATASET_ID] = dsFolder["_id"]
             Job().save(newjob.job)
 
         # transcode IMAGERY if necessary
@@ -474,6 +475,7 @@ def postprocess(
                 ),
             )
             newjob.job[constants.JOBCONST_PRIVATE_QUEUE] = job_is_private
+            newjob.job[constants.JOBCONST_DATASET_ID] = dsFolder["_id"]
             Job().save(newjob.job)
 
         elif imageItems.count() > 0:

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -94,7 +94,7 @@ AuxiliaryFolderName = "auxiliary"
 MetaFileName = "meta.json"
 
 # job constants
-JOBCONST_DATASET_ID = 'datset_id'
+JOBCONST_DATASET_ID = 'dataset_id'
 JOBCONST_PARAMS = 'params'
 JOBCONST_PRIVATE_QUEUE = 'private_queue'
 JOBCONST_CREATOR = 'creator'

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -12,7 +12,7 @@ from dive_utils.models import Feature, Track, interpolate
 
 
 def format_timestamp(fps: int, frame: int) -> str:
-    return str(datetime.datetime.utcfromtimestamp(frame / fps).strftime(r'%H:%M:%S.%f'))
+    return str(datetime.datetime.utcfromtimestamp(frame / fps).isoformat())
 
 
 def writeHeader(writer: 'csv._writer', metadata: Dict):  # type: ignore


### PR DESCRIPTION
Expose and centralize what jobs are running on what datasets.

Now, running jobs are visible directly in the data browser.  This will hopefully lead to less confusion about why "Launch annotator' isn't visible during transcoding or what pipelines are running.

Nothing is visible for training yet because training isn't "blocking" anything.

![Screenshot from 2022-01-20 15-10-38](https://user-images.githubusercontent.com/4214172/150414581-6ea91d4e-ffe0-480f-ad7b-f83f488c82bb.png)
