### PR TITLE
Fixing Confidence Pair Alignment Issues

### DIFF
--- a/client/dive-common/components/ConfidenceSubsection.vue
+++ b/client/dive-common/components/ConfidenceSubsection.vue
@@ -86,11 +86,14 @@ export default defineComponent({
                 }"
               />
             </v-col>
-            <v-col>
+            <v-col :cols="pair[1] !== 1 && !disabled ? '7' : '8'">
               {{ pair[0] }}
             </v-col>
             <v-spacer />
-            <v-col class="type-score shrink mr-1">
+            <v-col
+              cols="2"
+              class="type-score shrink mr-1"
+            >
               {{ pair[1].toFixed(4) }}
             </v-col>
             <v-col


### PR DESCRIPTION
fixes #1221 

Dataset that demonstrates the issue: https://viame.kitware.com/#/viewer/62584c41f3a0a95bd8eb1f2c

Click the first fish on the left and go to the detailed panel.

Fixing the column sizes allows for proper wrapping of the type text:
![image](https://user-images.githubusercontent.com/61746913/163433470-e1c643d5-faab-47fc-85fe-13f690fb15b1.png)

The one column has a ternary operator to adjust the column width slightly.  Without this a single already set confidence value may look weird:
Without ternary operator:
![image](https://user-images.githubusercontent.com/61746913/163433772-64b940f7-70b1-415a-88cd-dc294b7a681e.png)
(Note additional white space)

With ternary operator:
![image](https://user-images.githubusercontent.com/61746913/163433672-45fe1ec2-776d-4074-ba8b-bcd5c3aa5846.png)



