### PR TITLE
fixing detections afterTrack logic

### DIFF
--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -319,9 +319,11 @@ export default function useModeManager({
     const { frame } = aggregateController.value;
     let trackType = trackSettings.value.newTrackSettings.type;
     if (overrideTrackId !== undefined) {
-      const track = cameraStore.getAnyTrack(overrideTrackId);
-      // eslint-disable-next-line prefer-destructuring
-      trackType = track.confidencePairs[0][0];
+      const track = cameraStore.getAnyPossibleTrack(overrideTrackId);
+      if (track !== undefined) {
+        // eslint-disable-next-line prefer-destructuring
+        trackType = track.confidencePairs[0][0];
+      }
     } else {
       // eslint-disable-next-line no-param-reassign
       overrideTrackId = cameraStore.getNewTrackId();


### PR DESCRIPTION
Closes #1272 

Issue was caused by using getAnyTrack with a trackId that doesn't exists.
Original intention was that this was being used for creating a track in another camera where the original track already had a trackId.  This code was just grabbing the type of the source camera track to make sure they aligned.
The newTracksettingsAfterLogic when the user is in Continuous detection mode uses a new overrideId by grabbing a new trackId to assign to the new Track.  When in singlecam the new trackId doesn't exist already so you get the error.  Swapping this to `getAnyPossibleTrack` will return an undefined if it is not located and will revert back to the default track type instead of trying to match it up.

https://user-images.githubusercontent.com/61746913/179258517-12de12c3-06f3-43c8-8251-51ce18ee56b7.mp4


