### PR TITLE
Button to boost confidence to 1.0

### DIFF
--- a/client/dive-common/components/ConfidenceSubsection.vue
+++ b/client/dive-common/components/ConfidenceSubsection.vue
@@ -19,6 +19,10 @@ export default defineComponent({
       type: Array as PropType<[string, number][]>,
       required: true,
     },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup() {
     const typeStylingRef = useTypeStyling();
@@ -82,11 +86,34 @@ export default defineComponent({
                 }"
               />
             </v-col>
-            <v-col class="type-item-value">
+            <v-col>
               {{ pair[0] }}
             </v-col>
-            <v-col class="type-score">
+            <v-spacer />
+            <v-col class="type-score shrink mr-1">
               {{ pair[1].toFixed(4) }}
+            </v-col>
+            <v-col
+              v-if="pair[1] !== 1 && !disabled"
+              class="shrink"
+            >
+              <v-tooltip
+                open-delay="200"
+                bottom
+              >
+                <template #activator="{ bind, on }">
+                  <v-btn
+                    x-small
+                    icon
+                    v-bind="bind"
+                    v-on="on"
+                    @click="$emit('set-type', pair[0])"
+                  >
+                    <v-icon>mdi-check</v-icon>
+                  </v-btn>
+                </template>
+                <span>Accept {{ pair[0] }} as correct type</span>
+              </v-tooltip>
             </v-col>
           </v-row>
         </span>
@@ -97,19 +124,9 @@ export default defineComponent({
 
 <style lang="scss">
 .type-color-box {
-  margin-top: 5px;
   min-width: 10px;
   max-width: 10px;
   min-height: 10px;
   max-height: 10px;
-}
-.type-item-value {
-  max-width: 80%;
-  margin: 0px;
-}
-.type-score {
-  font-size: 1em;
-  max-width: 25%;
-  min-width: 25%;
 }
 </style>

--- a/client/dive-common/components/TrackDetailsPanel.vue
+++ b/client/dive-common/components/TrackDetailsPanel.vue
@@ -332,6 +332,8 @@ export default defineComponent({
         :confidence-pairs="
           flatten(selectedTrackList.map((t) => t.confidencePairs)).sort((a, b) => b[1] - a[1])
         "
+        :disabled="selectedTrackList.length > 1"
+        @set-type="selectedTrackList[0].setType($event)"
       />
       <attribute-subsection
         v-if="!mergeInProgress"


### PR DESCRIPTION
fixes #1202

![Screenshot from 2022-03-29 13-27-24](https://user-images.githubusercontent.com/4214172/160670407-c1e5cf50-f1c0-4459-a1c5-ed5ee27bc121.png)


This is the easy/obvious solution I could add quickly to give the user something that worked.  There may be a more ergonomic version that accepts the current top confidence as correct from the track list, but I didn't do that because there's no way to show the user feedback that this has done something, and adding visual feedback will require a bit more thought.

We'll need a way to display on a track list item where `confidence == 1` or not, and then a button or hotkey or something to boost it to 1.  This is related to #614.

I think this PR is a minimal fix that will give users something to provide feedback on.