### PR TITLE
Change Linked Camera Behavior

### DIFF
--- a/client/src/components/controls/Controls.vue
+++ b/client/src/components/controls/Controls.vue
@@ -62,6 +62,12 @@ export default defineComponent({
       { bind: 'space', handler: togglePlay, disabled: visible() },
       { bind: 'f', handler: mediaController.nextFrame, disabled: visible() },
       { bind: 'd', handler: mediaController.prevFrame, disabled: visible() },
+      {
+        bind: 'l',
+        handler: () => mediaController.toggleSynchronizeCameras(!mediaController.cameraSync.value),
+        disabled: visible(),
+      },
+
     ]"
   >
     <v-card


### PR DESCRIPTION
Part of feedback from demo-ing the Multicam UI was that the linked cameras should operate with a bit more freedom.  
The specific use case is zooming into a adjacent images and being able to pan both at the same time.
Like panning down near the seam between two cameras.

The previous mode would link cameras spacially meaning if you were looking at the bottom right in one camera you would be looking at the bottom right in all cameras.
This update allows the user to manually position cameras and then link them so their panning and zooms are synchronized.