### PR TITLE
Polygon control point multi delete

### DIFF
--- a/client/dive-common/components/DeleteControls.vue
+++ b/client/dive-common/components/DeleteControls.vue
@@ -29,43 +29,70 @@ export default Vue.extend({
   },
 
   methods: {
-    deleteSelected() {
+    deleteHandle() {
       if (this.disabled) {
         throw new Error('Cannot delete while disabled!');
       }
       if (this.selectedFeatureHandle >= 0) {
         this.$emit('delete-point');
-      } else {
-        this.$emit('delete-annotation');
       }
+    },
+    deleteAnnotation() {
+      if (this.disabled) {
+        throw new Error('Cannot delete while disabled!');
+      }
+      this.$emit('delete-annotation');
     },
   },
 });
 </script>
 
 <template>
-  <span class="mx-1">
+  <div class="d-flex flex-row">
+    <v-divider
+      vertical
+      class="mx-2"
+    />
     <v-btn
       v-if="!disabled"
       color="error"
       depressed
       small
-      @click="deleteSelected"
+      class="mr-2"
+      @click="deleteAnnotation"
     >
-      <pre class="mr-1 text-body-2">del</pre>
-      <span v-if="selectedFeatureHandle >= 0">
-        point {{ selectedFeatureHandle }}
-      </span>
-      <span v-else-if="editingMode">
-        {{ editingMode }}
-      </span>
-      <span v-else>unselected</span>
       <v-icon
         small
-        class="ml-2"
+        class="mr-2"
       >
         mdi-delete
       </v-icon>
+      <v-icon
+        v-if="editingMode === 'Polygon'"
+      >
+        mdi-vector-polygon
+      </v-icon>
+      <v-icon v-else>
+        mdi-vector-line
+      </v-icon>
     </v-btn>
-  </span>
+    <v-btn
+      v-if="!disabled && selectedFeatureHandle >= 0"
+      color="error"
+      depressed
+      small
+      @click="deleteHandle"
+    >
+      <v-icon
+        small
+        class="mr-1"
+      >
+        mdi-delete
+      </v-icon>
+      <v-icon class="pr-1">
+        mdi-circle-outline
+      </v-icon>
+      {{ selectedFeatureHandle }}
+    </v-btn>
+  </div>
 </template>

--- a/client/dive-common/components/UserGuideDialog.vue
+++ b/client/dive-common/components/UserGuideDialog.vue
@@ -88,6 +88,9 @@ export default {
             {
               name: 'Add Head/Tail', icon: 'mdi-keyboard', actions: ['H Key - Head', 'T Key - Tail'], description: 'While a track is selected add head/tail annotations',
             },
+            {
+              name: 'Delete control point', icon: 'mdi-keyboard', actions: ['Shift + p'], description: 'Delete selected control point',
+            },
           ],
         },
       ],

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -638,6 +638,7 @@ export default defineComponent({
           v-mousetrap="[
             { bind: 'n', handler: () => !readonlyState && handler.trackAdd() },
             { bind: 'r', handler: () => mediaController.resetZoom() },
+            { bind: 'shift+p', handler: () => handler.removePoint() },
             { bind: 'esc', handler: () => handler.trackAbort() },
           ]"
           v-bind="{ imageData, videoUrl, updateTime, frameRate,

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -436,6 +436,7 @@ export default defineComponent({
         typeStyling,
         selectedKey,
         selectedTrackId,
+        selectedHandleIndex: selectedFeatureHandle,
         stateStyles: stateStyling,
         time,
         visibleModes,

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -138,6 +138,7 @@ export default function useModeManager({
   }
 
   function handleSelectFeatureHandle(i: number, key = '') {
+    console.log('selectFeatureHandle', i);
     if (i !== selectedFeatureHandle.value) {
       selectedFeatureHandle.value = i;
     } else {
@@ -380,8 +381,10 @@ export default function useModeManager({
           }
         });
       }
+      handleSelectFeatureHandle(Math.max(selectedFeatureHandle.value - 1, 0));
+    } else {
+      handleSelectFeatureHandle(-1);
     }
-    handleSelectFeatureHandle(-1);
   }
 
   /* If any recipes are active, remove the geometry they added */

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -138,7 +138,6 @@ export default function useModeManager({
   }
 
   function handleSelectFeatureHandle(i: number, key = '') {
-    console.log('selectFeatureHandle', i);
     if (i !== selectedFeatureHandle.value) {
       selectedFeatureHandle.value = i;
     } else {
@@ -164,6 +163,8 @@ export default function useModeManager({
     }
     /* Do not allow editing when merge is in progres */
     selectTrack(trackId, edit && !mergeInProgress.value);
+
+    handleSelectFeatureHandle(-1);
   }
 
   //Handles deselection or hitting escape including while editing
@@ -378,12 +379,10 @@ export default function useModeManager({
               selectedKey.value,
               annotationModes.editing,
             );
+            handleSelectFeatureHandle(Math.max(selectedFeatureHandle.value - 1, 0));
           }
         });
       }
-      handleSelectFeatureHandle(Math.max(selectedFeatureHandle.value - 1, 0));
-    } else {
-      handleSelectFeatureHandle(-1);
     }
   }
 
@@ -477,6 +476,7 @@ export default function useModeManager({
           r.deactivate();
         }
       });
+      handleSelectFeatureHandle(-1);
     }
   }
 

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -33,6 +33,7 @@ import {
   useStateStyles,
   useMergeList,
   useAnnotatorPreferences,
+  useSelectedHandleIndex,
 } from '../provides';
 
 /** LayerManager is a component intended to be used as a child of an Annotator.
@@ -53,6 +54,7 @@ export default defineComponent({
     const trackMap = useTrackMap();
     const enabledTracksRef = useEnabledTracks();
     const selectedTrackIdRef = useSelectedTrackId();
+    const selectedHandleIndex = useSelectedHandleIndex();
     const mergeListRef = useMergeList();
     const typeStylingRef = useTypeStyling();
     const editingModeRef = useEditingMode();
@@ -243,6 +245,7 @@ export default defineComponent({
           if (editingTrack) {
             editAnnotationLayer.setType(editingTrack);
             editAnnotationLayer.setKey(selectedKey);
+            editAnnotationLayer.setSelectedHandleIndex(selectedHandleIndex.value);
             editAnnotationLayer.changeData(editingTracks);
           }
         } else {

--- a/client/src/layers/EditAnnotationLayer.ts
+++ b/client/src/layers/EditAnnotationLayer.ts
@@ -140,6 +140,15 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
     return () => { this.skipNextExternalUpdate = true; };
   }
 
+  setSelectedHandleIndex(val: number) {
+    let divisor = 1;
+    if (this.type === 'Polygon' && this.selectedHandleIndex >= 0) {
+      divisor = 2;
+    }
+    this.selectedHandleIndex = val * divisor;
+    this.hoverHandleIndex = this.selectedHandleIndex;
+  }
+
   /**
    * Listen to mousedown events and build a replica of the in-progress annotation
    * shape that GeoJS is keeps internally.  Emit the shape as update:in-progress-geojson
@@ -297,11 +306,6 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
       this.setMode(null);
       this.featureLayer.removeAllAnnotations(false);
       this.shapeInProgress = null;
-      if (this.selectedHandleIndex !== -1) {
-        this.selectedHandleIndex = -1;
-        this.hoverHandleIndex = -1;
-        this.bus.$emit('update:selectedIndex', this.selectedHandleIndex, this.type, this.selectedKey);
-      }
       this.annotator.setCursor('default');
       this.annotator.setImageCursor('');
     }
@@ -355,9 +359,6 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
    * @param frameData a single FrameDataTrack Array that is the editing item
    */
   formatData(frameData: FrameDataTrack[]) {
-    this.selectedHandleIndex = -1;
-    this.hoverHandleIndex = -1;
-    this.bus.$emit('update:selectedIndex', this.selectedHandleIndex, this.type, this.selectedKey);
     if (frameData.length > 0) {
       const track = frameData[0];
       if (track.features && track.features.bounds) {

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -79,6 +79,9 @@ type SelectedKeyType = Readonly<Ref<string>>;
 const SelectedTrackIdSymbol = Symbol('selectedTrackId');
 type SelectedTrackIdType = Readonly<Ref<TrackId | null>>;
 
+const SelectedHandleIndexSymbol = Symbol('selectedHandleIndex');
+type SelectedHandleIndexType = Readonly<Ref<number>>;
+
 const StateStylesSymbol = Symbol('stateStyles');
 type StateStylesType = Readonly<StateStyles>;
 
@@ -239,6 +242,7 @@ export interface State {
   typeStyling: TypeStylingType;
   selectedKey: SelectedKeyType;
   selectedTrackId: SelectedTrackIdType;
+  selectedHandleIndex: SelectedHandleIndexType;
   stateStyles: StateStylesType;
   time: TimeType;
   visibleModes: VisibleModesType;
@@ -288,6 +292,7 @@ function dummyState(): State {
     }),
     selectedKey: ref(''),
     selectedTrackId: ref(null),
+    selectedHandleIndex: ref(-1),
     stateStyles: {
       disabled: style,
       selected: style,
@@ -334,6 +339,7 @@ function provideAnnotator(state: State, handler: Handler) {
   provide(TypeStylingSymbol, state.typeStyling);
   provide(SelectedKeySymbol, state.selectedKey);
   provide(SelectedTrackIdSymbol, state.selectedTrackId);
+  provide(SelectedHandleIndexSymbol, state.selectedHandleIndex);
   provide(StateStylesSymbol, state.stateStyles);
   provide(TimeSymbol, state.time);
   provide(VisibleModesSymbol, state.visibleModes);
@@ -436,6 +442,10 @@ function useSelectedTrackId() {
   return use<SelectedTrackIdType>(SelectedTrackIdSymbol);
 }
 
+function useSelectedHandleIndex() {
+  return use<SelectedHandleIndexType>(SelectedHandleIndexSymbol);
+}
+
 function useStateStyles() {
   return use<StateStylesType>(StateStylesSymbol);
 }
@@ -480,6 +490,7 @@ export {
   useTypeStyling,
   useSelectedKey,
   useSelectedTrackId,
+  useSelectedHandleIndex,
   useStateStyles,
   useTime,
   useVisibleModes,


### PR DESCRIPTION
Control point delete is too cumbersome.   This makes it more ergonomic.   You can now just spam-click the delete button or press `shift+p`.  Also makes both delete point and delete shape buttons available at the same time because their distinction adds to their purpose: it's easier to know what they do when you can see both.

There's a small bug with swapping between editing modes now, but I want to get feedback before I fix that.

https://user-images.githubusercontent.com/4214172/166695761-ebd77dc4-b5d6-4476-a7c1-5f0cc3bc39eb.mp4

