### PR TITLE
multicamera unclamping

### DIFF
--- a/client/dive-common/components/ImportMultiCamDialog.vue
+++ b/client/dive-common/components/ImportMultiCamDialog.vue
@@ -424,8 +424,7 @@ export default defineComponent({
           outlined
           dense
         >
-          Visualization currently doesn't support multi views so please choose
-          a list of images or video to display by default when viewing
+          Please choose the camera which will be selected by default when the loading the dataset.
         </v-alert>
         <div>
           <div>

--- a/client/src/components/annotators/useMediaController.ts
+++ b/client/src/components/annotators/useMediaController.ts
@@ -258,9 +258,15 @@ export function useMediaController() {
         // 4x zoom max
         max: 4,
       });
-      geoViewerRef.value.clampBoundsX(true);
-      geoViewerRef.value.clampBoundsY(true);
-      geoViewerRef.value.clampZoom(true);
+      if (Object.keys(geoViewers).length === 1) {
+        geoViewerRef.value.clampBoundsX(true);
+        geoViewerRef.value.clampBoundsY(true);
+        geoViewerRef.value.clampZoom(true);
+      } else {
+        geoViewerRef.value.clampBoundsX(false);
+        geoViewerRef.value.clampBoundsY(false);
+        geoViewerRef.value.clampZoom(false);
+      }
       resetZoom();
     }
 

--- a/server/dive_utils/__init__.py
+++ b/server/dive_utils/__init__.py
@@ -61,7 +61,7 @@ def strNumericCompare(input1: str, input2: str) -> int:
             return -1
         if type(b) == int:
             return 1
-        return 1 if a > b else -1
+        return 1 if str(a) > str(b) else -1
     return 0
 
 

--- a/server/dive_utils/serializers/meva.py
+++ b/server/dive_utils/serializers/meva.py
@@ -43,7 +43,7 @@ def load_kpf_as_tracks(readers: List[Iterable[ByteString]]):
     error_report: Dict[str, str] = {}
     try:
         for reader in readers:
-            rows = b"".join(list(reader)).decode("utf-8")
+            rows = ''.join([str(elem) for elem in reader])
             yml = kpf.load_yaml(rows)
             for row in yml:
                 if kpf.TYPES in row:


### PR DESCRIPTION
A request to have multicamera data unclamp the camera bounds so that linked cameras will behave better when panning around.

There may still be a question of how zooming works where geoJS will unzoom around the location of the mouse cursor instead of the current area's bounds.  That may have to be updated to get this working properly.