### PR TITLE
Fix Admin Job User Directory Reference

### DIFF
--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -169,7 +169,7 @@ def run_pipeline(
         "input_type": fromMeta(folder, "type", required=True),
         "output_folder": folder_id_str,
         "input_revision": input_revision,
-        'user_id': user.get('_id', 'unknown'),
+        'user_id': str(user.get('_id', 'unknown')),
         'user_login': user.get('login', 'unknown'),
     }
     newjob = tasks.run_pipeline.apply_async(


### PR DESCRIPTION
I was calling `user.get('_id', 'unknown')` forgetting that it is a objectId and not a string.
Wrapping it in `str()` call will fix the issue and allow the button to work again in the admin interface.