### PR TITLE
Polling Based Job Cancellation

### DIFF
--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -96,6 +96,7 @@ def stream_subprocess(
                 manager.write('Killing subprocess')
                 process.send_signal(signal.SIGTERM)
                 process.send_signal(signal.SIGKILL)
+                time.sleep(10)
                 # VIAME doesn't respond to the above signals we need to interrupt
                 process.send_signal(signal.SIGINT)
 
@@ -116,6 +117,7 @@ def stream_subprocess(
                 process.send_signal(signal.SIGTERM)
                 process.send_signal(signal.SIGKILL)
                 # VIAME doesn't respond to the above signals we need to interrupt
+                time.sleep(10)
                 process.send_signal(signal.SIGINT)
         # flush logs
         manager._flush()

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -7,6 +7,7 @@ import signal
 import subprocess
 from subprocess import Popen
 import tempfile
+import time
 from typing import List, Tuple
 from urllib import request
 from urllib.parse import urlencode, urljoin
@@ -87,6 +88,16 @@ def stream_subprocess(
             stdout=subprocess.PIPE,
             stderr=stderr_file,
         )
+        while process.poll() is None:  # while there is no return code
+            time.sleep(60)  # every minute we check to see if the process is in the cancelling state
+            manager.refreshStatus()
+            print(manager.status)
+            if manager.status == JobStatus.CANCELING:
+                manager.write('Killing subprocess')
+                process.send_signal(signal.SIGTERM)
+                process.send_signal(signal.SIGKILL)
+                # VIAME doesn't respond to the above signals we need to interrupt
+                process.send_signal(signal.SIGINT)
 
         if process.stdout is None:
             raise RuntimeError("Stdout must not be none")
@@ -99,11 +110,13 @@ def stream_subprocess(
                 stdout += line_str
 
             # Cancel the subprocess if the status is cancelling
+            # note this only checks when there is stdout from the subprocess
             if check_canceled(task, context, force=False) or manager.status == JobStatus.CANCELING:
                 # Can never be sure what signal a process will respond to.
                 process.send_signal(signal.SIGTERM)
                 process.send_signal(signal.SIGKILL)
-
+                # VIAME doesn't respond to the above signals we need to interrupt
+                process.send_signal(signal.SIGINT)
         # flush logs
         manager._flush()
         # Wait for exit up to 30 seconds after kill


### PR DESCRIPTION
The previous cancellation logic was dependent on the subprocess printing lines.
This update does a 1 minute polling interval where it checks to see if the state is cancelling.
If it is cancelling it will send signals to kill the sub process.  For VIAME it seems that it only responds favorably to a SIGINT signal so that is added.