### PR TITLE
Fix bug in media pipelines

### DIFF
--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -15,7 +15,7 @@ from dive_utils import TRUTHY_META_VALUES, constants, fromMeta, models, types
 
 
 def get_url(dataset: types.GirderModel, item: types.GirderModel) -> str:
-    return f"api/v1/dive_dataset/{str(dataset['_id'])}/media/{str(item['_id'])}/download"
+    return f"/api/v1/dive_dataset/{str(dataset['_id'])}/media/{str(item['_id'])}/download"
 
 
 def createSoftClone(

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -146,10 +146,10 @@ def download_source_media(
             request.urlretrieve(url, filename=destination_path)
         return [str(dest / image.filename) for image in media.imageData], dataset.type
     elif dataset.type == constants.VideoType and media.video is not None:
-        destination_path = str(dest / media.video.filename)
+        destination_path = dest / media.video.filename
         url = urljoin(girder_client.urlBase, media.video.url)
         request.urlretrieve(url, filename=destination_path)
-        return [destination_path], dataset.type
+        return [str(destination_path)], dataset.type
     else:
         raise Exception(f"unexpected metadata {str(dataset.dict())}")
 

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -133,13 +133,6 @@ def download_revision_csv(gc: GirderClient, dataset_id: str, revision: int, path
     request.urlretrieve(url, filename=path)
 
 
-def download_media_item(girder_client: GirderClient, url: str, dest: Path):
-    url = url.replace(girder_client.urlBase, '')  # strip out the redundant part of the url
-    with girder_client.get(url, jsonResp=False) as r:
-        with open(dest, 'wb') as f:
-            f.write(r.content)
-
-
 def download_source_media(
     girder_client: GirderClient, datasetId: str, dest: Path
 ) -> Tuple[List[str], str]:
@@ -149,12 +142,13 @@ def download_source_media(
     if dataset.type == constants.ImageSequenceType:
         for frameImage in media.imageData:
             destination_path = dest / frameImage.filename
-            download_media_item(girder_client, frameImage.url, destination_path)
-            girder_client.downloadItem(frameImage.id, str(dest))
+            url = urljoin(girder_client.urlBase, frameImage.url)
+            request.urlretrieve(url, filename=destination_path)
         return [str(dest / image.filename) for image in media.imageData], dataset.type
     elif dataset.type == constants.VideoType and media.video is not None:
         destination_path = str(dest / media.video.filename)
-        download_media_item(girder_client, media.video.url, destination_path)
+        url = urljoin(girder_client.urlBase, media.video.url)
+        request.urlretrieve(url, filename=destination_path)
         return [destination_path], dataset.type
     else:
         raise Exception(f"unexpected metadata {str(dataset.dict())}")

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -133,6 +133,13 @@ def download_revision_csv(gc: GirderClient, dataset_id: str, revision: int, path
     request.urlretrieve(url, filename=path)
 
 
+def download_media_item(girder_client: GirderClient, url: str, dest: Path):
+    url = url.replace(girder_client.urlBase, '')  # strip out the redundant part of the url
+    with girder_client.get(url, jsonResp=False) as r:
+        with open(dest, 'wb') as f:
+            f.write(r.content)
+
+
 def download_source_media(
     girder_client: GirderClient, datasetId: str, dest: Path
 ) -> Tuple[List[str], str]:
@@ -141,11 +148,13 @@ def download_source_media(
     dataset = models.GirderMetadataStatic(**girder_client.get(f'dive_dataset/{datasetId}'))
     if dataset.type == constants.ImageSequenceType:
         for frameImage in media.imageData:
+            destination_path = dest / frameImage.filename
+            download_media_item(girder_client, frameImage.url, destination_path)
             girder_client.downloadItem(frameImage.id, str(dest))
         return [str(dest / image.filename) for image in media.imageData], dataset.type
     elif dataset.type == constants.VideoType and media.video is not None:
         destination_path = str(dest / media.video.filename)
-        girder_client.downloadFile(media.video.id, destination_path)
+        download_media_item(girder_client, media.video.url, destination_path)
         return [destination_path], dataset.type
     else:
         raise Exception(f"unexpected metadata {str(dataset.dict())}")

--- a/server/tests/integration/test_dataset_operations.py
+++ b/server/tests/integration/test_dataset_operations.py
@@ -30,7 +30,7 @@ def test_get_media(user: dict):
             assert len(media['imageData']) == 0
             assert type(media['video']) == dict
             assert 'mp4' in media['video']['filename']
-            client.getFile(media['video']['id'])
+            client.getItem(media['video']['id'])
 
 
 @pytest.mark.integration


### PR DESCRIPTION
media downloads for pipelines and training were failing after the ID used for media changed from a file id to an item ID.