### PR TITLE
useModeManager updates

### DIFF
--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -3,12 +3,8 @@ import { cloneDeep, merge } from 'lodash';
 import Vue from 'vue';
 import { AnnotatorPreferences } from 'vue-media-annotator/types';
 
-interface AnnotationSettings {
-  typeSettings: {
-    showEmptyTypes: boolean;
-    lockTypes: boolean;
-  };
-  trackSettings: {
+
+export interface TrackSettings {
     newTrackSettings: {
       mode: 'Track' | 'Detection';
       type: string;
@@ -25,7 +21,13 @@ interface AnnotationSettings {
     deletionSettings: {
       promptUser: boolean;
     };
+  }
+interface AnnotationSettings {
+  typeSettings: {
+    showEmptyTypes: boolean;
+    lockTypes: boolean;
   };
+  trackSettings: TrackSettings;
   groupSettings: {
     newGroupSettings: {
       type: string;
@@ -35,6 +37,7 @@ interface AnnotationSettings {
   annotationFPS: number;
   annotatorPreferences: AnnotatorPreferences;
 }
+
 
 const defaultSettings: AnnotationSettings = {
   trackSettings: {

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -235,9 +235,11 @@ export default function useModeManager({
     const { frame } = aggregateController.value;
     let trackType = trackSettings.value.newTrackSettings.type;
     if (overrideTrackId !== undefined) {
-      const track = cameraStore.getAnyTrack(overrideTrackId);
-      // eslint-disable-next-line prefer-destructuring
-      trackType = track.confidencePairs[0][0];
+      const track = cameraStore.getAnyPossibleTrack(overrideTrackId);
+      if (track !== undefined) {
+        // eslint-disable-next-line prefer-destructuring
+        trackType = track.confidencePairs[0][0];
+      }
     } else {
       // eslint-disable-next-line no-param-reassign
       overrideTrackId = cameraStore.getNewTrackId();
@@ -452,6 +454,7 @@ export default function useModeManager({
     addTrackOrDetection: handleAddTrackOrDetection,
     selectTrack,
     recipes,
+    trackSettings,
   });
 
 

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -18,8 +18,6 @@ import CameraStore from 'vue-media-annotator/CameraStore';
 import useTrackEditor from './useTrackEditor';
 
 
-type SupportedFeature = GeoJSON.Feature<GeoJSON.Point | GeoJSON.Polygon | GeoJSON.LineString>;
-
 /* default to index + 1
  * call with -1 to select previous, or pass any other delta
  */
@@ -474,25 +472,29 @@ export default function useModeManager({
     selectedCamera,
     selectNextTrack,
     handler: {
+      //Merging
       commitMerge: handleCommitMerge,
+      toggleMerge: handleToggleMerge,
+      unstageFromMerge: handleUnstageFromMerge,
+      //Group Editing
       groupAdd: handleAddGroup,
       groupEdit: handleGroupEdit,
-      toggleMerge: handleToggleMerge,
+      removeGroup: handleRemoveGroup,
       trackAdd: handleAddTrackOrDetection,
       trackAbort: handleEscapeMode,
       trackEdit: handleTrackEdit,
+      removeTrack: handleRemoveTrack,
       trackSeek: handleTrackClick,
       trackSelect: handleSelectTrack,
       trackSelectNext: handleSelectNext,
+      // Editing Tracks
       updateRectBounds: editHandler.updateRectBounds,
       updateGeoJSON: editHandler.updateGeoJSON,
-      removeTrack: handleRemoveTrack,
       removePoint: editHandler.removePoint,
       removeAnnotation: editHandler.removeAnnotation,
-      removeGroup: handleRemoveGroup,
       selectFeatureHandle: editHandler.selectFeatureHandle,
       setAnnotationState: editHandler.setAnnotationState,
-      unstageFromMerge: handleUnstageFromMerge,
+      // MultiCamera Linking
       startLinking: handleStartLinking,
       stopLinking: handleStopLinking,
     },

--- a/client/dive-common/use/useTrackEditor.ts
+++ b/client/dive-common/use/useTrackEditor.ts
@@ -6,10 +6,10 @@ import CameraStore from 'vue-media-annotator/CameraStore';
 import { AggregateMediaController } from 'vue-media-annotator/components/annotators/mediaControllerType';
 import { EditAnnotationTypes, VisibleAnnotationTypes } from 'vue-media-annotator/layers';
 import Recipe from 'vue-media-annotator/recipe';
-import { clientSettings } from 'dive-common/store/settings';
 import Track, { TrackId } from 'vue-media-annotator/track';
 import { RectBounds, updateBounds } from 'vue-media-annotator/utils';
 import { flatMapDeep, uniq } from 'lodash';
+import { TrackSettings } from 'dive-common/store/settings';
 
 type SupportedFeature = GeoJSON.Feature<GeoJSON.Point | GeoJSON.Polygon | GeoJSON.LineString>;
 interface SetAnnotationStateArgs {
@@ -32,6 +32,7 @@ export default function useTrackEditor({
   addTrackOrDetection,
   selectTrack,
   recipes,
+  trackSettings,
 }: {
     selectedTrackId: Ref<AnnotationId | null>;
     editingTrack: Ref<boolean>;
@@ -41,6 +42,7 @@ export default function useTrackEditor({
     addTrackOrDetection: (overrideTrackId?: AnnotationId) => TrackId;
     selectTrack: (trackId: TrackId | null, edit?: boolean) => void;
     recipes: Recipe[];
+    trackSettings: Ref<TrackSettings>;
 }) {
   let creating = false;
   const editingCanary = ref(false);
@@ -55,7 +57,6 @@ export default function useTrackEditor({
     editing: 'rectangle' as EditAnnotationTypes,
   });
 
-  const trackSettings = toRef(clientSettings, 'trackSettings');
   const editingMode = computed(() => editingTrack.value && annotationModes.editing);
 
   const visibleModes = computed(() => (
@@ -168,6 +169,7 @@ export default function useTrackEditor({
           keyframe: true,
           interpolate: _shouldInterpolate(interpolate),
         });
+        creating = editingDetails.value === 'Creating';
         newTrackSettingsAfterLogic(track);
       }
     }
@@ -283,6 +285,7 @@ export default function useTrackEditor({
           // Treat this as a completed annotation if eventType is editing
           // Or none of the recieps reported that they were unfinished.
           if (eventType === 'editing' || update.done.every((v) => v !== false)) {
+            creating = editingDetails.value === 'Creating';
             newTrackSettingsAfterLogic(track);
           }
         }

--- a/client/dive-common/use/useTrackEditor.ts
+++ b/client/dive-common/use/useTrackEditor.ts
@@ -1,0 +1,357 @@
+import {
+  computed, onBeforeUnmount, reactive, ref, Ref, toRef,
+} from '@vue/composition-api';
+import { AnnotationId } from 'vue-media-annotator/BaseAnnotation';
+import CameraStore from 'vue-media-annotator/CameraStore';
+import { AggregateMediaController } from 'vue-media-annotator/components/annotators/mediaControllerType';
+import { EditAnnotationTypes, VisibleAnnotationTypes } from 'vue-media-annotator/layers';
+import Recipe from 'vue-media-annotator/recipe';
+import { clientSettings } from 'dive-common/store/settings';
+import Track from 'vue-media-annotator/track';
+import { RectBounds } from 'vue-media-annotator/utils';
+
+type SupportedFeature = GeoJSON.Feature<GeoJSON.Point | GeoJSON.Polygon | GeoJSON.LineString>;
+interface SetAnnotationStateArgs {
+    visible?: VisibleAnnotationTypes[];
+    editing?: EditAnnotationTypes;
+    key?: string;
+    recipeName?: string;
+}
+
+export default function useTrackEditor({
+  selectedTrackId,
+  cameraStore,
+  aggregateController,
+  selectedCamera,
+  recipes,
+}: {
+    selectedTrackId: Ref<AnnotationId | null>;
+    cameraStore: CameraStore;
+    aggregateController: Ref<AggregateMediaController>;
+    selectedCamera: Ref<string>;
+    recipes: Recipe[];
+}) {
+  let creating = false;
+  const editingTrack = ref(false);
+  const editingCanary = ref(false);
+  // Meaning of this value varies based on the editing mode.  When in
+  // polygon edit mode, this corresponds to a polygon point.  Ditto in line mode.
+  const selectedFeatureHandle = ref(-1);
+  //The Key of the selected type, for now mostly ''
+  const selectedKey = ref('');
+
+  const annotationModes = reactive({
+    visible: ['rectangle', 'Polygon', 'LineString', 'text'] as VisibleAnnotationTypes[],
+    editing: 'rectangle' as EditAnnotationTypes,
+  });
+  const trackSettings = toRef(clientSettings, 'trackSettings');
+  const editingMode = computed(() => editingTrack.value && annotationModes.editing);
+  function _depend(): boolean {
+    return editingCanary.value;
+  }
+  function _nudgeEditingCanary() {
+    editingCanary.value = !editingCanary.value;
+  }
+  // What is occuring in editing mode
+  const editingDetails = computed(() => {
+    _depend();
+    if (editingMode.value && selectedTrackId.value !== null) {
+      const { frame } = aggregateController.value;
+      try {
+        const track = cameraStore.getPossibleTrack(selectedTrackId.value, selectedCamera.value);
+        if (track) {
+          const [feature] = track.getFeature(frame.value);
+          if (feature) {
+            if (!feature?.bounds?.length) {
+              return 'Creating';
+            } if (annotationModes.editing === 'rectangle') {
+              return 'Editing';
+            }
+            return (feature.geometry?.features.filter((item) => item.geometry.type === annotationModes.editing).length ? 'Editing' : 'Creating');
+          }
+          return 'Creating';
+        }
+      } catch {
+        // No Track for this camera
+        return 'disabled';
+      }
+    }
+    return 'disabled';
+  });
+
+  /**
+   * Figure out if a new feature should enable interpolation
+   * based on current state and the result of canInterolate.
+   */
+  function _shouldInterpolate(canInterpolate: boolean) {
+    // if this is a track, then whether to interpolate
+    // is determined by newTrackSettings (if new track)
+    // or canInterpolate (if existing track)
+    const interpolateTrack = creating
+      ? trackSettings.value.newTrackSettings.modeSettings.Track.interpolate
+      : canInterpolate;
+    // if detection, interpolate is always false
+    return trackSettings.value.newTrackSettings.mode === 'Detection'
+      ? false
+      : interpolateTrack;
+  }
+
+  function _selectKey(key: string | undefined) {
+    if (typeof key === 'string') {
+      selectedKey.value = key;
+    } else {
+      selectedKey.value = '';
+    }
+  }
+
+  function handleSelectFeatureHandle(i: number, key = '') {
+    if (i !== selectedFeatureHandle.value) {
+      selectedFeatureHandle.value = i;
+    } else {
+      selectedFeatureHandle.value = -1;
+    }
+    _selectKey(key);
+  }
+
+  function newTrackSettingsAfterLogic(addedTrack: Track) {
+    // Default settings which are updated by the TrackSettings component
+    let newCreatingValue = false; // by default, disable creating at the end of this function
+    if (creating) {
+      if (addedTrack && trackSettings.value.newTrackSettings !== null) {
+        if (trackSettings.value.newTrackSettings.mode === 'Track'
+        && trackSettings.value.newTrackSettings.modeSettings.Track.autoAdvanceFrame
+        ) {
+          aggregateController.value.nextFrame();
+          newCreatingValue = true;
+        } else if (trackSettings.value.newTrackSettings.mode === 'Detection') {
+          if (
+            trackSettings.value.newTrackSettings.modeSettings.Detection.continuous) {
+            handleAddTrackOrDetection(cameraStore.getNewTrackId());
+            newCreatingValue = true; // don't disable creating mode
+          }
+        }
+      }
+    }
+    _nudgeEditingCanary();
+    creating = newCreatingValue;
+  }
+
+  function handleUpdateRectBounds(frameNum: number, flickNum: number, bounds: RectBounds) {
+    if (selectedTrackId.value !== null) {
+      const track = cameraStore.getPossibleTrack(selectedTrackId.value, selectedCamera.value);
+      if (track) {
+        // Determines if we are creating a new Detection
+        const { interpolate } = track.canInterpolate(frameNum);
+
+        track.setFeature({
+          frame: frameNum,
+          flick: flickNum,
+          bounds,
+          keyframe: true,
+          interpolate: _shouldInterpolate(interpolate),
+        });
+        newTrackSettingsAfterLogic(track);
+      }
+    }
+  }
+
+  function handleUpdateGeoJSON(
+    eventType: 'in-progress' | 'editing',
+    frameNum: number,
+    flickNum: number,
+    // Type alias this
+    data: SupportedFeature,
+    key?: string,
+    preventInterrupt?: () => void,
+  ) {
+    /**
+     * Declare aggregate update collector. Each recipe
+     * will have the opportunity to modify this object.
+     */
+    const update = {
+      // Geometry data to be applied to the feature
+      geoJsonFeatureRecord: {} as Record<string, SupportedFeature[]>,
+      // Ploygons to be unioned with existing bounds (update)
+      union: [] as GeoJSON.Polygon[],
+      // Polygons to be unioned without existing bounds (overwrite)
+      unionWithoutBounds: [] as GeoJSON.Polygon[],
+      // If the editor mode should change types
+      newType: undefined as EditAnnotationTypes | undefined,
+      // If the selected key should change
+      newSelectedKey: undefined as string | undefined,
+      // If the recipe has completed
+      done: [] as (boolean|undefined)[],
+    };
+
+    if (selectedTrackId.value !== null) {
+      const track = cameraStore.getPossibleTrack(selectedTrackId.value, selectedCamera.value);
+      if (track) {
+        // newDetectionMode is true if there's no keyframe on frameNum
+        const { features, interpolate } = track.canInterpolate(frameNum);
+        const [real] = features;
+
+        // Give each recipe the opportunity to make changes
+        recipes.forEach((recipe) => {
+          const changes = recipe.update(eventType, frameNum, track, [data], key);
+          // Prevent key conflicts among recipes
+          Object.keys(changes.data).forEach((key_) => {
+            if (key_ in update.geoJsonFeatureRecord) {
+              throw new Error(`Recipe ${recipe.name} tried to overwrite key ${key_} when it was already set`);
+            }
+          });
+          Object.assign(update.geoJsonFeatureRecord, changes.data);
+          // Collect unions
+          update.union.push(...changes.union);
+          update.unionWithoutBounds.push(...changes.unionWithoutBounds);
+          update.done.push(changes.done);
+          // Prevent more than 1 recipe from changing a given mode/key
+          if (changes.newType) {
+            if (update.newType) {
+              throw new Error(`Recipe ${recipe.name} tried to modify type when it was already set`);
+            }
+            update.newType = changes.newType;
+          }
+          if (changes.newSelectedKey) {
+            if (update.newSelectedKey) {
+              throw new Error(`Recipe ${recipe.name} tried to modify selectedKey when it was already set`);
+            }
+            update.newSelectedKey = changes.newSelectedKey;
+          }
+        });
+
+        // somethingChanged indicates whether there will need to be a redraw
+        // of the geometry currently displayed
+        const somethingChanged = (
+          update.union.length !== 0
+          || update.unionWithoutBounds.length !== 0
+          || Object.keys(update.geoJsonFeatureRecord).length !== 0
+        );
+
+        // If a drawable changed, but we aren't changing modes
+        // prevent an interrupt within EditAnnotationLayer
+        if (
+          somethingChanged
+          && !update.newSelectedKey
+          && !update.newType
+          && preventInterrupt
+        ) {
+          preventInterrupt();
+        } else {
+          // Otherwise, one of these state changes will trigger an interrupt.
+          if (update.newSelectedKey) {
+            selectedKey.value = update.newSelectedKey;
+          }
+          if (update.newType) {
+            annotationModes.editing = update.newType;
+            recipes.forEach((r) => r.deactivate());
+          }
+        }
+        // Update the state of the track in the trackstore.
+        if (somethingChanged) {
+          track.setFeature({
+            frame: frameNum,
+            flick: flickNum,
+            keyframe: true,
+            bounds: updateBounds(real?.bounds, update.union, update.unionWithoutBounds),
+            interpolate,
+          }, flatMapDeep(update.geoJsonFeatureRecord,
+            (geomlist, key_) => geomlist.map((geom) => ({
+              type: geom.type,
+              geometry: geom.geometry,
+              properties: { key: key_ },
+            }))));
+
+          // Only perform "initialization" after the first shape.
+          // Treat this as a completed annotation if eventType is editing
+          // Or none of the recieps reported that they were unfinished.
+          if (eventType === 'editing' || update.done.every((v) => v !== false)) {
+            newTrackSettingsAfterLogic(track);
+          }
+        }
+      } else {
+        throw new Error(`${selectedTrackId.value} missing from trackMap`);
+      }
+    } else {
+      throw new Error('Cannot call handleUpdateGeojson without a selected Track ID');
+    }
+  }
+
+  /* If any recipes are active, allow them to remove a point */
+  function handleRemovePoint() {
+    if (selectedTrackId.value !== null && selectedFeatureHandle.value !== -1) {
+      const track = cameraStore.getPossibleTrack(selectedTrackId.value, selectedCamera.value);
+      if (track) {
+        recipes.forEach((r) => {
+          if (r.active.value) {
+            const { frame } = aggregateController.value;
+            r.deletePoint(
+              frame.value,
+              track,
+              selectedFeatureHandle.value,
+              selectedKey.value,
+              annotationModes.editing,
+            );
+          }
+        });
+      }
+    }
+    handleSelectFeatureHandle(-1);
+  }
+
+  /* If any recipes are active, remove the geometry they added */
+  function handleRemoveAnnotation() {
+    if (selectedTrackId.value !== null) {
+      const track = cameraStore.getPossibleTrack(selectedTrackId.value, selectedCamera.value);
+      if (track) {
+        const { frame } = aggregateController.value;
+        recipes.forEach((r) => {
+          if (r.active.value) {
+            r.delete(frame.value, track, selectedKey.value, annotationModes.editing);
+          }
+        });
+        _nudgeEditingCanary();
+      }
+    }
+  }
+
+  function handleSetAnnotationState({
+    visible, editing, key, recipeName,
+  }: SetAnnotationStateArgs) {
+    if (visible) {
+      annotationModes.visible = visible;
+    }
+    if (editing) {
+      annotationModes.editing = editing;
+      _selectKey(key);
+      handleSelectTrack(selectedTrackId.value, true);
+      recipes.forEach((r) => {
+        if (recipeName !== r.name) {
+          r.deactivate();
+        }
+      });
+    }
+  }
+
+  recipes.forEach((r) => r.bus.$on('activate', handleSetAnnotationState));
+  /* Unsubscribe before unmount */
+  onBeforeUnmount(() => {
+    recipes.forEach((r) => r.bus.$off('activate', handleSetAnnotationState));
+  });
+
+  return {
+    editingMode,
+    editingTrack,
+    editingDetails,
+    selectedFeatureHandle,
+    selectedKey,
+    handler: {
+      updateRectBounds: handleUpdateRectBounds,
+      updateGeoJSON: handleUpdateGeoJSON,
+      removePoint: handleRemovePoint,
+      removeAnnotation: handleRemoveAnnotation,
+      selectFeatureHandle: handleSelectFeatureHandle,
+      setAnnotationState: handleSetAnnotationState,
+    },
+  };
+}
+


### PR DESCRIPTION
A simple refactoring of useModeManager to break out useTrackEditor.

useTrackEditor just breaks out all of the function that are specifically used for track modification/
useTrackEditor has it's own internal state dependent on the following:
- selected Annotation mode (Rectangle/polygon/head-tail)
- If an annotation for that mode exists.  This determines differences between editing/creating
- Current Frame - used for interpolation

I tried to minimize the ingoing/outfoing for this file to make it as encapsulated as possible.  There may be a few more things that could be done to improve it.

20220714 - placed a possible fix to #1272 in this PR.  Could easily be done in main as well.

Possible TODOs:
- Break out Group Editor
- Break out Camera track/linking
- Determine if the state transferred between the two can be reduced further