### PR TITLE
Don't strip off too many periods from bulk uploaded filenames

### DIFF
--- a/client/platform/web-girder/constants.ts
+++ b/client/platform/web-girder/constants.ts
@@ -30,7 +30,10 @@ interface GirderMetadataStatic extends DatasetMetaMutable {
  */
 type GirderMetadata = DatasetMeta & GirderMetadataStatic;
 
+const fileSuffixRegex = /\.[^.]*$/;
+
 export {
+  fileSuffixRegex,
   GirderMetadataStatic,
   GirderMetadata,
 };

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -113,7 +113,7 @@ export default defineComponent({
         createSubFolders,
         name:
           internalFiles.length > 1
-            ? defaultFilename.replace(/\..*/, '')
+            ? defaultFilename.replace(/\.[^.]*$/, '')
             : defaultFilename,
         files: [], //Will be set in the GirderUpload Component
         meta,

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -9,6 +9,10 @@ import {
   websafeImageTypes, otherImageTypes, JsonMetaRegEx,
 } from 'dive-common/constants';
 
+import {
+  fileSuffixRegex,
+} from 'platform/web-girder/constants';
+
 import ImportButton from 'dive-common/components/ImportButton.vue';
 import ImportMultiCamDialog from 'dive-common/components/ImportMultiCamDialog.vue';
 import { DatasetType, MultiCamImportArgs } from 'dive-common/apispec';
@@ -113,7 +117,7 @@ export default defineComponent({
         createSubFolders,
         name:
           internalFiles.length > 1
-            ? defaultFilename.replace(/\.[^.]*$/, '')
+            ? defaultFilename.replace(fileSuffixRegex, '')
             : defaultFilename,
         files: [], //Will be set in the GirderUpload Component
         meta,

--- a/client/platform/web-girder/views/UploadGirder.vue
+++ b/client/platform/web-girder/views/UploadGirder.vue
@@ -6,6 +6,9 @@ import { getResponseError } from 'vue-media-annotator/utils';
 import {
   DefaultVideoFPS,
 } from 'dive-common/constants';
+import {
+  fileSuffixRegex,
+} from 'platform/web-girder/constants';
 
 import { makeViameFolder, postProcess } from 'platform/web-girder/api';
 
@@ -114,7 +117,7 @@ export default Vue.extend({
         while (files.length > 0) {
           // take the file name and convert it to a folder name;
           const subfile = files.splice(0, 1);
-          const subname = subfile[0].file.name.replace(/\.[^.]*$/, '');
+          const subname = subfile[0].file.name.replace(fileSuffixRegex, '');
           // All sub-folders for a pendingUpload must be the same type
           const subtype = pendingUpload.type;
           // eslint-disable-next-line no-await-in-loop

--- a/client/platform/web-girder/views/UploadGirder.vue
+++ b/client/platform/web-girder/views/UploadGirder.vue
@@ -114,7 +114,7 @@ export default Vue.extend({
         while (files.length > 0) {
           // take the file name and convert it to a folder name;
           const subfile = files.splice(0, 1);
-          const subname = subfile[0].file.name.replace(/\..*/, '');
+          const subname = subfile[0].file.name.replace(/\.[^.]*$/, '');
           // All sub-folders for a pendingUpload must be the same type
           const subtype = pendingUpload.type;
           // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
This PR updates the regex that is used to strip off filename suffixes when multiple files are being bulk uploaded. The existing regex was too greedy and would strip off everything after the first period in the name; the new one does so only for the last one.

Closes #838.