### PR TITLE
Canvas renderer for large images

### DIFF
--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -312,10 +312,16 @@ export default defineComponent({
       const imgInternal = cacheFrame(0);
       imgInternal.onloadPromise.then(() => {
         initializeViewer(imgInternal.image.naturalWidth, imgInternal.image.naturalHeight);
-        const quadFeatureLayer = geoViewer.value.createLayer('feature', {
+        const params = {
           features: ['quad'],
           autoshareRenderer: false,
-        });
+          renderer: 'canvas',
+        };
+        if (imgInternal.image.naturalWidth > 8192 || imgInternal.image.naturalHeight > 8192) {
+          params.renderer = 'canvas';
+        }
+
+        const quadFeatureLayer = geoViewer.value.createLayer('feature', params);
         // Set quadFeature and conditionally apply brightness filter
         local.quadFeature = quadFeatureLayer.createFeature('quad');
         setBrightnessFilter(props.brightness !== undefined);

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -312,14 +312,13 @@ export default defineComponent({
       const imgInternal = cacheFrame(0);
       imgInternal.onloadPromise.then(() => {
         initializeViewer(imgInternal.image.naturalWidth, imgInternal.image.naturalHeight);
+        const bigImage = (
+          imgInternal.image.naturalWidth > 8192 || imgInternal.image.naturalHeight > 8192);
         const params = {
           features: ['quad'],
           autoshareRenderer: false,
-          renderer: 'canvas',
+          renderer: bigImage ? 'canvas' : 'webgl',
         };
-        if (imgInternal.image.naturalWidth > 8192 || imgInternal.image.naturalHeight > 8192) {
-          params.renderer = 'canvas';
-        }
 
         const quadFeatureLayer = geoViewer.value.createLayer('feature', params);
         // Set quadFeature and conditionally apply brightness filter

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -314,13 +314,11 @@ export default defineComponent({
         initializeViewer(imgInternal.image.naturalWidth, imgInternal.image.naturalHeight);
         const bigImage = (
           imgInternal.image.naturalWidth > 8192 || imgInternal.image.naturalHeight > 8192);
-        const params = {
+        const quadFeatureLayer = geoViewer.value.createLayer('feature', {
           features: ['quad'],
           autoshareRenderer: false,
           renderer: bigImage ? 'canvas' : 'webgl',
-        };
-
-        const quadFeatureLayer = geoViewer.value.createLayer('feature', params);
+        });
         // Set quadFeature and conditionally apply brightness filter
         local.quadFeature = quadFeatureLayer.createFeature('quad');
         setBrightnessFilter(props.brightness !== undefined);


### PR DESCRIPTION
Swaps the geoJS renderer from Webgl to Canvas when the image size exceeds 8192 (8k) in any dimension.
WebGL has a maximum texture size and this will allow larger images to be displayed in the renderer.