### PR TITLE
Revision History UI

### DIFF
--- a/client/dive-common/components/SidebarContext.vue
+++ b/client/dive-common/components/SidebarContext.vue
@@ -9,7 +9,6 @@ export default defineComponent({
       default: 300,
     },
   },
-  components: context.componentMap,
   setup() {
     return { context };
   },
@@ -40,9 +39,7 @@ export default defineComponent({
         </v-btn>
       </v-card-title>
       <div class="sidebar-content">
-        <component
-          :is="context.state.active"
-        />
+        <slot v-bind="{ name: context.state.active }" />
       </div>
     </v-card>
   </div>

--- a/client/dive-common/components/TypeThreshold.vue
+++ b/client/dive-common/components/TypeThreshold.vue
@@ -13,7 +13,6 @@ import { DefaultConfidence } from 'vue-media-annotator/use/useTrackFilters';
 
 export default defineComponent({
   name: 'TypeThreshold',
-  description: 'Threshold Controls',
 
   components: { ConfidenceFilter },
 

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -420,6 +420,7 @@ export default defineComponent({
         intervalTree,
         mergeList,
         pendingSaveCount,
+        progress,
         revisionId: toRef(props, 'revision'),
         trackMap,
         filteredTracks,

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -310,10 +310,6 @@ export default defineComponent({
       return result;
     }
 
-    function checkout(revisionId: number) {
-      ctx.emit('update:revision', revisionId);
-    }
-
     /** Trigger data load */
     const loadData = async () => {
       try {
@@ -407,7 +403,6 @@ export default defineComponent({
       setConfidenceFilters,
       deleteAttribute,
       reloadAnnotations,
-      checkout,
     };
 
     provideAnnotator(

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -34,7 +34,6 @@ import UserGuideButton from 'dive-common/components/UserGuideButton.vue';
 import DeleteControls from 'dive-common/components/DeleteControls.vue';
 import ControlsContainer from 'dive-common/components/ControlsContainer.vue';
 import Sidebar from 'dive-common/components/Sidebar.vue';
-import SidebarContext from 'dive-common/components/SidebarContext.vue';
 import { useModeManager, useSave } from 'dive-common/use';
 import clientSettingsSetup, { clientSettings } from 'dive-common/store/settings';
 import { useApi, FrameImage, DatasetType } from 'dive-common/apispec';
@@ -48,7 +47,6 @@ export default defineComponent({
     ControlsContainer,
     DeleteControls,
     Sidebar,
-    SidebarContext,
     LayerManager,
     VideoAnnotator,
     ImageAnnotator,
@@ -312,6 +310,10 @@ export default defineComponent({
       return result;
     }
 
+    function checkout(revisionId: number) {
+      ctx.emit('update:revision', revisionId);
+    }
+
     /** Trigger data load */
     const loadData = async () => {
       try {
@@ -405,6 +407,7 @@ export default defineComponent({
       setConfidenceFilters,
       deleteAttribute,
       reloadAnnotations,
+      checkout,
     };
 
     provideAnnotator(
@@ -422,6 +425,7 @@ export default defineComponent({
         intervalTree,
         mergeList,
         pendingSaveCount,
+        revisionId: toRef(props, 'revision'),
         trackMap,
         filteredTracks,
         typeStyling,
@@ -555,6 +559,7 @@ export default defineComponent({
             {{ item }} {{ item === defaultCamera ? '(Default)': '' }}
           </template>
         </v-select>
+        <slot name="extension-right" />
       </template>
 
       <slot name="title-right" />
@@ -666,7 +671,7 @@ export default defineComponent({
           </v-progress-circular>
         </div>
       </v-col>
-      <SidebarContext />
+      <slot name="right-sidebar" />
     </v-row>
   </v-main>
 </template>

--- a/client/dive-common/store/context.ts
+++ b/client/dive-common/store/context.ts
@@ -40,8 +40,10 @@ function getComponents() {
 function toggle(active: string | null) {
   if (active && state.active === active) {
     state.active = null;
-  } else {
+  } else if (active === null || active in componentMap) {
     state.active = active;
+  } else {
+    throw new Error(`${active} is not a valid context component`);
   }
   window.dispatchEvent(new Event('resize'));
 }

--- a/client/dive-common/store/context.ts
+++ b/client/dive-common/store/context.ts
@@ -1,26 +1,43 @@
 import Install, { reactive } from '@vue/composition-api';
-import Vue from 'vue';
+import Vue, { VueConstructor } from 'vue';
 /* Components */
 import TypeThreshold from 'dive-common/components/TypeThreshold.vue';
 
 Vue.use(Install);
 
-
-const componentMap = {
-  TypeThreshold,
-};
-
-type ContextType = keyof typeof componentMap;
-
 interface ContextState {
-  active: ContextType | null;
+  active: string | null;
+}
+
+interface ComponentMapItem {
+  description: string;
+  component: VueConstructor<Vue>;
 }
 
 const state: ContextState = reactive({
   active: null,
 });
 
-function toggle(active: ContextType | null) {
+const componentMap: Record<string, ComponentMapItem> = {
+  TypeThreshold: {
+    description: 'Threshold Controls',
+    component: TypeThreshold,
+  },
+};
+
+function register(item: ComponentMapItem) {
+  componentMap[item.component.name] = item;
+}
+
+function getComponents() {
+  const components: Record<string, VueConstructor<Vue>> = {};
+  Object.values(componentMap).forEach((v) => {
+    components[v.component.name] = v.component;
+  });
+  return components;
+}
+
+function toggle(active: string | null) {
   if (active && state.active === active) {
     state.active = null;
   } else {
@@ -31,6 +48,8 @@ function toggle(active: ContextType | null) {
 
 export default {
   toggle,
+  register,
+  getComponents,
   componentMap,
   state,
 };

--- a/client/dive-common/use/useRequest.ts
+++ b/client/dive-common/use/useRequest.ts
@@ -50,7 +50,7 @@ export function usePaginatedRequest<T>() {
   function reset() {
     paginationParams.totalCount = 0;
     paginationParams.offset = 0;
-    paginationParams.limit = 10;
+    paginationParams.limit = 20;
     allPages.value = [];
     main.reset();
   }

--- a/client/dive-common/use/useRequest.ts
+++ b/client/dive-common/use/useRequest.ts
@@ -1,4 +1,5 @@
-import { reactive, toRefs } from '@vue/composition-api';
+import { reactive, shallowRef, toRefs } from '@vue/composition-api';
+import { AxiosResponse } from 'axios';
 import { getResponseError } from 'vue-media-annotator/utils';
 
 export default function useRequest() {
@@ -34,5 +35,45 @@ export default function useRequest() {
     state,
     request,
     reset,
+  };
+}
+
+export function usePaginatedRequest<T>() {
+  const main = useRequest();
+  const paginationParams = reactive({
+    totalCount: 0,
+    offset: 0,
+    limit: 20,
+  });
+  const allPages = shallowRef([] as T[]);
+
+  function reset() {
+    paginationParams.totalCount = 0;
+    paginationParams.offset = 0;
+    paginationParams.limit = 10;
+    allPages.value = [];
+    main.reset();
+  }
+
+  async function loadNextPage(
+    func: (limit: number, offset: number) => Promise<AxiosResponse<T[]>>,
+  ) {
+    const wrapped = () => main.request(() => func(paginationParams.limit, paginationParams.offset));
+    const nextOffset = paginationParams.offset + paginationParams.limit;
+    const maxOffset = (paginationParams.totalCount + paginationParams.limit);
+    if (nextOffset < maxOffset || main.count.value === 0) {
+      const resp = await wrapped();
+      paginationParams.offset = nextOffset;
+      paginationParams.totalCount = Number.parseInt(resp.headers['girder-total-count'], 10);
+      allPages.value = allPages.value.concat(resp.data);
+    }
+  }
+
+  return {
+    ...main,
+    ...toRefs(paginationParams),
+    allPages,
+    reset,
+    loadNextPage,
   };
 }

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -6,7 +6,8 @@ import {
 import Viewer from 'dive-common/components/Viewer.vue';
 import RunPipelineMenu from 'dive-common/components/RunPipelineMenu.vue';
 import ImportAnnotations from 'dive-common//components/ImportAnnotations.vue';
-
+import SidebarContext from 'dive-common/components/SidebarContext.vue';
+import context from 'dive-common/store/context';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import Export from './Export.vue';
 import JobTab from './JobTab.vue';
@@ -33,8 +34,10 @@ export default defineComponent({
     Export,
     JobTab,
     RunPipelineMenu,
+    SidebarContext,
     Viewer,
     ImportAnnotations,
+    ...context.getComponents(),
   },
   props: {
     id: { // always the base ID
@@ -142,6 +145,13 @@ export default defineComponent({
         :id="compoundId"
         :button-options="buttonOptions"
       />
+    </template>
+    <template #right-sidebar>
+      <SidebarContext>
+        <template #default="{ name }">
+          <component :is="name" />
+        </template>
+      </SidebarContext>
     </template>
   </Viewer>
 </template>

--- a/client/platform/web-girder/api/annotation.service.ts
+++ b/client/platform/web-girder/api/annotation.service.ts
@@ -2,12 +2,36 @@ import { SaveDetectionsArgs } from 'dive-common/apispec';
 import { TrackData } from 'vue-media-annotator/track';
 import girderRest from 'platform/web-girder/plugins/girder';
 
+export interface Revision {
+  additions: Readonly<number>;
+  deletions: Readonly<number>;
+  author_id: Readonly<string>;
+  author_name: Readonly<string>;
+  created: Readonly<string>;
+  dataset: Readonly<string>;
+  description: Readonly<string>;
+  revision: Readonly<number>;
+}
+
 function loadDetections(folderId: string, revision?: number) {
   const params: Record<string, unknown> = { folderId };
   if (revision !== undefined) {
     params.revision = revision;
   }
   return girderRest.get<{ [key: string]: TrackData }>('dive_annotation', { params });
+}
+
+function loadRevisions(
+  folderId: string,
+  limit?: number,
+  offset?: number,
+  sort?: string,
+) {
+  return girderRest.get<Revision[]>('dive_annotation/revision', {
+    params: {
+      folderId, sortdir: -1, limit, offset, sort,
+    },
+  });
 }
 
 function saveDetections(folderId: string, args: SaveDetectionsArgs) {
@@ -21,5 +45,6 @@ function saveDetections(folderId: string, args: SaveDetectionsArgs) {
 
 export {
   loadDetections,
+  loadRevisions,
   saveDetections,
 };

--- a/client/platform/web-girder/router.ts
+++ b/client/platform/web-girder/router.ts
@@ -28,14 +28,7 @@ const router = new Router({
       component: Login,
     },
     {
-      path: '/viewer/:id',
-      name: 'viewer',
-      component: ViewerLoader,
-      props: true,
-      beforeEnter,
-    },
-    {
-      path: '/viewer/:id/rev/:revision',
+      path: '/viewer/:id/:revision?',
       name: 'viewer',
       component: ViewerLoader,
       props: true,

--- a/client/platform/web-girder/router.ts
+++ b/client/platform/web-girder/router.ts
@@ -28,8 +28,15 @@ const router = new Router({
       component: Login,
     },
     {
-      path: '/viewer/:id/:revision?',
+      path: '/viewer/:id',
       name: 'viewer',
+      component: ViewerLoader,
+      props: true,
+      beforeEnter,
+    },
+    {
+      path: '/viewer/:id/revision/:revision',
+      name: 'revision viewer',
       component: ViewerLoader,
       props: true,
       beforeEnter,

--- a/client/platform/web-girder/views/Clone.vue
+++ b/client/platform/web-girder/views/Clone.vue
@@ -151,6 +151,12 @@ export default defineComponent({
       </v-card-title>
       <v-card-text>
         <v-alert
+          v-if="revision"
+          type="info"
+        >
+          Revision {{ revision }} selected.
+        </v-alert>
+        <v-alert
           v-if="cloneError"
           type="error"
           dismissible

--- a/client/platform/web-girder/views/RevisionHistory.vue
+++ b/client/platform/web-girder/views/RevisionHistory.vue
@@ -111,18 +111,20 @@ export default defineComponent({
                 <span
                   v-bind="attrs"
                   v-on="on"
-                >
-                  {{ revision.revision }}: {{ revision.description }} by
-                  <router-link
-                    :to="`/user/${revision.author_id}`"
-                  >
-                    {{ revision.author_name }}
-                  </router-link>
-                </span>
+                  v-text="`${revision.revision}: ${revision.description}`"
+                />
               </template>
-              <span>{{ revision.description }} by {{ revision.author_name }}</span>
+              <span>{{ revision.description }}</span>
             </v-tooltip>
           </v-list-item-title>
+          <v-list-item-subtitle>
+            by
+            <router-link
+              :to="`/user/${revision.author_id}`"
+            >
+              {{ revision.author_name }}
+            </router-link>
+          </v-list-item-subtitle>
           <v-list-item-subtitle v-text="(new Date(revision.created)).toLocaleString()" />
         </v-list-item-content>
         <v-list-item-action>

--- a/client/platform/web-girder/views/RevisionHistory.vue
+++ b/client/platform/web-girder/views/RevisionHistory.vue
@@ -103,12 +103,25 @@ export default defineComponent({
       >
         <v-list-item-content>
           <v-list-item-title>
-            {{ revision.revision }}: {{ revision.description }} by
-            <router-link
-              :to="`/user/${revision.author_id}`"
+            <v-tooltip
+              bottom
+              open-delay="500"
             >
-              {{ revision.author_name }}
-            </router-link>
+              <template #activator="{ on, attrs }">
+                <span
+                  v-bind="attrs"
+                  v-on="on"
+                >
+                  {{ revision.revision }}: {{ revision.description }} by
+                  <router-link
+                    :to="`/user/${revision.author_id}`"
+                  >
+                    {{ revision.author_name }}
+                  </router-link>
+                </span>
+              </template>
+              <span>{{ revision.description }} by {{ revision.author_name }}</span>
+            </v-tooltip>
           </v-list-item-title>
           <v-list-item-subtitle v-text="(new Date(revision.created)).toLocaleString()" />
         </v-list-item-content>

--- a/client/platform/web-girder/views/RevisionHistory.vue
+++ b/client/platform/web-girder/views/RevisionHistory.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { defineComponent, watch } from '@vue/composition-api';
 import {
-  useDatasetId, useHandler, usePendingSaveCount, useRevisionId,
+  useDatasetId, usePendingSaveCount, useRevisionId,
 } from 'vue-media-annotator/provides';
 import { loadRevisions, Revision } from 'platform/web-girder/api';
 import { usePaginatedRequest } from 'dive-common/use/useRequest';
@@ -10,17 +10,20 @@ export default defineComponent({
   name: 'RevisionHistory',
   description: 'Revision History',
 
-  setup() {
+  setup(_, ctx) {
     const saveCount = usePendingSaveCount();
     const datasetId = useDatasetId();
     const revisionId = useRevisionId();
-    const { checkout } = useHandler();
     const {
       loading, count, allPages: revisions, totalCount, loadNextPage, reset,
     } = usePaginatedRequest<Revision>();
 
     async function loadNext() {
       await loadNextPage((l, o) => loadRevisions(datasetId.value, l, o));
+    }
+
+    function checkout(id: number) {
+      ctx.emit('update:revision', id);
     }
 
     watch(saveCount, (newval) => {

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -163,7 +163,6 @@ export default defineComponent({
     ref="viewerRef"
     :revision="revisionNum"
     :read-only-mode="!!getters['Jobs/datasetRunningState'](id)"
-    @update:revision="routeRevision"
   >
     <template #title>
       <ViewerAlert />
@@ -227,7 +226,10 @@ export default defineComponent({
     <template #right-sidebar>
       <SidebarContext>
         <template #default="{ name }">
-          <component :is="name" />
+          <component
+            :is="name"
+            @update:revision="routeRevision"
+          />
         </template>
       </SidebarContext>
     </template>

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -1,19 +1,21 @@
 <script lang="ts">
 import {
-  computed,
-  defineComponent, onBeforeUnmount, onMounted, ref, toRef, watch,
+  computed, defineComponent, onBeforeUnmount, onMounted, ref, toRef, watch,
 } from '@vue/composition-api';
 
 import Viewer from 'dive-common/components/Viewer.vue';
 import NavigationTitle from 'dive-common/components/NavigationTitle.vue';
 import RunPipelineMenu from 'dive-common/components/RunPipelineMenu.vue';
 import ImportAnnotations from 'dive-common/components/ImportAnnotations.vue';
+import SidebarContext from 'dive-common/components/SidebarContext.vue';
+import context from 'dive-common/store/context';
 import { useStore } from 'platform/web-girder/store/types';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import JobsTab from './JobsTab.vue';
 import Export from './Export.vue';
 import Clone from './Clone.vue';
 import ViewerAlert from './ViewerAlert.vue';
+import RevisionHistory from './RevisionHistory.vue';
 
 const buttonOptions = {
   text: true,
@@ -28,6 +30,11 @@ const menuOptions = {
   bottom: true,
 };
 
+context.register({
+  component: RevisionHistory,
+  description: 'Revision History',
+});
+
 /**
  * ViewerLoader is responsible for loading
  * data from girder.
@@ -41,7 +48,10 @@ export default defineComponent({
     NavigationTitle,
     Viewer,
     ImportAnnotations,
+    RevisionHistory,
+    SidebarContext,
     ViewerAlert,
+    ...context.getComponents(),
   },
 
   props: {
@@ -62,7 +72,7 @@ export default defineComponent({
     }
   },
 
-  setup(props) {
+  setup(props, ctx) {
     const { prompt } = usePrompt();
     const viewerRef = ref();
     const store = useStore();
@@ -81,6 +91,12 @@ export default defineComponent({
       }
       return results;
     });
+
+    if (props.revision) {
+      /* When a revision is loaded, toggle the revision history on */
+      context.state.active = 'RevisionHistory';
+    }
+
     watch(currentJob, async () => {
       if (currentJob.value !== false && currentJob.value !== undefined) {
         if (currentJob.value.success) {
@@ -117,15 +133,24 @@ export default defineComponent({
       window.removeEventListener('beforeunload', viewerRef.value.warnBrowserExit);
     });
 
+    function routeRevision(revisionId: number) {
+      ctx.root.$router.replace({
+        name: 'viewer',
+        params: { id: props.id, revision: revisionId.toString() },
+      });
+    }
+
     return {
       buttonOptions,
       brandData,
+      context,
       menuOptions,
       revisionNum,
       viewerRef,
       getters,
       currentJob,
       runningPipelines,
+      routeRevision,
     };
   },
 });
@@ -138,6 +163,7 @@ export default defineComponent({
     ref="viewerRef"
     :revision="revisionNum"
     :read-only-mode="!!getters['Jobs/datasetRunningState'](id)"
+    @update:revision="routeRevision"
   >
     <template #title>
       <ViewerAlert />
@@ -154,6 +180,23 @@ export default defineComponent({
         </v-tab>
         <JobsTab />
       </v-tabs>
+    </template>
+    <template #extension-right>
+      <v-divider
+        vertical
+        class="mx-2"
+      />
+      <v-btn
+        text
+        small
+        :input-value="context.state.active === 'RevisionHistory'"
+        @click="context.toggle('RevisionHistory')"
+      >
+        <v-icon class="pr-1">
+          mdi-history
+        </v-icon>
+        History
+      </v-btn>
     </template>
     <template #title-right>
       <RunPipelineMenu
@@ -180,6 +223,13 @@ export default defineComponent({
         :dataset-id="id"
         :revision="revisionNum"
       />
+    </template>
+    <template #right-sidebar>
+      <SidebarContext>
+        <template #default="{ name }">
+          <component :is="name" />
+        </template>
+      </SidebarContext>
     </template>
   </Viewer>
 </template>

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -135,7 +135,7 @@ export default defineComponent({
 
     function routeRevision(revisionId: number) {
       ctx.root.$router.replace({
-        name: 'viewer',
+        name: 'revision viewer',
         params: { id: props.id, revision: revisionId.toString() },
       });
     }
@@ -159,7 +159,7 @@ export default defineComponent({
 <template>
   <Viewer
     :id="id"
-    :key="`${id}/${revisionNum}`"
+    :key="id"
     ref="viewerRef"
     :revision="revisionNum"
     :read-only-mode="!!getters['Jobs/datasetRunningState'](id)"
@@ -202,12 +202,12 @@ export default defineComponent({
         v-bind="{ buttonOptions, menuOptions }"
         :selected-dataset-ids="[id]"
         :running-pipelines="runningPipelines"
+        :read-only-mode="revisionNum !== undefined"
       />
       <ImportAnnotations
-        v-bind="{ buttonOptions,
-                  menuOptions,
-                  readOnlyMode: !!getters['Jobs/datasetRunningState'](id),
-        }"
+        :button-options="buttonOptions"
+        :menu-options="menuOptions"
+        :read-only-mode="!!getters['Jobs/datasetRunningState'](id) || revisionNum !== undefined"
         :dataset-id="id"
         block-on-unsaved
       />

--- a/client/src/layers/BaseLayer.ts
+++ b/client/src/layers/BaseLayer.ts
@@ -110,6 +110,7 @@ export default abstract class BaseLayer<D> {
       return {
         strokeColor: 'black',
         strokeWidth: 1.0,
+        antialiasing: 0,
       };
     }
 }

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -161,8 +161,6 @@ export interface Handler {
   unstageFromMerge(ids: TrackId[]): void;
   /* Reload Annotation File */
   reloadAnnotations(): Promise<void>;
-  /* Check out a different revision */
-  checkout(revisionId: number): void;
 }
 const HandlerSymbol = Symbol('handler');
 
@@ -201,7 +199,6 @@ function dummyHandler(handle: (name: string, args: unknown[]) => void): Handler 
     commitMerge(...args) { handle('commitMerge', args); },
     unstageFromMerge(...args) { handle('unstageFromMerge', args); },
     reloadAnnotations(...args) { handle('reloadTracks', args); return Promise.resolve(); },
-    checkout(...args) { handle('checkout', args); },
   };
 }
 

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -57,6 +57,9 @@ type pendingSaveCountType = Readonly<Ref<number>>;
 const IntervalTreeSymbol = Symbol('intervalTree');
 type IntervalTreeType = Readonly<IntervalTree>;
 
+const RevisionIdSymbol = Symbol('revisionId');
+type RevisionIdType = Readonly<Ref<number>>;
+
 const TrackMapSymbol = Symbol('trackMap');
 type TrackMapType = Readonly<Map<TrackId, Track>>;
 
@@ -158,6 +161,8 @@ export interface Handler {
   unstageFromMerge(ids: TrackId[]): void;
   /* Reload Annotation File */
   reloadAnnotations(): Promise<void>;
+  /* Check out a different revision */
+  checkout(revisionId: number): void;
 }
 const HandlerSymbol = Symbol('handler');
 
@@ -196,6 +201,7 @@ function dummyHandler(handle: (name: string, args: unknown[]) => void): Handler 
     commitMerge(...args) { handle('commitMerge', args); },
     unstageFromMerge(...args) { handle('unstageFromMerge', args); },
     reloadAnnotations(...args) { handle('reloadTracks', args); return Promise.resolve(); },
+    checkout(...args) { handle('checkout', args); },
   };
 }
 
@@ -221,6 +227,7 @@ export interface State {
   intervalTree: IntervalTreeType;
   mergeList: MergeList;
   pendingSaveCount: pendingSaveCountType;
+  revisionId: RevisionIdType;
   trackMap: TrackMapType;
   typeStyling: TypeStylingType;
   selectedKey: SelectedKeyType;
@@ -259,6 +266,7 @@ function dummyState(): State {
     intervalTree: new IntervalTree(),
     mergeList: ref([]),
     pendingSaveCount: ref(0),
+    revisionId: ref(0),
     trackMap: new Map<TrackId, Track>(),
     typeStyling: ref({
       color() { return style.color; },
@@ -309,6 +317,7 @@ function provideAnnotator(state: State, handler: Handler) {
   provide(IntervalTreeSymbol, state.intervalTree);
   provide(MergeListSymbol, state.mergeList);
   provide(PendingSaveCountSymbol, state.pendingSaveCount);
+  provide(RevisionIdSymbol, state.revisionId);
   provide(TrackMapSymbol, state.trackMap);
   provide(TracksSymbol, state.filteredTracks);
   provide(TypeStylingSymbol, state.typeStyling);
@@ -387,6 +396,10 @@ function usePendingSaveCount() {
   return use<pendingSaveCountType>(PendingSaveCountSymbol);
 }
 
+function useRevisionId() {
+  return use<RevisionIdType>(RevisionIdSymbol);
+}
+
 function useTrackMap() {
   return use<TrackMapType>(TrackMapSymbol);
 }
@@ -443,6 +456,7 @@ export {
   usePendingSaveCount,
   useTrackMap,
   useFilteredTracks,
+  useRevisionId,
   useTypeStyling,
   useSelectedKey,
   useSelectedTrackId,

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -1,6 +1,6 @@
 import IntervalTree from '@flatten-js/interval-tree';
 import {
-  provide, inject, ref, Ref,
+  provide, inject, ref, Ref, reactive,
 } from '@vue/composition-api';
 
 import { AnnotatorPreferences as AnnotatorPrefsIface } from './types';
@@ -53,6 +53,9 @@ type MergeList = Readonly<Ref<readonly TrackId[]>>;
 
 const PendingSaveCountSymbol = Symbol('pendingSaveCount');
 type pendingSaveCountType = Readonly<Ref<number>>;
+
+const ProgressSymbol = Symbol('progress');
+type ProgressType = Readonly<{ loaded: boolean }>;
 
 const IntervalTreeSymbol = Symbol('intervalTree');
 type IntervalTreeType = Readonly<IntervalTree>;
@@ -224,6 +227,7 @@ export interface State {
   intervalTree: IntervalTreeType;
   mergeList: MergeList;
   pendingSaveCount: pendingSaveCountType;
+  progress: ProgressType;
   revisionId: RevisionIdType;
   trackMap: TrackMapType;
   typeStyling: TypeStylingType;
@@ -263,6 +267,7 @@ function dummyState(): State {
     intervalTree: new IntervalTree(),
     mergeList: ref([]),
     pendingSaveCount: ref(0),
+    progress: reactive({ loaded: true }),
     revisionId: ref(0),
     trackMap: new Map<TrackId, Track>(),
     typeStyling: ref({
@@ -314,6 +319,7 @@ function provideAnnotator(state: State, handler: Handler) {
   provide(IntervalTreeSymbol, state.intervalTree);
   provide(MergeListSymbol, state.mergeList);
   provide(PendingSaveCountSymbol, state.pendingSaveCount);
+  provide(ProgressSymbol, state.progress);
   provide(RevisionIdSymbol, state.revisionId);
   provide(TrackMapSymbol, state.trackMap);
   provide(TracksSymbol, state.filteredTracks);
@@ -393,6 +399,10 @@ function usePendingSaveCount() {
   return use<pendingSaveCountType>(PendingSaveCountSymbol);
 }
 
+function useProgress() {
+  return use<ProgressType>(ProgressSymbol);
+}
+
 function useRevisionId() {
   return use<RevisionIdType>(RevisionIdSymbol);
 }
@@ -451,6 +461,7 @@ export {
   useIntervalTree,
   useMergeList,
   usePendingSaveCount,
+  useProgress,
   useTrackMap,
   useFilteredTracks,
   useRevisionId,

--- a/docs/Web-Version.md
+++ b/docs/Web-Version.md
@@ -144,3 +144,21 @@ A clone is a **shallow copy** of a dataset.
 * Open the dataset you wish to clone by clicking ==Launch Annotator==.
 * Click the ==:material-content-copy: Clone== button in the top navigation bar on the right side.
 * Choose a name and location for the clone within your own workspace.
+
+
+## Revision History
+
+Revision history is accessible through the annotation UI in the Web version.  Each time you press ==:material-content-save: Save==, a new revision of your annotation state is created.  It is possible to inspect (or "check out") past revisions.  The viewer will be in **read-only mode** when past revisions are checked out because only the most recent revision can be modified.
+
+* Click ==:material-history: History== in the [Navigation Bar area](UI-Navigation-Bar.md) to open the Revision History panel.
+    * Each row shows the revision datetime, the action that caused it, and the number of additions and deletions.
+    * Click a row to check out a previous revision
+* Click ==:material-download: Download== when a previous revision is checked out to download the annotation CSV from that revision.
+* Click ==:material-content-copy: Clone== when a previous revision is checked out to create a new clone of the dataset from that revision.
+
+!!! info
+
+    Revision roll-back is **not yet supported**, but will be added in a future update.  If you need to roll-back to a previous version of your anotation state
+
+    * check out the old version and create a CSV download, then re-upload the older version using import;
+    * or [contact us for support](Support.md).

--- a/server/dive_server/crud_annotation.py
+++ b/server/dive_server/crud_annotation.py
@@ -112,6 +112,7 @@ def get_annotation_csv_generator(
     user: types.GirderUserModel,
     excludeBelowThreshold=False,
     typeFilter=None,
+    revision=None,
 ) -> Tuple[str, Callable[[], Generator[str, None, None]]]:
     """Get the annotation generator for a folder"""
     fps = None
@@ -126,7 +127,7 @@ def get_annotation_csv_generator(
     thresholds = fromMeta(folder, "confidenceFilters", {})
 
     def downloadGenerator():
-        datalist, _ = get_annotations(folder)
+        datalist, _ = get_annotations(folder, revision=revision)
         for data in viame.export_tracks_as_csv(
             datalist,
             excludeBelowThreshold,
@@ -134,6 +135,7 @@ def get_annotation_csv_generator(
             filenames=imageFiles,
             fps=fps,
             typeFilter=typeFilter,
+            revision=revision,
         ):
             yield data
 

--- a/server/dive_server/views_annotation.py
+++ b/server/dive_server/views_annotation.py
@@ -76,6 +76,14 @@ class AnnotationResource(Resource):
             dataType="boolean",
             default=False,
         )
+        .param(
+            "revisionId",
+            "Optional revision to export from",
+            paramType="query",
+            dataType="integer",
+            default=None,
+            required=False,
+        )
         .jsonParam(
             "typeFilter",
             "List of track types to filter by",
@@ -85,13 +93,16 @@ class AnnotationResource(Resource):
             requireArray=True,
         )
     )
-    def export(self, folder, excludeBelowThreshold: bool, typeFilter: Optional[List[str]]):
+    def export(
+        self, folder, excludeBelowThreshold: bool, revisionId: int, typeFilter: Optional[List[str]]
+    ):
         crud.verify_dataset(folder)
         filename, gen = crud_annotation.get_annotation_csv_generator(
             folder,
             self.getCurrentUser(),
             excludeBelowThreshold=excludeBelowThreshold,
             typeFilter=typeFilter,
+            revision=revisionId,
         )
         setContentDisposition(filename, mime='text/csv')
         return gen

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -331,6 +331,7 @@ def export_tracks_as_csv(
     fps=None,
     header=True,
     typeFilter=None,
+    revision=None,
 ) -> Generator[str, None, None]:
     """
     Export track json to a CSV format.
@@ -353,6 +354,8 @@ def export_tracks_as_csv(
         metadata = {}
         if fps is not None:
             metadata["fps"] = fps
+        if revision is not None:
+            metadata["revision"] = revision
         writeHeader(writer, metadata)
 
     for t in track_iterator:


### PR DESCRIPTION
## Summary of changes

* Adds revision history contextual sidebar, and a button to open it which so far I really dislike.  Feedback needed.
* Clone or download annotations when a past revision is loaded.

Please forgive the random book cover instead of real data.

# Menu open, Latest selected

![Screenshot from 2022-02-28 08-22-10](https://user-images.githubusercontent.com/4214172/155990492-39c3e0f0-c832-47b4-8a5c-3faf61cdec6c.png)

# Menu open, previous rev selected 

![Screenshot from 2022-02-28 08-22-23](https://user-images.githubusercontent.com/4214172/155990490-5dabaf6d-ac99-438e-9ce7-eccc6e2341ea.png)

# Download menu

![Screenshot from 2022-02-28 08-22-37](https://user-images.githubusercontent.com/4214172/155990488-e7401589-4076-449c-a479-d22409dcfc80.png)

fixes #1078 