### PR TITLE
Refactor Sorted Annotations

### DIFF
--- a/client/dive-common/components/TrackDetailsPanel.vue
+++ b/client/dive-common/components/TrackDetailsPanel.vue
@@ -298,7 +298,7 @@ export default defineComponent({
           <span class="trackNumber">{{ editingGroup.id }}</span>
           <v-spacer />
           <TypePicker
-            :value="editingGroup.getType()[0]"
+            :value="editingGroup.getType()"
             :all-types="allGroupTypesRef"
             :read-only-mode="readOnlyMode"
             data-list-source="allGroupTypesOptions"

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -10,12 +10,12 @@ import { AggregateMediaController } from 'vue-media-annotator/components/annotat
 import Recipe from 'vue-media-annotator/recipe';
 import type { AnnotationId } from 'vue-media-annotator/BaseAnnotation';
 import type TrackFilterControls from 'vue-media-annotator/TrackFilterControls';
-import BaseAnnotation from 'vue-media-annotator/BaseAnnotation';
 
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { clientSettings } from 'dive-common/store/settings';
 import GroupFilterControls from 'vue-media-annotator/GroupFilterControls';
 import CameraStore from 'vue-media-annotator/CameraStore';
+import { SortedAnnotation } from 'vue-media-annotator/BaseAnnotationStore';
 
 
 type SupportedFeature = GeoJSON.Feature<GeoJSON.Point | GeoJSON.Polygon | GeoJSON.LineString>;
@@ -23,7 +23,7 @@ type SupportedFeature = GeoJSON.Feature<GeoJSON.Point | GeoJSON.Polygon | GeoJSO
 /* default to index + 1
  * call with -1 to select previous, or pass any other delta
  */
-function selectNext<T extends BaseAnnotation>(
+function selectNext<T extends SortedAnnotation>(
   filtered: Readonly<T>[], selected: Readonly<AnnotationId | null>, delta = 1,
 ): AnnotationId | null {
   if (filtered.length > 0) {
@@ -334,7 +334,7 @@ export default function useModeManager({
         frame.value, trackType,
         selectedTrackId.value || undefined,
         overrideTrackId,
-      ).trackId;
+      ).id;
       selectTrack(newTrackId, true);
       creating = true;
       return newTrackId;
@@ -684,7 +684,7 @@ export default function useModeManager({
       ));
       handleRemoveTrack(otherTrackIds, true);
       handleToggleMerge();
-      handleSelectTrack(track.trackId, false);
+      handleSelectTrack(track.id, false);
     }
   }
 

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -20,6 +20,10 @@ export default defineComponent({
       type: Object as PropType<DesktopMediaImportResponse>,
       required: true,
     },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props) {
     const argCopy = ref(cloneDeep(props.importData));
@@ -316,7 +320,7 @@ export default defineComponent({
         </v-btn>
         <v-btn
           color="primary"
-          :disabled="!ready"
+          :disabled="!ready || disabled"
           @click="$emit('finalize-import', argCopy)"
         >
           Finish Import

--- a/client/platform/desktop/frontend/components/Recent.vue
+++ b/client/platform/desktop/frontend/components/Recent.vue
@@ -47,6 +47,7 @@ export default defineComponent({
     const searchText: Ref<string | null> = ref('');
     const stereo = ref(false);
     const multiCamOpenType: Ref<'image-sequence'|'video'> = ref('image-sequence');
+    const importing = ref(false);
     const { prompt } = usePrompt();
     const {
       error, loading: checkingMedia, request, reset: resetError,
@@ -61,6 +62,7 @@ export default defineComponent({
 
     /** Accept args from the dialog, as it may have modified some parts */
     async function finalizeImport(args: DesktopMediaImportResponse) {
+      importing.value = true;
       await request(async () => {
         const jsonMeta = await api.finalizeImport(args);
         pendingImportPayload.value = null; // close dialog
@@ -75,6 +77,7 @@ export default defineComponent({
           setRecents(recentsMeta);
         }
       });
+      importing.value = false;
     }
 
     function openMultiCamDialog(args: {stereo: boolean; openType: 'image-sequence' | 'video'}) {
@@ -195,6 +198,7 @@ export default defineComponent({
       pendingImportPayload,
       searchText,
       error,
+      importing,
       importMultiCamDialog,
       headers,
       upgradedVersion,
@@ -220,6 +224,7 @@ export default defineComponent({
       <ImportDialog
         v-if="pendingImportPayload !== null"
         :import-data="pendingImportPayload"
+        :disabled="importing"
         @finalize-import="finalizeImport($event)"
         @abort="pendingImportPayload = null"
       />

--- a/client/src/CameraStore.ts
+++ b/client/src/CameraStore.ts
@@ -4,8 +4,8 @@ import {
 import { cloneDeep, uniq } from 'lodash';
 import type Track from './track';
 import type Group from './Group';
-import { AnnotationId } from './BaseAnnotation';
-import { MarkChangesPending } from './BaseAnnotationStore';
+import { AnnotationId, ConfidencePair } from './BaseAnnotation';
+import { MarkChangesPending, SortedAnnotation } from './BaseAnnotationStore';
 import GroupStore from './GroupStore';
 import TrackStore from './TrackStore';
 
@@ -20,9 +20,9 @@ export default class CameraStore {
 
     markChangesPending: MarkChangesPending;
 
-    sortedTracks: Ref<Track[]>;
+    sortedTracks: Ref<SortedAnnotation[]>;
 
-    sortedGroups: Ref<Group[]>;
+    sortedGroups: Ref<SortedAnnotation[]>;
 
     defaultGroup: [string, number];
 
@@ -45,10 +45,10 @@ export default class CameraStore {
          * This allows the full range begin/end for the track across multiple cameras to
          * be displayed.
          */
-        return uniq(idList).map((id) => this.getTracksMerged(id));
+        return uniq(idList).map((id) => this.getTracksMergedForSorted(id));
       });
       this.sortedGroups = computed(() => {
-        let list: Group[] = [];
+        let list: SortedAnnotation[] = [];
         this.camMap.value.forEach((camera) => {
           list = list.concat(camera.groupStore.sorted.value);
         });
@@ -140,6 +140,17 @@ export default class CameraStore {
       return track;
     }
 
+    getTracksMergedForSorted(trackId: Readonly<AnnotationId>): SortedAnnotation {
+      const track = this.getTracksMerged(trackId);
+      return {
+        id: track.id,
+        confidencePairs: track.confidencePairs,
+        begin: track.begin,
+        end: track.end,
+        getType: (index?: number) => (track.confidencePairs[index || 0][0] || 'unknown'),
+      };
+    }
+
     addCamera(cameraName: string) {
       if (this.camMap.value.get(cameraName) === undefined) {
         this.camMap.value.set(cameraName, {
@@ -224,11 +235,11 @@ export default class CameraStore {
     }
 
     // Update all cameras to have the same track type
-    setTrackType(id: AnnotationId, type: string) {
+    setTrackType(id: AnnotationId, newType: string, confidenceVal?: number, currentType?: string) {
       this.camMap.value.forEach((camera) => {
         const track = camera.trackStore.getPossible(id);
         if (track !== undefined) {
-          track.setType(type);
+          track.setType(newType, confidenceVal, currentType);
         }
       });
     }
@@ -239,11 +250,25 @@ export default class CameraStore {
           for (let i = 0; i < annotation.confidencePairs.length; i += 1) {
             const [name, confidenceVal] = annotation.confidencePairs[i];
             if (name === currentType) {
-              annotation.setType(newType, confidenceVal, currentType);
+              const track = camera.trackStore.get(annotation.id);
+              if (track) {
+                track.setType(newType, confidenceVal, currentType);
+              }
               break;
             }
           }
         });
       });
+    }
+
+    removeTypes(id: AnnotationId, types: string[]) {
+      let resultingTypes: ConfidencePair[] = [];
+      this.camMap.value.forEach((camera) => {
+        const track = camera.trackStore.getPossible(id);
+        if (track !== undefined) {
+          resultingTypes = track.removeTypes(types);
+        }
+      });
+      return resultingTypes;
     }
 }

--- a/client/src/CameraStore.ts
+++ b/client/src/CameraStore.ts
@@ -271,4 +271,15 @@ export default class CameraStore {
       });
       return resultingTypes;
     }
+
+    getGroupMemebers(id: AnnotationId) {
+      let members = {};
+      this.camMap.value.forEach((camera) => {
+        const group = camera.groupStore.get(id);
+        if (group !== undefined) {
+          members = group.members;
+        }
+      });
+      return members;
+    }
 }

--- a/client/src/TrackStore.spec.ts
+++ b/client/src/TrackStore.spec.ts
@@ -8,16 +8,17 @@ Vue.use(CompositionApi);
 describe('TrackStore', () => {
   it('can add and remove tracks', () => {
     const ts = new TrackStore({ markChangesPending: () => null, cameraName: 'singleCam' });
+    ts.setEnableSorting();
     const t0 = ts.add(20, 'foo', undefined, ts.getNewId());
     const t1 = ts.add(10, 'foo', undefined, ts.getNewId());
     expect(Array.from(ts.annotationMap.keys()).length).toBe(2);
-    expect(ts.sorted.value[0].trackId).toBe(1);
+    expect(ts.sorted.value[0].id).toBe(1);
     expect(ts.intervalTree.search([10, 10]).length).toBe(1);
     expect(ts.intervalTree.search([10, 20]).length).toBe(2);
 
     ts.remove(t1.id);
     expect(Array.from(ts.annotationMap.keys()).length).toBe(1);
-    expect(ts.sorted.value[0].trackId).toBe(0);
+    expect(ts.sorted.value[0].id).toBe(0);
     expect(ts.intervalTree.search([10, 10]).length).toBe(0);
     expect(ts.intervalTree.search([10, 20]).length).toBe(1);
 
@@ -57,6 +58,7 @@ describe('TrackStore', () => {
 
   it('updates a reactive list when member tracks change', async () => {
     const ts = new TrackStore({ markChangesPending: () => null, cameraName: 'singleCam' });
+    ts.setEnableSorting();
     const track = ts.add(0, 'foo', undefined, ts.getNewId());
 
     let called = false;

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -131,7 +131,7 @@ export default defineComponent({
     const typeCounts = computed(() => filteredTracksRef.value.reduce((acc, filteredTrack) => {
       const confidencePair = filteredTrack.annotation
         .getType(filteredTrack.context.confidencePairIndex);
-      const trackType = confidencePair[0];
+      const trackType = confidencePair;
       acc.set(trackType, (acc.get(trackType) || 0) + 1);
 
       return acc;
@@ -223,6 +223,7 @@ export default defineComponent({
       virtualHeight,
       virtualTypes,
       readOnlyMode,
+      filteredTracksRef,
       /* methods */
       clickDelete,
       clickEdit,

--- a/client/src/components/GroupItem.vue
+++ b/client/src/components/GroupItem.vue
@@ -104,7 +104,7 @@ export default defineComponent({
       </v-tooltip>
       <v-spacer />
       <TypePicker
-        :value="group.getType()[0]"
+        :value="group.getType()"
         :all-types="groupFilters.allTypes.value"
         :read-only-mode="readOnlyMode"
         data-list-source="allGroupTypesOptions"

--- a/client/src/components/GroupList.vue
+++ b/client/src/components/GroupList.vue
@@ -81,13 +81,14 @@ export default defineComponent({
 
     function getItemProps(item: typeof virtualListItems.value[number]) {
       const confidencePair = item.filteredGroup.annotation.getType();
+      const members = cameraStore.getGroupMemebers(item.filteredGroup.annotation.id);
       return {
         group: item.filteredGroup.annotation,
         color: typeStylingRef.value.color(confidencePair[0]),
         selected: item.filteredGroup.annotation.id === selectedId.value,
         selectedTrackId: selectedTrack.value,
         secondarySelected: (selectedTrack.value !== null)
-          ? selectedTrack.value in item.filteredGroup.annotation.members
+          ? selectedTrack.value in members
           : false,
         inputValue: item.checkedTrackIds.includes(item.filteredGroup.annotation.id),
       };

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -112,11 +112,12 @@ export default defineComponent({
       const confidencePair = item.filteredTrack.annotation.getType(
         item.filteredTrack.context.confidencePairIndex,
       );
-      const trackType = confidencePair[0];
+      const trackType = confidencePair;
       const selected = item.selectedTrackId === item.filteredTrack.annotation.id;
+      const track = cameraStore.getTracksMerged(item.filteredTrack.annotation.id);
       return {
         trackType,
-        track: item.filteredTrack.annotation,
+        track,
         inputValue: item.checkedTrackIds.includes(item.filteredTrack.annotation.id),
         selected,
         secondarySelected: item.multiSelect.includes(item.filteredTrack.annotation.id),
@@ -134,7 +135,7 @@ export default defineComponent({
       virtualListItems.value.forEach((item) => {
         if (item.checkedTrackIds.includes(item.filteredTrack.annotation.id)) {
           if (count < limit) {
-            text.push(item.filteredTrack.annotation.trackId.toString());
+            text.push(item.filteredTrack.annotation.id.toString());
           }
           tracksDisplayed.push(item.filteredTrack.annotation.id);
           count += 1;

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -250,11 +250,18 @@ const markChangesPending = () => { };
  */
 function dummyState(): State {
   const cameraStore = new CameraStore({ markChangesPending });
+  const setTrackType = (id: AnnotationId, newType: string,
+    confidenceVal?: number, currentType?: string) => {
+    cameraStore.setTrackType(id, newType, confidenceVal, currentType);
+  };
+  const removeTypes = (id: AnnotationId, types: string[]) => cameraStore.removeTypes(id, types);
   const groupFilterControls = new GroupFilterControls(
     {
       sorted: cameraStore.sortedGroups,
       remove: cameraStore.removeGroups,
       markChangesPending,
+      setType: setTrackType,
+      removeTypes,
     },
   );
   const trackFilterControls = new TrackFilterControls({
@@ -263,6 +270,9 @@ function dummyState(): State {
     markChangesPending,
     groupFilterControls,
     lookupGroups: cameraStore.lookupGroups,
+    setType: setTrackType,
+    removeTypes,
+
   });
   return {
     annotatorPreferences: ref({ trackTails: { before: 20, after: 10 } }),

--- a/client/src/use/useEventChart.ts
+++ b/client/src/use/useEventChart.ts
@@ -10,6 +10,7 @@ interface EventChartParams<T extends BaseAnnotation> {
   enabledTracks: Readonly<Ref<AnnotationWithContext<OneOf<T, [Group, Track]>>[]>>;
   selectedTrackIds: Ref<AnnotationId[]>;
   typeStyling: Ref<TypeStyling>;
+  getTracksMerged: (id: AnnotationId) => Track;
 }
 
 export interface EventChartData {
@@ -23,7 +24,7 @@ export interface EventChartData {
 }
 
 export default function useEventChart<T extends BaseAnnotation>({
-  enabledTracks, selectedTrackIds, typeStyling,
+  enabledTracks, selectedTrackIds, typeStyling, getTracksMerged,
 }: EventChartParams<T>) {
   const eventChartData = computed(() => {
     const values = [] as EventChartData[];
@@ -34,9 +35,12 @@ export default function useEventChart<T extends BaseAnnotation>({
       const { annotation: track } = filtered;
       const { confidencePairs } = track;
       let markers: [number, boolean][] = [];
-      if ('featureIndex' in track) {
-        markers = track.featureIndex.map((i) => (
-          [i, track.features[i].interpolate || false]));
+      if (selectedTrackIds.value.includes(filtered.annotation.id)) {
+        const mergedTrack = getTracksMerged(filtered.annotation.id);
+        if ('featureIndex' in mergedTrack) {
+          markers = mergedTrack.featureIndex.map((i) => (
+            [i, mergedTrack.features[i].interpolate || false]));
+        }
       }
       if (confidencePairs.length) {
         const trackType = track.getType(filtered.context.confidencePairIndex)[0];

--- a/client/src/use/useLineChart.ts
+++ b/client/src/use/useLineChart.ts
@@ -48,7 +48,7 @@ export default function useLineChart({
       const ibegin = track.begin;
       const iend = track.end > track.begin ? track.end : track.begin + 1;
       [totalArr[ibegin], totalArr[iend]] = updateHistogram(ibegin, iend, totalArr);
-      const trackType = track.getType(filtered.context.confidencePairIndex)[0];
+      const trackType = track.getType(filtered.context.confidencePairIndex);
       const typeArr = histograms.get(trackType) as number[];
       [typeArr[ibegin], typeArr[iend]] = updateHistogram(ibegin, iend, typeArr);
     });


### PR DESCRIPTION
A problem involving large data (~130,000 tracks) which included a large amount sub-data (multiple polygon annotations per track) was crashing during loading.

I narrowed down the problem to the fact that the `baseAnnotationStore` which is the basis for the `trackStore` and `groupStore` has a computed property called `sorted` which was passing around a direct copy of each Track.  The sorted property was used to display tracks in the track list, the event timeline, and multiple other areas.  Each time there may need be another computed property based on this list which may require either `forEach` or `map` for all of the values.

Initially I have changed the `sorted` computed property to not sort and create tracks until a call to `setEnableSorting`.  For track lists that are < 20000 I've enabled it by default.  For greater than it will be enabled once all cameras are loaded and ready.  The intermediate sorting as groups of tracks were added were slowing down the loading process.

I decided the remedy was to modify the `sorted` computed property to return only the data inside of Tracks/Groups that are needed.  They happened to be the `id, begin, end, confidencePairs` and a small function`getType` which gets the current type of the annotation or returns 'unknown'.  I created a new type called `SortedAnnotation` which has only this data available on it.
This prevents bounds/geometry/attributes/features and all the data from being copied and passed around.

`AnnotationWithContext` is another type which is based on `sorted` so everything that used `AnnotationWithContext` needed to be modified to to use `SortedAnnotation[]`

The `BaseFilterControl` used two functions called `setType` and `removeTypes` on the tracks themselves for when they were being edited.  I moved those functions into the root `cameraStore` and provided them to the `BaseFilterControl`.  You will not that I have to wrap those functions in the Viewer.vue to maintain the proper `this` context.  You can see that in Viewer.vue this is done for the `remove` function as well.

`useEventChart` had a section in the computed value where it would get `markers`.  Markers were an indication of a feature existing on aspecific frame or not.  It happened to grab markers for all of the track data.  The only time markers are used are when a track is selected for editing.  I refactored this to use the `getTracksMerged` from the `cameraStore` only on selected tracks.  This reduces greatly the amount of information being passed around in `useEventChart`.

I changed the `getType` that was typically referenced to make it return the string value instead of the confidencPair themselves.  That's why in some location I removed the  ending `[0]` so it went from `getType()[0]` to `getType()`

Finally the tests have been updated to reflect the new reorganization.
