### PR TITLE
Numeric Slider Support

### DIFF
--- a/client/dive-common/components/AttributeEditor.vue
+++ b/client/dive-common/components/AttributeEditor.vue
@@ -173,7 +173,7 @@ export default defineComponent({
           />
           <div v-if="datatype=== 'number'">
             <v-radio-group
-              :value="editor.type || 'combo'"
+              :value="(editor && editor.type) || 'combo'"
               row
               label="Display Type:"
               @change="numericChange"

--- a/client/dive-common/components/AttributeEditor.vue
+++ b/client/dive-common/components/AttributeEditor.vue
@@ -173,7 +173,7 @@ export default defineComponent({
           />
           <div v-if="datatype=== 'number'">
             <v-radio-group
-              :value="editor.type"
+              :value="editor.type || 'combo'"
               row
               label="Display Type:"
               @change="numericChange"

--- a/client/dive-common/components/AttributeEditor.vue
+++ b/client/dive-common/components/AttributeEditor.vue
@@ -24,6 +24,7 @@ export default defineComponent({
     const belongs: Ref<string> = ref(props.selectedAttribute.belongs);
     const datatype: Ref<string> = ref(props.selectedAttribute.datatype);
     const color: Ref<string | undefined> = ref(props.selectedAttribute.color);
+    const areSettingsValid = ref(false);
     const editor: Ref<
       undefined | StringAttributeEditorOptions | NumericAttributeEditorOptions
     > = ref(props.selectedAttribute.editor);
@@ -124,6 +125,7 @@ export default defineComponent({
       values,
       addNew,
       editor,
+      areSettingsValid,
       //computed
       textValues,
       //functions
@@ -154,7 +156,10 @@ export default defineComponent({
             }}
           </div>
         </v-alert>
-        <v-form ref="form">
+        <v-form
+          ref="form"
+          v-model="areSettingsValid"
+        >
           <v-text-field
             v-model="name"
             label="Name"
@@ -196,9 +201,12 @@ export default defineComponent({
                 outlined
                 :step="editor.range[0]> 1 ? 1 : 0.01"
                 type="number"
-                label="Lower"
+                label="Min"
+                :rules="[
+                  v => !isNaN(parseFloat(v))|| 'Number is required',
+                  v => v < editor.range[1] || 'Min needs to be smaller than the Max']"
                 :max="editor.range[1]"
-                hint="Lower limit for slider"
+                hint="Min limit for slider"
                 persistent-hint
               />
               <v-text-field
@@ -207,9 +215,12 @@ export default defineComponent({
                 outlined
                 :step="editor.range[1]> 1 ? 1 : 0.01"
                 type="number"
-                label="Upper"
+                label="Max"
+                :rules="[
+                  v => !isNaN(parseFloat(v)) || 'Number is required',
+                  v => v > editor.range[0] || 'Max needs to be larger than the Min']"
                 :min="editor.range[0]"
-                hint="Upper limit for slider"
+                hint="Max limit for slider"
                 persistent-hint
               />
             </v-row>
@@ -220,7 +231,11 @@ export default defineComponent({
                 outlined
                 :step="editor.steps> 1 ? 1 : 0.01"
                 type="number"
-                label="Slider Resolution"
+                :rules="[
+                  v => !isNaN(parseFloat(v)) || 'Number is required',
+                  v => v < (editor.range[1] - editor.range[0])
+                    || 'Steps should be smaller than the range']"
+                label="Slider Step Interval"
                 min="0"
                 hint="Each movement will move X amount"
                 persistent-hint
@@ -271,7 +286,7 @@ export default defineComponent({
             </v-btn>
             <v-btn
               color="primary"
-              :disabled="!name || name.includes(' ')"
+              :disabled="!areSettingsValid || (!name || name.includes(' '))"
               @click.prevent="submit"
             >
               Save

--- a/client/dive-common/components/AttributeEditor.vue
+++ b/client/dive-common/components/AttributeEditor.vue
@@ -2,7 +2,7 @@
 import {
   computed, defineComponent, PropType, Ref, ref,
 } from '@vue/composition-api';
-import { Attribute } from 'vue-media-annotator/use/useAttributes';
+import { Attribute, NumericAttributeEditorOptions, StringAttributeEditorOptions } from 'vue-media-annotator/use/useAttributes';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 
 
@@ -23,6 +23,10 @@ export default defineComponent({
     const name: Ref<string> = ref(props.selectedAttribute.name);
     const belongs: Ref<string> = ref(props.selectedAttribute.belongs);
     const datatype: Ref<string> = ref(props.selectedAttribute.datatype);
+    const color: Ref<string | undefined> = ref(props.selectedAttribute.color);
+    const editor: Ref<
+      undefined | StringAttributeEditorOptions | NumericAttributeEditorOptions
+    > = ref(props.selectedAttribute.editor);
     let values: string[] = props.selectedAttribute.values ? props.selectedAttribute.values : [];
     let addNew = !props.selectedAttribute.key.length;
 
@@ -66,6 +70,8 @@ export default defineComponent({
         datatype: datatype.value,
         values: datatype.value === 'text' && values ? values : [],
         key: `${belongs.value}_${name.value}`,
+        editor: editor.value,
+        color: color.value,
       };
 
       if (addNew) {
@@ -86,18 +92,46 @@ export default defineComponent({
       }
       emit('delete', props.selectedAttribute);
     }
+    const typeChange = (type: 'number' | 'text' | 'boolean') => {
+      if (type === 'number') {
+        editor.value = {
+          type: 'combo',
+        };
+      } else if (type === 'text') {
+        editor.value = {
+          type: 'freeform',
+        };
+      }
+      datatype.value = type;
+    };
+    const numericChange = (type: 'combo' | 'slider') => {
+      if (type === 'combo') {
+        editor.value = {
+          type: 'combo',
+        };
+      } else if (type === 'slider') {
+        editor.value = {
+          type: 'slider',
+          range: [0, 1],
+          steps: 0.1,
+        };
+      }
+    };
     return {
       name,
       belongs,
       datatype,
       values,
       addNew,
+      editor,
       //computed
       textValues,
       //functions
       add,
       submit,
       deleteAttribute,
+      typeChange,
+      numericChange,
     };
   },
 });
@@ -128,14 +162,71 @@ export default defineComponent({
             required
           />
           <v-select
-            v-model="datatype"
+            :value="datatype"
             :items="[
               { text: 'Boolean', value: 'boolean' },
               { text: 'Number', value: 'number' },
               { text: 'Text', value: 'text' }
             ]"
             label="Datatype"
+            @change="typeChange"
           />
+          <div v-if="datatype=== 'number'">
+            <v-radio-group
+              :value="editor.type"
+              row
+              label="Display Type:"
+              @change="numericChange"
+            >
+              <v-radio
+                label="Input Box"
+                value="combo"
+              />
+              <v-radio
+                label="Slider"
+                value="slider"
+              />
+            </v-radio-group>
+          </div>
+          <div v-if="datatype === 'number' && editor && editor.type === 'slider'">
+            <v-row class="pt-2">
+              <v-text-field
+                v-model.number="editor.range[0]"
+                dense
+                outlined
+                :step="editor.range[0]> 1 ? 1 : 0.01"
+                type="number"
+                label="Lower"
+                :max="editor.range[1]"
+                hint="Lower limit for slider"
+                persistent-hint
+              />
+              <v-text-field
+                v-model.number="editor.range[1]"
+                dense
+                outlined
+                :step="editor.range[1]> 1 ? 1 : 0.01"
+                type="number"
+                label="Upper"
+                :min="editor.range[0]"
+                hint="Upper limit for slider"
+                persistent-hint
+              />
+            </v-row>
+            <v-row class="pt-2">
+              <v-text-field
+                v-model.number="editor.steps"
+                dense
+                outlined
+                :step="editor.steps> 1 ? 1 : 0.01"
+                type="number"
+                label="Slider Resolution"
+                min="0"
+                hint="Each movement will move X amount"
+                persistent-hint
+              />
+            </v-row>
+          </div>
           <v-textarea
             v-if="datatype === 'text'"
             v-model="textValues"

--- a/client/dive-common/components/AttributeInput.vue
+++ b/client/dive-common/components/AttributeInput.vue
@@ -6,6 +6,7 @@ import {
   onMounted,
   watch,
 } from '@vue/composition-api';
+import { NumericAttributeEditorOptions, StringAttributeEditorOptions } from 'vue-media-annotator/use/useAttributes';
 
 export default defineComponent({
   props: {
@@ -32,6 +33,10 @@ export default defineComponent({
     disabled: {
       type: Boolean,
       default: false,
+    },
+    typeSettings: {
+      type: Object as PropType<null | NumericAttributeEditorOptions | StringAttributeEditorOptions>,
+      default: null,
     },
   },
   setup(props, { emit }) {
@@ -90,6 +95,11 @@ export default defineComponent({
       }
       target.blur();
     }
+    function sliderChange(num: number) {
+      const { name } = props;
+      emit('change', { name, value: num });
+    }
+
     return {
       inputBoxRef,
       tempVal,
@@ -98,6 +108,7 @@ export default defineComponent({
       onFocus,
       onInputKeyEvent,
       change,
+      sliderChange,
     };
   },
 });
@@ -132,7 +143,7 @@ export default defineComponent({
       @keydown="onInputKeyEvent"
     >
     <input
-      v-else-if="datatype === 'number'"
+      v-else-if="datatype === 'number' && (!typeSettings || typeSettings.type ==='combo')"
       ref="inputBoxRef"
       :label="datatype"
       :value="value"
@@ -143,6 +154,23 @@ export default defineComponent({
       @change="change"
       @keydown="onInputKeyEvent"
     >
+    <div
+      v-else-if="datatype === 'number' && (typeSettings && typeSettings.type ==='slider')"
+    >
+      <div class="slider-label">
+        {{ value }}
+      </div>
+      <v-slider
+        :value="value"
+        :step="typeSettings.steps ? typeSettings.steps
+          : (typeSettings.range[1] - typeSettings.range[0])/2.0"
+        :min="typeSettings.range[0]"
+        :max="typeSettings.range[1]"
+        dense
+        class="attribute-slider"
+        @input="sliderChange"
+      />
+    </div>
     <select
       v-else-if="datatype === 'boolean'"
       ref="inputBoxRef"
@@ -176,5 +204,17 @@ export default defineComponent({
     width: 110px;
     background-color: #1e1e1e;
     appearance: menulist;
+  }
+    .attribute-slider {
+    font-size: 12px !important;
+    padding: 0;
+    margin: 0;
+    max-height:35px;
+    overflow:hidden;
+  }
+  .slider-label {
+    margin: auto;
+    text-align: center;
+    width: 100%;
   }
 </style>

--- a/client/dive-common/components/AttributesSubsection.vue
+++ b/client/dive-common/components/AttributesSubsection.vue
@@ -304,6 +304,7 @@ export default defineComponent({
                     ? selectedAttributes.attributes[attribute.name]
                     : undefined
                 "
+                :type-settings="attribute.editor || null"
                 @change="
                   updateAttribute($event)"
               />
@@ -326,6 +327,7 @@ export default defineComponent({
                         ? selectedAttributes.attributes[attribute.name]
                         : undefined
                     "
+                    :type-settings="attribute.editor || null"
                     focus
                     @change="updateAttribute($event)"
                   />

--- a/client/src/use/useAttributes.ts
+++ b/client/src/use/useAttributes.ts
@@ -7,6 +7,15 @@ import { StyleManager, Track } from '..';
 import CameraStore from '../CameraStore';
 import { LineChartData } from './useLineChart';
 
+export interface NumericAttributeEditorOptions {
+  type: 'combo'| 'slider';
+  range?: number[];
+  steps?: number;
+}
+export interface StringAttributeEditorOptions {
+  type: 'locked'| 'freeform';
+}
+
 export interface Attribute {
   belongs: 'track' | 'detection';
   datatype: 'text' | 'number' | 'boolean';
@@ -14,6 +23,7 @@ export interface Attribute {
   name: string;
   key: string;
   color?: string;
+  editor?: NumericAttributeEditorOptions | StringAttributeEditorOptions;
 }
 
 export type Attributes = Record<string, Attribute>;

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -128,6 +128,7 @@ class RevisionLog(BaseModel):
     created: datetime = Field(default_factory=datetime.utcnow)
     description: Optional[str]
 
+
 class NumericAttributeOptions(BaseModel):
     type: Literal['combo', 'slider']
     range: Optional[List[float]]

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -128,6 +128,15 @@ class RevisionLog(BaseModel):
     created: datetime = Field(default_factory=datetime.utcnow)
     description: Optional[str]
 
+class NumericAttributeOptions(BaseModel):
+    type: Literal['combo', 'slider']
+    range: Optional[List[float]]
+    steps: Optional[float]
+
+
+class StringAttributeOptions(BaseModel):
+    type: Literal['locked', 'freeform']
+
 
 class Attribute(BaseModel):
     belongs: Literal['track', 'detection']
@@ -135,6 +144,8 @@ class Attribute(BaseModel):
     values: Optional[List[str]]
     name: str
     key: str
+    color: Optional[str]
+    editor: Optional[Union[NumericAttributeOptions, StringAttributeOptions]]
 
 
 class CustomStyle(BaseModel):


### PR DESCRIPTION
- models.py updated the attributes for optional `editor` object which can include future visualization options for attributes
- Added in the `color` option for the attribute timeline/filtering tools
- Added selection between input box/slider for numeric attributes

https://user-images.githubusercontent.com/61746913/184219479-56bc1e5d-d2ad-4821-9b73-8820a0cf98d3.mp4