### PR TITLE
Fix CSV parse

### DIFF
--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -269,7 +269,7 @@ def load_csv_as_tracks_and_attributes(
             expectedFrameNumber = imageMap.get(imageName)
             if expectedFrameNumber is None:
                 missingImages.append(imageFile)
-            elif expectedFrameNumber is not feature.frame:
+            elif expectedFrameNumber != feature.frame:
                 # force reorder the annotations
                 reordered = True
                 anyImageMatched = True


### PR DESCRIPTION
Image sequences with tracks and more than 256 images will fail to load annotations.

I was bamboozled by cpython: https://stackoverflow.com/questions/2239737/is-it-better-to-use-is-or-for-number-comparison-in-python