### PR TITLE
Fixes Sentry Error #1082 (Cannot read properties of null)

### DIFF
--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -100,6 +100,9 @@ export default defineComponent({
      * Draw image to the GeoJS map, and update the map dimensions if they have changed.
      */
     function drawImage(img: HTMLImageElement) {
+      if (!data.ready) {
+        return;
+      }
       if (
         img.naturalWidth > 0
         && img.naturalHeight > 0
@@ -207,6 +210,9 @@ export default defineComponent({
     }
 
     async function seek(f: number) {
+      if (!data.ready) {
+        return;
+      }
       let newFrame = f;
       if (f < 0) newFrame = 0;
       if (f > data.maxFrame) newFrame = data.maxFrame;

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -335,8 +335,8 @@ export default defineComponent({
         // Set quadFeature and conditionally apply brightness filter
         local.quadFeature = quadFeatureLayer.createFeature('quad');
         setBrightnessFilter(props.brightness !== undefined);
-        seek(0);
         data.ready = true;
+        seek(0);
       });
     }
 
@@ -368,8 +368,8 @@ export default defineComponent({
           // Set quadFeature and conditionally apply brightness filter
           local.quadFeature = quadFeatureLayer.createFeature('quad');
           setBrightnessFilter(props.brightness !== undefined);
-          seek(0);
           data.ready = true;
+          seek(0);
         });
       }
     }


### PR DESCRIPTION
fixes #1082 

To Reproduce:
Load a dataset with large images and decent number of tracks like: https://viame.kitware.com/#/viewer/5f52a38d683ae84c2a4f58de
Once the tracks have loaded and before the image has loaded click in the timeline bar or on the video/image scrubber to jump to another frame.  You should see the corresponding error in the console log as well as if you do it on the server it will be shown in sentry.

The Fix:
Simply guarding the `seek` and just in case the `drawImage` functions to make sure they return directly when `data.ready` is false.  If they try to access geoJS map parameters before hand there are errors.

I tried to see if I could get the same problem to occur in Video mode but it looks like it doesn't happen.  Going to log an additional error that is caused by selecting TrackIds before the tracks have fully loaded.  It will be connected to sentry error as well.