### PR TITLE
Use zero padding on bounding box extensions

### DIFF
--- a/client/dive-common/recipes/headtail.ts
+++ b/client/dive-common/recipes/headtail.ts
@@ -12,21 +12,22 @@ export const TailPointKey = 'tail';
 const EmptyResponse: UpdateResponse = { data: {}, union: [], unionWithoutBounds: [] };
 
 /* Standard 10% padding */
-const PaddingVector: [number, number][] = [
-  [-0.10, -0.10],
-  [-0.10, 0.10],
-  [1.10, -0.10],
-  [1.10, 0.10],
-  [-0.10, -0.10],
-];
-/* No padding */
-// const PaddingVectorZero: [number, number][] = [
-//   [0, 0],
-//   [0, 0],
-//   [1, 0],
-//   [1, 0],
-//   [0, 0],
+// const PaddingVector: [number, number][] = [
+//   [-0.10, -0.10],
+//   [-0.10, 0.10],
+//   [1.10, -0.10],
+//   [1.10, 0.10],
+//   [-0.10, -0.10],
 // ];
+
+/* No padding */
+const PaddingVector: [number, number][] = [
+  [0, 0],
+  [0, 0],
+  [1, 0],
+  [1, 0],
+  [0, 0],
+];
 
 export default class HeadTail implements Recipe {
   active: Ref<boolean>;


### PR DESCRIPTION
See #1168 for background.

This seems like the right approach to me, in general. If there's a need to have padding sometimes, but not other times, we should address that, possibly immediately (if changing this behavior is going to break someone else's workflow).

There's some uncertainty expressed by the codebase itself: a zero-padding vector was already in there, but commented out. This PR comments out the 10% box in favor of the zero box. We should probably figure out which one is the better choice, and whether to expose the padding vector to the frontend as a user setting.

Closes #1168.