### PR TITLE
Fix Desktop Configuration File Importing

### DIFF
--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -574,10 +574,10 @@ async function _ingestFilePath(
     } else if (DatasetMetaMutableKeys.some((key) => key in jsonObject)) {
       // DIVE Json metadata config file
       merge(meta, pick(jsonObject, DatasetMetaMutableKeys));
+      metadataConfig = true;
     } else {
       // Regular dive json
       annotations = await loadAnnotationFile(path);
-      metadataConfig = true;
     }
   } else if (CsvFileName.test(path)) {
     // VIAME CSV File

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -562,6 +562,7 @@ async function _ingestFilePath(
   // Attempt to process the file
   let annotations = dive.makeEmptyAnnotationFile();
   const meta: DatasetMetaMutable & { fps?: number } = {};
+  let metadataConfig = false;
   if (JsonFileName.test(path)) {
     const jsonObject = await _loadAsJson(path);
     if (nistSerializers.confirmNistFormat(jsonObject)) {
@@ -576,6 +577,7 @@ async function _ingestFilePath(
     } else {
       // Regular dive json
       annotations = await loadAnnotationFile(path);
+      metadataConfig = true;
     }
   } else if (CsvFileName.test(path)) {
     // VIAME CSV File
@@ -590,7 +592,10 @@ async function _ingestFilePath(
     const processed = processTrackAttributes(Object.values(annotations.tracks));
     meta.attributes = processed.attributes;
   }
-  await _saveSerialized(settings, datasetId, annotations, true);
+  if (!metadataConfig) { // Only save Annotations when not a metadata Config file
+    await _saveSerialized(settings, datasetId, annotations, true);
+  }
+
   return meta;
 }
 


### PR DESCRIPTION
On desktop if you import a configuration file it will overwrite all the annotations for the user at the same time.  This seems to be a bug in the import function that this PR should resolve.
So if you import a configuration json (meta.json) or file which contains the keys it will prevent it from overwriting the current annotations now.