### PR TITLE
Fixing negative Coordinates in polygons 

### DIFF
--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -109,22 +109,31 @@ const console = new Console(process.stdout, process.stderr);
 
 const emptyCsvString = '# comment line\n# metadata,fps: 32,"whatever"\n#comment line';
 
-// Adding in some ingest pairs
+// Below sets up data in the mockfs
 type testPairs = [string[], MultiTrackRecord, Record<string, Attribute>];
-
+/* Viame.spec.json is an array in the format [CSV row Array, MultiTrackRecord, Attributes Object][]
+   This is restructured to be images and annotations files within a folder for the mockfs system
+   test[index] (folder):
+      -1.png
+      -2.png
+      -3.png
+      -annotations.csv
+  This is then used to run a complete load of a folder and then compare
+  with the results located in the MultiTrackRecord and Attributes for the corresponding index
+*/
 const testData: testPairs[] = fs.readJSONSync('../testutils/viame.spec.json');
 const images: Record<string, string> = {};
+//Create a list of numbers 0-9
 const imageList = Array.from(Array(10).keys());
-imageList.shift(); //remove 0.png
+imageList.shift(); //remove 0 to line up with source data images list
 // eslint-disable-next-line no-return-assign
-imageList.forEach((item) => images[`${item}.png`] = '');
-
-type TestKey = string | 'annotations.csv';
+imageList.forEach((item) => images[`${item}.png`] = ''); // 1.png, 2.png,...
+//Create a mockfs file struction of a list of images and a root annotations.csv file
 const fileSystemData: Record<string, Record<string, string>> = { };
 testData.forEach((triplet, index) => {
   fileSystemData[`test${index}`] = {
-    ...images,
-    'annotations.csv': triplet[0].join('\n'),
+    ...images, //list of images [1-9].png
+    'annotations.csv': triplet[0].join('\n'), //join csv string[] into a string for mockfs
   };
 });
 

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -114,9 +114,10 @@ type testPairs = [string[], MultiTrackRecord, Record<string, Attribute>];
 
 const testData: testPairs[] = fs.readJSONSync('../testutils/viame.spec.json');
 const images: Record<string, string> = {};
-const list = Array.from(Array(10).keys());
+const imageList = Array.from(Array(10).keys());
+imageList.shift(); //remove 0.png
 // eslint-disable-next-line no-return-assign
-list.forEach((item) => images[`${item}.png`] = '');
+imageList.forEach((item) => images[`${item}.png`] = '');
 
 type TestKey = string | 'annotations.csv';
 const fileSystemData: Record<string, Record<string, string>> = { };
@@ -732,7 +733,6 @@ describe('native.common', () => {
         settings, `/home/user/testPairs/test${num}`, checkMedia,
       );
       expect(payload.jsonMeta.originalImageFiles).toEqual([
-        '0.png',
         '1.png',
         '2.png',
         '3.png',

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -116,7 +116,7 @@ const testData: testPairs[] = fs.readJSONSync('../testutils/viame.spec.json');
 const images: Record<string, string> = {};
 const list = Array.from(Array(10).keys());
 // eslint-disable-next-line no-return-assign
-list.forEach((item) => images[`image${item}.png`] = '');
+list.forEach((item) => images[`${item}.png`] = '');
 
 type TestKey = string | 'annotations.csv';
 const fileSystemData: Record<string, Record<string, string>> = { };
@@ -732,16 +732,16 @@ describe('native.common', () => {
         settings, `/home/user/testPairs/test${num}`, checkMedia,
       );
       expect(payload.jsonMeta.originalImageFiles).toEqual([
-        'image0.png',
-        'image1.png',
-        'image2.png',
-        'image3.png',
-        'image4.png',
-        'image5.png',
-        'image6.png',
-        'image7.png',
-        'image8.png',
-        'image9.png',
+        '0.png',
+        '1.png',
+        '2.png',
+        '3.png',
+        '4.png',
+        '5.png',
+        '6.png',
+        '7.png',
+        '8.png',
+        '9.png',
       ]);
       // eslint-disable-next-line no-await-in-loop
       const final = await common.finalizeMediaImport(settings, payload, updater, convertMedia);

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -600,6 +600,7 @@ async function _ingestFilePath(
   }
   if (tracks !== null) {
     const processed = processTrackAttributes(tracks);
+    meta.attributes = processed.attributes;
     await _saveSerialized(settings, datasetId, processed.data, true);
   }
   return meta;

--- a/client/platform/desktop/backend/serializers/nist.ts
+++ b/client/platform/desktop/backend/serializers/nist.ts
@@ -105,7 +105,6 @@ function loadObjects(
             track.begin = Math.min(track.begin, frameNum);
             track.features.push({
               frame: frameNum,
-              keyframe: true,
               bounds: adjustedBounds,
               attributes: {
                 objectID,
@@ -167,15 +166,12 @@ function loadActivity(
           features.push({
             frame: parseInt(frame, 10) - 1,
             bounds,
-            keyframe: true,
-            interpolate: false,
           });
         } else if (val === 1) {
           track.end = parseInt(key, 10) - 1;
           features.push({
             frame: parseInt(frame, 10) - 1,
             bounds,
-            keyframe: true,
             interpolate: true,
           });
         }

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -27,8 +27,6 @@ const data: MultiTrackRecord = {
           968,
           433,
         ],
-        interpolate: false,
-        keyframe: true,
       },
       {
         frame: 1,
@@ -38,8 +36,6 @@ const data: MultiTrackRecord = {
           968,
           433,
         ],
-        interpolate: false,
-        keyframe: true,
       },
       {
         frame: 2,
@@ -49,8 +45,6 @@ const data: MultiTrackRecord = {
           968,
           433,
         ],
-        interpolate: false,
-        keyframe: true,
       },
       {
         frame: 3,
@@ -60,8 +54,6 @@ const data: MultiTrackRecord = {
           968,
           433,
         ],
-        interpolate: false,
-        keyframe: true,
       },
       {
         frame: 4,
@@ -71,8 +63,6 @@ const data: MultiTrackRecord = {
           968,
           433,
         ],
-        interpolate: false,
-        keyframe: true,
       },
     ],
     confidencePairs: [

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -20,11 +20,11 @@ import Track, {
 } from 'vue-media-annotator/track';
 
 const CommentRegex = /^\s*#/g;
-const HeadRegex = /^\(kp\) head ([0-9]+\.*[0-9]*) ([0-9]+\.*[0-9]*)/g;
-const TailRegex = /^\(kp\) tail ([0-9]+\.*[0-9]*) ([0-9]+\.*[0-9]*)/g;
+const HeadRegex = /^\(kp\) head (-?[0-9]+\.*-?[0-9]*) (-?[0-9]+\.*-?[0-9]*)/g;
+const TailRegex = /^\(kp\) tail (-?[0-9]+\.*-?[0-9]*) (-?[0-9]+\.*-?[0-9]*)/g;
 const AttrRegex = /^\(atr\) (.*?)\s(.+)/g;
 const TrackAttrRegex = /^\(trk-atr\) (.*?)\s(.+)/g;
-const PolyRegex = /^(\(poly\)) ((?:[0-9]+\.*[0-9]*\s*)+)/g;
+const PolyRegex = /^(\(poly\)) ((?:-?[0-9]+\.*-?[0-9]*\s*)+)/g;
 const FpsRegex = /fps:\s*(\d+(\.\d+)?)/ig;
 const AtrToken = '(atr)';
 const TrackAtrToken = '(trk-atr)';

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -220,8 +220,6 @@ function _parseFeature(row: string[]) {
   const feature: Feature = {
     frame: rowInfo.frame,
     bounds: rowInfo.bounds,
-    interpolate: false,
-    keyframe: true,
   };
   if (rowInfo.fishLength !== -1) {
     feature.fishLength = rowInfo.fishLength;

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -220,8 +220,12 @@ function _parseFeature(row: string[]) {
   const feature: Feature = {
     frame: rowInfo.frame,
     bounds: rowInfo.bounds,
-    fishLength: rowInfo.fishLength,
+    interpolate: false,
+    keyframe: true,
   };
+  if (rowInfo.fishLength !== -1) {
+    feature.fishLength = rowInfo.fishLength;
+  }
   if (rowData.attributes) {
     feature.attributes = rowData.attributes;
   }
@@ -268,7 +272,6 @@ async function parse(input: Readable): Promise<AnnotationFileData> {
               begin: rowInfo.frame,
               end: rowInfo.frame,
               trackId: rowInfo.trackId,
-              meta: {},
               attributes: {},
               confidencePairs: [],
               features: [],

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -36,7 +36,7 @@ export interface Feature {
 /** TrackData is the json schema for Track transport */
 export interface TrackData {
   trackId: TrackId;
-  meta: StringKeyObject;
+  meta?: StringKeyObject;
   attributes: StringKeyObject;
   confidencePairs: Array<ConfidencePair>;
   features: Array<Feature>;

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -46,8 +46,8 @@ class Feature(BaseModel):
     head: Optional[Tuple[float, float]] = None
     tail: Optional[Tuple[float, float]] = None
     fishLength: Optional[float] = None
-    interpolate: Optional[bool] = False
-    keyframe: Optional[bool] = True
+    interpolate: Optional[bool] = None
+    keyframe: Optional[bool] = None
 
 
 class Track(BaseModel):

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -57,6 +57,7 @@ class Track(BaseModel):
     features: List[Feature] = Field(default_factory=lambda: [])
     confidencePairs: List[Tuple[str, float]] = Field(default_factory=lambda: [])
     attributes: Dict[str, Any] = Field(default_factory=lambda: {})
+    meta: Optional[Dict[str, Any]]
 
     @validator('features')
     @classmethod

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -117,14 +117,14 @@ def _parse_row(row: List[str]) -> Tuple[Dict, Dict, Dict, List]:
 
     for j in range(start, len(row)):
         # (kp) head x y
-        head_regex = re.match(r"^\(kp\) head ([0-9]+\.*[0-9]*) ([0-9]+\.*[0-9]*)", row[j])
+        head_regex = re.match(r"^\(kp\) head (-?[0-9]+\.*-?[0-9]*) (-?[0-9]+\.*-?[0-9]*)", row[j])
         if head_regex:
             point = [float(head_regex[1]), float(head_regex[2])]
             head_tail.append(point)
             create_geoJSONFeature(features, 'Point', point, 'head')
 
         # (kp) tail x y
-        tail_regex = re.match(r"^\(kp\) tail ([0-9]+\.*[0-9]*) ([0-9]+\.*[0-9]*)", row[j])
+        tail_regex = re.match(r"^\(kp\) tail (-?[0-9]+\.*-?[0-9]*) (-?[0-9]+\.*-?[0-9]*)", row[j])
         if tail_regex:
             point = [float(tail_regex[1]), float(tail_regex[2])]
             head_tail.append(point)

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -141,7 +141,7 @@ def _parse_row(row: List[str]) -> Tuple[Dict, Dict, Dict, List]:
             track_attributes[trk_regex[1]] = _deduceType(trk_regex[2])
 
         # (poly) x1 y1 x2 y2 ...
-        poly_regex = re.match(r"^(\(poly\)) ((?:[0-9]+\.*[0-9]*\s*)+)", row[j])
+        poly_regex = re.match(r"^(\(poly\)) ((?:-?[0-9]+\.*-?[0-9]*\s*)+)", row[j])
         if poly_regex:
             temp = [float(x) for x in poly_regex[2].split()]
             coords = list(zip(temp[::2], temp[1::2]))

--- a/server/scripts/generateLargeDataset.py
+++ b/server/scripts/generateLargeDataset.py
@@ -87,7 +87,6 @@ def create_track_json(
                 frame = start_frame + frame
                 feature = {
                     "frame": frame,
-                    "keyframe": True,
                     "bounds": [0, 0, width, height],
                 }
                 track_obj["begin"] = min(track_obj["begin"], frame)

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -126,8 +126,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                                 },
                             ],
                         },
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["astronaut", 1.0]],
@@ -141,8 +139,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [350, 5, 480, 295],
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["rocket", 1.0]],
@@ -156,8 +152,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [326, 369, 600, 600],
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["helmet", 1.0]],
@@ -346,8 +340,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                                 },
                             ],
                         },
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["eff", 1.0]],
@@ -361,8 +353,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [73, 125, 142, 184],
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["eff", 1.0]],
@@ -428,8 +418,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                                 },
                             ],
                         },
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["superstar", 1.0]],
@@ -465,8 +453,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                                 }
                             ],
                         },
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["eff", 1.0]],
@@ -480,8 +466,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [153, 151, 200, 183],
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["star", 1.0]],
@@ -495,8 +479,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [42, 240, 66, 254],
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["eff", 1.0]],
@@ -591,14 +573,10 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 10,
                         "bounds": [300, 103, 321, 134],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                     {
                         "frame": 11,
                         "bounds": [299, 104, 320, 133],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                 ],
                 "confidencePairs": [["person", 1.0]],
@@ -612,14 +590,10 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 14,
                         "bounds": [81, 41, 227, 113],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                     {
                         "frame": 15,
                         "bounds": [81, 41, 227, 113],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                 ],
                 "confidencePairs": [["car", 1.0]],
@@ -633,20 +607,14 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 13,
                         "bounds": [266, 8, 305, 53],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                     {
                         "frame": 14,
                         "bounds": [266, 8, 305, 53],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                     {
                         "frame": 15,
                         "bounds": [266, 8, 305, 53],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                 ],
                 "confidencePairs": [["tree", 1.0]],
@@ -691,14 +659,10 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 10,
                         "bounds": [300, 103, 321, 134],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                     {
                         "frame": 11,
                         "bounds": [299, 104, 320, 133],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                 ],
                 "confidencePairs": [["person", 1.0]],

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -5,7 +5,7 @@ import pytest
 
 from dive_utils.serializers import viame
 
-test_tuple: List[Tuple[list, dict, dict]] = [
+old_tuple: List[Tuple[list, dict, dict]] = [
     (
         [
             # all frames in a track must be the same type, so the type name for 0 will be ignored
@@ -487,6 +487,9 @@ test_tuple: List[Tuple[list, dict, dict]] = [
         {},
     ),
 ]
+
+with open('../testutils/viame.spec.json', 'r') as fp:
+    test_tuple = json.load(fp)
 
 
 @pytest.mark.parametrize("input,expected_tracks,expected_attributes", test_tuple)

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -35,14 +35,10 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                         "frame": 0,
                         # NOTICE numbers that were rounded!
                         "bounds": [885, 510, 1220, 738],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -56,8 +52,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     }
                 ],
                 "begin": 0,
@@ -71,8 +65,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 2,
                         "bounds": [10, 50, 20, 35],
-                        "keyframe": True,
-                        "interpolate": False,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -109,8 +101,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 3,
                         "bounds": [10, 50, 20, 35],
-                        "keyframe": True,
-                        "interpolate": False,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -137,8 +127,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 4,
                         "bounds": [10, 10, 20, 20],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 4,
@@ -152,8 +140,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 5,
                         "bounds": [10, 10, 20, 20],
-                        "keyframe": True,
-                        "interpolate": False,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -188,8 +174,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 6,
                         "bounds": [10, 10, 20, 20],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {"attrNAME": "spaced attr name"},
                     },
                 ],
@@ -204,8 +188,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 4,
                         "bounds": [10, 10, 20, 20],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 4,
@@ -246,20 +228,14 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 2,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -295,8 +271,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [885, 510, 1220, 738],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                             "DetectionNumber": 2.002,
@@ -305,8 +279,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value2",
                         },
@@ -314,8 +286,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 2,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value3",
                         },
@@ -323,8 +293,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 3,
                         "bounds": [885, 510, 1220, 738],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                         },
@@ -332,8 +300,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 4,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value2",
                         },
@@ -341,8 +307,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 5,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value3",
                         },
@@ -359,8 +323,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [885, 510, 1220, 738],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                             "DetectionNumber": 2.002,
@@ -369,8 +331,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value2",
                         },
@@ -378,8 +338,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 2,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value3",
                         },
@@ -387,8 +345,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 3,
                         "bounds": [885, 510, 1220, 738],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                         },
@@ -396,8 +352,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 4,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value2",
                         },
@@ -405,8 +359,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 5,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value3",
                         },
@@ -455,14 +407,10 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -476,8 +424,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     }
                 ],
                 "begin": 0,

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -13,13 +13,13 @@ test_tuple: List[Tuple[list, dict, dict]] = [
             "0,2.png,1,111,222,3333,444,1,-1,typestring,0.55",
             "1,1.png,0,747,457,1039,633,1,-1,type2,1",
             # Keypoint testing with HeadTails Line
-            "2,3.png,2,10,50,20,35,1,-1,type3,0.765,(kp) head 22.4534 45.6564,(kp) tail 55.232 22.3445",
+            "2,3.png,2,10,50,20,35,1,-1,type3,0.765,(kp) head 22.4534 -45.6564,(kp) tail 55.232 -22.3445",
             # Keypoint without HeadTails Line
-            "2,4.png,3,10,50,20,35,1,-1,type3,0.765,(kp) head 22.4534 45.6564",
+            "2,4.png,3,10,50,20,35,1,-1,type3,0.765,(kp) head 22.4534 -45.6564",
             # Multiple ConfidencePair Test
             "3,4.png,4,10,10,20,20,1,-1,type1,0.89,type2,0.65",
             # Polygon Test with floats
-            "4,5.png,5,10,10,20,20,1,-1,type1,0.89,type2,0.65,(poly) 1 2.34 3 4 5 6 7 8.08 9 10",
+            "4,5.png,5,10,10,20,20,1,-1,type1,0.89,type2,0.65,(poly) 1 -2.34 3 4 5 6 7 8.08 9 -10",
             # Track and Frame Attr testing
             "5,6.png,6,10,10,20,20,1,-1,type1,0.89,(atr) attrNAME spaced attr name,(trk-atr) booleanAttr true",
             # Multiple ConfidencePair Sorting Test
@@ -81,7 +81,7 @@ test_tuple: List[Tuple[list, dict, dict]] = [
                                     "properties": {"key": "head"},
                                     "geometry": {
                                         "type": "Point",
-                                        "coordinates": [22.4534, 45.6564],
+                                        "coordinates": [22.4534, -45.6564],
                                     },
                                 },
                                 {
@@ -89,7 +89,7 @@ test_tuple: List[Tuple[list, dict, dict]] = [
                                     "properties": {"key": "tail"},
                                     "geometry": {
                                         "type": "Point",
-                                        "coordinates": [55.232, 22.3445],
+                                        "coordinates": [55.232, -22.3445],
                                     },
                                 },
                                 {
@@ -97,8 +97,8 @@ test_tuple: List[Tuple[list, dict, dict]] = [
                                     "properties": {"key": "HeadTails"},
                                     "geometry": {
                                         "coordinates": [
-                                            [22.4534, 45.6564],
-                                            [55.232, 22.3445],
+                                            [22.4534, -45.6564],
+                                            [55.232, -22.3445],
                                         ],
                                         "type": "LineString",
                                     },
@@ -119,7 +119,7 @@ test_tuple: List[Tuple[list, dict, dict]] = [
                                     "properties": {"key": "head"},
                                     "geometry": {
                                         "type": "Point",
-                                        "coordinates": [22.4534, 45.6564],
+                                        "coordinates": [22.4534, -45.6564],
                                     },
                                 },
                             ],
@@ -164,11 +164,11 @@ test_tuple: List[Tuple[list, dict, dict]] = [
                                         "type": "Polygon",
                                         "coordinates": [
                                             [
-                                                [1.0, 2.34],
+                                                [1.0, -2.34],
                                                 [3.0, 4.0],
                                                 [5.0, 6.0],
                                                 [7.0, 8.08],
-                                                [9.0, 10.0],
+                                                [9.0, -10.0],
                                             ]
                                         ],
                                     },

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -18,14 +18,10 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -39,8 +35,6 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     }
                 ],
                 "begin": 0,
@@ -66,13 +60,11 @@ test_tuple: List[Tuple[dict, list, list]] = [
                         "frame": 1,
                         "bounds": [2, 2, 4, 4],
                         "interpolate": True,
-                        "keyframe": True,
                     },
                     {
                         "frame": 3,
                         "bounds": [4, 4, 8, 8],
                         "interpolate": True,
-                        "keyframe": True,
                     },
                 ],
                 "confidencePairs": [["foo", 0.2], ["bar", 0.9], ["baz", 0.1]],
@@ -98,7 +90,6 @@ test_tuple: List[Tuple[dict, list, list]] = [
                         "frame": 1,
                         "bounds": [2, 2, 4, 4],
                         "interpolate": True,
-                        "keyframe": True,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -136,7 +127,6 @@ test_tuple: List[Tuple[dict, list, list]] = [
                         "frame": 3,
                         "bounds": [4, 4, 8, 8],
                         "interpolate": True,
-                        "keyframe": True,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -183,15 +173,11 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {"detectionAttr": "frame 0 attr"},
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {"detectionAttr": "frame 1 attr"},
                     },
                 ],
@@ -217,14 +203,10 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -238,8 +220,6 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     }
                 ],
                 "begin": 0,
@@ -262,14 +242,10 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -283,8 +259,6 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     }
                 ],
                 "begin": 0,

--- a/testutils/attributes.spec.json
+++ b/testutils/attributes.spec.json
@@ -1,7 +1,7 @@
 [
   [
     {
-      "0":{
+      "0": {
         "trackId": 0,
         "attributes": {
           "booleanAttr": true
@@ -21,8 +21,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -36,8 +34,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -50,8 +46,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -64,8 +58,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -78,8 +70,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -92,8 +82,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -102,7 +90,7 @@
         "begin": 0,
         "end": 5
       },
-      "1":{
+      "1": {
         "trackId": 1,
         "attributes": {
           "booleanAttr": true
@@ -122,8 +110,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -137,8 +123,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -151,8 +135,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -165,8 +147,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -179,8 +159,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -193,8 +171,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -225,8 +201,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -240,8 +214,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -254,8 +226,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -268,8 +238,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -282,8 +250,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -296,8 +262,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -326,8 +290,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -341,8 +303,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -355,8 +315,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -369,8 +327,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -383,8 +339,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -397,8 +351,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -436,7 +388,7 @@
   ],
   [
     {
-      "0":{
+      "0": {
         "trackId": 0,
         "attributes": {
           "booleanAttr": true
@@ -456,8 +408,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -471,8 +421,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -485,8 +433,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -499,8 +445,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -513,8 +457,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -527,8 +469,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -537,7 +477,7 @@
         "begin": 0,
         "end": 5
       },
-      "1":{
+      "1": {
         "trackId": 1,
         "attributes": {
           "booleanAttr": true
@@ -557,8 +497,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -572,8 +510,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -586,8 +522,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -600,8 +534,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -614,8 +546,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -628,8 +558,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -660,8 +588,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -675,8 +601,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -689,8 +613,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -703,8 +625,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -717,8 +637,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -731,8 +649,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -761,8 +677,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -776,8 +690,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -790,8 +702,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -804,8 +714,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -818,8 +726,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -832,8 +738,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }

--- a/testutils/nist.spec.json
+++ b/testutils/nist.spec.json
@@ -25,7 +25,6 @@
                         1,
                         1
                     ],
-                    "keyframe": true,
                     "interpolate": true
                 },
                 {
@@ -35,9 +34,7 @@
                         0,
                         1,
                         1
-                    ],
-                    "keyframe": true,
-                    "interpolate": false
+                    ]
                 }
             ]
         },
@@ -62,7 +59,6 @@
             "features": [
                 {
                     "frame": 0,
-                    "keyframe": true,
                     "bounds": [
                         0,
                         0,
@@ -76,7 +72,6 @@
                 },
                 {
                     "frame": 4,
-                    "keyframe": true,
                     "bounds": [
                         0,
                         0,
@@ -115,7 +110,6 @@
                         1,
                         31
                     ],
-                    "keyframe": true,
                     "interpolate": true
                 },
                 {
@@ -125,9 +119,7 @@
                         30,
                         1,
                         31
-                    ],
-                    "keyframe": true,
-                    "interpolate": false
+                    ]
                 },
                 {
                     "frame": 12,
@@ -137,7 +129,6 @@
                         1,
                         31
                     ],
-                    "keyframe": true,
                     "interpolate": true
                 },
                 {
@@ -147,9 +138,7 @@
                         30,
                         1,
                         31
-                    ],
-                    "keyframe": true,
-                    "interpolate": false
+                    ]
                 }
             ]
         },
@@ -174,7 +163,6 @@
             "features": [
                 {
                     "frame": 8,
-                    "keyframe": true,
                     "bounds": [
                         290,
                         286,
@@ -188,7 +176,6 @@
                 },
                 {
                     "frame": 9,
-                    "keyframe": true,
                     "bounds": [
                         480,
                         286,
@@ -202,7 +189,6 @@
                 },
                 {
                     "frame": 14,
-                    "keyframe": true,
                     "bounds": [
                         645,
                         413,
@@ -216,7 +202,6 @@
                 },
                 {
                     "frame": 16,
-                    "keyframe": true,
                     "bounds": [
                         588,
                         409,

--- a/testutils/tracks.json
+++ b/testutils/tracks.json
@@ -1,1 +1,25 @@
-{"999999": {"begin": 0, "end": 0, "trackId": 999999, "features": [{"frame": 0, "bounds": [670, 183, 968, 433], "interpolate": false, "keyframe": true}], "confidencePairs": [["motion_signature", 0.996269]], "attributes": {}}}
+{
+  "999999": {
+    "begin": 0,
+    "end": 0,
+    "trackId": 999999,
+    "features": [
+      {
+        "frame": 0,
+        "bounds": [
+          670,
+          183,
+          968,
+          433
+        ]
+      }
+    ],
+    "confidencePairs": [
+      [
+        "motion_signature",
+        0.996269
+      ]
+    ],
+    "attributes": {}
+  }
+}

--- a/testutils/viame.spec.json
+++ b/testutils/viame.spec.json
@@ -29,9 +29,7 @@
                             510,
                             1220,
                             738
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     },
                     {
                         "frame": 1,
@@ -40,9 +38,7 @@
                             222,
                             3333,
                             444
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 0,
@@ -65,9 +61,7 @@
                             457,
                             1039,
                             633
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 0,
@@ -91,8 +85,6 @@
                             20,
                             35
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -152,8 +144,6 @@
                             20,
                             35
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -198,9 +188,7 @@
                             10,
                             20,
                             20
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 4,
@@ -228,8 +216,6 @@
                             20,
                             20
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -293,8 +279,6 @@
                             20,
                             20
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "attrNAME": "spaced attr name"
                         }
@@ -328,9 +312,7 @@
                             10,
                             20,
                             20
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 4,
@@ -376,9 +358,7 @@
                             510,
                             1219,
                             737
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     },
                     {
                         "frame": 1,
@@ -387,9 +367,7 @@
                             222,
                             3333,
                             444
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     },
                     {
                         "frame": 2,
@@ -398,9 +376,7 @@
                             457,
                             1039,
                             633
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 0,
@@ -447,8 +423,6 @@
                             1220,
                             738
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                             "DetectionNumber": 2.002
@@ -462,8 +436,6 @@
                             3333,
                             444
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value2"
                         }
@@ -476,8 +448,6 @@
                             1039,
                             633
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value3"
                         }
@@ -490,8 +460,6 @@
                             1220,
                             738
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value1"
                         }
@@ -504,8 +472,6 @@
                             3333,
                             444
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value2"
                         }
@@ -518,8 +484,6 @@
                             1039,
                             633
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value3"
                         }
@@ -548,8 +512,6 @@
                             1220,
                             738
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                             "DetectionNumber": 2.002
@@ -563,8 +525,6 @@
                             3333,
                             444
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value2"
                         }
@@ -577,8 +537,6 @@
                             1039,
                             633
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value3"
                         }
@@ -591,8 +549,6 @@
                             1220,
                             738
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value1"
                         }
@@ -605,8 +561,6 @@
                             3333,
                             444
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value2"
                         }
@@ -619,8 +573,6 @@
                             1039,
                             633
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value3"
                         }
@@ -681,9 +633,7 @@
                             510,
                             1219,
                             737
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     },
                     {
                         "frame": 1,
@@ -692,9 +642,7 @@
                             222,
                             3333,
                             444
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 0,
@@ -717,9 +665,7 @@
                             457,
                             1039,
                             633
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 0,

--- a/testutils/viame.spec.json
+++ b/testutils/viame.spec.json
@@ -6,10 +6,10 @@
             "1,1.png,0,747,457,1039,633,1,-1,type2,1",
             "2,3.png,2,10,50,20,35,1,-1,type3,0.765,(kp) head 22.4534 -45.6564,(kp) tail 55.232 -22.3445",
             "2,4.png,3,10,50,20,35,1,-1,type3,0.765,(kp) head 22.4534 -45.6564",
-            "3,4.png,4,10,10,20,20,1,-1,type1,0.89,type2,0.65",
-            "4,5.png,5,10,10,20,20,1,-1,type1,0.89,type2,0.65,(poly) 1 -2.34 3 4 5 6 7 8.08 9 -10",
-            "5,6.png,6,10,10,20,20,1,-1,type1,0.89,(atr) attrNAME spaced attr name,(trk-atr) booleanAttr true",
-            "6,4.png,4,10,10,20,20,1,-1,type2,0.65,type1,0.89,type3,0.24"
+            "3,5.png,4,10,10,20,20,1,-1,type1,0.89,type2,0.65",
+            "4,6.png,5,10,10,20,20,1,-1,type1,0.89,type2,0.65,(poly) 1 -2.34 3 4 5 6 7 8.08 9 -10",
+            "5,7.png,6,10,10,20,20,1,-1,type1,0.89,(atr) attrNAME spaced attr name,(trk-atr) booleanAttr true",
+            "6,5.png,4,10,10,20,20,1,-1,type2,0.65,type1,0.89,type3,0.24"
         ],
         {
             "0": {
@@ -414,16 +414,16 @@
             "0,1.png,0,884.66,510,1219.66,737.66,1,-1,typestring,1,(atr) DetectionNumber 2.002,(atr) DetectionPredefinedValue value1",
             "0,2.png,1,111,222,3333,444,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value2",
             "0,3.png,2,747,457,1039,633,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value3",
-            "0,3.png,3,884.66,510,1219.66,737.66,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value1",
-            "0,4.png,4,111,222,3333,444,1,-1,typestring,1,(atr) DetectionPredefinedValue value2",
-            "0,5.png,5,747,457,1039,633,1,-1,typestring,1,(atr) DetectionPredefinedValue value3",
+            "0,4.png,3,884.66,510,1219.66,737.66,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value1",
+            "0,5.png,4,111,222,3333,444,1,-1,typestring,1,(atr) DetectionPredefinedValue value2",
+            "0,6.png,5,747,457,1039,633,1,-1,typestring,1,(atr) DetectionPredefinedValue value3",
             "#comment line",
             "1,1.png,0,884.66,510,1219.66,737.66,1,-1,typestring,1,(atr) DetectionNumber 2.002,(atr) DetectionPredefinedValue value1",
             "1,2.png,1,111,222,3333,444,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value2",
             "1,3.png,2,747,457,1039,633,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value3",
-            "1,3.png,3,884.66,510,1219.66,737.66,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value1",
-            "1,4.png,4,111,222,3333,444,1,-1,typestring,1,(atr) DetectionPredefinedValue value2",
-            "1,5.png,5,747,457,1039,633,1,-1,typestring,1,(atr) DetectionPredefinedValue value3",
+            "1,4.png,3,884.66,510,1219.66,737.66,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value1",
+            "1,5.png,4,111,222,3333,444,1,-1,typestring,1,(atr) DetectionPredefinedValue value2",
+            "1,6.png,5,747,457,1039,633,1,-1,typestring,1,(atr) DetectionPredefinedValue value3",
             ""
         ],
         {

--- a/testutils/viame.spec.json
+++ b/testutils/viame.spec.json
@@ -1,0 +1,731 @@
+[
+    [
+        [
+            "0,1.png,0,884.66,510,1219.66,737.66,1,-1,ignored,0.98",
+            "0,2.png,1,111,222,3333,444,1,-1,typestring,0.55",
+            "1,1.png,0,747,457,1039,633,1,-1,type2,1",
+            "2,3.png,2,10,50,20,35,1,-1,type3,0.765,(kp) head 22.4534 -45.6564,(kp) tail 55.232 -22.3445",
+            "2,4.png,3,10,50,20,35,1,-1,type3,0.765,(kp) head 22.4534 -45.6564",
+            "3,4.png,4,10,10,20,20,1,-1,type1,0.89,type2,0.65",
+            "4,5.png,5,10,10,20,20,1,-1,type1,0.89,type2,0.65,(poly) 1 -2.34 3 4 5 6 7 8.08 9 -10",
+            "5,6.png,6,10,10,20,20,1,-1,type1,0.89,(atr) attrNAME spaced attr name,(trk-atr) booleanAttr true",
+            "6,4.png,4,10,10,20,20,1,-1,type2,0.65,type1,0.89,type3,0.24"
+        ],
+        {
+            "0": {
+                "trackId": 0,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "typestring",
+                        0.55
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            885,
+                            510,
+                            1220,
+                            738
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    },
+                    {
+                        "frame": 1,
+                        "bounds": [
+                            111,
+                            222,
+                            3333,
+                            444
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    }
+                ],
+                "begin": 0,
+                "end": 1
+            },
+            "1": {
+                "trackId": 1,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "type2",
+                        1.0
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            747,
+                            457,
+                            1039,
+                            633
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    }
+                ],
+                "begin": 0,
+                "end": 0
+            },
+            "2": {
+                "trackId": 2,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "type3",
+                        0.765
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 2,
+                        "bounds": [
+                            10,
+                            50,
+                            20,
+                            35
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "geometry": {
+                            "type": "FeatureCollection",
+                            "features": [
+                                {
+                                    "type": "Feature",
+                                    "properties": {
+                                        "key": "head"
+                                    },
+                                    "geometry": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            22.4534,
+                                            -45.6564
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "Feature",
+                                    "properties": {
+                                        "key": "tail"
+                                    },
+                                    "geometry": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            55.232,
+                                            -22.3445
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "Feature",
+                                    "properties": {
+                                        "key": "HeadTails"
+                                    },
+                                    "geometry": {
+                                        "coordinates": [
+                                            [
+                                                22.4534,
+                                                -45.6564
+                                            ],
+                                            [
+                                                55.232,
+                                                -22.3445
+                                            ]
+                                        ],
+                                        "type": "LineString"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "frame": 3,
+                        "bounds": [
+                            10,
+                            50,
+                            20,
+                            35
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "geometry": {
+                            "type": "FeatureCollection",
+                            "features": [
+                                {
+                                    "type": "Feature",
+                                    "properties": {
+                                        "key": "head"
+                                    },
+                                    "geometry": {
+                                        "type": "Point",
+                                        "coordinates": [
+                                            22.4534,
+                                            -45.6564
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "begin": 2,
+                "end": 3
+            },
+            "3": {
+                "trackId": 3,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "type1",
+                        0.89
+                    ],
+                    [
+                        "type2",
+                        0.65
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 4,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    }
+                ],
+                "begin": 4,
+                "end": 4
+            },
+            "4": {
+                "trackId": 4,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "type1",
+                        0.89
+                    ],
+                    [
+                        "type2",
+                        0.65
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 5,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "geometry": {
+                            "type": "FeatureCollection",
+                            "features": [
+                                {
+                                    "type": "Feature",
+                                    "properties": {
+                                        "key": ""
+                                    },
+                                    "geometry": {
+                                        "type": "Polygon",
+                                        "coordinates": [
+                                            [
+                                                [
+                                                    1.0,
+                                                    -2.34
+                                                ],
+                                                [
+                                                    3.0,
+                                                    4.0
+                                                ],
+                                                [
+                                                    5.0,
+                                                    6.0
+                                                ],
+                                                [
+                                                    7.0,
+                                                    8.08
+                                                ],
+                                                [
+                                                    9.0,
+                                                    -10.0
+                                                ]
+                                            ]
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "begin": 5,
+                "end": 5
+            },
+            "5": {
+                "trackId": 5,
+                "attributes": {
+                    "booleanAttr": true
+                },
+                "confidencePairs": [
+                    [
+                        "type1",
+                        0.89
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 6,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "attrNAME": "spaced attr name"
+                        }
+                    }
+                ],
+                "begin": 6,
+                "end": 6
+            },
+            "6": {
+                "trackId": 6,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "type1",
+                        0.89
+                    ],
+                    [
+                        "type2",
+                        0.65
+                    ],
+                    [
+                        "type3",
+                        0.24
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 4,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    }
+                ],
+                "begin": 4,
+                "end": 4
+            }
+        },
+        {
+            "detection_attrNAME": {
+                "belongs": "detection",
+                "datatype": "text",
+                "key": "detection_attrNAME",
+                "name": "attrNAME"
+            },
+            "track_booleanAttr": {
+                "belongs": "track",
+                "datatype": "boolean",
+                "key": "track_booleanAttr",
+                "name": "booleanAttr"
+            }
+        }
+    ],
+    [
+        [
+            "0,1.png,0,884,510,1219,737,1,-1,typestring,1,",
+            "0,2.png,1,111,222,3333,444,1,-1,typestring,1,(note) note",
+            "0,3.png,2,747,457,1039,633,1,-1,typestring,1,(note) note,(note) note2"
+        ],
+        {
+            "0": {
+                "trackId": 0,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "typestring",
+                        1.0
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            884,
+                            510,
+                            1219,
+                            737
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    },
+                    {
+                        "frame": 1,
+                        "bounds": [
+                            111,
+                            222,
+                            3333,
+                            444
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    },
+                    {
+                        "frame": 2,
+                        "bounds": [
+                            747,
+                            457,
+                            1039,
+                            633
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    }
+                ],
+                "begin": 0,
+                "end": 2
+            }
+        },
+        {}
+    ],
+    [
+        [
+            "0,1.png,0,884.66,510,1219.66,737.66,1,-1,typestring,1,(atr) DetectionNumber 2.002,(atr) DetectionPredefinedValue value1",
+            "0,2.png,1,111,222,3333,444,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value2",
+            "0,3.png,2,747,457,1039,633,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value3",
+            "0,3.png,3,884.66,510,1219.66,737.66,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value1",
+            "0,4.png,4,111,222,3333,444,1,-1,typestring,1,(atr) DetectionPredefinedValue value2",
+            "0,5.png,5,747,457,1039,633,1,-1,typestring,1,(atr) DetectionPredefinedValue value3",
+            "#comment line",
+            "1,1.png,0,884.66,510,1219.66,737.66,1,-1,typestring,1,(atr) DetectionNumber 2.002,(atr) DetectionPredefinedValue value1",
+            "1,2.png,1,111,222,3333,444,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value2",
+            "1,3.png,2,747,457,1039,633,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value3",
+            "1,3.png,3,884.66,510,1219.66,737.66,1,-1,typestring,1,(trk-atr) booleanAttr true,(atr) DetectionPredefinedValue value1",
+            "1,4.png,4,111,222,3333,444,1,-1,typestring,1,(atr) DetectionPredefinedValue value2",
+            "1,5.png,5,747,457,1039,633,1,-1,typestring,1,(atr) DetectionPredefinedValue value3",
+            ""
+        ],
+        {
+            "0": {
+                "trackId": 0,
+                "attributes": {
+                    "booleanAttr": true
+                },
+                "confidencePairs": [
+                    [
+                        "typestring",
+                        1.0
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            885,
+                            510,
+                            1220,
+                            738
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value1",
+                            "DetectionNumber": 2.002
+                        }
+                    },
+                    {
+                        "frame": 1,
+                        "bounds": [
+                            111,
+                            222,
+                            3333,
+                            444
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value2"
+                        }
+                    },
+                    {
+                        "frame": 2,
+                        "bounds": [
+                            747,
+                            457,
+                            1039,
+                            633
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value3"
+                        }
+                    },
+                    {
+                        "frame": 3,
+                        "bounds": [
+                            885,
+                            510,
+                            1220,
+                            738
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value1"
+                        }
+                    },
+                    {
+                        "frame": 4,
+                        "bounds": [
+                            111,
+                            222,
+                            3333,
+                            444
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value2"
+                        }
+                    },
+                    {
+                        "frame": 5,
+                        "bounds": [
+                            747,
+                            457,
+                            1039,
+                            633
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value3"
+                        }
+                    }
+                ],
+                "begin": 0,
+                "end": 5
+            },
+            "1": {
+                "trackId": 1,
+                "attributes": {
+                    "booleanAttr": true
+                },
+                "confidencePairs": [
+                    [
+                        "typestring",
+                        1.0
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            885,
+                            510,
+                            1220,
+                            738
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value1",
+                            "DetectionNumber": 2.002
+                        }
+                    },
+                    {
+                        "frame": 1,
+                        "bounds": [
+                            111,
+                            222,
+                            3333,
+                            444
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value2"
+                        }
+                    },
+                    {
+                        "frame": 2,
+                        "bounds": [
+                            747,
+                            457,
+                            1039,
+                            633
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value3"
+                        }
+                    },
+                    {
+                        "frame": 3,
+                        "bounds": [
+                            885,
+                            510,
+                            1220,
+                            738
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value1"
+                        }
+                    },
+                    {
+                        "frame": 4,
+                        "bounds": [
+                            111,
+                            222,
+                            3333,
+                            444
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value2"
+                        }
+                    },
+                    {
+                        "frame": 5,
+                        "bounds": [
+                            747,
+                            457,
+                            1039,
+                            633
+                        ],
+                        "keyframe": true,
+                        "interpolate": false,
+                        "attributes": {
+                            "DetectionPredefinedValue": "value3"
+                        }
+                    }
+                ],
+                "begin": 0,
+                "end": 5
+            }
+        },
+        {
+            "detection_DetectionNumber": {
+                "belongs": "detection",
+                "datatype": "number",
+                "key": "detection_DetectionNumber",
+                "name": "DetectionNumber"
+            },
+            "detection_DetectionPredefinedValue": {
+                "belongs": "detection",
+                "datatype": "text",
+                "key": "detection_DetectionPredefinedValue",
+                "name": "DetectionPredefinedValue",
+                "values": [
+                    "value1",
+                    "value2",
+                    "value3"
+                ]
+            },
+            "track_booleanAttr": {
+                "belongs": "track",
+                "datatype": "boolean",
+                "key": "track_booleanAttr",
+                "name": "booleanAttr"
+            }
+        }
+    ],
+    [
+        [
+            "0,1.png,0,884,510,1219,737,1.0,-1,",
+            "0,2.png,1,111,222,3333,444,1.0,-1,,",
+            "1,1.png,0,747,457,1039,633,0.8,-1",
+            ""
+        ],
+        {
+            "0": {
+                "trackId": 0,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "unknown",
+                        1.0
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            884,
+                            510,
+                            1219,
+                            737
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    },
+                    {
+                        "frame": 1,
+                        "bounds": [
+                            111,
+                            222,
+                            3333,
+                            444
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    }
+                ],
+                "begin": 0,
+                "end": 1
+            },
+            "1": {
+                "trackId": 1,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "unknown",
+                        0.8
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            747,
+                            457,
+                            1039,
+                            633
+                        ],
+                        "keyframe": true,
+                        "interpolate": false
+                    }
+                ],
+                "begin": 0,
+                "end": 0
+            }
+        },
+        {}
+    ]
+]


### PR DESCRIPTION
fixes #993 
fixes #1152 

- Simple fix involved adding optional `-` specifiers to the RegEx for polygon.  Decided it should be added to head tail points as well and did it in both desktop and python.
- Updated the unit tests to account for negative values.  Doing that I also decided that I wanted unified tests between python and node so I refactored the viame serializers to use the same JSON file.
- Noticed there were discrepancies in the outputs of Python vs Node so I remedied them:
    - `fishLength` was always set to `-1` on Node but set to `None`  in Python so I made it so both will set it to `None/undefined` if it equals `-1`
    - Node gave each track a `meta:{}` attribute that was never used.  Python didn't read in or create this attribute so I removed the automatic creation from the node version.  I added the `meta: Optional[Dict[str, Any]]` to make sure that the type specifications between the two were the same.
    - Python had each detections start with the properties `interpolate:false` and `keyframe:true`.  I added both of these to the Node version so there is parity.


1152 Fix (attributes were not loading properly)

- The single change in `common.ts` - `meta.attributes = processed.attributes;` should fix this.  It wasn't loading the attributes into the metafile so they weren't being populated in the interface.
- I also updated the `common.spec.ts` to do a sort of end to end loading of folder and check the attributes.  This is like above where I use the `viame.spec.json` to do this.
