### PR TITLE
Use a working "desktop" icon in docs front page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 
 This is the documentation site for DIVE, a [**free and open-source**](https://www.kitware.com/open-philosophy/) annotation and analysis platform for web and desktop built by [Kitware](https://kitware.com). DIVE integrates with the [VIAME toolkit](https://www.viametoolkit.org/), but it can also be used on its own.
 
-[:material-compass: Try the web version](Web-Version.md){ .md-button } [:material-desktop-mac: Get the desktop app](Dive-Desktop.md){ .md-button } [:material-lifebuoy: Get support](Support.md){ .md-button }
+[:material-compass: Try the web version](Web-Version.md){ .md-button } [:fontawesome-solid-desktop: Get the desktop app](Dive-Desktop.md){ .md-button } [:material-lifebuoy: Get support](Support.md){ .md-button }
 
 
 ![Home](images/Banner.png)


### PR DESCRIPTION
@zachmullen discovered a bad material icon name on the DIVE front page:

<img width="870" alt="Screen Shot 2022-12-13 at 10 12 25 AM" src="https://user-images.githubusercontent.com/2903332/207375260-c2833971-cbc5-4d66-b7ed-1b8e30322cd9.png">

This PR replaces the broken icon specifier with [this one from Fontawesome](https://fontawesome.com/v5/icons/desktop?style=solid&s=solid&f=classic) (which is also part of the mkdocs material theme):

![fixed](https://user-images.githubusercontent.com/2903332/207376520-bc5180e3-69d7-4df8-9bd6-acd78de8aae0.png)

(I don't know why the buttons are blue in my local build, but black in the deployed version.)