### PR TITLE
NOAA Upload Script

### DIFF
--- a/samples/scripts/syncAnnotationsScript.py
+++ b/samples/scripts/syncAnnotationsScript.py
@@ -1,0 +1,90 @@
+import girder_client
+import json
+import os
+import click
+
+'''
+This script is used to sync a folder Hierarchy of Annotation files with a deployed version
+It will mimic 
+'''
+
+
+apiURL = "localhost"
+port = 8010
+baseGirderId = "64c167a0ddec2a1b05eabb76"  # Sample folder 
+baseGirderType = "folder" # folder | collection | user
+limit = 10  # for testing purposes kkeep lower then increase
+
+# Login to the girder client, interactive means it will prompt for username and password
+def login():
+    gc = girder_client.GirderClient(apiURL, port=port, apiRoot='girder/api/v1')
+    gc.authenticate(interactive=True)
+    return gc
+
+# Simple search within folder to get annotation files and their paths
+def get_annotations(folder):
+    checkFolder = folder
+    foundfiles = []
+    for root, dirs, files in os.walk(checkFolder):
+        for file in files:
+            if file.endswith('.csv'):
+                # base name exists we can get a list of files
+                foundfiles.append(os.path.join(root, file))
+    return foundfiles
+# returns the girder base path for the indexed folder
+def getBasePath(gc: girder_client.GirderClient, folder: str, type: str):
+    return gc.sendRestRequest('GET', f'resource/{folder}/path?type={type}')
+
+# attempts to find the filename dataset and the 'Video {filename}' 
+def find_dataset(gc: girder_client.GirderClient, filename: str, baseGirderPath: str):
+    basename = os.path.basename(filename)
+    check_path = filename.replace(basename, f'Video {basename}')
+    found = gc.sendRestRequest('GET', f'resource/lookup', parameters={"path": f'{baseGirderPath}/{check_path}'})
+    if found:
+        if found.get('meta', {}).get('annotate', False):
+            return found.get('_id', False)
+    # secondary check on the root name with out "Video "
+    found = gc.sendRestRequest('GET', f'resource/lookup', parameters={"path": f'{baseGirderPath}/{filename}'})
+    if found:
+        if found.get('meta', {}).get('annotate', False):
+            return found.get('_id', False)
+    return False
+
+def upload_annotations(gc: girder_client.GirderClient, annotations):
+    for annotation in annotations:
+        gc.uploadFileToFolder(annotation['girderId'], annotation['file'])
+        gc.sendRestRequest('POST', f'dive_rpc/postprocess/{annotation["girderId"]}', data={'skipTranscoding': True, 'skipJobs': True})
+
+def get_public_folder(gc: girder_client.GirderClient):
+    current_user = gc.sendRestRequest('GET', 'user/me')
+    userId = current_user['_id']
+    folders = gc.sendRestRequest('GET', f'folder?parentType=user&parentId={userId}&text=Public&limit=50&sort=lowerName&sortdir=1')
+    if len(folders) > 0:
+        uploadFolder = folders[0]['_id']
+    else:
+        print('No folder found for the user')
+    return uploadFolder
+
+@click.command(name="LoadData", help="Load in ")
+@click.argument('folder') # a local folder to search for mp4 video files and json/csv files.
+def load_data(folder):
+    annotations = get_annotations(folder)
+    print(annotations)
+    gc = login()
+    base_path = getBasePath(gc, baseGirderId, baseGirderType)
+    print(base_path)
+    upload_list = []
+    for annotation in annotations:
+        print(annotation)
+        modifed = annotation.replace(folder, '').replace('.csv', '.mp4')
+        result = find_dataset(gc, modifed, base_path)
+        if result:
+            upload_list.append({
+                'girderId': result,
+                'file': annotation,
+                'type': 'upload'
+            })
+   
+    upload_annotations(gc, upload_list)
+if __name__ == '__main__':
+    load_data()

--- a/samples/scripts/syncAnnotationsScript.py
+++ b/samples/scripts/syncAnnotationsScript.py
@@ -213,11 +213,12 @@ def ask_yes_no_question(prompt):
             print("Invalid input. Please enter 'y' or 'n'.")
 
 
-@click.command(name="LoadData", help="Load in ")
+@click.command(name="LoadData", help="Load in annotation from local directory ")
 @click.argument(
-    "folder"
+    "folder",
+    help="Path of directory containing the annotation csv"
 )  # a local folder to search for mp4 video files and json/csv files.
-@click.argument("girder_id", required=False)
+@click.argument("girder_id", required=False, help="girder_id of the destination directory on DIVE")
 def load_data(folder, girder_id):
     baseGirderId = girder_id
     annotations = get_annotations(folder)

--- a/samples/scripts/syncAnnotationsScript.py
+++ b/samples/scripts/syncAnnotationsScript.py
@@ -240,7 +240,7 @@ def load_data(folder, girder_id):
                 }
             )
     local_public = ask_yes_no_question(
-        f'Would you like to create a cloned copy of the images in your public folder?  If you choose "n" it will upload the annotations to the source image locations. (y/n)\n'
+        f'Would you like to create a cloned copy of the images in your DIVE public folder?  If you choose "n" it will upload the annotations to the source image locations. (y/n)\n'
     )
     if local_public:
         folder_name = None

--- a/samples/scripts/syncAnnotationsScript.py
+++ b/samples/scripts/syncAnnotationsScript.py
@@ -246,7 +246,7 @@ def load_data(folder, girder_id):
         folder_name = None
         while not folder_name:
             folder_name = ask_question(
-                "What is the root folder that should be created in your Public folder?"
+                "Provide the name for the folder that will be created in your DIVE Public folder:"
             )
         public_folder = get_public_folder(gc)
         base_folder = gc.createFolder(

--- a/samples/scripts/syncAnnotationsScript.py
+++ b/samples/scripts/syncAnnotationsScript.py
@@ -34,11 +34,10 @@ it will create a clone with the name {Dataset} - {label}.  This allows multiple 
 
 apiURL = "localhost"
 port = 8010
-baseGirderId = ""  # Sample folder
+baseGirderId = ""  # Set by the second argument to the script
 baseGirderType = "folder"  # folder | collection | user
 keyFolderName = "ANNOTATIONS"  # The folder name under which to look for Annotations
 keyFileName = "annotations-"  # a key for replacement on the annotation-file to sync it with the dataset
-limit = 10  # for testing purposes kkeep lower then increase
 default_label = "unlabeled"  # when uploading this will be the folder that will replace the existing annotations.
 # all other labels will create a clone with the name of the dataset and the label type.
 

--- a/samples/scripts/syncAnnotationsScript.py
+++ b/samples/scripts/syncAnnotationsScript.py
@@ -14,7 +14,7 @@ Arguments:
 Process:
 
 1.  The system will look through the current folder for CSV files.  It is specifically looking for files with
-The format of /folder/folder/{keyFolderName}/{label}/{keyFilename}Dataset.csv where the keyFolderName and keyFilename are specified below in the main settings
+The format of */{keyFolderName}/{label}/{keyFilename}Dataset.csv where the keyFolderName and keyFilename are specified below in the main settings
 
 2. It retrieves the full base Path to the currently indicated girder_id specified in the arguments.
 

--- a/samples/scripts/syncAnnotationsScript.py
+++ b/samples/scripts/syncAnnotationsScript.py
@@ -5,8 +5,30 @@ import click
 import girder_client
 
 """
-This script is used to sync a folder Hierarchy of Annotation files with a deployed version
-It will mimic 
+This script is used to sync a folder Hierarchy of Annotation files with a similar folder structure within Girder
+
+Arguments: 
+- folder: local Folder Location
+- girder_id: girderId for matching folder on the server
+
+Process:
+
+1.  The system will look through the current folder for CSV files.  It is specifically looking for files with
+The format of /folder/folder/{keyFolderName}/{label}/{keyFilename}Dataset.csv where the keyFolderName and keyFilename are specified below in the main settings
+
+2. It retrieves the full base Path to the currently indicated girder_id specified in the arguments.
+
+3. The script attempts to find the matching dataset within the girder_id folder by removing the keyFolderName and keyFilename
+
+4. After finding the dataset it returns back an object with the label for the annotations, the girder parent folderId and the filename for the CSV files
+
+5. Now options are presented to the user, they can either upload the annotations to the source directory or they can create a folder in their User/Public
+directory with a custom name and clone the datasets to add annotations to.
+
+6. Once the decisions to either create a User/Public folder or upload to the dataset source locations is made the system will then upload the annotations.
+
+7. This is where the 'default_label' option is used.  If the the folder under Annotations doesn't match the 'default_label' when uploading to the source images
+it will create a clone with the name {Dataset} - {label}.  This allows multiple folders to be used to upload different annotations to the system.
 """
 
 
@@ -59,7 +81,7 @@ def find_dataset(gc: girder_client.GirderClient, filename: str, baseGirderPath: 
     # Check for a Video
     found = gc.sendRestRequest(
         "GET",
-        f"resource/lookup",
+        "resource/lookup",
         parameters={"path": f'/{baseGirderPath}/{check_path.replace(".csv", ".mp4")}'},
     )
     if found:
@@ -73,7 +95,7 @@ def find_dataset(gc: girder_client.GirderClient, filename: str, baseGirderPath: 
     check_path = check_path.replace(f"Video ", "")
     found = gc.sendRestRequest(
         "GET",
-        f"resource/lookup",
+        "resource/lookup",
         parameters={"path": f"/{baseGirderPath}/{check_path}"},
     )
     if found:

--- a/samples/scripts/syncAnnotationsScript.py
+++ b/samples/scripts/syncAnnotationsScript.py
@@ -218,7 +218,7 @@ def ask_yes_no_question(prompt):
     "folder",
     help="Path of directory containing the annotation csv"
 )  # a local folder to search for mp4 video files and json/csv files.
-@click.argument("girder_id", required=False, help="girder_id of the destination directory on DIVE")
+@click.argument("girder_id", help="girder_id of the destination directory on DIVE")
 def load_data(folder, girder_id):
     baseGirderId = girder_id
     annotations = get_annotations(folder)

--- a/samples/scripts/syncAnnotationsScript.py
+++ b/samples/scripts/syncAnnotationsScript.py
@@ -73,7 +73,7 @@ def find_dataset(gc: girder_client.GirderClient, filename: str, baseGirderPath: 
     print(filename)
     start_index = filename.find(keyFolderName)
     end_index = filename.find(keyFileName) + len(keyFileName)
-    removed_label = filename[start_index:end_index].split("/")[1]
+    removed_label = filename[start_index:end_index].split(os.path.sep)[1]
     removed_data = filename[end_index:]
     check_path = removed_data.replace(".csv", "")
     check_path = check_path.replace(basename, f"Video {basename}")

--- a/samples/scripts/uploadScript.py
+++ b/samples/scripts/uploadScript.py
@@ -1,18 +1,20 @@
-import girder_client
 import json
 import os
-import click
 
+import click
+import girder_client
 
 apiURL = "localhost"
 rootUploadFolder = "642577ffac91ad91682b0298"  # Sample folder girder Id
 limit = 10  # for testing purposes kkeep lower then increase
 
+
 # Login to the girder client, interactive means it will prompt for username and password
 def login():
-    gc = girder_client.GirderClient(apiURL, port=8010, apiRoot='girder/api/v1')
+    gc = girder_client.GirderClient(apiURL, port=8010, apiRoot="girder/api/v1")
     gc.authenticate(interactive=True)
     return gc
+
 
 # Simple search within folder for videos and json files (could do by mimetype instead)
 def get_videos(folder):
@@ -22,27 +24,29 @@ def get_videos(folder):
         if count >= limit:
             break
         if file.endswith(".mp4"):
-            replaced = file.replace('.mp4', '')
+            replaced = file.replace(".mp4", "")
             if replaced not in videomap.keys():
                 videomap[replaced] = {}
-            videomap[replaced]['video'] = os.path.join(folder, file)
+            videomap[replaced]["video"] = os.path.join(folder, file)
         # check for JSON/CSV files with the same name as the video file
         if file.endswith(".json"):
-            replaced = file.replace('.json', '')
+            replaced = file.replace(".json", "")
             if replaced not in videomap.keys():
                 videomap[replaced] = {}
-            videomap[replaced]['json'] = os.path.join(folder, file)
+            videomap[replaced]["json"] = os.path.join(folder, file)
         if file.endswith(".csv"):
-            replaced = file.replace('.csv', '')
+            replaced = file.replace(".csv", "")
             if replaced not in videomap.keys():
                 videomap[replaced] = {}
-            videomap[replaced]['csv'] = os.path.join(folder, file)
+            videomap[replaced]["csv"] = os.path.join(folder, file)
         count = count + 1
     return videomap
 
 
 @click.command(name="LoadData", help="Load in ")
-@click.argument('folder') # a local folder to search for mp4 video files and json/csv files.
+@click.argument(
+    "folder"
+)  # a local folder to search for mp4 video files and json/csv files.
 def load_data(folder):
     # search the folder for .mp4 videos and JSON files
     videomap = get_videos(folder)
@@ -52,23 +56,34 @@ def load_data(folder):
     count = 1
     for key in keys:
         item = videomap[key]
-        print(f'Creating Folder: {key}.mp4')
-        new_folder = gc.createFolder(rootUploadFolder, f'{key}.mp4')
+        print(f"Creating Folder: {key}.mp4")
+        new_folder = gc.createFolder(rootUploadFolder, f"{key}.mp4")
         # upload the video file to the folder
-        gc.uploadFileToFolder(new_folder['_id'], item['video'])
+        gc.uploadFileToFolder(new_folder["_id"], item["video"])
         # upload annotations in JSON or CSV Format
-        if 'json' in item.keys():
-            gc.uploadFileToFolder(new_folder['_id'], item['json'])
-        if 'csv' in item.keys():
-            gc.uploadFileToFolder(new_folder['_id'], item['csv'])
+        if "json" in item.keys():
+            gc.uploadFileToFolder(new_folder["_id"], item["json"])
+        if "csv" in item.keys():
+            gc.uploadFileToFolder(new_folder["_id"], item["csv"])
         # Now we send a postprocess request
-        newFolderId = str(new_folder['_id'])
+        newFolderId = str(new_folder["_id"])
         # required metadata to be set on the folder for post processing to work properly
-        gc.addMetadataToFolder(newFolderId, { 'type': 'video', 'fps': -1, })
+        gc.addMetadataToFolder(
+            newFolderId,
+            {
+                "type": "video",
+                "fps": -1,
+            },
+        )
 
-        gc.sendRestRequest('POST', f'dive_rpc/postprocess/{newFolderId}', data={'skipTranscoding': True})
-        print(f'Completed: {count} out of {len(keys)}')
+        gc.sendRestRequest(
+            "POST",
+            f"dive_rpc/postprocess/{newFolderId}",
+            data={"skipTranscoding": True},
+        )
+        print(f"Completed: {count} out of {len(keys)}")
         count = count + 1
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     load_data()


### PR DESCRIPTION
This is a script for NOAA to import their mirrored bucket annotations into their system.  I'm going to deliver it directly to them but I feel it should be included in the repo as a reference point for others who may want to utilize similar features of girder-client.

- Allows specifying a GirderId for a root folder and local mounted folder location to mirror.  It will then upload the annotations to the mirrored directory structure in the system.
- ImageSet Structure is :
    - ./bucket-name-images/platform/date/ID/imageType/images/Dir0001
    - ./bucket-name-images/platform/date/ID/imageType/images/Dir0002
    - ./bucket-name-images/platform/date/ID/imageType/images/Dir0003
- Annotation Struture is:
    - ./bucket-name-annotations/platform/date/ID/imageType/images/ANNOTATIONS
    - ./bucket-name-images/platform/date/ID/imageType/images/ANNOTATIONS/unlabled/annotations-Dir0001.csv
    - ./bucket-name-images/platform/date/ID/imageType/images/ANNOTATIONS/unlabled/annotations-Dir0002.csv
    - ./bucket-name-images/platform/date/ID/imageType/images/ANNOTATIONS/unlabled/annotations-Dir0003.csv

TODO:
- [x] Modify the current setup to support this new structure.  I would probably make it so you input the `/images/` directory on girder and reference the ANNOTATIONS folder locally and it will go through and match the annotations and Directory name to the image sequence names.
- [x] Add capability to clone videos to public folder for easier organization, or possibly clone to a specified folder.
- [x] Add support for specific keys in the annotation files that will cause it to clone the dataset instead of uploading directly.
- [x] Create an explanation video about how it works

For reference I also ran our `poetry tox -e format ../samples/scripts` and that's why the uploadScript.py has been modified


https://github.com/Kitware/dive/assets/61746913/fd583450-5d8d-42b6-9e5b-956d333ebba3
