### PR TITLE
fix desktop ordering error

### DIFF
--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -338,10 +338,11 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<A
           dataMap.set(track.id, track);
         });
       } else if (missingImages.length === 0 && foundImages.length && multiFrameTracks) {
+        foundImages.sort((a, b) => a.csvFrame - b.csvFrame); // Sort to frame
         for (let i = 0; i < foundImages.length; i += 1) {
           const k = i + 1;
           if (k < foundImages.length) {
-            if (foundImages[i].csvFrame + 1 !== foundImages[k].csvFrame || foundImages[i].frame + 1 !== foundImages[k].frame) {
+            if (foundImages[i].csvFrame > foundImages[k].csvFrame || foundImages[i].frame > foundImages[k].frame) {
             // We have misaligned video sequences so we error out
               error = new Error('Images were provided in an unexpected order and dataset contains multi-frame tracks.');
             }


### PR DESCRIPTION
Fixes some ordering issues with sparsed tracks in a CSV.

Specifically if you had sparsely populated tracks it would throw an ordering error.

I.E if you had tracks on frame 1, 3, 5 the logic from before would throw an error about being out of order but that isn't necessarily true.  That logic just checked to make sure that the next frame in each instance was equal to the current frame + 1, we really just want the next frame to be greater than the lower frame and throw and error if it isn't.

To add to this I also did some pre-sorting of the frames.  Annotators kept giving my CSV files that don't have the frame ordering sorted.