### PR TITLE
Stats Page Support

### DIFF
--- a/client/platform/web-girder/api/annotation.service.ts
+++ b/client/platform/web-girder/api/annotation.service.ts
@@ -13,6 +13,16 @@ export interface Revision {
   revision: Readonly<number>;
 }
 
+export interface Label {
+  _id: string;
+  count: number;
+  datasets: Record<string, {
+    id: string;
+    name: string;
+    color?: string;
+  }>;
+}
+
 function loadDetections(folderId: string, revision?: number) {
   const params: Record<string, unknown> = { folderId };
   if (revision !== undefined) {
@@ -43,7 +53,13 @@ function saveDetections(folderId: string, args: SaveDetectionsArgs) {
   });
 }
 
+async function getLabels() {
+  const response = await girderRest.get<Label[]>('dive_annotation/labels');
+  return response;
+}
+
 export {
+  getLabels,
   loadDetections,
   loadRevisions,
   saveDetections,

--- a/client/platform/web-girder/router.ts
+++ b/client/platform/web-girder/router.ts
@@ -63,15 +63,15 @@ const router = new Router({
               beforeEnter,
             },
             {
-              path: ':routeType?/:routeId?',
-              name: 'home',
-              component: DataBrowser,
-              beforeEnter,
-            },
-            {
               path: 'summary',
               name: 'summary',
               component: Summary,
+              beforeEnter,
+            },
+            {
+              path: ':routeType?/:routeId?',
+              name: 'home',
+              component: DataBrowser,
               beforeEnter,
             },
           ],

--- a/client/platform/web-girder/router.ts
+++ b/client/platform/web-girder/router.ts
@@ -9,6 +9,7 @@ import RouterPage from './views/RouterPage.vue';
 import ViewerLoader from './views/ViewerLoader.vue';
 import DataShared from './views/DataShared.vue';
 import DataBrowser from './views/DataBrowser.vue';
+import Summary from './views/Summary.vue';
 
 Vue.use(Router);
 
@@ -65,6 +66,12 @@ const router = new Router({
               path: ':routeType?/:routeId?',
               name: 'home',
               component: DataBrowser,
+              beforeEnter,
+            },
+            {
+              path: 'summary',
+              name: 'summary',
+              component: Summary,
               beforeEnter,
             },
           ],

--- a/client/platform/web-girder/views/ShareTab.vue
+++ b/client/platform/web-girder/views/ShareTab.vue
@@ -48,6 +48,12 @@ export default defineComponent({
       </v-icon>
       Shared with Me
     </v-tab>
+    <v-tab :to="{name: 'summary'}">
+      <v-icon class="tab-icon">
+        mdi-tag
+      </v-icon>
+      Label summaries
+    </v-tab>
   </v-tabs>
 </template>
 

--- a/client/platform/web-girder/views/Summary.vue
+++ b/client/platform/web-girder/views/Summary.vue
@@ -1,0 +1,13 @@
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({
+  setup() {
+    console.log('whatever');
+  },
+});
+</script>
+
+<template>
+  <p>Summary placeholder</p>
+</template>

--- a/client/platform/web-girder/views/Summary.vue
+++ b/client/platform/web-girder/views/Summary.vue
@@ -1,13 +1,86 @@
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent, ref } from '@vue/composition-api';
+import * as d3 from 'd3';
+import type { DataTableHeader } from 'vuetify';
+import { generateColors } from 'vue-media-annotator/use/useStyling';
+import { itemsPerPageOptions } from 'dive-common/constants';
+import { clientSettings } from 'dive-common/store/settings';
+import { getLabels } from '../api';
+import { Label } from '../api/annotation.service';
+
 
 export default defineComponent({
   setup() {
-    console.log('whatever');
+    const summaryList = ref<Array<Label>>();
+    const expanded = ref<Array<Label>>();
+    const headers: DataTableHeader[] = [
+      { text: 'Type', value: '_id' },
+      { text: 'Number of Datasets', value: 'datasets.length' },
+      { text: 'Number of Tracks', value: 'count' },
+      { text: '', value: 'data-table-expand' },
+    ];
+
+    const labelColors = generateColors(10);
+    const ordinalColorMapper = d3.scaleOrdinal<string>().range(labelColors);
+
+    const color = (label: string) => ordinalColorMapper(label);
+
+
+    const updateList = async () => {
+      const response = await getLabels();
+
+      summaryList.value = response.data;
+
+      summaryList.value.forEach((item: Label) => {
+        Object.keys(item.datasets).forEach((key) => {
+          // eslint-disable-next-line no-param-reassign
+          item.datasets[key].color = color((item.datasets[key].name));
+        });
+      });
+    };
+    updateList();
+
+
+    return {
+      expanded,
+      summaryList,
+      headers,
+      clientSettings,
+      itemsPerPageOptions,
+    };
   },
 });
 </script>
 
 <template>
-  <p>Summary placeholder</p>
+  <v-data-table
+    :headers="headers"
+    :items="summaryList"
+    :expanded.sync="expanded"
+    :items-per-page.sync="clientSettings.rowsPerPage"
+    :footer-props="{ itemsPerPageOptions }"
+    item-key="_id"
+    show-expand
+  >
+    <template
+      v-slot:expanded-item="{ headers, item }"
+    >
+      <td :colspan="headers.length">
+        <v-chip
+          v-for="dataset in item.datasets"
+          :key="`${dataset.id}-${item._id}`"
+          class="ma-1 float-left"
+          small
+          :color="dataset.color"
+          text-color="#000000"
+          depressed
+          :to="{ name: 'viewer', params: { id: dataset.id } }"
+        >
+          {{
+            dataset.name
+          }}
+        </v-chip>
+      </td>
+    </template>
+  </v-data-table>
 </template>

--- a/client/src/use/useStyling.ts
+++ b/client/src/use/useStyling.ts
@@ -50,7 +50,7 @@ interface UseStylingParams {
    * the number the more similar the colors will be.  Cyan like colors will be filtered out,
    * so numColors isn't a guarantee of x*3 (normal, dark, light) colors.
    */
-function generateColors(numColors: number) {
+export function generateColors(numColors: number) {
   const colorList = [];
   for (let i = 0; i < numColors; i += 1) {
     //We are using a rainbow but we want to skip the cyan area so number will be reduced
@@ -200,6 +200,7 @@ export default function useStyling({ markChangesPending }: UseStylingParams) {
     });
     return savedTypeStyles;
   }
+
 
   return {
     stateStyling,

--- a/server/dive_server/crud_annotation.py
+++ b/server/dive_server/crud_annotation.py
@@ -275,7 +275,13 @@ def get_labels(user: types.GirderUserModel, published=False, shared=False):
         # Drop unwanted fields.
         {'$project': {'label.confidencePairs': 1, '_id': 1, 'dataset': 1}},
         # Group records by label values
-        {'$group': {'_id': '$label.confidencePairs', 'count': {'$count': {}}, 'datasets': {'$addToSet': '$dataset'}}},
+        {
+            '$group': {
+                '_id': '$label.confidencePairs',
+                'count': {'$count': {}},
+                'datasets': {'$addToSet': '$dataset'},
+            }
+        },
         {'$sort': {'_id': 1}},
     ]
     return Folder().collection.aggregate(pipeline)

--- a/server/dive_server/views_annotation.py
+++ b/server/dive_server/views_annotation.py
@@ -139,14 +139,14 @@ class AnnotationResource(Resource):
             constants.PublishedMarker,
             'Return only labels from published data',
             required=False,
-            default=False,
+            default=True,
             dataType='boolean',
         )
         .param(
             constants.SharedMarker,
             'Return only labels from data shared with me',
             required=False,
-            default=False,
+            default=True,
             dataType='boolean',
         )
     )

--- a/server/dive_server/views_annotation.py
+++ b/server/dive_server/views_annotation.py
@@ -7,7 +7,7 @@ from girder.api.rest import Resource
 from girder.constants import AccessType, TokenScope
 from girder.models.folder import Folder
 
-from dive_utils import setContentDisposition
+from dive_utils import constants, setContentDisposition
 
 from . import crud, crud_annotation
 
@@ -133,6 +133,22 @@ class AnnotationResource(Resource):
         crud_annotation.rollback(folder, revision)
 
     @access.user
-    @autoDescribeRoute(Description("Get all labels visible to a particular user"))
-    def get_labels(self):
-        return crud_annotation.get_labels(self.getCurrentUser())
+    @autoDescribeRoute(
+        Description("Get all labels visible to a particular user")
+        .param(
+            constants.PublishedMarker,
+            'Return only labels from published data',
+            required=False,
+            default=False,
+            dataType='boolean',
+        )
+        .param(
+            constants.SharedMarker,
+            'Return only labels from data shared with me',
+            required=False,
+            default=False,
+            dataType='boolean',
+        )
+    )
+    def get_labels(self, published: bool, shared: bool):
+        return crud_annotation.get_labels(self.getCurrentUser(), published=published, shared=shared)


### PR DESCRIPTION
## Summary of changes

Now, individual users can get personalized summaries of the data they have access to.  This summary page can be customized to show summaries for...

1. All datasets to which the user has write access.
2. All datasets that have been "published"
3. All datasets that a user has either read or write access to that have been shared.

## API Response

Request

`GET http://localhost:8010/api/v1/dive_annotation/labels?published=false&shared=false`

Response Example

``` json
[
  {
    "_id": "Bull",
    "count": 1882,
    "datasets": [
      {
        "id": "62583302bb61f47e1adc5112",
        "name": "20070609_SLAP5808_Orig"
      }
    ]
  },
  {
    "_id": "Fem",
    "count": 11910,
    "datasets": [
      {
        "id": "62583302bb61f47e1adc5112",
        "name": "20070609_SLAP5808_Orig"
      },
      {
        "id": "62583176bb61f47e1adc50d6",
        "name": "20171027.214830.290.029136"
      }
    ]
  },
  {
    "_id": "Groupers_Seabass",
    "count": 1,
    "datasets": [
      {
        "id": "62583176bb61f47e1adc50d6",
        "name": "20171027.214830.290.029136"
      }
    ]
  }
]
```

Fixes #1158 