### PR TITLE
SubSample Image Loading

### DIFF
--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -55,7 +55,7 @@ const imageFilenameTests = [
   },
   {
     pass: false,
-    error: 'Error: annotations were provided in an unexpected order and dataset contains multi-frame tracks',
+    error: 'Error: Images were provided in an unexpected order and dataset contains multi-frame tracks.',
     csv: [
       '99,1.png,0,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
       '99,3.png,1,111,222,3333,444,1,-1,typestring,0.55',

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -15,7 +15,7 @@ const testData: testPairs[] = fs.readJSONSync('../testutils/viame.spec.json');
 const imageFilenameTests = [
   {
     pass: false,
-    error: 'CSV import was found to have a mix of missing images and images that were found in the data. This usually indicates a problem with the annotation file, but if you want to force the import to proceed, you can set all values in the Image Name column to be blank.  Then DIVE will not attempt to validate image names. Missing images include:        ...',
+    error: 'A subsampling of images were used with the CSV but they were not sequential',
     csv: [
       '0,       ,1,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
       '1,2.png,0,111,222,3333,444,1,-1,typestring,0.55',
@@ -23,7 +23,7 @@ const imageFilenameTests = [
   },
   {
     pass: false,
-    error: 'CSV import was found to have a mix of missing images and images that were found in the data. This usually indicates a problem with the annotation file, but if you want to force the import to proceed, you can set all values in the Image Name column to be blank.  Then DIVE will not attempt to validate image names. Missing images include: invalid...',
+    error: 'A subsampling of images were used with the CSV but they were not sequential',
     csv: [
       '0,1.png,1,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
       '1,invalid,0,111,222,3333,444,1,-1,typestring,0.55',

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -251,7 +251,6 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<A
   const dataMap = new Map<number, TrackData>();
   const missingImages: string[] = [];
   const foundImages: {image: string; frame: number; csvFrame: number}[] = [];
-  let anyImageMatched = false;
   let error: Error | undefined;
 
   return new Promise<AnnotationFileData>((resolve, reject) => {
@@ -371,8 +370,6 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<A
             }
             if (expectedFrameNumber === undefined) {
               missingImages.push(rowInfo.filename);
-            } else {
-              anyImageMatched = true;
             }
           }
 

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /**
  * VIAME CSV parser/serializer copied logically from
  * dive_utils.serializers.viame python module
@@ -7,7 +8,7 @@ import csvparser from 'csv-parse';
 import csvstringify from 'csv-stringify';
 import fs from 'fs-extra';
 import moment from 'moment';
-import { flattenDeep } from 'lodash';
+import { cloneDeep, flattenDeep } from 'lodash';
 import { pipeline, Readable, Writable } from 'stream';
 
 import { AnnotationSchema, MultiGroupRecord, MultiTrackRecord } from 'dive-common/apispec';
@@ -249,9 +250,9 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<A
   let fps: number | undefined;
   const dataMap = new Map<number, TrackData>();
   const missingImages: string[] = [];
-  let reordered = false;
+  const foundImages: {image: string; frame: number; csvFrame: number}[] = [];
   let anyImageMatched = false;
-  let error: Error;
+  let error: Error | undefined;
 
   return new Promise<AnnotationFileData>((resolve, reject) => {
     pipeline([input, parser], (err) => {
@@ -259,28 +260,89 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<A
       if (err !== undefined) {
         reject(err);
       }
-      if (error !== undefined) {
-        reject(error);
+
+      // Do a secondary pass for if we are only visualizing a subset of sequences of images
+      if (missingImages.length > 0 && imageMap !== undefined && foundImages.length) {
+        if (error !== undefined) { // Most likely a reorder error so reset it
+          error = undefined;
+        }
+        // We need to find the total number of images mapped and make sure they are continuous
+        // Also need to create a mapping of old frame numbers to new numbers
+        // Additionall a min/max frame is required to cap tracks and remove items outside the range
+        let minFrame = Infinity;
+        let maxFrame = -Infinity;
+        const frameMapper: Record<number, number> = {};
+        const filteredImages = foundImages.filter((item) => item.frame !== -1);
+        for (let i = 0; i < filteredImages.length; i += 1) {
+          if (filteredImages[i].frame === -1) {
+            // eslint-disable-next-line no-continue
+            continue;
+          }
+          const k = i + 1;
+          if (k < filteredImages.length) {
+            if (filteredImages[i].csvFrame + 1 !== filteredImages[k].csvFrame) {
+            // We have misaligned video sequences so we error out
+              error = new Error('A subsampling of images were used with the CSV but they were not sequential');
+            }
+          }
+          frameMapper[filteredImages[i].csvFrame] = i;
+          minFrame = Math.min(minFrame, filteredImages[i].csvFrame);
+          maxFrame = Math.max(maxFrame, filteredImages[i].csvFrame);
+        }
+        // Now we need to remap and filter tracks that are outside the frame range
+        const newDataMap: Record<TrackData['id'], TrackData> = {};
+        const trackList = Object.values(Object.fromEntries(dataMap));
+        trackList.forEach((track) => {
+          if ((track.end >= minFrame)
+          || (track.begin <= maxFrame)) {
+            // begin and end frames need to be remapped to the subsampled region
+            let { begin } = track;
+            let { end } = track;
+            if (begin < minFrame || frameMapper[begin] === undefined) {
+              begin = frameMapper[minFrame];
+            } else {
+              begin = frameMapper[begin];
+            }
+            if (end > maxFrame || frameMapper[end] === undefined) {
+              end = frameMapper[maxFrame];
+            } else {
+              end = frameMapper[end];
+            }
+            const newTrack: TrackData = {
+              begin,
+              end,
+              id: track.id,
+              attributes: track.attributes,
+              confidencePairs: track.confidencePairs,
+              features: [],
+            };
+            track.features.forEach((feature) => {
+              // if feature frame is within the range add and remap the frame to the new time
+              if (feature.frame >= minFrame && feature.frame <= maxFrame) {
+                const newFeature = cloneDeep(feature);
+                newFeature.frame = frameMapper[newFeature.frame];
+                newTrack.features.push(newFeature);
+              }
+            });
+            if (newTrack.features.length) {
+              // Only add the track if it has features
+              newDataMap[newTrack.id] = newTrack;
+            }
+          }
+        });
+        // Clear the existing dataMap to add the updated data
+        dataMap.clear();
+
+        // Set the new data in the dataMap
+        Object.values(newDataMap).forEach((track) => {
+          dataMap.set(track.id, track);
+        });
       }
+
       const tracks = Object.fromEntries(dataMap);
 
-      if (imageMap !== undefined && missingImages.length > 0 && anyImageMatched) {
-        /**
-         * If any image from CSV was not missing, then some number of images
-         * from column 2 were actually valid and some were not.  This indicates that the dataset
-         * being loaded is probably corrupt.
-         *
-         * If all images were missing, then every single image was missing, which indicates
-         * that the dataset either had all empty values in column 2 or some other type of invalid
-         * string that should not prevent import.
-         */
-        reject([
-          'CSV import was found to have a mix of missing images and images that were found',
-          'in the data. This usually indicates a problem with the annotation file, but if',
-          'you want to force the import to proceed, you can set all values in the',
-          'Image Name column to be blank.  Then DIVE will not attempt to validate image names.',
-          `Missing images include: ${missingImages.slice(0, 5)}...`,
-        ].join(' '));
+      if (error !== undefined) {
+        reject(error);
       }
       resolve({ tracks, groups: {}, fps });
     });
@@ -293,17 +355,22 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<A
             rowInfo, feature, trackAttributes, confidencePairs,
           } = _parseFeature(record);
           if (imageMap !== undefined) {
-            // validate image ordering if the imageMap is provided and a non-whitespace filename
             const [imageName] = splitExt(rowInfo.filename);
             const expectedFrameNumber = imageMap.get(imageName);
+            // Create a foundImage to map frames if a subset of images are used
+            const foundImage = {
+              image: imageName,
+              frame: expectedFrameNumber !== undefined ? expectedFrameNumber : -1,
+              csvFrame: rowInfo.frame,
+            };
+            const hasImageAlready = foundImages.find(
+              (item) => (item.frame === foundImage.frame && item.image === foundImage.image),
+            );
+            if (foundImage.frame !== -1 && hasImageAlready === undefined) {
+              foundImages.push(foundImage);
+            }
             if (expectedFrameNumber === undefined) {
               missingImages.push(rowInfo.filename);
-            } else if (expectedFrameNumber !== feature.frame) {
-              // force reorder the annotations
-              reordered = true;
-              anyImageMatched = true;
-              feature.frame = expectedFrameNumber;
-              rowInfo.frame = expectedFrameNumber;
             } else {
               anyImageMatched = true;
             }
@@ -321,13 +388,19 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<A
               features: [],
             };
             dataMap.set(rowInfo.id, track);
-          } else if (reordered) {
-            // trackId was already in dataMap, so the track has more than 1 detection.
-            error = new Error(
-              'annotations were provided in an unexpected order and dataset contains multi-frame tracks',
-            );
-            // eslint-disable-next-line no-continue
-            continue;
+          } else {
+            let maxFeatureFrame = -Infinity;
+            track.features.forEach((subFeature) => {
+              maxFeatureFrame = Math.max(maxFeatureFrame, subFeature.frame);
+            });
+            if (rowInfo.frame < maxFeatureFrame) {
+            // trackId was already in dataMap, and frame is out of order
+              error = new Error(
+                'annotations were provided in an unexpected order and dataset contains multi-frame tracks',
+              );
+              // eslint-disable-next-line no-continue
+              continue;
+            }
           }
           track.begin = Math.min(rowInfo.frame, track.begin);
           track.end = Math.max(rowInfo.frame, track.end);

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -263,7 +263,7 @@ def export_datasets_zipstream(
                     mediaFolder,
                     filters={"lowerName": {"$regex": mediaRegex}},
                 ):
-                    for (path, file) in Item().fileList(item):
+                    for path, file in Item().fileList(item):
                         for data in z.addFile(file, Path(f'{zip_path}{path}')):
                             yield data
                         break  # Media items should only have 1 valid file

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -212,10 +212,10 @@ def load_coco_as_tracks_and_attributes(
         track.features.append(feature)
         track.confidencePairs = confidence_pairs
 
-        for (key, val) in track_attributes.items():
+        for key, val in track_attributes.items():
             track.attributes[key] = val
             viame.create_attributes(metadata_attributes, test_vals, 'track', key, val)
-        for (key, val) in attributes.items():
+        for key, val in attributes.items():
             viame.create_attributes(metadata_attributes, test_vals, 'detection', key, val)
 
     # Now we process all the metadata_attributes for the types

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -279,7 +279,7 @@ def load_csv_as_tracks_and_attributes(
     test_vals: Dict[str, Dict[str, int]] = {}
     multiFrameTracks = False
     missingImages: List[str] = []
-    foundImages: List[Dict[str, Union[str, int]]] = []  # {image:str, frame: int, csvFrame: int}
+    foundImages: List[Dict[str, Any]] = []  # {image:str, frame: int, csvFrame: int}
     for row in reader:
         if len(row) == 0 or row[0].startswith('#'):
             # This is not a data row

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -38,7 +38,7 @@ def writeHeader(writer: 'csv._writer', metadata: Dict):  # type: ignore
     metadata_dict['exported_by'] = 'dive:python'
     metadata_dict['exported_time'] = datetime.datetime.now().ctime()
     metadata_list = []
-    for (key, value) in metadata_dict.items():
+    for key, value in metadata_dict.items():
         metadata_list.append(f"{key}: {json.dumps(value)}")
     writer.writerow(['# metadata', *metadata_list])
 
@@ -217,7 +217,7 @@ def calculate_attribute_types(
             attribute_type = 'number'
             low_count = predefined_min_count
             values = []
-            for (key, val) in test_vals[attributeKey].items():
+            for key, val in test_vals[attributeKey].items():
                 if val <= low_count:
                     low_count = val
                 values.append(key)
@@ -246,18 +246,18 @@ def load_json_as_track_and_attributes(
     test_vals: Dict[str, Dict[str, int]] = {}
     tracks = json_data['tracks']
     # Get Attribute Maps to values
-    for (key, track) in tracks.items():
+    for key, track in tracks.items():
         track_attributes = {}
         detection_attributes = {}
-        for (attrkey, attribute) in track['attributes'].items():
+        for attrkey, attribute in track['attributes'].items():
             track_attributes[attrkey] = _deduceType(attribute)
         for feature in track['features']:
             if 'attributes' in feature.keys():
-                for (attrkey, attribute) in feature['attributes'].items():
+                for attrkey, attribute in feature['attributes'].items():
                     detection_attributes[attrkey] = _deduceType(attribute)
-        for (key, val) in track_attributes.items():
+        for key, val in track_attributes.items():
             create_attributes(metadata_attributes, test_vals, 'track', key, val)
-        for (key, val) in detection_attributes.items():
+        for key, val in detection_attributes.items():
             create_attributes(metadata_attributes, test_vals, 'detection', key, val)
 
     calculate_attribute_types(metadata_attributes, test_vals)
@@ -324,10 +324,10 @@ def load_csv_as_tracks_and_attributes(
         track.features.append(feature)
         track.confidencePairs = confidence_pairs
 
-        for (key, val) in track_attributes.items():
+        for key, val in track_attributes.items():
             track.attributes[key] = val
             create_attributes(metadata_attributes, test_vals, 'track', key, val)
-        for (key, val) in attributes.items():
+        for key, val in attributes.items():
             create_attributes(metadata_attributes, test_vals, 'detection', key, val)
 
     trackarr = tracks.items()
@@ -394,7 +394,6 @@ def export_tracks_as_csv(
     for t in track_iterator:
         track = Track(**t)
         if (not excludeBelowThreshold) or track.exceeds_thresholds(thresholds):
-
             # filter by types if applicable
             if typeFilter:
                 confidence_pairs = [item for item in track.confidencePairs if item[0] in typeFilter]

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -310,6 +310,7 @@ def load_csv_as_tracks_and_attributes(
         if trackId not in tracks:
             tracks[trackId] = Track(begin=feature.frame, end=feature.frame, id=trackId)
         else:
+            track = tracks[trackId]
             multiFrameTracks = True
             maxFeatureFrame = float('-inf')
             for subFeature in track.features:
@@ -352,7 +353,8 @@ def load_csv_as_tracks_and_attributes(
                     # We have misaligned video sequences so we error out
                     raise ValueError(
                         (
-                            'A subsampling of images were used with the CSV but they were not sequential'
+                            'A subsampling of images were used with the CSV '
+                            'but they were not sequential'
                         )
                     )
             frameMapper[item['csvFrame']] = index
@@ -382,7 +384,7 @@ def load_csv_as_tracks_and_attributes(
                     confidencePairs=track.confidencePairs,
                 )
                 for subFeature in track.features:
-                    # if feature frame is within the subFeature add and remap the frame to the new time
+                    # feature frame is within the subFeature add and remap the frame to the new time
                     if subFeature.frame >= minFrame and subFeature.frame <= maxFrame:
                         newFeature = Feature(
                             frame=subFeature.frame,
@@ -414,7 +416,8 @@ def load_csv_as_tracks_and_attributes(
                     # We have misaligned video sequences so we error out
                     raise ValueError(
                         (
-                            'Images were provided in an unexpected order and dataset contains multi-frame tracks.'
+                            'Images were provided in an unexpected order '
+                            'and dataset contains multi-frame tracks.'
                         )
                     )
 

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -277,8 +277,7 @@ test_tuple: List[Tuple[dict, list, list]] = [
 
 image_filename_tests = [
     {
-        'pass': False,
-        'error': 'CSV import was found to have a mix of missing images and images that were found in the data. This usually indicates a problem with the annotation file, but if you want to force the import to proceed, you can set all values in the Image Name column to be blank.  Then DIVE will not attempt to validate image names. Missing images include:        ...',
+        'pass': True,
         'csv': [
             '0,       ,1,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
             '1,2.png,0,111,222,3333,444,1,-1,typestring,0.55',
@@ -286,10 +285,11 @@ image_filename_tests = [
     },
     {
         'pass': False,
-        'error': 'CSV import was found to have a mix of missing images and images that were found in the data. This usually indicates a problem with the annotation file, but if you want to force the import to proceed, you can set all values in the Image Name column to be blank.  Then DIVE will not attempt to validate image names. Missing images include: invalid...',
+        'error': 'A subsampling of images were used with the CSV but they were not sequential',
         'csv': [
             '0,1.png,1,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
             '1,invalid,0,111,222,3333,444,1,-1,typestring,0.55',
+            '2,2.png,1,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
         ],
     },
     {
@@ -318,7 +318,7 @@ image_filename_tests = [
     },
     {
         'pass': False,
-        'error': 'images were provided in an unexpected order and dataset contains multi-frame tracks.',
+        'error': 'Images were provided in an unexpected order and dataset contains multi-frame tracks.',
         'csv': [
             '99,1.png,0,884.66,510,1219.66,737.66,1,-1,ignored,0.98',
             '99,3.png,1,111,222,3333,444,1,-1,typestring,0.55',


### PR DESCRIPTION
resolves #1329 

Done:
- Frame remapping when images are a subsample of those referenced in a loaded CSV file for electron
- Updated client tests for new errors and formats
- If images referenced in CSV include images in the dataset and they are in the proper order it will allow loading
- Extra images are ignored then
- Logic for this has been updated on Electron version as well as python version

Testing:
- Take a sample dataset like Ehu from the server and copy and create 3 different folders. [Ehu Link](https://viame.kitware.com/#/viewer/5e4c282ba0fc86aa0315cd93)
    - The base dataset with all the images
    - A subsampled dataset with 20-30 sequential images
    - A subsampled dataset with 20-30 non-sequential images
- Take the original annotations.csv file from Ehu and load it into the sequential images dataset.  It should load and display annotations properly.  The frame numbers will be different but it should load
- Attempt to load the original into the non-sequential image dataset and an error should occur.
- You can take a look at the `viame.spec.ts` file for the client version and the `test_serialize_viame_csv.py` for the python version and create some other sample CSVs and check that they import properly and give the proper errors.