### PR TITLE
Fix get_dataset_query

### DIFF
--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import cherrypy
 from girder.constants import AccessType
@@ -284,7 +284,7 @@ def get_dataset_query(
             Folder().permissionClauses(user=user, level=level),
         ]
     }
-    optional_query_parts = []
+    optional_query_parts: List[Dict[str, Any]] = []
 
     if published:
         optional_query_parts.append(

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -299,7 +299,8 @@ def get_dataset_query(
                         '$nor': [{'creatorId': {'$eq': user['_id']}}, {'creatorId': {'$eq': None}}]
                     },
                     {
-                        # But where the current user still has access
+                        # But where the current user has been given explicit access
+                        # Implicit public datasets should not be considered "shared"
                         'access.users': {'$elemMatch': {'id': user['_id']}}
                     },
                 ]

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -278,36 +278,37 @@ def get_dataset_query(
     shared: bool,
     level=AccessType.READ,
 ):
-    permissionsClause = Folder().permissionClauses(user=user, level=level)
-    dataset_clause = {f'meta.{constants.DatasetMarker}': {'$in': TRUTHY_META_VALUES}}
-    query_parts = [{'$and': [dataset_clause, permissionsClause]}]
-    if published:
-        published_query = {f'meta.{constants.PublishedMarker}': {'$in': TRUTHY_META_VALUES}}
-        query_parts.append({'$and': [published_query, dataset_clause]})
-    if shared:
-        shared_query = [
-            {
-                # Find datasets not owned by the current user
-                '$nor': [
-                    {'creatorId': {'$eq': user['_id']}},
-                    {'creatorId': {'$eq': None}},
-                ],
-            },
-            {
-                # But where the current user still has access
-                'access.users': {
-                    '$elemMatch': {
-                        'id': user['_id'],
-                    }
-                },
-            },
-            dataset_clause,
+    base_query = {
+        '$and': [
+            {f'meta.{constants.DatasetMarker}': {'$in': TRUTHY_META_VALUES}},
+            Folder().permissionClauses(user=user, level=level),
         ]
-        query_parts.append({'$and': shared_query})
+    }
+    optional_query_parts = []
 
-    if published and shared:
-        return {'$or': query_parts}
-    return {'$and': query_parts}
+    if published:
+        optional_query_parts.append(
+            {f'meta.{constants.PublishedMarker}': {'$in': TRUTHY_META_VALUES}}
+        )
+    if shared:
+        optional_query_parts.append(
+            {
+                '$and': [
+                    {
+                        # Find datasets not owned by the current user
+                        '$nor': [{'creatorId': {'$eq': user['_id']}}, {'creatorId': {'$eq': None}}]
+                    },
+                    {
+                        # But where the current user still has access
+                        'access.users': {'$elemMatch': {'id': user['_id']}}
+                    },
+                ]
+            }
+        )
+
+    if len(optional_query_parts):
+        return {'$and': [base_query, {'$or': optional_query_parts}]}
+    return base_query
 
 
 def validate_files(files: List[str]):


### PR DESCRIPTION
There is a bug caused by `published=True, shared=True` that causes this function to return a query that will search for every public dataset, which is exactly the thing we were trying to avoid with this summary feature.

* What it did: `OR(dataset_query, shared_clause, published_clause)`
* What it should have done: `AND(dataset_query, OR(shared_clause, published_clause))`

It will also allow an unprivileged user to inspect labels inside all other user's private datasets IF those datasets are marked with the "published" metadata tag.  This is an edge case that **doesn't actually exist in prod**, but it's definitely an issue. 

Rewrite this function to have a `base_query` that will always be `$and` combined with `optional_query_parts`.

This is required before the stats page can be added again.