### PR TITLE
reading FPS from CSV Metadata

### DIFF
--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -60,7 +60,7 @@ function _rowInfo(row: string[]) {
     // we have a comment, check for FPS
     let hasComment = false;
     if (row.length > 1) {
-      if (row[1].startsWith('fps:')) {
+      if (row[1].startsWith('Fps:')) {
         const fpsSplit = row[1].split(':');
         if (fpsSplit.length > 1) {
           [, fps] = fpsSplit;
@@ -269,7 +269,6 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<[
   let error: Error | undefined;
   let multiFrameTracks = false;
   const warnings: string[] = [];
-  let fps;
 
   return new Promise<[AnnotationFileData, string[]]>((resolve, reject) => {
     pipeline([input, parser], (err) => {
@@ -389,7 +388,10 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<[
             rowInfo, feature, trackAttributes, confidencePairs,
           } = _parseFeature(record);
           if (rowInfo.fps) {
-            fps = rowInfo.fps;
+            const parsedFps = parseInt(rowInfo.fps, 10);
+            if (!Number.isNaN(parsedFps)) {
+              fps = parsedFps;
+            }
             throw new Error('comment row with FPS');
           }
           if (imageMap !== undefined) {

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -8,7 +8,7 @@ import csvparser from 'csv-parse';
 import csvstringify from 'csv-stringify';
 import fs from 'fs-extra';
 import moment from 'moment';
-import { cloneDeep, flattenDeep, has } from 'lodash';
+import { cloneDeep, flattenDeep } from 'lodash';
 import { pipeline, Readable, Writable } from 'stream';
 
 import { AnnotationSchema, MultiGroupRecord, MultiTrackRecord } from 'dive-common/apispec';

--- a/samples/scripts/setAnnotationFPS.py
+++ b/samples/scripts/setAnnotationFPS.py
@@ -1,0 +1,54 @@
+import json
+import os
+
+import click
+import girder_client
+
+apiURL = "localhost"
+rootFolder = "642577ffac91ad91682b0298"  # Sample folder girder Id
+
+
+# Login to the girder client, interactive means it will prompt for username and password
+def login():
+    gc = girder_client.GirderClient(apiURL, port=8010, apiRoot="girder/api/v1")
+    gc.authenticate(interactive=True)
+    return gc
+
+
+def getFolderList(gc: girder_client.GirderClient, folderId, parentType="folder"):
+    folders = list(gc.listFolder(folderId, parentFolderType=parentType))
+    return folders
+
+def process_folder(gc: girder_client.GirderClient, folderId, fps):
+    folders = getFolderList(gc,folderId)
+    processed = []
+    for folder in folders:
+        if folder.get('meta', {}).get('annotate', False):  # is a DIVE Dataset
+            old_annotation_fps = folder.get('meta', {},).get('fps', None)
+            video_fps = folder.get('meta', {},).get('orignalFps', None)
+            gc.addMetadataToFolder(str(folder['_id']), {
+                "fps": fps
+            })
+            processed.append({
+                'name': folder.get('name', 'unknown'),
+                'oldAnnotationFPS': old_annotation_fps,
+                'newAnnotationFPS': fps,
+                'videoFPS': video_fps,
+            })
+        else:
+            processed = processed + process_folder(gc, str(folder['_id']), fps)
+
+    return processed
+@click.command(name="LoadData", help="Load in ")
+@click.argument(
+    "fps"
+)  # An numerical FPS value to annotate bas
+def load_data(fps):
+    gc = login()
+    # Search the root folder for a list of folders
+    processed = process_folder(gc, rootFolder, fps)
+    with open('processed.json', 'w', encoding='utf8') as outfile:
+        json.dump(processed, outfile, ensure_ascii=False, indent=True)
+
+if __name__ == "__main__":
+    load_data()

--- a/samples/scripts/setAnnotationFPS.py
+++ b/samples/scripts/setAnnotationFPS.py
@@ -5,7 +5,7 @@ import click
 import girder_client
 
 apiURL = "localhost"
-rootFolder = "642577ffac91ad91682b0298"  # Sample folder girder Id
+rootFolder = "64c405c01cb3956240d67709"  # Sample folder girder Id
 
 
 # Login to the girder client, interactive means it will prompt for username and password
@@ -25,14 +25,14 @@ def process_folder(gc: girder_client.GirderClient, folderId, fps):
     for folder in folders:
         if folder.get('meta', {}).get('annotate', False):  # is a DIVE Dataset
             old_annotation_fps = folder.get('meta', {},).get('fps', None)
-            video_fps = folder.get('meta', {},).get('orignalFps', None)
+            video_fps = folder.get('meta', {},).get('originalFps', None)
             gc.addMetadataToFolder(str(folder['_id']), {
-                "fps": fps
+                "fps": int(fps)
             })
             processed.append({
                 'name': folder.get('name', 'unknown'),
                 'oldAnnotationFPS': old_annotation_fps,
-                'newAnnotationFPS': fps,
+                'newAnnotationFPS': int(fps),
                 'videoFPS': video_fps,
             })
         else:

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -326,10 +326,13 @@ def _get_data_by_type(
 
     # Parse the file as the now known type
     if as_type == crud.FileType.VIAME_CSV:
-        converted, attributes, warnings = viame.load_csv_as_tracks_and_attributes(
+        converted, attributes, warnings, fps = viame.load_csv_as_tracks_and_attributes(
             file_string.splitlines(), image_map
         )
-        return {'annotations': converted, 'meta': None, 'attributes': attributes, 'type': as_type}, warnings
+        meta = None
+        if fps is not None:
+            meta = { "fps" : fps }
+        return {'annotations': converted, 'meta': meta, 'attributes': attributes, 'type': as_type}, warnings
     if as_type == crud.FileType.MEVA_KPF:
         converted, attributes = kpf.convert(kpf.load(file_string))
         return {'annotations': converted, 'meta': None, 'attributes': attributes, 'type': as_type}, warnings
@@ -349,7 +352,7 @@ def _get_data_by_type(
     return None, None
 
 
-def process_items(
+def process_items( 
     folder: types.GirderModel,
     user: types.GirderUserModel,
     additive=False,

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -217,6 +217,7 @@ class MetadataMutable(BaseModel):
     confidenceFilters: Optional[Dict[str, float]]
     attributes: Optional[Dict[str, Attribute]]
     attributeTrackFilters: Optional[Dict[str, AttributeTrackFilter]]
+    fps: Optional[float]
 
     @staticmethod
     def is_dive_configuration(value: dict):

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -280,7 +280,7 @@ def custom_sort(row):
 
 def load_csv_as_tracks_and_attributes(
     rows: List[str], imageMap: Optional[Dict[str, int]] = None,
-) -> Tuple[types.DIVEAnnotationSchema, dict, List[str]]:
+) -> Tuple[types.DIVEAnnotationSchema, dict, List[str], Optional[str]]:
     """
     Convert VIAME CSV to json tracks
 
@@ -300,7 +300,7 @@ def load_csv_as_tracks_and_attributes(
     for row in sortedlist:
         if len(row) == 0 or row[0].startswith('#'):
             # This is not a data row
-            if (row[0] == '# metadata'):
+            if (len(row) > 0 and row[0] == '# metadata'):
                 if (row[1].startswith('Fps: ')):
                     fps_splits = row[1].split(':')
                     if len(fps_splits) > 1:
@@ -364,8 +364,6 @@ def load_csv_as_tracks_and_attributes(
         maxFrame = float('-inf')
         frameMapper = {}
         filteredImages = [item for item in foundImages if item['frame'] != -1]
-        print('IMAGEMAP')
-        print(imageMap)
         for index, item in enumerate(filteredImages):
             if item['frame'] == -1:
                 continue
@@ -462,7 +460,6 @@ def load_csv_as_tracks_and_attributes(
         'groups': {},
         'version': constants.AnnotationsCurrentVersion,
     }
-    print(f"FPS IS: {fps}")
     return annotations, metadata_attributes, warnings, fps
 
 

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -301,7 +301,7 @@ def load_csv_as_tracks_and_attributes(
         if len(row) == 0 or row[0].startswith('#'):
             # This is not a data row
             if (row[0] == '# metadata'):
-                if (row[1].startswith('fps: ')):
+                if (row[1].startswith('Fps: ')):
                     fps_splits = row[1].split(':')
                     if len(fps_splits) > 1:
                         fps = fps_splits[1]
@@ -462,6 +462,7 @@ def load_csv_as_tracks_and_attributes(
         'groups': {},
         'version': constants.AnnotationsCurrentVersion,
     }
+    print(f"FPS IS: {fps}")
     return annotations, metadata_attributes, warnings, fps
 
 

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -296,9 +296,15 @@ def load_csv_as_tracks_and_attributes(
     foundImages: List[Dict[str, Any]] = []  # {image:str, frame: int, csvFrame: int}
     sortedlist = sorted(reader, key=custom_sort)
     warnings: List[str] = []
+    fps = None
     for row in sortedlist:
         if len(row) == 0 or row[0].startswith('#'):
             # This is not a data row
+            if (row[0] == '# metadata'):
+                if (row[1].startswith('fps: ')):
+                    fps_splits = row[1].split(':')
+                    if len(fps_splits) > 1:
+                        fps = fps_splits[1]
             continue
         (
             feature,
@@ -456,7 +462,7 @@ def load_csv_as_tracks_and_attributes(
         'groups': {},
         'version': constants.AnnotationsCurrentVersion,
     }
-    return annotations, metadata_attributes, warnings
+    return annotations, metadata_attributes, warnings, fps
 
 
 def export_tracks_as_csv(

--- a/server/tests/test_attributes_processor.py
+++ b/server/tests/test_attributes_processor.py
@@ -26,7 +26,7 @@ def test_read_viame_attributes(
         rows.append(line)
         text = text + line
         print()
-    converted, attributes, warnings = load_csv_as_tracks_and_attributes(text.split('\n'))
+    converted, attributes, warnings, fps = load_csv_as_tracks_and_attributes(text.split('\n'))
     assert json.dumps(converted['tracks'], sort_keys=True) == json.dumps(
         expected_tracks, sort_keys=True
     )

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -15,7 +15,7 @@ def test_read_viame_csv(
     expected_tracks: Dict[str, dict],
     expected_attributes: Dict[str, dict],
 ):
-    (converted, attributes, warnings) = viame.load_csv_as_tracks_and_attributes(input)
+    (converted, attributes, warnings, fps) = viame.load_csv_as_tracks_and_attributes(input)
     assert json.dumps(converted['tracks'], sort_keys=True) == json.dumps(
         expected_tracks, sort_keys=True
     )

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -354,9 +354,9 @@ def test_image_filenames():
     image_map = {'1': 0, '2': 1, '3': 2}
     for test in image_filename_tests:
         if not test['warning']:
-            converted, _, warnings = viame.load_csv_as_tracks_and_attributes(test['csv'], image_map)
+            converted, _, warnings, fps = viame.load_csv_as_tracks_and_attributes(test['csv'], image_map)
             assert len(converted['tracks'].values()) > 0
         else:
-            converted, _, warnings = viame.load_csv_as_tracks_and_attributes(test['csv'], image_map)
+            converted, _, warnings, fps = viame.load_csv_as_tracks_and_attributes(test['csv'], image_map)
             assert len(warnings) > 0
 


### PR DESCRIPTION
- Sets Server to utilize the # metadata, fps: 30 for the FPS when uploading a CSV.
- Sets the Desktop to also utilize the fps in metadata as well.
- Finalizes a script to set the FPS on multiple subfolders using a python script

TODO:

- [x] Test the Server version of setting FPS with VIAME CSV File.
- [x] Finalize Desktop version so it will update the metadata for the annotation fps.
- [x] Test Desktop version of setting FPS with VIAME CSV File.

Made a decision to delay a UI tool for setting annotation FPS to another PR.