### PR TITLE
Fix Empty Image Filenames in CSV

### DIFF
--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -271,7 +271,7 @@ describe('Test Image Filenames', () => {
       if (!imageOrderData.pass) {
         try {
         // eslint-disable-next-line no-await-in-loop
-          const result = await parseFile(testPath, imageMap);
+          await parseFile(testPath, imageMap);
         } catch (err) {
           expect(err).toBe(imageOrderData.error);
         }

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -6,7 +6,6 @@ import { JsonMeta } from 'platform/desktop/constants';
 import { serialize, parse } from 'platform/desktop/backend/serializers/viame';
 import { Attribute } from 'vue-media-annotator/use/useAttributes';
 import processTrackAttributes from 'platform/desktop/backend/native/attributeProcessor';
-import { Console } from 'console';
 
 type testPairs = [string[], MultiTrackRecord, Record<string, Attribute>];
 
@@ -93,32 +92,6 @@ const data: MultiTrackRecord = {
   },
 };
 
-const imageOrderTests = [
-  {
-    pass: false,
-    error: 'There was a mixture of fields that specified image names and fields that did not.  Please check the CSV',
-    csv: [
-      '0, ,1,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
-      '1,2.png,0,111,222,3333,444,1,-1,typestring,0.55',
-    ],
-  },
-  // {
-  //   pass: false,
-  //   error: 'There was a mixture of fields that specified image names and fields that did not.  Please check the CSV',
-  //   csv: [
-  //     '0,       ,1,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
-  //     '1,2.png,0,111,222,3333,444,1,-1,typestring,0.55',
-  //   ],
-  // },
-  // {
-  //   pass: true,
-  //   error: 'There was a mixture of fields that specified image names and fields that did not.  Please check the CSV',
-  //   csv: [
-  //     '0,       ,1,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
-  //     '1,,0,111,222,3333,444,1,-1,typestring,0.55',
-  //   ],
-  // },
-];
 
 const meta = {
   version: 1,
@@ -147,15 +120,6 @@ testData.forEach((item, index) => {
   // eslint-disable-next-line prefer-destructuring
   testFiles[`${index}.csv`] = item[0].join('\n');
 });
-const imageOrderFiles: Record<string, string> = { };
-imageOrderTests.forEach((item, index) => {
-  // eslint-disable-next-line prefer-destructuring
-  imageOrderFiles[`${index}.csv`] = item.csv.join('\n');
-});
-
-// https://github.com/tschaub/mock-fs/issues/234
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const console = new Console(process.stdout, process.stderr);
 
 mockfs({
   '/home': {},
@@ -164,7 +128,6 @@ mockfs({
     'bar.png': '',
   },
   '/csv': testFiles,
-  '/imageorder': imageOrderFiles,
 });
 
 
@@ -254,31 +217,6 @@ describe('VIAME serialize testing', () => {
     const output = fs.readFileSync(path).toString().split('\n');
     const expectedOutput = ['first_type', '0.9', 'second_type', '0.7'];
     expect(checkConfidenceOutput(output)).toEqual(expectedOutput);
-  });
-});
-
-describe('Test Image Ordering', () => {
-  it('testing image ordering t', async () => {
-    const imageMap = new Map([
-      ['1', 0],
-      ['2', 1],
-      ['3', 2],
-    ]);
-    for (let i = 0; i < imageOrderTests.length; i += 1) {
-      const testPath = `/imageorder/${i}.csv`;
-      const csvStream = fs.createReadStream(testPath);
-      const imageOrderData = imageOrderTests[i];
-      if (!imageOrderData.pass) {
-      // eslint-disable-next-line no-await-in-loop
-        await expect(parse(csvStream, imageMap)).rejects.toEqual({
-          error: imageOrderData.error,
-        });
-      } else {
-        // eslint-disable-next-line no-await-in-loop
-        const result = await parse(csvStream, imageMap);
-        expect(result.tracks.length).toBeGreaterThan(0);
-      }
-    }
   });
 });
 

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -12,7 +12,7 @@ type testPairs = [string[], MultiTrackRecord, Record<string, Attribute>];
 
 const testData: testPairs[] = fs.readJSONSync('../testutils/viame.spec.json');
 
-const imageOrderTests = [
+const imageFilenameTests = [
   {
     pass: false,
     error: 'There was a mixture of fields that specified image names and fields that did not.  Please check the CSV',
@@ -27,14 +27,6 @@ const imageOrderTests = [
     csv: [
       '0,1.png,1,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
       '1,,0,111,222,3333,444,1,-1,typestring,0.55',
-    ],
-  },
-  {
-    pass: false,
-    error: 'encountered annotation for image not found in dataset: test.png',
-    csv: [
-      '0,test.png,1,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
-      '1,2.png,0,111,222,3333,444,1,-1,typestring,0.55',
     ],
   },
   {
@@ -157,7 +149,7 @@ testData.forEach((item, index) => {
   testFiles[`${index}.csv`] = item[0].join('\n');
 });
 const imageOrderFiles: Record<string, string> = { };
-imageOrderTests.forEach((item, index) => {
+imageFilenameTests.forEach((item, index) => {
   // eslint-disable-next-line prefer-destructuring
   imageOrderFiles[`${index}.csv`] = item.csv.join('\n');
 });
@@ -266,16 +258,16 @@ describe('VIAME serialize testing', () => {
   });
 });
 
-describe('Test Image Filenames and Ordering', () => {
-  it('testing image filenames and ordering ordering', async () => {
+describe('Test Image Filenames', () => {
+  it('testing image filenames', async () => {
     const imageMap = new Map([
       ['1', 0],
       ['2', 1],
       ['3', 2],
     ]);
-    for (let i = 0; i < imageOrderTests.length; i += 1) {
+    for (let i = 0; i < imageFilenameTests.length; i += 1) {
       const testPath = `/imageorder/${i}.csv`;
-      const imageOrderData = imageOrderTests[i];
+      const imageOrderData = imageFilenameTests[i];
       if (!imageOrderData.pass) {
         try {
         // eslint-disable-next-line no-await-in-loop

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -268,7 +268,7 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<A
           const currentHasFileName = rowInfo.filename.trim() !== '';
           if (imageMap !== undefined && hasFilenames === undefined) {
             hasFilenames = currentHasFileName;
-          } else if (hasFilenames !== currentHasFileName) {
+          } else if (imageMap !== undefined && hasFilenames !== currentHasFileName) {
             throw new Error('Image Filenames specified in the Column 2 of the CSV must either be all set or all empty. Encountered a mixture of set and empty filenames');
           }
           if (imageMap !== undefined && hasFilenames) {

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -258,7 +258,7 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<A
     });
     parser.on('readable', () => {
       let record: string[];
-      let hasFilenames;
+      let hasFilenames: undefined | boolean;
       // eslint-disable-next-line no-cond-assign
       while (record = parser.read()) {
         try {

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -261,15 +261,15 @@ def load_csv_as_tracks_and_attributes(
         ) = _parse_row_for_tracks(row)
 
         trackId, imageFile, _, _, _ = row_info(row)
-        current_has_filename = imageFile.strip() == ''
+        current_has_filename = imageFile.strip() != ''
         if has_image_filenames is None and imageMap:
             has_image_filenames = current_has_filename
         elif imageMap and has_image_filenames != current_has_filename:
             raise ValueError(
-                'Image Filenames specified in the Column 2 of the CSV must either be\
-                    all set or all empty. '
-                'Encountered a mixture of set and empty filenames. '
+                'There was a mixture of fields that specified image names and fields that'
+                ' did not.  Please check the CSV'
             )
+            return
         if imageMap and has_image_filenames:
             # validate image ordering if the imageMap is provided
             imageName, _ = os.path.splitext(os.path.basename(imageFile))

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -248,7 +248,7 @@ def load_csv_as_tracks_and_attributes(
     metadata_attributes: Dict[str, Dict[str, Any]] = {}
     test_vals: Dict[str, Dict[str, int]] = {}
     reordered = False
-
+    has_image_filenames: Union[None, bool] = None
     for row in reader:
         if len(row) == 0 or row[0].startswith('#'):
             # This is not a data row
@@ -261,8 +261,16 @@ def load_csv_as_tracks_and_attributes(
         ) = _parse_row_for_tracks(row)
 
         trackId, imageFile, _, _, _ = row_info(row)
-
-        if imageMap:
+        current_has_filename = imageFile.strip() == ''
+        if has_image_filenames is None and imageMap:
+            has_image_filenames = current_has_filename
+        elif imageMap and has_image_filenames != current_has_filename:
+            raise ValueError(
+                'Image Filenames specified in the Column 2 of the CSV must either be\
+                    all set or all empty. '
+                'Encountered a mixture of set and empty filenames. '
+            )
+        if imageMap and has_image_filenames:
             # validate image ordering if the imageMap is provided
             imageName, _ = os.path.splitext(os.path.basename(imageFile))
             expectedFrameNumber = imageMap.get(imageName)


### PR DESCRIPTION
fixes #1173 


- Adds a check to see if the field is empty when using the image map.  It will skip using the image map if the field is empty.  
- Added another check to make sure that there are no files where it swaps between providing image filenames and not.  This needed to handle both cases of (first row empty, second row populated) and (first row populated, second row empty).  So it will throw an error when it encounters a row which is different than the previous rows.

Note:  I wanted to add tests but the rejection process within the `viame.ts` `parse` function wasn't working well using jest.  I may need to look into this more to figure out how I can add some relevant tests for image ordering and this new error.