### PR TITLE
Clarity into current editing modes

### DIFF
--- a/client/dive-common/components/DeleteControls.vue
+++ b/client/dive-common/components/DeleteControls.vue
@@ -44,7 +44,7 @@ export default Vue.extend({
 </script>
 
 <template>
-  <span>
+  <span class="mx-1">
     <v-btn
       v-if="!disabled"
       color="error"

--- a/client/dive-common/components/DeleteControls.vue
+++ b/client/dive-common/components/DeleteControls.vue
@@ -44,7 +44,7 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div>
+  <span>
     <v-btn
       v-if="!disabled"
       color="error"
@@ -67,5 +67,5 @@ export default Vue.extend({
         mdi-delete
       </v-icon>
     </v-btn>
-  </div>
+  </span>
 </template>

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -202,6 +202,13 @@ export default Vue.extend({
             <span class="text-subtitle-2">
               {{ editingHeader.text }}
             </span>
+            <span v-if="editingHeader.color !== ''">
+              <v-icon
+                color="error "
+                style="font-weight:bold"
+                @click="$emit('exit-edit')"
+              > mdi-close </v-icon>
+            </span>
           </span>
         </template>
         <span v-if="mergeMode">

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -248,9 +248,8 @@ export default Vue.extend({
         <v-btn
           v-for="button in viewButtons"
           :key="button.id"
-          :outlined="!button.active"
           :color="button.active ? 'grey darken-2' : ''"
-          class="mx-1"
+          class="mx-1 mode-button"
           small
           @click="button.click"
         >
@@ -265,9 +264,8 @@ export default Vue.extend({
           <template #activator="{ on, attrs }">
             <v-btn
               v-bind="attrs"
-              :outlined="!isVisible('TrackTail')"
               :color="isVisible('TrackTail') ? 'grey darken-2' : ''"
-              class="mx-1"
+              class="mx-1 mode-button"
               small
               v-on="on"
               @click="toggleVisible('TrackTail')"
@@ -322,6 +320,9 @@ export default Vue.extend({
 .mode-group {
   border: 1px solid grey;
   border-radius: 4px;
+}
+.mode-button{
+  border: 1px solid grey;
 }
 .tail-slider-width {
   width: 240px;

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -159,14 +159,13 @@ export default Vue.extend({
   },
   watch: {
     editingDetails() {
+      clearTimeout(this.toolTimeTimeout);
       if (this.editingDetails !== 'disabled') {
-        clearTimeout(this.toolTimeTimeout);
         this.toolTipForce = true;
         this.toolTimeTimeout = setTimeout(
-          () => { this.toolTipForce = false; }, 3000,
+          () => { this.toolTipForce = false; }, 2000,
         ) as unknown as number;
       } else {
-        clearTimeout(this.toolTimeTimeout);
         this.toolTipForce = false;
       }
     },
@@ -279,7 +278,7 @@ export default Vue.extend({
           v-model="toolTipForce"
           bottom
           max-width="300"
-          close-delay="1000"
+          close-delay="2000"
         >
           <template #activator="{ on, attrs }">
             <span

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -53,15 +53,14 @@ export default Vue.extend({
       toolTimeTimeout: 0,
       modeToolTips: {
         Creating: {
-          rectangle: 'Hit ESC to exit creation',
-          Polygon: 'Click to place points, right click to close polygon',
-          LineString: 'Click to place Head/Tail Points',
+          rectangle: 'Drag to draw rectangle. Press ESC to exit.',
+          Polygon: 'Click to place vertices. Right click to close.',
+          LineString: 'Click to place head/tail points.',
         },
         Editing: {
-          rectangle: 'Drag points to resize the rectangle',
-          Polygon: 'Click and drag midpoints to add new points, or click on vertices to move or delete',
-          LineString: 'Click and drag points, or click once to select and delete',
-
+          rectangle: 'Drag vertices to resize the rectangle',
+          Polygon: 'Drag midpoints to create new vertices. Click vertices to select for deletion.',
+          LineString: 'Click endpoints to select for deletion.',
         },
       },
     };
@@ -154,7 +153,7 @@ export default Vue.extend({
           color: this.editingDetails === 'Creating' ? 'success' : 'primary',
         };
       }
-      return { text: 'Editing Modes', icon: 'mdi-pencil', color: '' };
+      return { text: 'Not editing', icon: 'mdi-pencil-off-outline', color: '' };
     },
   },
   watch: {
@@ -193,19 +192,57 @@ export default Vue.extend({
 <template>
   <v-row
     v-mousetrap="mousetrap"
+    class="pa-0 ma-0 grow"
+    no-gutters
   >
-    <v-col class="d-flex align-center px-4">
-      <span
-        class="pa-2 pb-1 mode-group"
+    <div class="d-flex align-center grow">
+      <div
+        class="pa-1 d-flex"
+        style="width: 280px;"
       >
-        <span
-          class="mr-1 px-3 py-1"
-        >
+        <v-icon class="pr-1">
+          {{ editingHeader.icon }}
+        </v-icon>
+        <div>
+          <div class="text-subtitle-2">
+            {{ editingHeader.text }}
+          </div>
+          <div
+            style="line-height: 1.22em; font-size: 10px;"
+          >
+            <span v-if="mergeMode">
+              Merge in progress.  Editing is disabled.
+              Select additional tracks to merge.
+            </span>
+            <span v-else-if="editingDetails !== 'disabled'">
+              {{ modeToolTips[editingDetails][editingMode] }}
+            </span>
+            <span v-else>Right click on an annotation to edit</span>
+          </div>
+        </div>
+      </div>
+      <v-btn
+        v-for="button in editButtons"
+        :key="button.id + 'view'"
+        :disabled="!editingMode"
+        :outlined="!button.active"
+        :color="button.active ? editingHeader.color : ''"
+        class="mx-1"
+        small
+        @click="button.click"
+      >
+        <pre v-if="button.mousetrap">{{ button.mousetrap[0].bind }}:</pre>
+        <v-icon>{{ button.icon }}</v-icon>
+      </v-btn>
+      <slot name="delete-controls" />
+      <v-spacer />
+      <span class="pb-1">
+        <span class="mr-1 px-3 py-1">
           <v-icon class="pr-1">
             mdi-eye
           </v-icon>
           <span class="text-subtitle-2">
-            Visibilty
+            Visibility
           </span>
         </span>
         <v-btn
@@ -271,56 +308,7 @@ export default Vue.extend({
           </v-card>
         </v-menu>
       </span>
-      <span
-        class="ml-4 pb-1 pa-2 grey darken-2 mode-group"
-      >
-        <v-tooltip
-          v-model="toolTipForce"
-          bottom
-          max-width="300"
-          close-delay="2000"
-        >
-          <template #activator="{ on, attrs }">
-            <span
-              v-bind="attrs"
-              :class="[
-                'mr-1', 'px-3', 'py-1',
-              ]"
-              v-on="on"
-            >
-              <v-icon class="pr-1">
-                {{ editingHeader.icon }}
-              </v-icon>
-              <span class="text-subtitle-2">
-                {{ editingHeader.text }}
-              </span>
-            </span>
-          </template>
-          <span v-if="mergeMode">
-            Merge in progress.  Editing is disabled.
-            Select additional tracks to merge.
-          </span>
-          <span v-else-if="editingDetails !== 'disabled'">
-            {{ modeToolTips[editingDetails][editingMode] }}
-          </span>
-          <span v-else>Right Click on a detection/track to enter Editing Mode</span>
-        </v-tooltip>
-        <v-btn
-          v-for="button in editButtons"
-          :key="button.id + 'view'"
-          :disabled="!editingMode"
-          :outlined="!button.active"
-          :color="button.active ? editingHeader.color : ''"
-          class="mx-1"
-          small
-          @click="button.click"
-        >
-          <pre v-if="button.mousetrap">{{ button.mousetrap[0].bind }}:</pre>
-          <v-icon>{{ button.icon }}</v-icon>
-        </v-btn>
-        <slot name="delete-controls" />
-      </span>
-    </v-col>
+    </div>
   </v-row>
 </template>
 

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -30,6 +30,10 @@ export default Vue.extend({
       type: [String, Boolean] as PropType<false | EditAnnotationTypes>,
       required: true,
     },
+    editingDetails: {
+      type: String as PropType<'disabled' | 'Creating' | 'Editing'>,
+      required: true,
+    },
     recipes: {
       type: Array as PropType<Recipe[]>,
       required: true,
@@ -118,6 +122,19 @@ export default Vue.extend({
     mousetrap(): Mousetrap[] {
       return flatten(this.editButtons.map((b) => b.mousetrap || []));
     },
+    editingHeader(): {text: string; icon: string; color: string} {
+      if (this.mergeMode) {
+        return { text: 'Merge Mode', icon: 'mdi-call-merge', color: 'error' };
+      }
+      if (this.editingDetails !== 'disabled') {
+        return {
+          text: `${this.editingDetails} ${this.editingMode} `,
+          icon: this.editingDetails === 'Creating' ? 'mdi-pencil-plus' : 'mdi-pencil',
+          color: this.editingDetails === 'Creating' ? 'success' : 'primary',
+        };
+      }
+      return { text: 'Editing Modes', icon: 'mdi-pencil', color: '' };
+    },
   },
 
   methods: {
@@ -175,17 +192,15 @@ export default Vue.extend({
             v-bind="attrs"
             :class="[
               'ml-8', 'mr-1', 'px-3', 'py-1',
-              'modechip', editingTrack ? 'primary' : (
-                mergeMode ? 'error' : ''
-              )
+              'modechip', editingHeader.color,
             ]"
             v-on="on"
           >
             <v-icon class="pr-1">
-              {{ mergeMode ? 'mdi-call-merge' : 'mdi-pencil' }}
+              {{ editingHeader.icon }}
             </v-icon>
             <span class="text-subtitle-2">
-              {{ mergeMode ? 'Merge Mode' : 'Editing Mode' }}
+              {{ editingHeader.text }}
             </span>
           </span>
         </template>

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -195,6 +195,7 @@ export default defineComponent({
       selectedFeatureHandle,
       handler,
       editingMode,
+      editingDetails,
       visibleModes,
       selectedKey,
     } = useModeManager({
@@ -437,6 +438,7 @@ export default defineComponent({
       datasetType,
       editingTrack,
       editingMode,
+      editingDetails,
       eventChartData,
       imageData,
       lineChartData,
@@ -499,7 +501,7 @@ export default defineComponent({
           Viewer/Edit Controls
         </span>
         <editor-menu
-          v-bind="{ editingMode, visibleModes, editingTrack, recipes, mergeMode }"
+          v-bind="{ editingMode, visibleModes, editingTrack, recipes, mergeMode, editingDetails }"
           class="shrink"
           @set-annotation-state="handler.setAnnotationState"
         />

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -505,13 +505,16 @@ export default defineComponent({
           class="shrink"
           @set-annotation-state="handler.setAnnotationState"
           @exit-edit="handler.trackAbort"
-        />
-        <delete-controls
-          v-bind="{ editingMode, selectedFeatureHandle }"
-          class="mr-2"
-          @delete-point="handler.removePoint"
-          @delete-annotation="handler.removeAnnotation"
-        />
+        >
+          <template slot="delete-controls">
+            <delete-controls
+              v-bind="{ editingMode, selectedFeatureHandle }"
+              class="mr-2"
+              @delete-point="handler.removePoint"
+              @delete-annotation="handler.removeAnnotation"
+            />
+          </template>
+        </editor-menu>
         <v-spacer />
         <v-select
           v-if="multiCamList.length"

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -504,6 +504,7 @@ export default defineComponent({
           v-bind="{ editingMode, visibleModes, editingTrack, recipes, mergeMode, editingDetails }"
           class="shrink"
           @set-annotation-state="handler.setAnnotationState"
+          @exit-edit="handler.trackAbort"
         />
         <delete-controls
           v-bind="{ editingMode, selectedFeatureHandle }"

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -494,18 +494,9 @@ export default defineComponent({
         {{ datasetName }}
       </span>
       <v-spacer />
-
       <template #extension>
-        <span
-          v-if="$vuetify.breakpoint.lgAndUp"
-          style="min-width: 180px;"
-        >
-          Viewer/Edit Controls
-        </span>
         <EditorMenu
           v-bind="{ editingMode, visibleModes, editingTrack, recipes, mergeMode, editingDetails }"
-          :tail-settings.sync="clientSettings.annotatorPreferences.trackTails"
-          class="shrink"
           @set-annotation-state="handler.setAnnotationState"
           @exit-edit="handler.trackAbort"
         >
@@ -518,7 +509,6 @@ export default defineComponent({
             />
           </template>
         </EditorMenu>
-        <v-spacer />
         <v-select
           v-if="multiCamList.length"
           :value="defaultCamera"

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -64,8 +64,17 @@ export default function useModeManager({
   const selectedKey = ref('');
   // which type is currently being edited, if any
   const editingMode = computed(() => editingTrack.value && annotationModes.editing);
+  const editingCanary = ref(false);
+  function _depend(): boolean {
+    return editingCanary.value;
+  }
+  function _nudgeEditingCanary() {
+    editingCanary.value = !editingCanary.value;
+  }
+
   // What is occuring in editing mode
   const editingDetails = computed(() => {
+    _depend();
     if (editingMode.value && selectedTrackId.value !== null) {
       const { frame } = mediaController.value;
       const track = trackMap.get(selectedTrackId.value);
@@ -209,6 +218,7 @@ export default function useModeManager({
         }
       }
     }
+    _nudgeEditingCanary();
     creating = newCreatingValue;
   }
 
@@ -385,6 +395,7 @@ export default function useModeManager({
             r.delete(frame.value, track, selectedKey.value, annotationModes.editing);
           }
         });
+        _nudgeEditingCanary();
       }
     }
   }

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -64,6 +64,26 @@ export default function useModeManager({
   const selectedKey = ref('');
   // which type is currently being edited, if any
   const editingMode = computed(() => editingTrack.value && annotationModes.editing);
+  // What is occuring in editing mode
+  const editingDetails = computed(() => {
+    if (editingMode.value && selectedTrackId.value !== null) {
+      const { frame } = mediaController.value;
+      const track = trackMap.get(selectedTrackId.value);
+      if (track) {
+        const [feature] = track.getFeature(frame.value);
+        if (feature) {
+          if (!feature?.bounds?.length) {
+            return 'Creating';
+          } if (annotationModes.editing === 'rectangle') {
+            return 'Editing';
+          }
+          return (feature.geometry?.features.filter((item) => item.geometry.type === annotationModes.editing).length ? 'Editing' : 'Creating');
+        }
+        return 'Creating';
+      }
+    }
+    return 'disabled';
+  });
   // which types are currently visible, always including the editingType
   const visibleModes = computed(() => (
     uniq(annotationModes.visible.concat(editingMode.value || []))
@@ -484,6 +504,7 @@ export default function useModeManager({
 
   return {
     editingMode,
+    editingDetails,
     mergeList,
     mergeInProgress,
     visibleModes,


### PR DESCRIPTION
fixes #697 
fixes #1172  (Thanks Mary)

Latest update has changed how this works based on mockups.

![image](https://user-images.githubusercontent.com/61746913/153287880-d4efb3db-d387-4325-8f91-ca057d0ab951.png)
![image](https://user-images.githubusercontent.com/61746913/153287980-55d33a8d-8d2e-43ed-a088-036d9ab6f3fb.png)
![image](https://user-images.githubusercontent.com/61746913/153288077-77ef4256-50b9-48ce-b384-f516b615b877.png)

Switching between different modes (being Creating/Editing OR rectangle/Poly/Line) will display a tooltip for 3 seconds giving information about the mode like "Hit ESC to exist creation", or "select midpoints to add new points to polygon"

These tooltips are still there when returning to hover over the main title section.

Implementation:

- `useModeManager` has a canary variable used to determine creating vs editing modes and provides that to the `EditorMenu.vue`.  This is a prop in EditorMenu.vue called `editingDetails = 'disabled' | 'Creating' | 'Editing'`.
- There is a computed property called `EditorHeader` which provides the text and coloring for the buttons based on the editing mode and the `editingDetails` (I.E When creating a polygon it needs to say creating and the polygon should be colored green).
- `EditorMenu.vue` now contains a slot for the deletion controls because they are inside of the Editor gray box in the mockup
