### PR TITLE
fixing default low confidence

### DIFF
--- a/client/src/use/useTrackFilters.ts
+++ b/client/src/use/useTrackFilters.ts
@@ -69,7 +69,7 @@ export default function useFilteredTracks(
       const confidencePairIndex = track.confidencePairs
         .findIndex(([confkey, confval]) => {
           const confidenceThresh = Math.max(
-            confidenceFiltersVal[confkey] || DefaultConfidence,
+            confidenceFiltersVal[confkey] || 0,
             confidenceFiltersVal.default,
           );
           return confval >= confidenceThresh && checkedSet.has(confkey);


### PR DESCRIPTION
Low confidence wouldn't work under 0.10 because of a Max comparison.  Switched it to default to 0 for the lower value.