### PR TITLE
No keyframe or interpolate defaults

### DIFF
--- a/client/platform/desktop/backend/serializers/nist.ts
+++ b/client/platform/desktop/backend/serializers/nist.ts
@@ -105,7 +105,6 @@ function loadObjects(
             track.begin = Math.min(track.begin, frameNum);
             track.features.push({
               frame: frameNum,
-              keyframe: true,
               bounds: adjustedBounds,
               attributes: {
                 objectID,
@@ -167,15 +166,12 @@ function loadActivity(
           features.push({
             frame: parseInt(frame, 10) - 1,
             bounds,
-            keyframe: true,
-            interpolate: false,
           });
         } else if (val === 1) {
           track.end = parseInt(key, 10) - 1;
           features.push({
             frame: parseInt(frame, 10) - 1,
             bounds,
-            keyframe: true,
             interpolate: true,
           });
         }

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -27,8 +27,6 @@ const data: MultiTrackRecord = {
           968,
           433,
         ],
-        interpolate: false,
-        keyframe: true,
       },
       {
         frame: 1,
@@ -38,8 +36,6 @@ const data: MultiTrackRecord = {
           968,
           433,
         ],
-        interpolate: false,
-        keyframe: true,
       },
       {
         frame: 2,
@@ -49,8 +45,6 @@ const data: MultiTrackRecord = {
           968,
           433,
         ],
-        interpolate: false,
-        keyframe: true,
       },
       {
         frame: 3,
@@ -60,8 +54,6 @@ const data: MultiTrackRecord = {
           968,
           433,
         ],
-        interpolate: false,
-        keyframe: true,
       },
       {
         frame: 4,
@@ -71,8 +63,6 @@ const data: MultiTrackRecord = {
           968,
           433,
         ],
-        interpolate: false,
-        keyframe: true,
       },
     ],
     confidencePairs: [

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -220,8 +220,6 @@ function _parseFeature(row: string[]) {
   const feature: Feature = {
     frame: rowInfo.frame,
     bounds: rowInfo.bounds,
-    interpolate: false,
-    keyframe: true,
   };
   if (rowInfo.fishLength !== -1) {
     feature.fishLength = rowInfo.fishLength;

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -46,8 +46,8 @@ class Feature(BaseModel):
     head: Optional[Tuple[float, float]] = None
     tail: Optional[Tuple[float, float]] = None
     fishLength: Optional[float] = None
-    interpolate: Optional[bool] = False
-    keyframe: Optional[bool] = True
+    interpolate: Optional[bool] = None
+    keyframe: Optional[bool] = None
 
 
 class Track(BaseModel):

--- a/server/scripts/generateLargeDataset.py
+++ b/server/scripts/generateLargeDataset.py
@@ -87,7 +87,6 @@ def create_track_json(
                 frame = start_frame + frame
                 feature = {
                     "frame": frame,
-                    "keyframe": True,
                     "bounds": [0, 0, width, height],
                 }
                 track_obj["begin"] = min(track_obj["begin"], frame)

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -126,8 +126,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                                 },
                             ],
                         },
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["astronaut", 1.0]],
@@ -141,8 +139,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [350, 5, 480, 295],
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["rocket", 1.0]],
@@ -156,8 +152,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [326, 369, 600, 600],
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["helmet", 1.0]],
@@ -346,8 +340,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                                 },
                             ],
                         },
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["eff", 1.0]],
@@ -361,8 +353,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [73, 125, 142, 184],
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["eff", 1.0]],
@@ -428,8 +418,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                                 },
                             ],
                         },
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["superstar", 1.0]],
@@ -465,8 +453,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                                 }
                             ],
                         },
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["eff", 1.0]],
@@ -480,8 +466,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [153, 151, 200, 183],
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["star", 1.0]],
@@ -495,8 +479,6 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [42, 240, 66, 254],
-                        "interpolate": False,
-                        "keyframe": True,
                     }
                 ],
                 "confidencePairs": [["eff", 1.0]],
@@ -591,14 +573,10 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 10,
                         "bounds": [300, 103, 321, 134],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                     {
                         "frame": 11,
                         "bounds": [299, 104, 320, 133],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                 ],
                 "confidencePairs": [["person", 1.0]],
@@ -612,14 +590,10 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 14,
                         "bounds": [81, 41, 227, 113],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                     {
                         "frame": 15,
                         "bounds": [81, 41, 227, 113],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                 ],
                 "confidencePairs": [["car", 1.0]],
@@ -633,20 +607,14 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 13,
                         "bounds": [266, 8, 305, 53],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                     {
                         "frame": 14,
                         "bounds": [266, 8, 305, 53],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                     {
                         "frame": 15,
                         "bounds": [266, 8, 305, 53],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                 ],
                 "confidencePairs": [["tree", 1.0]],
@@ -691,14 +659,10 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 10,
                         "bounds": [300, 103, 321, 134],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                     {
                         "frame": 11,
                         "bounds": [299, 104, 320, 133],
-                        "interpolate": False,
-                        "keyframe": True,
                     },
                 ],
                 "confidencePairs": [["person", 1.0]],

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -35,14 +35,10 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                         "frame": 0,
                         # NOTICE numbers that were rounded!
                         "bounds": [885, 510, 1220, 738],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -56,8 +52,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     }
                 ],
                 "begin": 0,
@@ -71,8 +65,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 2,
                         "bounds": [10, 50, 20, 35],
-                        "keyframe": True,
-                        "interpolate": False,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -109,8 +101,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 3,
                         "bounds": [10, 50, 20, 35],
-                        "keyframe": True,
-                        "interpolate": False,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -137,8 +127,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 4,
                         "bounds": [10, 10, 20, 20],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 4,
@@ -152,8 +140,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 5,
                         "bounds": [10, 10, 20, 20],
-                        "keyframe": True,
-                        "interpolate": False,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -188,8 +174,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 6,
                         "bounds": [10, 10, 20, 20],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {"attrNAME": "spaced attr name"},
                     },
                 ],
@@ -204,8 +188,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 4,
                         "bounds": [10, 10, 20, 20],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 4,
@@ -246,20 +228,14 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 2,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -295,8 +271,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [885, 510, 1220, 738],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                             "DetectionNumber": 2.002,
@@ -305,8 +279,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value2",
                         },
@@ -314,8 +286,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 2,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value3",
                         },
@@ -323,8 +293,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 3,
                         "bounds": [885, 510, 1220, 738],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                         },
@@ -332,8 +300,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 4,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value2",
                         },
@@ -341,8 +307,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 5,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value3",
                         },
@@ -359,8 +323,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [885, 510, 1220, 738],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                             "DetectionNumber": 2.002,
@@ -369,8 +331,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value2",
                         },
@@ -378,8 +338,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 2,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value3",
                         },
@@ -387,8 +345,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 3,
                         "bounds": [885, 510, 1220, 738],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                         },
@@ -396,8 +352,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 4,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value2",
                         },
@@ -405,8 +359,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 5,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {
                             "DetectionPredefinedValue": "value3",
                         },
@@ -455,14 +407,10 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -476,8 +424,6 @@ old_tuple: List[Tuple[list, dict, dict]] = [
                     {
                         "frame": 0,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     }
                 ],
                 "begin": 0,

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -18,14 +18,10 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -39,8 +35,6 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     }
                 ],
                 "begin": 0,
@@ -66,13 +60,11 @@ test_tuple: List[Tuple[dict, list, list]] = [
                         "frame": 1,
                         "bounds": [2, 2, 4, 4],
                         "interpolate": True,
-                        "keyframe": True,
                     },
                     {
                         "frame": 3,
                         "bounds": [4, 4, 8, 8],
                         "interpolate": True,
-                        "keyframe": True,
                     },
                 ],
                 "confidencePairs": [["foo", 0.2], ["bar", 0.9], ["baz", 0.1]],
@@ -98,7 +90,6 @@ test_tuple: List[Tuple[dict, list, list]] = [
                         "frame": 1,
                         "bounds": [2, 2, 4, 4],
                         "interpolate": True,
-                        "keyframe": True,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -136,7 +127,6 @@ test_tuple: List[Tuple[dict, list, list]] = [
                         "frame": 3,
                         "bounds": [4, 4, 8, 8],
                         "interpolate": True,
-                        "keyframe": True,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -183,15 +173,11 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {"detectionAttr": "frame 0 attr"},
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                         "attributes": {"detectionAttr": "frame 1 attr"},
                     },
                 ],
@@ -217,14 +203,10 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -238,8 +220,6 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     }
                 ],
                 "begin": 0,
@@ -262,14 +242,10 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [884, 510, 1219, 737],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                     {
                         "frame": 1,
                         "bounds": [111, 222, 3333, 444],
-                        "keyframe": True,
-                        "interpolate": False,
                     },
                 ],
                 "begin": 0,
@@ -283,8 +259,6 @@ test_tuple: List[Tuple[dict, list, list]] = [
                     {
                         "frame": 0,
                         "bounds": [747, 457, 1039, 633],
-                        "keyframe": True,
-                        "interpolate": False,
                     }
                 ],
                 "begin": 0,

--- a/testutils/attributes.spec.json
+++ b/testutils/attributes.spec.json
@@ -1,7 +1,7 @@
 [
   [
     {
-      "0":{
+      "0": {
         "trackId": 0,
         "attributes": {
           "booleanAttr": true
@@ -21,8 +21,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -36,8 +34,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -50,8 +46,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -64,8 +58,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -78,8 +70,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -92,8 +82,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -102,7 +90,7 @@
         "begin": 0,
         "end": 5
       },
-      "1":{
+      "1": {
         "trackId": 1,
         "attributes": {
           "booleanAttr": true
@@ -122,8 +110,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -137,8 +123,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -151,8 +135,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -165,8 +147,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -179,8 +159,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -193,8 +171,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -225,8 +201,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -240,8 +214,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -254,8 +226,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -268,8 +238,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -282,8 +250,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -296,8 +262,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -326,8 +290,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -341,8 +303,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -355,8 +315,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -369,8 +327,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -383,8 +339,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -397,8 +351,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -436,7 +388,7 @@
   ],
   [
     {
-      "0":{
+      "0": {
         "trackId": 0,
         "attributes": {
           "booleanAttr": true
@@ -456,8 +408,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -471,8 +421,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -485,8 +433,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -499,8 +445,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -513,8 +457,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -527,8 +469,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -537,7 +477,7 @@
         "begin": 0,
         "end": 5
       },
-      "1":{
+      "1": {
         "trackId": 1,
         "attributes": {
           "booleanAttr": true
@@ -557,8 +497,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -572,8 +510,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -586,8 +522,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -600,8 +534,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -614,8 +546,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -628,8 +558,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -660,8 +588,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -675,8 +601,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -689,8 +613,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -703,8 +625,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -717,8 +637,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -731,8 +649,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -761,8 +677,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1",
               "DetectionNumber": 2.002
@@ -776,8 +690,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -790,8 +702,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }
@@ -804,8 +714,6 @@
               1220,
               738
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value1"
             }
@@ -818,8 +726,6 @@
               3333,
               444
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value2"
             }
@@ -832,8 +738,6 @@
               1039,
               633
             ],
-            "keyframe": true,
-            "interpolate": false,
             "attributes": {
               "DetectionPredefinedValue": "value3"
             }

--- a/testutils/nist.spec.json
+++ b/testutils/nist.spec.json
@@ -25,7 +25,6 @@
                         1,
                         1
                     ],
-                    "keyframe": true,
                     "interpolate": true
                 },
                 {
@@ -35,9 +34,7 @@
                         0,
                         1,
                         1
-                    ],
-                    "keyframe": true,
-                    "interpolate": false
+                    ]
                 }
             ]
         },
@@ -62,7 +59,6 @@
             "features": [
                 {
                     "frame": 0,
-                    "keyframe": true,
                     "bounds": [
                         0,
                         0,
@@ -76,7 +72,6 @@
                 },
                 {
                     "frame": 4,
-                    "keyframe": true,
                     "bounds": [
                         0,
                         0,
@@ -115,7 +110,6 @@
                         1,
                         31
                     ],
-                    "keyframe": true,
                     "interpolate": true
                 },
                 {
@@ -125,9 +119,7 @@
                         30,
                         1,
                         31
-                    ],
-                    "keyframe": true,
-                    "interpolate": false
+                    ]
                 },
                 {
                     "frame": 12,
@@ -137,7 +129,6 @@
                         1,
                         31
                     ],
-                    "keyframe": true,
                     "interpolate": true
                 },
                 {
@@ -147,9 +138,7 @@
                         30,
                         1,
                         31
-                    ],
-                    "keyframe": true,
-                    "interpolate": false
+                    ]
                 }
             ]
         },
@@ -174,7 +163,6 @@
             "features": [
                 {
                     "frame": 8,
-                    "keyframe": true,
                     "bounds": [
                         290,
                         286,
@@ -188,7 +176,6 @@
                 },
                 {
                     "frame": 9,
-                    "keyframe": true,
                     "bounds": [
                         480,
                         286,
@@ -202,7 +189,6 @@
                 },
                 {
                     "frame": 14,
-                    "keyframe": true,
                     "bounds": [
                         645,
                         413,
@@ -216,7 +202,6 @@
                 },
                 {
                     "frame": 16,
-                    "keyframe": true,
                     "bounds": [
                         588,
                         409,

--- a/testutils/tracks.json
+++ b/testutils/tracks.json
@@ -1,1 +1,25 @@
-{"999999": {"begin": 0, "end": 0, "trackId": 999999, "features": [{"frame": 0, "bounds": [670, 183, 968, 433], "interpolate": false, "keyframe": true}], "confidencePairs": [["motion_signature", 0.996269]], "attributes": {}}}
+{
+  "999999": {
+    "begin": 0,
+    "end": 0,
+    "trackId": 999999,
+    "features": [
+      {
+        "frame": 0,
+        "bounds": [
+          670,
+          183,
+          968,
+          433
+        ]
+      }
+    ],
+    "confidencePairs": [
+      [
+        "motion_signature",
+        0.996269
+      ]
+    ],
+    "attributes": {}
+  }
+}

--- a/testutils/viame.spec.json
+++ b/testutils/viame.spec.json
@@ -29,9 +29,7 @@
                             510,
                             1220,
                             738
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     },
                     {
                         "frame": 1,
@@ -40,9 +38,7 @@
                             222,
                             3333,
                             444
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 0,
@@ -65,9 +61,7 @@
                             457,
                             1039,
                             633
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 0,
@@ -91,8 +85,6 @@
                             20,
                             35
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -152,8 +144,6 @@
                             20,
                             35
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -198,9 +188,7 @@
                             10,
                             20,
                             20
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 4,
@@ -228,8 +216,6 @@
                             20,
                             20
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "geometry": {
                             "type": "FeatureCollection",
                             "features": [
@@ -293,8 +279,6 @@
                             20,
                             20
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "attrNAME": "spaced attr name"
                         }
@@ -328,9 +312,7 @@
                             10,
                             20,
                             20
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 4,
@@ -376,9 +358,7 @@
                             510,
                             1219,
                             737
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     },
                     {
                         "frame": 1,
@@ -387,9 +367,7 @@
                             222,
                             3333,
                             444
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     },
                     {
                         "frame": 2,
@@ -398,9 +376,7 @@
                             457,
                             1039,
                             633
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 0,
@@ -447,8 +423,6 @@
                             1220,
                             738
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                             "DetectionNumber": 2.002
@@ -462,8 +436,6 @@
                             3333,
                             444
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value2"
                         }
@@ -476,8 +448,6 @@
                             1039,
                             633
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value3"
                         }
@@ -490,8 +460,6 @@
                             1220,
                             738
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value1"
                         }
@@ -504,8 +472,6 @@
                             3333,
                             444
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value2"
                         }
@@ -518,8 +484,6 @@
                             1039,
                             633
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value3"
                         }
@@ -548,8 +512,6 @@
                             1220,
                             738
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value1",
                             "DetectionNumber": 2.002
@@ -563,8 +525,6 @@
                             3333,
                             444
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value2"
                         }
@@ -577,8 +537,6 @@
                             1039,
                             633
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value3"
                         }
@@ -591,8 +549,6 @@
                             1220,
                             738
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value1"
                         }
@@ -605,8 +561,6 @@
                             3333,
                             444
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value2"
                         }
@@ -619,8 +573,6 @@
                             1039,
                             633
                         ],
-                        "keyframe": true,
-                        "interpolate": false,
                         "attributes": {
                             "DetectionPredefinedValue": "value3"
                         }
@@ -681,9 +633,7 @@
                             510,
                             1219,
                             737
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     },
                     {
                         "frame": 1,
@@ -692,9 +642,7 @@
                             222,
                             3333,
                             444
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 0,
@@ -717,9 +665,7 @@
                             457,
                             1039,
                             633
-                        ],
-                        "keyframe": true,
-                        "interpolate": false
+                        ]
                     }
                 ],
                 "begin": 0,


### PR DESCRIPTION
This reconciles differences between web and desktop in the other direction:

* keyframe is not set by default and should _never_ be set, because all frames in a json export are always keyframes.
* interpolate is not set by default

Because these are repeated in every frame, even small datasets will have lots of useless information encoded in these.  keyframe=True is meaningless because interpolated frames are never exported: they only exist at runtime.  interpolate=True can be set, but the default is for them to be false and unset.

## Note

This does not change how the annotator saves annotations.  If an annotation is drawn, it will still have these useless values in the "upsert" payload and end up getting saved.  Scrubbing these useless values at save time (either client side or server side) is out of scope for this PR