### PR TITLE
Current Pipeline Running information

### DIFF
--- a/client/dive-common/components/AttributeInput.vue
+++ b/client/dive-common/components/AttributeInput.vue
@@ -29,6 +29,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props, { emit }) {
     const tempVal = ref(props.value as null | boolean | number | string);
@@ -104,6 +108,7 @@ export default defineComponent({
     <datalist
       v-if="datatype === 'text' && values && values.length"
       :id="`optionsList_${_uid}`"
+      :disabled="disabled"
     >
       <option
         v-for="type in [' ', ...values]"
@@ -119,6 +124,7 @@ export default defineComponent({
       ref="inputBoxRef"
       v-model="tempVal"
       type="text"
+      :disabled="disabled"
       :list="`optionsList_${_uid}`"
       class="input-box"
       @change="change"
@@ -130,6 +136,7 @@ export default defineComponent({
       ref="inputBoxRef"
       :label="datatype"
       :value="value"
+      :disabled="disabled"
       class="input-box"
       type="number"
       @change="change"
@@ -139,6 +146,7 @@ export default defineComponent({
       v-else-if="datatype === 'boolean'"
       ref="inputBoxRef"
       :label="datatype"
+      :disabled="disabled"
       :value="value"
       class="input-box select-input"
       @change="change"

--- a/client/dive-common/components/AttributesSubsection.vue
+++ b/client/dive-common/components/AttributesSubsection.vue
@@ -9,6 +9,7 @@ import {
   useSelectedTrackId,
   useTrackMap,
   useTime,
+  useReadOnlyMode,
 } from 'vue-media-annotator/provides';
 import { getTrack } from 'vue-media-annotator/use/useTrackStore';
 import { Attribute } from 'vue-media-annotator/use/useAttributes';
@@ -36,6 +37,7 @@ export default defineComponent({
     },
   },
   setup(props, { emit }) {
+    const readOnlyMode = useReadOnlyMode();
     const { frame: frameRef } = useTime();
     const selectedTrackIdRef = useSelectedTrackId();
     const trackMap = useTrackMap();
@@ -111,6 +113,7 @@ export default defineComponent({
       selectedAttributes,
       filteredFullAttributes,
       activeSettings,
+      readOnlyMode,
       //functions
       toggleActiveSettings,
       updateAttribute,
@@ -143,6 +146,7 @@ export default defineComponent({
             <v-btn
               outlined
               x-small
+              :disabled="readOnlyMode"
               v-on="on"
               @click="addAttribute"
             >
@@ -214,6 +218,7 @@ export default defineComponent({
                 v-if="activeSettings"
                 :datatype="attribute.datatype"
                 :name="attribute.name"
+                :disabled="readOnlyMode"
                 :values="attribute.values ? attribute.values : null"
                 :value="
                   selectedAttributes && selectedAttributes.attributes
@@ -235,6 +240,7 @@ export default defineComponent({
                   <AttributeInput
                     :datatype="attribute.datatype"
                     :name="attribute.name"
+                    :disabled="readOnlyMode"
                     :values="attribute.values ? attribute.values : null"
                     :value="
                       selectedAttributes && selectedAttributes.attributes

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -24,6 +24,10 @@ export default defineComponent({
       type: Object,
       default: () => ({}),
     },
+    readOnlyMode: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props) {
     const { openFromDisk, importAnnotationFile } = useApi();
@@ -103,7 +107,14 @@ export default defineComponent({
       </v-tooltip>
     </template>
     <template>
+      <v-card v-if="readOnlyMode">
+        <v-card-title> Read only Mode</v-card-title>
+        <v-card-text>
+          This Dataset is in ReadOnly Mode.  You cannot import annotations for this dataset.
+        </v-card-text>
+      </v-card>
       <v-card
+        v-else
         outlined
       >
         <v-card-title>

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -11,7 +11,6 @@ import {
 import JobLaunchDialog from 'dive-common/components/JobLaunchDialog.vue';
 import { stereoPipelineMarker, multiCamPipelineMarkers } from 'dive-common/constants';
 import { useRequest } from 'dive-common/use';
-import { useStore } from 'platform/web-girder/store/types';
 
 export default defineComponent({
   name: 'RunPipelineMenu',
@@ -157,16 +156,10 @@ export default defineComponent({
           <template #activator="{ on: tooltipOn }">
             <v-btn
               v-bind="buttonOptions"
-              :disabled="pipelinesNotRunnable || pipelinesCurrentlyRunning"
+              :disabled="pipelinesNotRunnable"
+              :color="pipelinesCurrentlyRunning? 'warning' : ''"
               v-on="{ ...tooltipOn, ...menuOn }"
             >
-              <v-icon
-                v-if="pipelinesCurrentlyRunning"
-                class="rotate"
-                color="warning"
-              >
-                mdi-autorenew
-              </v-icon>
               <v-icon> mdi-pipe </v-icon>
               <span
                 v-show="!$vuetify.breakpoint.mdAndDown || buttonOptions.block"
@@ -180,13 +173,21 @@ export default defineComponent({
               </v-icon>
             </v-btn>
           </template>
-          <span>Run CV algorithm pipelines on this data</span>
+          <span v-if="!pipelinesCurrentlyRunning">Run CV algorithm pipelines on this data</span>
+          <span v-else>Pipeline is Currently running </span>
         </v-tooltip>
       </template>
 
       <template>
+        <v-card v-if="pipelinesCurrentlyRunning">
+          <v-card-title> Pipeline Running </v-card-title>
+          <v-card-text>
+            A pipeline is currently running on this dataset.
+            Please wait until it is complete before running another pipeline or making any changes
+          </v-card-text>
+        </v-card>
         <v-card
-          v-if="pipelines"
+          v-else-if="pipelines"
           outlined
         >
           <v-card-title> VIAME Pipelines </v-card-title>

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -40,9 +40,9 @@ export default defineComponent({
       type: Array as PropType<number[]>,
       default: () => ([1]),
     },
-    getRunningPipelines: {
-      type: Function as PropType<(id: string) => boolean | string>,
-      default: () => false,
+    runningPipelines: {
+      type: Array as PropType<string[]>,
+      default: () => ([]),
     },
     readOnlyMode: {
       type: Boolean,
@@ -105,13 +105,13 @@ export default defineComponent({
 
     const pipelinesCurrentlyRunning = computed(
       () => props.selectedDatasetIds.reduce(
-        (acc, item) => acc || !!props.getRunningPipelines(item), false,
+        (acc, item) => acc || props.runningPipelines.includes(item), false,
       ),
     );
 
     const singlePipelineValue = computed(() => {
       if (props.selectedDatasetIds.length === 1) {
-        return props.getRunningPipelines(props.selectedDatasetIds[0]);
+        return props.runningPipelines.includes(props.selectedDatasetIds[0]);
       }
       return false;
     });

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -194,8 +194,9 @@ export default defineComponent({
         <v-card v-if="pipelinesCurrentlyRunning">
           <v-card-title> Pipeline Running </v-card-title>
           <v-card-text>
-            A pipeline is currently running on this dataset.
-            Please wait until it is complete before running another pipeline or making any changes
+            Data cannot be edited while a pipeline is queued.
+            Pipelines produce output that will replace the existing annotations.
+            You can check the status of your job or cancel it
           </v-card-text>
           <v-row class="pb-1">
             <!-- Viewer Loaded with single Job Running -->
@@ -210,9 +211,9 @@ export default defineComponent({
             >
               View Running Job
             </v-btn>
-            <!-- Desktop Job Running -->
+            <!-- Desktop Job Running or Home/DataBrowser View -->
             <v-btn
-              v-else-if="singlePipelineValue === true"
+              v-else
               large
               depressed
               to="/jobs"

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -41,7 +41,7 @@ export default defineComponent({
       default: () => ([1]),
     },
     getRunningPipelines: {
-      type: Function as PropType<(id: string) => boolean>,
+      type: Function as PropType<(id: string) => boolean | string>,
       default: () => false,
     },
     readOnlyMode: {
@@ -105,9 +105,16 @@ export default defineComponent({
 
     const pipelinesCurrentlyRunning = computed(
       () => props.selectedDatasetIds.reduce(
-        (acc, item) => acc || props.getRunningPipelines(item), false,
+        (acc, item) => acc || !!props.getRunningPipelines(item), false,
       ),
     );
+
+    const singlePipelineValue = computed(() => {
+      if (props.selectedDatasetIds.length === 1) {
+        return props.getRunningPipelines(props.selectedDatasetIds[0]);
+      }
+      return false;
+    });
 
     async function runPipelineOnSelectedItem(pipeline: Pipe) {
       if (props.selectedDatasetIds.length === 0) {
@@ -140,6 +147,7 @@ export default defineComponent({
       pipeTypeDisplay,
       runPipelineOnSelectedItem,
       pipelinesCurrentlyRunning,
+      singlePipelineValue,
     };
   },
 });
@@ -161,7 +169,7 @@ export default defineComponent({
             <v-btn
               v-bind="buttonOptions"
               :disabled="pipelinesNotRunnable"
-              :color="pipelinesCurrentlyRunning? 'warning' : ''"
+              :color="pipelinesCurrentlyRunning? 'warning' : buttonOptions.color"
               v-on="{ ...tooltipOn, ...menuOn }"
             >
               <v-icon> mdi-pipe </v-icon>
@@ -189,6 +197,29 @@ export default defineComponent({
             A pipeline is currently running on this dataset.
             Please wait until it is complete before running another pipeline or making any changes
           </v-card-text>
+          <v-row class="pb-1">
+            <v-btn
+              v-if="singlePipelineValue && singlePipelineValue !== true"
+              large
+              depressed
+              :href="singlePipelineValue"
+              target="_blank"
+              color="info"
+              class="ma-auto"
+            >
+              View Running Job
+            </v-btn>
+            <v-btn
+              v-else-if="singlePipelineValue === true"
+              large
+              depressed
+              to="/jobs"
+              color="info"
+              class="ma-auto"
+            >
+              View Running Job
+            </v-btn>
+          </v-row>
         </v-card>
         <v-card v-else-if="readOnlyMode">
           <v-card-title> Read only Mode</v-card-title>

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -44,6 +44,10 @@ export default defineComponent({
       type: Function as PropType<(id: string) => boolean>,
       default: () => false,
     },
+    readOnlyMode: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   setup(props) {
@@ -184,6 +188,12 @@ export default defineComponent({
           <v-card-text>
             A pipeline is currently running on this dataset.
             Please wait until it is complete before running another pipeline or making any changes
+          </v-card-text>
+        </v-card>
+        <v-card v-else-if="readOnlyMode">
+          <v-card-title> Read only Mode</v-card-title>
+          <v-card-text>
+            This Dataset is in ReadOnly Mode.  You cannot run pipelines on this dataset.
           </v-card-text>
         </v-card>
         <v-card

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -198,6 +198,7 @@ export default defineComponent({
             Please wait until it is complete before running another pipeline or making any changes
           </v-card-text>
           <v-row class="pb-1">
+            <!-- Viewer Loaded with single Job Running -->
             <v-btn
               v-if="singlePipelineValue && singlePipelineValue !== true"
               large
@@ -209,6 +210,7 @@ export default defineComponent({
             >
               View Running Job
             </v-btn>
+            <!-- Desktop Job Running -->
             <v-btn
               v-else-if="singlePipelineValue === true"
               large

--- a/client/dive-common/components/Sidebar.vue
+++ b/client/dive-common/components/Sidebar.vue
@@ -7,7 +7,7 @@ import {
 } from '@vue/composition-api';
 
 import { TypeList, TrackList } from 'vue-media-annotator/components';
-import { useAllTypes, useHandler } from 'vue-media-annotator/provides';
+import { useAllTypes, useHandler, useReadOnlyMode } from 'vue-media-annotator/provides';
 
 import { clientSettings } from 'dive-common/store/settings';
 import TrackDetailsPanel from 'dive-common/components/TrackDetailsPanel.vue';
@@ -41,6 +41,7 @@ export default defineComponent({
 
   setup(props) {
     const allTypesRef = useAllTypes();
+    const readOnlyMode = useReadOnlyMode();
     const { toggleMerge, commitMerge } = useHandler();
     const { visible } = usePrompt();
     const trackSettings = toRef(clientSettings, 'trackSettings');
@@ -84,6 +85,7 @@ export default defineComponent({
       data,
       trackSettings,
       typeSettings,
+      readOnlyMode,
       visible,
       /* methods */
       doToggleMerge,
@@ -143,7 +145,7 @@ export default defineComponent({
           :new-track-mode="trackSettings.newTrackSettings.mode"
           :new-track-type="trackSettings.newTrackSettings.type"
           :lock-types="typeSettings.lockTypes"
-          :hotkeys-disabled="visible()"
+          :hotkeys-disabled="visible() || readOnlyMode"
           :height="data.trackHeight"
           @track-seek="$emit('track-seek', $event)"
         >
@@ -157,7 +159,7 @@ export default defineComponent({
       <track-details-panel
         v-else-if="data.currentTab === 'attributes'"
         :lock-types="typeSettings.lockTypes"
-        :hotkeys-disabled="visible()"
+        :hotkeys-disabled="visible() || readOnlyMode"
         :width="width"
         @track-seek="$emit('track-seek', $event)"
         @toggle-merge="doToggleMerge"

--- a/client/dive-common/components/TrackDetailsPanel.vue
+++ b/client/dive-common/components/TrackDetailsPanel.vue
@@ -16,6 +16,7 @@ import {
   useAttributes,
   useMergeList,
   useTime,
+  useReadOnlyMode,
 } from 'vue-media-annotator/provides';
 import { getTrack } from 'vue-media-annotator/use/useTrackStore';
 import { Attribute } from 'vue-media-annotator/use/useAttributes';
@@ -51,6 +52,7 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const readOnlyMode = useReadOnlyMode();
     const attributes = useAttributes();
     const editingAttribute: Ref<Attribute | null> = ref(null);
     const editingError: Ref<string | null> = ref(null);
@@ -171,7 +173,7 @@ export default defineComponent({
         {
           bind: 'del',
           handler: () => {
-            if (selectedTrackIdRef.value !== null) {
+            if (!readOnlyMode.value && selectedTrackIdRef.value !== null) {
               removeTrack([selectedTrackIdRef.value]);
             }
           },
@@ -179,7 +181,8 @@ export default defineComponent({
         },
         {
           bind: 'x',
-          handler: () => trackSplit(selectedTrackIdRef.value, frameRef.value),
+          handler: () => !readOnlyMode.value
+          && trackSplit(selectedTrackIdRef.value, frameRef.value),
           disabled,
         },
       ];
@@ -187,6 +190,7 @@ export default defineComponent({
 
     return {
       selectedTrackIdRef,
+      readOnlyMode,
       /* Attributes */
       attributes,
       /* Editing */
@@ -291,6 +295,7 @@ export default defineComponent({
         <v-btn
           :color="mergeInProgress ? 'error' : 'primary'"
           class="mx-2 my-2 grow"
+          :disabled="readOnlyMode"
           depressed
           x-small
           @click="$emit('toggle-merge')"

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -380,6 +380,7 @@ export default defineComponent({
     };
 
     watch(datasetId, reloadAnnotations);
+    watch(readonlyState, () => selectTrack(null, false));
 
     const changeCamera = async (camera: string) => {
       if (!camera || !baseMulticamDatasetId.value) {

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -623,7 +623,7 @@ export default defineComponent({
           v-if="(imageData.length || videoUrl) && progress.loaded"
           ref="playbackComponent"
           v-mousetrap="[
-            { bind: 'n', handler: () => !readOnlyMode.value && handler.trackAdd() },
+            { bind: 'n', handler: () => !readonlyState && handler.trackAdd() },
             { bind: 'r', handler: () => mediaController.resetZoom() },
             { bind: 'esc', handler: () => handler.trackAbort() },
           ]"

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -67,7 +67,7 @@ export default defineComponent({
       type: Number,
       default: undefined,
     },
-    readonlyMode: {
+    readOnlyMode: {
       type: Boolean,
       default: false,
     },
@@ -81,7 +81,7 @@ export default defineComponent({
     const defaultCamera = ref('');
     const currentCamera = ref('');
     const playbackComponent = ref(undefined as Vue | undefined);
-    const readonlyState = computed(() => props.readonlyMode || props.revision !== undefined);
+    const readonlyState = computed(() => props.readOnlyMode || props.revision !== undefined);
     const mediaController = computed(() => {
       if (playbackComponent.value) {
         // TODO: Bug in composition-api types incorrectly organizes the static members of a Vue
@@ -489,9 +489,26 @@ export default defineComponent({
     <v-app-bar app>
       <slot name="title" />
       <span
-        class="title pl-3"
+        class="title pl-3 flex-row"
+        style="white-space:nowrap;overflow:hidden;text-overflow: ellipsis;"
       >
         {{ datasetName }}
+      </span>
+      <!-- I DONT LIKE THIS YET -->
+      <span
+        v-if="readOnlyMode"
+        class="text warning flex-row"
+        style="white-space:nowrap;"
+      >
+        Read Only Mode
+        <v-tooltip
+          bottom
+        >
+          <template v-slot:activator="{on}">
+            <v-icon v-on="on"> mdi-help</v-icon>
+          </template>
+          <span>Read only mode, Editing, Deleting and Importing actions are disabled</span>
+        </v-tooltip>
       </span>
       <v-spacer />
 

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -503,12 +503,16 @@ export default defineComponent({
           >
             <template v-slot:activator="{on}">
               <v-chip
-                class="text warning"
+                class="warning pr-1"
                 style="white-space:nowrap;display:inline"
                 small
                 v-on="on"
               >
                 Read Only Mode
+                <v-icon
+                  class="pl-1"
+                  small
+                >mdi-information-outline</v-icon>
               </v-chip>
             </template>
             <span>Read Only Mode: Editing, Deleting and Importing actions are disabled</span>

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -493,25 +493,29 @@ export default defineComponent({
         style="white-space:nowrap;overflow:hidden;text-overflow: ellipsis;"
       >
         {{ datasetName }}
-      </span>
-      <!-- I DONT LIKE THIS YET -->
-      <span
-        v-if="readOnlyMode"
-        class="text warning flex-row"
-        style="white-space:nowrap;"
-      >
-        Read Only Mode
-        <v-tooltip
-          bottom
+        <div
+          v-if="readonlyState"
+          class="mx-auto my-0 pa-0"
+          style="line-height:0.2em;"
         >
-          <template v-slot:activator="{on}">
-            <v-icon v-on="on"> mdi-help</v-icon>
-          </template>
-          <span>Read only mode, Editing, Deleting and Importing actions are disabled</span>
-        </v-tooltip>
+          <v-tooltip
+            bottom
+          >
+            <template v-slot:activator="{on}">
+              <v-chip
+                class="text warning"
+                style="white-space:nowrap;display:inline"
+                small
+                v-on="on"
+              >
+                Read Only Mode
+              </v-chip>
+            </template>
+            <span>Read Only Mode: Editing, Deleting and Importing actions are disabled</span>
+          </v-tooltip>
+        </div>
       </span>
       <v-spacer />
-
       <template #extension>
         <span
           v-if="$vuetify.breakpoint.lgAndUp"

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -184,6 +184,7 @@ export default defineComponent({
       selectNextTrack,
     } = useTrackSelectionControls({
       filteredTracks,
+      readonlyState,
     });
 
     clientSettingsSetup(allTypes);
@@ -427,6 +428,7 @@ export default defineComponent({
         stateStyles: stateStyling,
         time,
         visibleModes,
+        readOnlyMode: readonlyState,
       },
       globalHandler,
     );

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -598,7 +598,7 @@ export default defineComponent({
           v-if="(imageData.length || videoUrl) && progress.loaded"
           ref="playbackComponent"
           v-mousetrap="[
-            { bind: 'n', handler: () => handler.trackAdd() },
+            { bind: 'n', handler: () => !readOnlyMode.value && handler.trackAdd() },
             { bind: 'r', handler: () => mediaController.resetZoom() },
             { bind: 'esc', handler: () => handler.trackAbort() },
           ]"

--- a/client/dive-common/vue-utilities/prompt-service/Prompt.vue
+++ b/client/dive-common/vue-utilities/prompt-service/Prompt.vue
@@ -127,7 +127,7 @@ export default defineComponent({
       <v-card-actions>
         <v-spacer />
         <v-btn
-          v-if="confirm && negative.length"
+          v-if="confirm && negative && negative.length"
           ref="negative"
           text
           @click="clickNegative"

--- a/client/dive-common/vue-utilities/prompt-service/Prompt.vue
+++ b/client/dive-common/vue-utilities/prompt-service/Prompt.vue
@@ -127,7 +127,7 @@ export default defineComponent({
       <v-card-actions>
         <v-spacer />
         <v-btn
-          v-if="confirm"
+          v-if="confirm && negative.length"
           ref="negative"
           text
           @click="clickNegative"

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -306,7 +306,7 @@ async function train(
   const jobBase: DesktopJob = {
     key: `pipeline_${job.pid}_${jobWorkDir}`,
     command: command.join(' '),
-    jobType: 'pipeline',
+    jobType: 'training',
     pid: job.pid,
     args: runTrainingArgs,
     title: cleanPipelineName,

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -48,7 +48,7 @@ export default defineComponent({
     const compoundId = ref(props.id);
     const subTypeList = computed(() => [datasets.value[props.id]?.subType || null]);
     const camNumbers = computed(() => [datasets.value[props.id]?.cameraNumber || 1]);
-    const readonlyMode = computed(() => settings.value?.readonlyMode || false);
+    const readOnlyMode = computed(() => settings.value?.readonlyMode || false);
 
     watch(runningJobs, async (_previous, current) => {
       const currentJob = current.find((item) => item.job.datasetIds.includes(props.id));
@@ -56,7 +56,7 @@ export default defineComponent({
         const result = await prompt({
           title: 'Pipeline Finished',
           text: [`Pipeline: ${currentJob.job.title}`,
-            'finished running sucesffully on the current dataset.  Click reload to load the annotations.  The current annotations will be replaced with the pipeline output.',
+            'finished running sucesfully on the current dataset.  Click reload to load the annotations.  The current annotations will be replaced with the pipeline output.',
           ],
           confirm: true,
           positiveButton: 'Reload',
@@ -78,7 +78,7 @@ export default defineComponent({
       menuOptions,
       subTypeList,
       camNumbers,
-      readonlyMode,
+      readOnlyMode,
       isPipelineRunning,
     };
   },
@@ -89,7 +89,7 @@ export default defineComponent({
   <Viewer
     :id.sync="compoundId"
     ref="viewerRef"
-    :readonly-mode="readonlyMode || isPipelineRunning(id)"
+    :read-only-mode="readOnlyMode || isPipelineRunning(id)"
   >
     <template #title>
       <v-tabs
@@ -116,11 +116,12 @@ export default defineComponent({
         :sub-type-list="subTypeList"
         :camera-numbers="camNumbers"
         :get-running-pipelines="isPipelineRunning"
+        :read-only-mode="readOnlyMode"
         v-bind="{ buttonOptions, menuOptions }"
       />
       <ImportAnnotations
         :dataset-id="compoundId"
-        v-bind="{ buttonOptions, menuOptions }"
+        v-bind="{ buttonOptions, menuOptions, readOnlyMode }"
         block-on-unsaved
       />
       <Export

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -68,7 +68,7 @@ export default defineComponent({
       }
     });
     const isPipelineRunning = (jobId: string) => (runningJobs.value.find(
-      (item) => item.job.datasetIds.includes(jobId),
+      (item) => item.job.datasetIds.includes(jobId) && item.job.jobType === 'pipeline',
     ) !== undefined);
     return {
       datasets,
@@ -89,7 +89,7 @@ export default defineComponent({
   <Viewer
     :id.sync="compoundId"
     ref="viewerRef"
-    :readonly-mode="readonlyMode"
+    :readonly-mode="readonlyMode || isPipelineRunning(id)"
   >
     <template #title>
       <v-tabs

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -89,7 +89,7 @@ export default defineComponent({
   <Viewer
     :id.sync="compoundId"
     ref="viewerRef"
-    :read-only-mode="readOnlyMode || isPipelineRunning(id)"
+    :read-only-mode="readOnlyMode || !!isPipelineRunning(id)"
   >
     <template #title>
       <v-tabs

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -56,20 +56,24 @@ export default defineComponent({
         const result = await prompt({
           title: 'Pipeline Finished',
           text: [`Pipeline: ${currentJob.job.title}`,
-            'finished running sucesfully on the current dataset.  Click reload to load the annotations.  The current annotations will be replaced with the pipeline output.',
+            'finished running on the current dataset.  Click reload to load the annotations.  The current annotations will be replaced with the pipeline output.',
           ],
           confirm: true,
           positiveButton: 'Reload',
-          negativeButton: 'Cancel',
+          negativeButton: '',
         });
         if (result) {
           viewerRef.value.reloadAnnotations();
         }
       }
     });
-    const isPipelineRunning = (jobId: string) => (runningJobs.value.find(
-      (item) => item.job.datasetIds.includes(jobId) && item.job.jobType === 'pipeline',
-    ) !== undefined);
+    const runningPipelines = computed(() => {
+      const results: string[] = [];
+      if (runningJobs.value.find((item) => item.job.datasetIds.includes(props.id))) {
+        results.push(props.id);
+      }
+      return results;
+    });
     return {
       datasets,
       compoundId,
@@ -79,7 +83,7 @@ export default defineComponent({
       subTypeList,
       camNumbers,
       readOnlyMode,
-      isPipelineRunning,
+      runningPipelines,
     };
   },
 });
@@ -89,7 +93,7 @@ export default defineComponent({
   <Viewer
     :id.sync="compoundId"
     ref="viewerRef"
-    :read-only-mode="readOnlyMode || !!isPipelineRunning(id)"
+    :read-only-mode="readOnlyMode || runningPipelines.length > 0"
   >
     <template #title>
       <v-tabs
@@ -115,7 +119,7 @@ export default defineComponent({
         :selected-dataset-ids="[id]"
         :sub-type-list="subTypeList"
         :camera-numbers="camNumbers"
-        :get-running-pipelines="isPipelineRunning"
+        :running-pipelines="runningPipelines"
         :read-only-mode="readOnlyMode"
         v-bind="{ buttonOptions, menuOptions }"
       />

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -52,18 +52,27 @@ export default defineComponent({
 
     watch(runningJobs, async (_previous, current) => {
       const currentJob = current.find((item) => item.job.datasetIds.includes(props.id));
-      if (currentJob && currentJob.job.exitCode === 0 && currentJob.job.jobType === 'pipeline') {
-        const result = await prompt({
-          title: 'Pipeline Finished',
-          text: [`Pipeline: ${currentJob.job.title}`,
-            'finished running on the current dataset.  Click reload to load the annotations.  The current annotations will be replaced with the pipeline output.',
-          ],
-          confirm: true,
-          positiveButton: 'Reload',
-          negativeButton: '',
-        });
-        if (result) {
-          viewerRef.value.reloadAnnotations();
+      if (currentJob && currentJob.job.jobType === 'pipeline') {
+        if (currentJob.job.exitCode === 0) {
+          const result = await prompt({
+            title: 'Pipeline Finished',
+            text: [`Pipeline: ${currentJob.job.title}`,
+              'finished running on the current dataset.  Click reload to load the annotations.  The current annotations will be replaced with the pipeline output.',
+            ],
+            confirm: true,
+            positiveButton: 'Reload',
+            negativeButton: '',
+          });
+          if (result) {
+            viewerRef.value.reloadAnnotations();
+          }
+        } else {
+          await prompt({
+            title: 'Pipeline Incomplete',
+            text: [`Pipeline: ${currentJob.job.title}`,
+              'either failed or was cancelled by the user',
+            ],
+          });
         }
       }
     });

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -67,6 +67,9 @@ export default defineComponent({
         }
       }
     });
+    const isPipelineRunning = (jobId: string) => (runningJobs.value.find(
+      (item) => item.job.datasetIds.includes(jobId),
+    ) !== undefined);
     return {
       datasets,
       compoundId,
@@ -76,6 +79,7 @@ export default defineComponent({
       subTypeList,
       camNumbers,
       readonlyMode,
+      isPipelineRunning,
     };
   },
 });
@@ -111,6 +115,7 @@ export default defineComponent({
         :selected-dataset-ids="[id]"
         :sub-type-list="subTypeList"
         :camera-numbers="camNumbers"
+        :get-running-pipelines="isPipelineRunning"
         v-bind="{ buttonOptions, menuOptions }"
       />
       <ImportAnnotations

--- a/client/platform/web-girder/store/Jobs.ts
+++ b/client/platform/web-girder/store/Jobs.ts
@@ -69,7 +69,7 @@ const jobModule: Module<JobState, RootState> = {
 
 export async function init(store: Store<RootState>) {
   const { data: runningJobs } = await girderRest.get<GirderJob[]>('/job', {
-    params: { statuses: `[${JobStatus.RUNNING.value}]` },
+    params: { statuses: `[${JobStatus.RUNNING.value}, ${JobStatus.QUEUED.value}, ${JobStatus.INACTIVE.value}]` },
   });
   function updateJob(job: GirderJob & {type?: string; title?: string}) {
     store.commit('Jobs/setJobState', { jobId: job._id, value: job.status });

--- a/client/platform/web-girder/store/Jobs.ts
+++ b/client/platform/web-girder/store/Jobs.ts
@@ -52,7 +52,16 @@ const jobModule: Module<JobState, RootState> = {
       { datasetId: string; type: string; title: string }) {
       Vue.set(state.completeJobsInfo, datasetId, { type, title });
     },
-
+    removeCompleteJobsInfo(state, { datasetId }: { datasetId: string }) {
+      if (datasetId in state.completeJobsInfo) {
+        Vue.delete(state.completeJobsInfo, datasetId);
+      }
+    },
+  },
+  actions: {
+    removeCompleteJob({ commit }, { datasetId }: {datasetId: string}) {
+      commit('removeCompleteJobsInfo', { datasetId });
+    },
   },
 };
 

--- a/client/platform/web-girder/store/Jobs.ts
+++ b/client/platform/web-girder/store/Jobs.ts
@@ -48,9 +48,11 @@ const jobModule: Module<JobState, RootState> = {
       { datasetId: string; status: number; jobId: string }) {
       Vue.set(state.datasetStatus, datasetId, { status, jobId });
     },
-    setCompleteJobsInfo(state, { datasetId, type, title }:
-      { datasetId: string; type: string; title: string }) {
-      Vue.set(state.completeJobsInfo, datasetId, { type, title });
+    setCompleteJobsInfo(state, {
+      datasetId, type, title, success,
+    }:
+      { datasetId: string; type: string; title: string; success: boolean }) {
+      Vue.set(state.completeJobsInfo, datasetId, { type, title, success });
     },
     removeCompleteJobsInfo(state, { datasetId }: { datasetId: string }) {
       if (datasetId in state.completeJobsInfo) {
@@ -73,8 +75,13 @@ export async function init(store: Store<RootState>) {
     store.commit('Jobs/setJobState', { jobId: job._id, value: job.status });
     if (typeof job.dataset_id === 'string') {
       store.commit('Jobs/setDatasetStatus', { datasetId: job.dataset_id, status: job.status, jobId: job._id });
-      if (job.status === 3 && job.type === 'pipelines') {
-        store.commit('Jobs/setCompleteJobsInfo', { datasetId: job.dataset_id, type: job.type, title: job.title });
+      if (job.type === 'pipelines' && NonRunningStates.includes(job.status)) {
+        store.commit('Jobs/setCompleteJobsInfo', {
+          datasetId: job.dataset_id,
+          type: job.type,
+          title: job.title,
+          success: job.status === JobStatus.SUCCESS.value,
+        });
       }
     }
   }

--- a/client/platform/web-girder/store/types.ts
+++ b/client/platform/web-girder/store/types.ts
@@ -29,6 +29,7 @@ export interface BrandState {
 export interface JobState {
   jobIds: Record<string, number>;
   datasetStatus: Record<string, number>;
+  completeJobsInfo: Record<string, {type: string; title: string}>;
 }
 
 export interface RootState {

--- a/client/platform/web-girder/store/types.ts
+++ b/client/platform/web-girder/store/types.ts
@@ -28,7 +28,7 @@ export interface BrandState {
 
 export interface JobState {
   jobIds: Record<string, number>;
-  datasetStatus: Record<string, number>;
+  datasetStatus: Record<string, {status: number; jobId: string}>;
   completeJobsInfo: Record<string, {type: string; title: string}>;
 }
 

--- a/client/platform/web-girder/store/types.ts
+++ b/client/platform/web-girder/store/types.ts
@@ -29,7 +29,7 @@ export interface BrandState {
 export interface JobState {
   jobIds: Record<string, number>;
   datasetStatus: Record<string, {status: number; jobId: string}>;
-  completeJobsInfo: Record<string, {type: string; title: string}>;
+  completeJobsInfo: Record<string, {type: string; title: string; success: boolean}>;
 }
 
 export interface RootState {

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -88,6 +88,15 @@ export default defineComponent({
     selectedDescription() {
       return this.location?.description;
     },
+    runningPipelines() {
+      const results = [];
+      this.locationInputs.forEach((item) => {
+        if (this.getters['Jobs/datasetRunningState'](item)) {
+          results.push(item);
+        }
+      });
+      return results;
+    },
   },
   methods: {
     async deleteSelection() {
@@ -154,7 +163,7 @@ export default defineComponent({
                 <run-pipeline-menu
                   v-bind="{ buttonOptions, menuOptions }"
                   :selected-dataset-ids="locationInputs"
-                  :get-running-pipelines="getters['Jobs/datasetRunningState']"
+                  :running-pipelines="runningPipelines"
                 />
                 <export
                   v-bind="{ buttonOptions, menuOptions }"

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -54,6 +54,7 @@ export default defineComponent({
     const loading = ref(false);
     const { prompt } = usePrompt();
     const store = useStore();
+    const { getters } = store;
 
     const clearSelected = () => {
       store.commit('Location/setSelected', []);
@@ -68,6 +69,7 @@ export default defineComponent({
       prompt,
       clearSelected,
       eventBus,
+      getters,
     };
   },
   // everything below needs to be refactored to composition-api
@@ -152,6 +154,7 @@ export default defineComponent({
                 <run-pipeline-menu
                   v-bind="{ buttonOptions, menuOptions }"
                   :selected-dataset-ids="locationInputs"
+                  :get-running-pipelines="getters['Jobs/datasetRunningState']"
                 />
                 <export
                   v-bind="{ buttonOptions, menuOptions }"

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -104,7 +104,6 @@ export default defineComponent({
       window.removeEventListener('beforeunload', viewerRef.value.warnBrowserExit);
     });
 
-
     return {
       buttonOptions,
       brandData,
@@ -112,6 +111,7 @@ export default defineComponent({
       revisionNum,
       viewerRef,
       getters,
+      currentJob,
     };
   },
 });
@@ -148,7 +148,10 @@ export default defineComponent({
         :get-running-pipelines="getters['Jobs/datasetRunningState']"
       />
       <ImportAnnotations
-        v-bind="{ buttonOptions, menuOptions }"
+        v-bind="{ buttonOptions,
+                  menuOptions,
+                  readOnlyMode: !!getters['Jobs/datasetRunningState'](id),
+        }"
         :dataset-id="id"
         block-on-unsaved
       />

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -80,6 +80,7 @@ export default defineComponent({
       window.removeEventListener('beforeunload', viewerRef.value.warnBrowserExit);
     });
 
+
     return {
       buttonOptions,
       brandData,
@@ -119,6 +120,7 @@ export default defineComponent({
       <RunPipelineMenu
         v-bind="{ buttonOptions, menuOptions }"
         :selected-dataset-ids="[id]"
+        :get-running-pipelines="getters['Jobs/datasetRunningState']"
       />
       <ImportAnnotations
         v-bind="{ buttonOptions, menuOptions }"

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -83,18 +83,28 @@ export default defineComponent({
     });
     watch(currentJob, async () => {
       if (currentJob.value !== false && currentJob.value !== undefined) {
-        const result = await prompt({
-          title: 'Pipeline Finished',
-          text: [`Pipeline: ${currentJob.value.title}`,
-            'finished running on the current dataset.  Click reload to load the annotations.  The current annotations will be replaced with the pipeline output.',
-          ],
-          confirm: true,
-          positiveButton: 'Reload',
-          negativeButton: '',
-        });
-        store.dispatch('Jobs/removeCompleteJob', { datasetId: props.id });
-        if (result) {
-          viewerRef.value.reloadAnnotations();
+        if (currentJob.value.success) {
+          const result = await prompt({
+            title: 'Pipeline Finished',
+            text: [`Pipeline: ${currentJob.value.title}`,
+              'finished running on the current dataset.  Click reload to load the annotations.  The current annotations will be replaced with the pipeline output.',
+            ],
+            confirm: true,
+            positiveButton: 'Reload',
+            negativeButton: '',
+          });
+          store.dispatch('Jobs/removeCompleteJob', { datasetId: props.id });
+          if (result) {
+            viewerRef.value.reloadAnnotations();
+          }
+        } else {
+          await prompt({
+            title: 'Pipeline Incomplete',
+            text: [`Pipeline: ${currentJob.value.title}`,
+              'either failed or was cancelled by the user',
+            ],
+          });
+          store.dispatch('Jobs/removeCompleteJob', { datasetId: props.id });
         }
       }
     });

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -90,6 +90,7 @@ export default defineComponent({
           positiveButton: 'Reload',
           negativeButton: 'Cancel',
         });
+        store.dispatch('Jobs/removeCompleteJob', { datasetId: props.id });
         if (result) {
           viewerRef.value.reloadAnnotations();
         }

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -122,7 +122,7 @@ export default defineComponent({
     :key="`${id}/${revisionNum}`"
     ref="viewerRef"
     :revision="revisionNum"
-    :read-only-mode="getters['Jobs/datasetRunningState'](id)"
+    :read-only-mode="!!getters['Jobs/datasetRunningState'](id)"
   >
     <template #title>
       <ViewerAlert />

--- a/client/src/components/TrackItem.vue
+++ b/client/src/components/TrackItem.vue
@@ -3,7 +3,9 @@ import {
   defineComponent, computed, watch, reactive, PropType, toRef, ref,
 } from '@vue/composition-api';
 import TooltipBtn from './TooltipButton.vue';
-import { useHandler, useAllTypes, useTime } from '../provides';
+import {
+  useHandler, useAllTypes, useTime, useReadOnlyMode,
+} from '../provides';
 import Track from '../track';
 
 export default defineComponent({
@@ -55,6 +57,7 @@ export default defineComponent({
     const { frame: frameRef } = useTime();
     const handler = useHandler();
     const allTypesRef = useAllTypes();
+    const readOnlyMode = useReadOnlyMode();
     const trackTypeRef = toRef(props, 'trackType');
     const typeInputBoxRef = ref(undefined as undefined | HTMLInputElement);
     const data = reactive({
@@ -194,6 +197,7 @@ export default defineComponent({
       frame: frameRef,
       allTypes: allTypesRef,
       keyframeDisabled,
+      readOnlyMode,
       /* methods */
       blurType,
       focusType,
@@ -258,6 +262,7 @@ export default defineComponent({
         ref="typeInputBoxRef"
         v-model="data.trackTypeValue"
         class="input-box select-input"
+        :disabled="readOnlyMode"
         @focus="onFocus"
         @change="onBlur"
         @keydown="onInputKeyEvent"
@@ -277,6 +282,7 @@ export default defineComponent({
         type="text"
         list="allTypesOptions"
         class="input-box freeform-input"
+        :disabled="readOnlyMode"
         @focus="onFocus"
         @blur="onBlur"
         @keydown="onInputKeyEvent"
@@ -307,21 +313,21 @@ export default defineComponent({
         <tooltip-btn
           color="error"
           icon="mdi-delete"
-          :disabled="merging"
+          :disabled="merging || readOnlyMode"
           :tooltip-text="`Delete ${isTrack ? 'Track' : 'Detection'}`"
           @click="handler.removeTrack([track.trackId])"
         />
 
         <tooltip-btn
           v-if="isTrack"
-          :disabled="!track.canSplit(frame) || merging"
+          :disabled="!track.canSplit(frame) || merging || readOnlyMode"
           icon="mdi-call-split"
           tooltip-text="Split Track"
           @click="handler.trackSplit(track.trackId, frame)"
         />
 
         <tooltip-btn
-          v-if="isTrack"
+          v-if="isTrack && !readOnlyMode"
           :icon="(feature.isKeyframe)
             ? 'mdi-star'
             : 'mdi-star-outline'"
@@ -331,7 +337,7 @@ export default defineComponent({
         />
 
         <tooltip-btn
-          v-if="isTrack"
+          v-if="isTrack && !readOnlyMode"
           :icon="(feature.shouldInterpolate)
             ? 'mdi-vector-selection'
             : 'mdi-selection-off'"
@@ -376,7 +382,7 @@ export default defineComponent({
         v-if="!merging"
         :icon="(editing) ? 'mdi-pencil-box' : 'mdi-pencil-box-outline'"
         tooltip-text="Toggle edit mode"
-        :disabled="!inputValue"
+        :disabled="!inputValue || readOnlyMode"
         @click="handler.trackEdit(track.trackId)"
       />
     </v-row>

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -18,6 +18,7 @@ import {
   useFilteredTracks,
   useTypeStyling,
   useTime,
+  useReadOnlyMode,
 } from '../provides';
 import TrackItem from './TrackItem.vue';
 
@@ -62,6 +63,7 @@ export default defineComponent({
 
   setup(props) {
     const { prompt } = usePrompt();
+    const readOnlyMode = useReadOnlyMode();
     const allTypesRef = useAllTypes();
     const checkedTrackIdsRef = useCheckedTrackIds();
     const editingModeRef = useEditingMode();
@@ -210,7 +212,7 @@ export default defineComponent({
         {
           bind: 'del',
           handler: () => {
-            if (selectedTrackIdRef.value !== null) {
+            if (!readOnlyMode.value && selectedTrackIdRef.value !== null) {
               removeTrack([selectedTrackIdRef.value]);
             }
           },
@@ -218,7 +220,8 @@ export default defineComponent({
         },
         {
           bind: 'x',
-          handler: () => trackSplit(selectedTrackIdRef.value, frameRef.value),
+          handler: () => !readOnlyMode.value
+          && trackSplit(selectedTrackIdRef.value, frameRef.value),
           disabled,
         },
       ];
@@ -233,6 +236,7 @@ export default defineComponent({
       mouseTrap,
       newTrackColor,
       filteredTracks: filteredTracksRef,
+      readOnlyMode,
       trackAdd,
       virtualHeight,
       virtualListItems,
@@ -257,6 +261,7 @@ export default defineComponent({
           >
             <template #activator="{ on, attrs }">
               <v-btn
+
                 icon
                 small
                 class="mr-2"
@@ -282,7 +287,7 @@ export default defineComponent({
           >
             <template #activator="{ on }">
               <v-btn
-                :disabled="filteredTracks.length === 0"
+                :disabled="filteredTracks.length === 0 || readOnlyMode"
                 icon
                 small
                 class="mr-2"
@@ -306,6 +311,7 @@ export default defineComponent({
           >
             <template #activator="{ on }">
               <v-btn
+                :disabled="readOnlyMode"
                 outlined
                 x-small
                 class="mr-2"

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -261,7 +261,6 @@ export default defineComponent({
           >
             <template #activator="{ on, attrs }">
               <v-btn
-
                 icon
                 small
                 class="mr-2"

--- a/client/src/components/TypeEditor.vue
+++ b/client/src/components/TypeEditor.vue
@@ -3,7 +3,9 @@ import {
   defineComponent, reactive, toRef, watch,
 } from '@vue/composition-api';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
-import { useHandler, useTypeStyling, useUsedTypes } from '../provides';
+import {
+  useHandler, useTypeStyling, useUsedTypes, useReadOnlyMode,
+} from '../provides';
 
 export default defineComponent({
   name: 'TypeEditor',
@@ -18,6 +20,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const typeStylingRef = useTypeStyling();
     const usedTypesRef = useUsedTypes();
+    const readOnlyMode = useReadOnlyMode();
     const { prompt } = usePrompt();
     const {
       updateTypeName,
@@ -89,6 +92,7 @@ export default defineComponent({
     return {
       data,
       usedTypesRef,
+      readOnlyMode,
       acceptChanges,
       clickDeleteType,
     };
@@ -130,7 +134,8 @@ export default defineComponent({
             <v-col clas="py-0">
               <v-text-field
                 v-model="data.editingType"
-                label="Type Name"
+                :disabled="readOnlyMode"
+                :label="readOnlyMode ? 'Type Name (disabled in ReadOnly Mode)' : 'Type Name'"
                 hide-details
               />
             </v-col>

--- a/client/src/components/TypeList.vue
+++ b/client/src/components/TypeList.vue
@@ -7,7 +7,7 @@ import { difference, union } from 'lodash';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import {
   useCheckedTypes, useAllTypes, useTypeStyling, useHandler,
-  useUsedTypes, useFilteredTracks, useConfidenceFilters,
+  useUsedTypes, useFilteredTracks, useConfidenceFilters, useReadOnlyMode,
 } from '../provides';
 import TooltipBtn from './TooltipButton.vue';
 import TypeEditor from './TypeEditor.vue';
@@ -46,6 +46,7 @@ export default defineComponent({
 
   setup(props) {
     const { prompt } = usePrompt();
+    const readOnlyMode = useReadOnlyMode();
 
     // Ordering of these lists should match
     const sortingMethods = ['a-z', 'count'];
@@ -202,6 +203,7 @@ export default defineComponent({
       sortingMethodIcons,
       virtualHeight,
       virtualTypes,
+      readOnlyMode,
       /* methods */
       clickDelete,
       clickEdit,
@@ -278,7 +280,7 @@ export default defineComponent({
             <template #activator="{ on }">
               <v-btn
                 class="hover-show-child"
-                :disabled="checkedTypesRef.length === 0"
+                :disabled="checkedTypesRef.length === 0 || readOnlyMode"
                 icon
                 small
                 v-on="on"

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -81,6 +81,9 @@ type TimeType = Readonly<Time>;
 const VisibleModesSymbol = Symbol('visibleModes');
 type VisibleModesType = Readonly<Ref<readonly VisibleAnnotationTypes[]>>;
 
+const ReadOnlyModeSymbol = Symbol('readOnlyMode');
+type ReadOnylModeType = Readonly<Ref<boolean>>;
+
 /**
  * Handler interface describes all global events mutations
  * for above state
@@ -225,6 +228,7 @@ export interface State {
   stateStyles: StateStylesType;
   time: TimeType;
   visibleModes: VisibleModesType;
+  readOnlyMode: ReadOnylModeType;
 }
 
 /**
@@ -279,6 +283,7 @@ function dummyState(): State {
       originalFps: ref(null),
     },
     visibleModes: ref(['rectangle', 'text'] as VisibleAnnotationTypes[]),
+    readOnlyMode: ref(false),
   };
 }
 
@@ -312,6 +317,7 @@ function provideAnnotator(state: State, handler: Handler) {
   provide(StateStylesSymbol, state.stateStyles);
   provide(TimeSymbol, state.time);
   provide(VisibleModesSymbol, state.visibleModes);
+  provide(ReadOnlyModeSymbol, state.readOnlyMode);
   provide(HandlerSymbol, handler);
 }
 
@@ -412,6 +418,9 @@ function useTime() {
 function useVisibleModes() {
   return use<VisibleModesType>(VisibleModesSymbol);
 }
+function useReadOnlyMode() {
+  return use<ReadOnylModeType>(ReadOnlyModeSymbol);
+}
 
 export {
   dummyHandler,
@@ -440,4 +449,5 @@ export {
   useStateStyles,
   useTime,
   useVisibleModes,
+  useReadOnlyMode,
 };

--- a/client/src/use/useTrackSelectionControls.spec.ts
+++ b/client/src/use/useTrackSelectionControls.spec.ts
@@ -1,6 +1,6 @@
 /// <reference types="jest" />
 import Vue from 'vue';
-import CompositionApi, { computed } from '@vue/composition-api';
+import CompositionApi, { computed, ref } from '@vue/composition-api';
 import Track from '../track';
 import useTrackSelectionControls from './useTrackSelectionControls';
 
@@ -35,7 +35,7 @@ const filteredTracks = computed(() => ([
 
 describe('useTrackSelectionControls', () => {
   it('can select individual tracks', () => {
-    const tsc = useTrackSelectionControls({ filteredTracks });
+    const tsc = useTrackSelectionControls({ filteredTracks, readonlyState: ref(false) });
     expect(tsc.selectedTrackId.value).toBeNull();
 
     tsc.selectTrack(2);
@@ -54,7 +54,7 @@ describe('useTrackSelectionControls', () => {
   });
 
   it('can select next or previous track', () => {
-    const tsc = useTrackSelectionControls({ filteredTracks });
+    const tsc = useTrackSelectionControls({ filteredTracks, readonlyState: ref(false) });
 
     expect(tsc.selectNextTrack()).toBe(0);
 

--- a/client/src/use/useTrackSelectionControls.ts
+++ b/client/src/use/useTrackSelectionControls.ts
@@ -22,7 +22,7 @@ export default function useTrackSelectionControls(
   function selectTrack(trackId: TrackId | null, edit = false) {
     selectedTrackId.value = trackId;
     if (edit && readonlyState.value) {
-      prompt.prompt({ title: 'Read Only Mode', text: 'The System is in Read Only mode, no edits can be made' });
+      prompt.prompt({ title: 'Read Only Mode', text: 'This Dataset is in Read Only mode, no edits can be made.' });
     } else {
       editingTrack.value = trackId !== null && edit;
     }

--- a/client/src/use/useTrackSelectionControls.ts
+++ b/client/src/use/useTrackSelectionControls.ts
@@ -1,22 +1,31 @@
 import { computed, ref, Ref } from '@vue/composition-api';
+import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { TrackWithContext } from './useTrackFilters';
 import { TrackId } from '../track';
 /* Maintain references to the selected Track, selected detection,
  * editing state, etc.
  */
 export default function useTrackSelectionControls(
-  { filteredTracks }: {filteredTracks: Readonly<Ref<readonly TrackWithContext[]>>},
+  { filteredTracks, readonlyState }:
+   {
+     filteredTracks: Readonly<Ref<readonly TrackWithContext[]>>;
+     readonlyState: Readonly<Ref<boolean>>;
+  },
 ) {
   // the currently selected Track
   const selectedTrackId = ref(null as TrackId | null);
   // boolean whether or not selectedTrackId is also being edited.
   const editingTrack = ref(false);
-
+  const prompt = usePrompt();
   const tracks = computed(() => filteredTracks.value.map((filtered) => filtered.track));
 
   function selectTrack(trackId: TrackId | null, edit = false) {
     selectedTrackId.value = trackId;
-    editingTrack.value = trackId !== null && edit;
+    if (edit && readonlyState.value) {
+      prompt.prompt({ title: 'Read Only Mode', text: 'The System is in Read Only mode, no edits can be done' });
+    } else {
+      editingTrack.value = trackId !== null && edit;
+    }
   }
   /* default to index + 1
    * call with -1 to select previous, or pass any other delta

--- a/client/src/use/useTrackSelectionControls.ts
+++ b/client/src/use/useTrackSelectionControls.ts
@@ -22,7 +22,7 @@ export default function useTrackSelectionControls(
   function selectTrack(trackId: TrackId | null, edit = false) {
     selectedTrackId.value = trackId;
     if (edit && readonlyState.value) {
-      prompt.prompt({ title: 'Read Only Mode', text: 'The System is in Read Only mode, no edits can be done' });
+      prompt.prompt({ title: 'Read Only Mode', text: 'The System is in Read Only mode, no edits can be made' });
     } else {
       editingTrack.value = trackId !== null && edit;
     }

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import json
 from typing import Dict, List, Optional, Tuple
 
@@ -6,6 +7,7 @@ from girder.exceptions import RestException
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
+from girder.models.notification import Notification
 from girder.models.setting import Setting
 from girder.models.token import Token
 from girder_jobs.models.job import Job, JobStatus
@@ -185,6 +187,13 @@ def run_pipeline(
     # see and possibly manage the job
     Job().copyAccessPolicies(folder, newjob.job)
     Job().save(newjob.job)
+    # Inform Client of new Job added in inactive state
+    Notification().createNotification(
+        type='job_status',
+        data=newjob.job,
+        user=user,
+        expires=datetime.now() + timedelta(seconds=30),
+    )
     return newjob.job
 
 


### PR DESCRIPTION
fixes #991 

Summary of the user interface changes:


https://user-images.githubusercontent.com/61746913/153610323-298fb684-c170-4da7-a547-c486112f3ad2.mp4


- The Data Browser won't allow pipelines to be run when you have selected a dataset which currently has a running a pipeline
- Within the Annotator when a pipeline is running on the current dataset the system switches to read-only mode and prevents edits and indicates to the user that a pipeline is running
- While the pipeline is running in the pipeline dropdown there is a link to currently running pipeline job data
- Read-only mode has been updated to disable various UI controls and shortcuts (Adding tracks, deleting tracks, editing tracks) and all of these items
- Read Only Mode has it's own indicator below the Dataset Title with some simple hover information
- The Dataset Title has been fixed to properly truncate if it is longer than the area provided.
- When pipelines finish and you are in the annotator for desktop it will now tell you to reload the dataset

Implementation:
- Added to provides `useReadOnlyMode` which provides a simple boolean return value as to if ReadOnly Mode is Active.  This involved adding this item to a lot of data places to disable specific items.  Lots of small code additions.
- Attempting to enter edit mode with right-click will now launch a prompt explaining that you can't edit in read only mode.
- ViewerLoader for both web and desktop has been modified to kick a Viewer into readOnlyMode while a pipeline is running.
- Web Vuex Jobs has been modified to store some more information including completed jobs and the job ID for returning a link to the proper job log.
- Within Web ViewerLoader it watches a getter for completed jobs and will trigger a reload if the current dataset job completes.  It then needs to call an action to remove that job from the joblist so it doesn't trigger any secondary reloads.