### PR TITLE
Job queue size

### DIFF
--- a/server/dive_server/__init__.py
+++ b/server/dive_server/__init__.py
@@ -17,7 +17,7 @@ from .event import process_fs_import, process_s3_import, send_new_user_email
 from .views_annotation import AnnotationResource
 from .views_configuration import ConfigurationResource
 from .views_dataset import DatasetResource
-from .views_override import use_private_queue
+from .views_override import countJobs, use_private_queue
 from .views_rpc import RpcResource
 
 
@@ -33,6 +33,7 @@ class GirderPlugin(plugin.GirderPlugin):
         info["apiRoot"].dive_rpc = RpcResource("dive_rpc")
 
         # Setup route additions for exsting resources
+        info['apiRoot'].job.route("GET", ("queued",), countJobs)
         info["apiRoot"].user.route("PUT", (":id", "use_private_queue"), use_private_queue)
         User().exposeFields(AccessType.READ, constants.UserPrivateQueueEnabledMarker)
 

--- a/server/dive_server/views_override.py
+++ b/server/dive_server/views_override.py
@@ -5,7 +5,7 @@ from girder.api.rest import boundHandler
 from girder.constants import AccessType
 from girder.models.user import User
 from girder_jobs.models import job
-from girder_worker.utils import JobStatus as GWJobStatus
+from girder_worker.utils import JobStatus
 
 from dive_utils import constants
 
@@ -44,13 +44,14 @@ def countJobs(self):
             user='all',
             currentUser=self.getCurrentUser(),
             statuses=[
-                GWJobStatus.QUEUED,
-                GWJobStatus.RUNNING,
-                GWJobStatus.CANCELING,
-                GWJobStatus.CONVERTING_INPUT,
-                GWJobStatus.CONVERTING_OUTPUT,
-                GWJobStatus.FETCHING_INPUT,
-                GWJobStatus.PUSHING_OUTPUT,
+                JobStatus.INACTIVE,
+                JobStatus.QUEUED,
+                JobStatus.RUNNING,
+                JobStatus.CANCELING,
+                JobStatus.CONVERTING_INPUT,
+                JobStatus.CONVERTING_OUTPUT,
+                JobStatus.FETCHING_INPUT,
+                JobStatus.PUSHING_OUTPUT,
             ],
         )
         .count()

--- a/server/dive_server/views_override.py
+++ b/server/dive_server/views_override.py
@@ -4,6 +4,8 @@ from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import boundHandler
 from girder.constants import AccessType
 from girder.models.user import User
+from girder_jobs.models import job
+from girder_worker.utils import JobStatus as GWJobStatus
 
 from dive_utils import constants
 
@@ -29,4 +31,31 @@ def use_private_queue(self, user: dict, privateQueueEnabled: bool):
         constants.UserPrivateQueueEnabledMarker: user.get(
             constants.UserPrivateQueueEnabledMarker, False
         ),
+    }
+
+
+@access.user
+@boundHandler
+@autoDescribeRoute(Description('Get number of outstanding jobs'))
+def countJobs(self):
+    outstanding = (
+        job.Job()
+        .list(
+            user='all',
+            currentUser=self.getCurrentUser(),
+            statuses=[
+                GWJobStatus.QUEUED,
+                GWJobStatus.RUNNING,
+                GWJobStatus.CANCELING,
+                GWJobStatus.CONVERTING_INPUT,
+                GWJobStatus.CONVERTING_OUTPUT,
+                GWJobStatus.FETCHING_INPUT,
+                GWJobStatus.PUSHING_OUTPUT,
+            ],
+        )
+        .count()
+    )
+
+    return {
+        'outstanding': outstanding,
     }


### PR DESCRIPTION
Show the size of the job queue to all users.

This is an imperfect solution because when another user in the system creates a job, it won't show up here because User A won't get push notifications about user B's jobs.  It will update for changes in User A's job status, but otherwise might require a page reload to be correct.

fixes #1260 

![Screenshot from 2022-07-05 16-45-32](https://user-images.githubusercontent.com/4214172/177413517-3fc752fa-95d4-4b6d-954f-11a9cabccd6c.png)
