### PR TITLE
Zip File Documentation and Errors

### DIFF
--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -544,6 +544,16 @@ export default defineComponent({
               @open="openImport($event)"
             />
           </div>
+          <div v-if="pendingUploads.length && pendingUploads.some((item) => item.type === 'zip')">
+            <h3 class="text-center">
+              <a
+                target="_blank"
+                href="https://kitware.github.io/dive/Web-Version/#zip-files"
+              >
+                Supported Zip Files
+              </a>
+            </h3>
+          </div>
           <v-btn
             v-if="pendingUploads.length"
             :disabled="uploading"

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -190,6 +190,9 @@ def upload_zipped_flat_media_files(
         gc.sendRestRequest("POST", f"/dive_rpc/postprocess/{str(root_folderId)}")
     else:
         manager.write(f"Message: {validation['message']}\n")
+        manager.write(
+            "Please check the documentation for Zip files at: https://kitware.github.io/dive/Web-Version/#zip-files\n"
+        )
         raise Exception("Could not Validate media Files")
 
 
@@ -217,12 +220,12 @@ def upload_exported_zipped_dataset(
         imageData = meta['imageData']
         for image in imageData:
             if image["filename"] not in listOfFileNames:
-                manager.write("Could not find {item['filename']} file within the list of files\n")
+                manager.write(f"Could not find {image['filename']} file within the list of files\n")
                 return
     elif type == constants.VideoType:
         video = meta["video"]
         if video["filename"] not in listOfFileNames:
-            manager.write("Could not find {item['filename']} file within the list of files\n")
+            manager.write(f"Could not find {video['filename']} file within the list of files\n")
             return
     # remove the auxilary directory so we don't have to tag them all
     if constants.AuxiliaryFolderName in listOfFileNames and os.path.isdir(

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -191,7 +191,8 @@ def upload_zipped_flat_media_files(
     else:
         manager.write(f"Message: {validation['message']}\n")
         manager.write(
-            "Please check the documentation for Zip files at: https://kitware.github.io/dive/Web-Version/#zip-files\n"
+            "Please check the documentation for Zip files at:\
+                 https://kitware.github.io/dive/Web-Version/#zip-files\n"
         )
         raise Exception("Could not Validate media Files")
 


### PR DESCRIPTION
fixes #1138 

- When uploading a zip file it provides direct references to the documentation for the Zip files.
- Updated the error message in the log to also reference the zip file documentation.
- Fix some minor bugs with printing out missing images/videos in a zip file.