### PR TITLE
fixing prompt

### DIFF
--- a/client/dive-common/vue-utilities/prompt-service/Prompt.vue
+++ b/client/dive-common/vue-utilities/prompt-service/Prompt.vue
@@ -127,7 +127,7 @@ export default defineComponent({
       <v-card-actions>
         <v-spacer />
         <v-btn
-          v-if="confirm && negative && negative.length"
+          v-if="confirm && negativeButton && negativeButton.length"
           ref="negative"
           text
           @click="clickNegative"


### PR DESCRIPTION
Fixes a bug with the prompt menu, to make sure it properly shows the cancel button when one is specified.
We needed a prompt with confirmation but without a cancel button so it uses the empty '' string for those instance when reloading pipelines.

This fixes it so it properly looks for the negativeButton and ensures that it has a length.