### PR TITLE
Batch Export

### DIFF
--- a/client/platform/web-girder/views/Export.vue
+++ b/client/platform/web-girder/views/Export.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  computed, defineComponent, ref, shallowRef, toRef, watch, PropType,
+  computed, defineComponent, ref, shallowRef, toRef, watch, PropType, Ref,
 } from '@vue/composition-api';
 import { usePendingSaveCount, useHandler, useCheckedTypes } from 'vue-media-annotator/provides';
 import AutosavePrompt from 'dive-common/components/AutosavePrompt.vue';
@@ -74,16 +74,17 @@ export default defineComponent({
     const excludeBelowThreshold = ref(true);
     const excludeUncheckedTypes = ref(false);
 
-    const singleDataSetId = computed(() => {
-      if (props.datasetIds.length === 1) {
-        return props.datasetIds[0];
-      }
-      return null;
-    });
+    const singleDataSetId: Ref<string|null> = ref(null);
     const dataset = shallowRef(null as GirderMetadataStatic | null);
     const datasetMedia = shallowRef(null as DatasetSourceMedia | null);
     const { request, error } = useRequest();
     const loadDatasetMeta = () => request(async () => {
+      if (props.datasetIds.length > 1) {
+        singleDataSetId.value = null;
+        dataset.value = null;
+      } else {
+        [singleDataSetId.value] = props.datasetIds;
+      }
       if (menuOpen.value && singleDataSetId.value) {
         dataset.value = (await getDataset(singleDataSetId.value)).data;
         if (dataset.value.type === 'video') {

--- a/client/platform/web-girder/views/Export.vue
+++ b/client/platform/web-girder/views/Export.vue
@@ -101,14 +101,19 @@ export default defineComponent({
       if (singleDataSetId.value) {
         return {
           exportAllUrl: getUri({
-            url: `dive_dataset/${singleDataSetId.value}/export`,
-            params,
+            url: 'dive_dataset/export',
+            params: { ...params, folderIds: JSON.stringify([singleDataSetId.value]) },
           }),
           exportMediaUrl: dataset.value?.type === 'video'
             ? datasetMedia.value?.video?.url
             : getUri({
-              url: `dive_dataset/${singleDataSetId.value}/export`,
-              params: { ...params, includeDetections: false, includeMedia: true },
+              url: 'dive_dataset/export',
+              params: {
+                ...params,
+                includeDetections: false,
+                includeMedia: true,
+                folderIds: JSON.stringify([singleDataSetId.value]),
+              },
             }),
           exportDetectionsUrl: getUri({
             url: 'dive_annotation/export',
@@ -121,29 +126,9 @@ export default defineComponent({
       }
       return {
         exportAllUrl: getUri({
-          url: 'dive_dataset/batch_export',
-          params: { ...params, batchIds: props.datasetIds },
-        }),
-        exportMediaUrl: dataset.value?.type === 'video'
-          ? datasetMedia.value?.video?.url
-          : getUri({
-            url: 'dive_dataset/batch_export',
-            params: {
-              ...params, includeDetections: false, includeMedia: true, batchIds: props.datasetIds,
-            },
-          }),
-        exportDetectionsUrl: getUri({
-          url: 'dive_annotation/batch_export',
-          params: { ...params, folderId: singleDataSetId.value, batchIds: props.datasetIds },
-        }),
-        exportConfigurationUrl: getUri({
-          url: 'dive_annotation/batch_export',
-          params: {
-            ...params,
-            folderId: singleDataSetId.value,
-            batchIds: props.datasetIds,
-            configurationsOnly: true,
-          },
+          url: 'dive_dataset/export',
+          params: { folderIds: JSON.stringify(props.datasetIds) },
+
         }),
       };
     });
@@ -168,6 +153,7 @@ export default defineComponent({
       exportUrls,
       checkedTypes,
       savePrompt,
+      singleDataSetId,
       doExport,
     };
   },
@@ -188,7 +174,7 @@ export default defineComponent({
           <v-btn
             class="ma-0"
             v-bind="buttonOptions"
-            :disabled="!singleDataSetId"
+            :disabled="!datasetIds.length"
             v-on="{ ...tooltipOn, ...menuOn }"
           >
             <v-icon>
@@ -310,6 +296,21 @@ export default defineComponent({
 
           <v-card-text class="pb-0">
             Zip all media, detections, and edit history recursively from all sub-folders
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn
+              depressed
+              block
+              @click="doExport({ url: exportUrls && exportUrls.exportAllUrl })"
+            >
+              Everything
+            </v-btn>
+          </v-card-actions>
+        </template>
+        <template v-else-if="exportUrls.exportAllUrl !== undefined">
+          <v-card-text class="pb-0">
+            Zip all media, detections, and edit history from all selected dataset folders
           </v-card-text>
           <v-card-actions>
             <v-spacer />

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -89,9 +89,6 @@ export default defineComponent({
       }
       return null;
     },
-    exportTargetId() {
-      return this.exportTarget?._id || null;
-    },
     selectedViameFolderIds() {
       return this.selected.filter(
         ({ _modelType, meta }) => _modelType === 'folder' && meta && meta.annotate,

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -172,7 +172,7 @@ export default defineComponent({
                 />
                 <export
                   v-bind="{ buttonOptions, menuOptions }"
-                  :dataset-id="exportTargetId"
+                  :dataset-ids="locationInputs"
                 />
                 <v-btn
                   :disabled="!selected.length"

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -75,20 +75,6 @@ export default defineComponent({
   computed: {
     ...mapState('Location', ['selected', 'location']),
     ...mapGetters('Location', ['locationIsViameFolder']),
-    exportTarget() {
-      let { selected } = this;
-      if (selected.length === 1) {
-        [selected] = selected;
-        if (selected._modelType !== 'folder') {
-          return null;
-        }
-        return selected;
-      }
-      if (this.locationIsViameFolder) {
-        return this.location;
-      }
-      return null;
-    },
     selectedViameFolderIds() {
       return this.selected.filter(
         ({ _modelType, meta }) => _modelType === 'folder' && meta && meta.annotate,

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -127,7 +127,7 @@ export default defineComponent({
       />
       <Export
         v-bind="{ buttonOptions, menuOptions }"
-        :dataset-id="id"
+        :dataset-ids="[id]"
         block-on-unsaved
       />
       <Clone

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -254,8 +254,6 @@ def export_datasets_zipstream(
                         break  # Media items should only have 1 valid file
 
             if includeDetections:
-                # TODO Add back in dump to json
-                # add CSV detections
                 for data in z.addFile(gen, Path(f'{zip_path}output_tracks.csv')):
                     yield data
         yield z.footer()

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import List, Optional, Tuple
 
 import cherrypy
@@ -193,60 +194,70 @@ def update_attributes(dsFolder: types.GirderModel, data: dict):
     }
 
 
-def export_dataset_zipstream(
-    dsFolder: types.GirderModel,
+def export_datasets_zipstream(
+    dsFolders: List[types.GirderModel],
     user: types.GirderUserModel,
     includeMedia: bool,
     includeDetections: bool,
     excludeBelowThreshold: bool,
     typeFilter: Optional[List[str]],
 ):
-    _, gen = crud_annotation.get_annotation_csv_generator(
-        dsFolder, user, excludeBelowThreshold, typeFilter
-    )
-    mediaFolder = crud.getCloneRoot(user, dsFolder)
-    source_type = fromMeta(mediaFolder, constants.TypeMarker)
-    mediaRegex = None
-    if source_type == constants.ImageSequenceType:
-        mediaRegex = constants.imageRegex
-    elif source_type == constants.VideoType:
-        mediaRegex = constants.videoRegex
-
-    def makeMetajson():
-        """Include dataset metadtata file with full export"""
-        meta = get_dataset(dsFolder, user)
-        media = get_media(dsFolder, user)
-        yield json.dumps(
-            {
-                **meta.dict(exclude_none=True),
-                **media.dict(exclude_none=True),
-            },
-            indent=2,
+    def makeAnnotationAndMedia(dsFolder: types.GirderModel):
+        _, gen = crud_annotation.get_annotation_csv_generator(
+            dsFolder, user, excludeBelowThreshold, typeFilter
         )
+        mediaFolder = crud.getCloneRoot(user, dsFolder)
+        source_type = fromMeta(mediaFolder, constants.TypeMarker)
+        mediaRegex = None
+        if source_type == constants.ImageSequenceType:
+            mediaRegex = constants.imageRegex
+        elif source_type == constants.VideoType:
+            mediaRegex = constants.videoRegex
+        return gen, mediaFolder, mediaRegex
 
     def stream():
-        z = ziputil.ZipGenerator(dsFolder['name'])
+        zip_name = "batch_export"
+        if len(dsFolders) == 1:
+            zip_name = dsFolders[0]['name']
+        z = ziputil.ZipGenerator(zip_name)
+        for dsFolder in dsFolders:
+            if len(dsFolders) > 1:
+                zip_path = f"./{dsFolder['name']}/"
+            else:
+                zip_path = "./"
 
-        # Always add the metadata file
-        for data in z.addFile(makeMetajson, 'meta.json'):
-            yield data
+            def makeMetajson():
+                """Include dataset metadtata file with full export"""
+                meta = get_dataset(dsFolder, user)
+                media = get_media(dsFolder, user)
+                yield json.dumps(
+                    {
+                        **meta.dict(exclude_none=True),
+                        **media.dict(exclude_none=True),
+                    },
+                    indent=2,
+                )
 
-        if includeMedia:
-            # Add media
-            for item in Folder().childItems(
-                mediaFolder,
-                filters={"lowerName": {"$regex": mediaRegex}},
-            ):
-                for (path, file) in Item().fileList(item):
-                    for data in z.addFile(file, path):
-                        yield data
-                    break  # Media items should only have 1 valid file
-
-        if includeDetections:
-            # TODO Add back in dump to json
-            # add CSV detections
-            for data in z.addFile(gen, "output_tracks.csv"):
+            for data in z.addFile(makeMetajson, Path(f'{zip_path}meta.json')):
                 yield data
+
+            gen, mediaFolder, mediaRegex = makeAnnotationAndMedia(dsFolder)
+            if includeMedia:
+                # Add media
+                for item in Folder().childItems(
+                    mediaFolder,
+                    filters={"lowerName": {"$regex": mediaRegex}},
+                ):
+                    for (path, file) in Item().fileList(item):
+                        for data in z.addFile(file, Path(f'{zip_path}{path}')):
+                            yield data
+                        break  # Media items should only have 1 valid file
+
+            if includeDetections:
+                # TODO Add back in dump to json
+                # add CSV detections
+                for data in z.addFile(gen, Path(f'{zip_path}output_tracks.csv')):
+                    yield data
         yield z.footer()
 
     return stream

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -162,7 +162,7 @@ class DatasetResource(Resource):
             "List of track types to filter by",
             paramType="query",
             required=True,
-            default=None,
+            default=[],
             requireArray=True,
         )
         .param(

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -156,7 +156,7 @@ class DatasetResource(Resource):
 
     @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(
-        Description("Batch Export all selected datasets")
+        Description("Export all selected datasets")
         .jsonParam(
             "folderIds",
             "List of track types to filter by",

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -31,7 +31,7 @@ class DatasetResource(Resource):
         self.route("GET", (), self.list_datasets)
         self.route("GET", (":id",), self.get_meta)
         self.route("GET", (":id", "media"), self.get_media)
-        self.route("GET", (":id", "export"), self.export)
+        self.route("GET", ("export",), self.export)
         self.route("GET", (":id", "configuration"), self.get_configuration)
         self.route("POST", ("validate_files",), self.validate_files)
 
@@ -156,8 +156,15 @@ class DatasetResource(Resource):
 
     @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @autoDescribeRoute(
-        Description("Export everything in a dataset")
-        .modelParam("id", level=AccessType.READ, **DatasetModelParam)
+        Description("Batch Export all selected datasets")
+        .jsonParam(
+            "folderIds",
+            "List of track types to filter by",
+            paramType="query",
+            required=True,
+            default=None,
+            requireArray=True,
+        )
         .param(
             "includeMedia",
             "Include media content",
@@ -190,21 +197,29 @@ class DatasetResource(Resource):
     )
     def export(
         self,
-        folder,
+        folderIds: List[str],
         includeMedia: bool,
         includeDetections: bool,
         excludeBelowThreshold: bool,
         typeFilter: Optional[List[str]],
     ):
-        gen = crud_dataset.export_dataset_zipstream(
-            folder,
+        girder_folders = []
+        for folder in folderIds:
+            girder_folders.append(
+                Folder().load(folder, level=AccessType.READ, user=self.getCurrentUser())
+            )
+        gen = crud_dataset.export_datasets_zipstream(
+            girder_folders,
             self.getCurrentUser(),
             includeMedia=includeMedia,
             includeDetections=includeDetections,
             excludeBelowThreshold=excludeBelowThreshold,
             typeFilter=typeFilter,
         )
-        setContentDisposition(f'{folder["name"]}.zip', mime='application/zip')
+        zip_name = "batch_export.zip"
+        if len(girder_folders) == 1:
+            zip_name = f"{girder_folders[0]['name']}.zip"
+        setContentDisposition(zip_name, mime='application/zip')
         return gen
 
     @access.user

--- a/server/tests/integration/test_dataset_download.py
+++ b/server/tests/integration/test_dataset_download.py
@@ -1,3 +1,8 @@
+import io
+import json
+import os
+from zipfile import ZipFile
+
 import pytest
 
 from .conftest import getClient, getTestFolder, match_user_server_data, users
@@ -36,6 +41,48 @@ def test_download_csv(user: dict):
                 if not row.startswith('#'):
                     track_set.add(row.split(',')[0])
             assert len(track_set) == expected[0]['trackCount']
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("user", users.values())
+@pytest.mark.run(order=6)
+def test_zip_download(user: dict):
+    if user['login'] == 'testCharacters':
+        return
+    client = getClient(user['login'])
+    privateFolder = getTestFolder(client)
+    for dataset in client.listFolder(privateFolder['_id']):
+        downloaded = client.sendRestRequest(
+            'GET',
+            f'dive_dataset/export?includeMedia=true&includeDetections=true&excludeBelowThreshold=false&folderIds={json.dumps([dataset["_id"]])}',
+            jsonResp=False,
+        )
+        z = ZipFile(io.BytesIO(downloaded.content))
+        folder_name = list(set([os.path.dirname(x) for x in z.namelist()]))[0]
+        assert folder_name == dataset['name']
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("user", users.values())
+@pytest.mark.run(order=6)
+def test_zip_batch_download(user: dict):
+    if user['login'] == 'testCharacters':
+        return
+    client = getClient(user['login'])
+    privateFolder = getTestFolder(client)
+    datasetIds = []
+    datasetNames = []
+    for dataset in client.listFolder(privateFolder['_id']):
+        datasetIds.append(dataset["_id"])
+        datasetNames.append(dataset["name"])
+    downloaded = client.sendRestRequest(
+        'GET',
+        f'dive_dataset/export?includeMedia=true&includeDetections=true&excludeBelowThreshold=false&folderIds={json.dumps(datasetIds)}',
+        jsonResp=False,
+    )
+    z = ZipFile(io.BytesIO(downloaded.content))
+    folder_names = list(set([os.path.dirname(x) for x in z.namelist()]))
+    assert len(folder_names) == len(datasetNames)
 
 
 @pytest.mark.integration

--- a/server/tests/integration/test_dataset_download.py
+++ b/server/tests/integration/test_dataset_download.py
@@ -47,7 +47,7 @@ def test_download_csv(user: dict):
 @pytest.mark.parametrize("user", users.values())
 @pytest.mark.run(order=6)
 def test_zip_download(user: dict):
-    if user['login'] == 'testCharacters':
+    if user['login'] == 'testCharacters': # listFolder returns non slugified folder names.
         return
     client = getClient(user['login'])
     privateFolder = getTestFolder(client)
@@ -66,7 +66,7 @@ def test_zip_download(user: dict):
 @pytest.mark.parametrize("user", users.values())
 @pytest.mark.run(order=6)
 def test_zip_batch_download(user: dict):
-    if user['login'] == 'testCharacters':
+    if user['login'] == 'testCharacters': # listFolder returns non slugified folder names.
         return
     client = getClient(user['login'])
     privateFolder = getTestFolder(client)

--- a/server/tests/integration/test_dataset_download.py
+++ b/server/tests/integration/test_dataset_download.py
@@ -47,7 +47,7 @@ def test_download_csv(user: dict):
 @pytest.mark.parametrize("user", users.values())
 @pytest.mark.run(order=6)
 def test_zip_download(user: dict):
-    if user['login'] == 'testCharacters': # listFolder returns non slugified folder names.
+    if user['login'] == 'testCharacters':  # listFolder returns non slugified folder names.
         return
     client = getClient(user['login'])
     privateFolder = getTestFolder(client)
@@ -66,7 +66,7 @@ def test_zip_download(user: dict):
 @pytest.mark.parametrize("user", users.values())
 @pytest.mark.run(order=6)
 def test_zip_batch_download(user: dict):
-    if user['login'] == 'testCharacters': # listFolder returns non slugified folder names.
+    if user['login'] == 'testCharacters':  # listFolder returns non slugified folder names.
         return
     client = getClient(user['login'])
     privateFolder = getTestFolder(client)


### PR DESCRIPTION
fixes #812 
fixes #925

Updated 20220131:

- Removed the `GET dive_annotation/{id}/export` for an endpoint `GET dive_annotation/export` where an array of `folderIds` is passed in.  Endpoint will now load the multiple folders and pass them to an updated `export_datasets_zipstream`.  If there are multiple folders it names the output `batch_export.zip` if not it will use the single folder's name.
- updated `export_datasets_zipstream` to `export_datasets_zipstream` to support multiple girder folders.  It will then use the settings and zip up the multiple folders instead of a single folder.  Just a minor restructuring of the function to support multiple datasets.
- Client side `platform/web-girder/views/Export.vue`  will now take in an array of folderIds instead of a single one.
- Behavior for a single dataset is the same using a new Ref `singleDatasetId` for multiple datasets there is only the option to export everything.
- Updated all references to the web-girder/Export.vue to pass in an array instead of a single datasetId.
- Added some integration tests that will test the regular export zip and batch export.  I avoided the `testCharacters` user because the names of the exported files don't match-up properly.
