### PR TITLE
Terminate subprocess when canceling

### DIFF
--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -98,7 +98,8 @@ def stream_subprocess(
             if keep_stdout:
                 stdout += line_str
 
-            if check_canceled(task, context, force=False):
+            # Cancel the subprocess if the status is cancelling
+            if check_canceled(task, context, force=False) or manager.status == JobStatus.CANCELING:
                 # Can never be sure what signal a process will respond to.
                 process.send_signal(signal.SIGTERM)
                 process.send_signal(signal.SIGKILL)


### PR DESCRIPTION
Within Girder and girder jobs itself when cancelling a job it calls celery `revoke()`
Girder Worker code: https://github.com/girder/girder_worker/blob/19b4fc3360a0c9d92fbd0ecd1bfab693f8c75ae7/girder_worker/girder_plugin/event_handlers.py#L142
Celery Reference for Revoke: https://docs.celeryq.dev/en/latest/userguide/workers.html#revoke-revoking-tasks

So it won't execute the task but it doesn't stop the execution of a currently running task.

This update checks in the logger for the Task to see if the task status is CANCELING.  If it is it will then kill the subprocess used to run VIAME for both pipelines and training.  Without this, the process needs to complete before the resources are released.  This should make cancelling a task for training/pipelines actually kill the process itself.