### PR TITLE
remove set query from revision list

### DIFF
--- a/server/dive_server/crud_annotation.py
+++ b/server/dive_server/crud_annotation.py
@@ -105,8 +105,6 @@ class RevisionLogItem(crud.PydanticModel):
             query[REVISION] = {'$lte': before}
         if set:
             query[SET] = set
-        else:
-            query[SET] = None
         cursor = self.find(
             offset=offset,
             limit=limit,


### PR DESCRIPTION
The set query of None in the revision list was causing a problem where it wouldn't show all revisions.  This fixes that issue.