### PR TITLE
Implement bulk import

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -161,7 +161,7 @@ interface Api {
   saveAttributeTrackFilters(datasetId: string,
     args: SaveAttributeTrackFilterArgs): Promise<unknown>;
   // Non-Endpoint shared functions
-  openFromDisk(datasetType: DatasetType | 'calibration' | 'annotation' | 'text' | 'zip', directory?: boolean):
+  openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 'annotation' | 'text' | 'zip', directory?: boolean):
     Promise<{canceled?: boolean; filePaths: string[]; fileList?: File[]; root?: string}>;
   getTiles?(itemId: string, projection?: string): Promise<StringKeyObject>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/client/dive-common/components/ImportButton.vue
+++ b/client/dive-common/components/ImportButton.vue
@@ -20,7 +20,7 @@ export default defineComponent({
       required: true,
     },
     openType: {
-      type: String as PropType<DatasetType | 'zip'>,
+      type: String as PropType<DatasetType | 'zip' | 'bulk'>,
       required: true,
     },
     multiCamImport: { //TODO: Temporarily used to hide the stereo settings from users

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -70,7 +70,6 @@ export default function register() {
     return defaults;
   });
 
-  // eslint-disable-next-line arrow-body-style
   ipcMain.handle('bulk-import-media', async (event, { path }: { path: string }) => {
     const results = await common.bulkMediaImport(path);
     return results;

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -70,6 +70,12 @@ export default function register() {
     return defaults;
   });
 
+  // eslint-disable-next-line arrow-body-style
+  ipcMain.handle('bulk-import-media', async (event, { path }: { path: string }) => {
+    const results = await common.bulkMediaImport(path);
+    return results;
+  });
+
   ipcMain.handle('import-media', async (event, { path }: { path: string }) => {
     const ret = await common.beginMediaImport(path);
     return ret;

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -448,7 +448,7 @@ describe('native.common', () => {
       name: 'myproject1_name',
       createdAt: (new Date()).toString(),
       originalBasePath: '/foo/bar/baz',
-      id: 'myproject1',
+      id: 'myproject1_name_tktfgyv2g9',
       originalImageFiles: [],
       transcodedImageFiles: [],
       originalVideoFile: '',
@@ -461,7 +461,7 @@ describe('native.common', () => {
     const contents = fs.readdirSync(result);
     expect(stat.isDirectory()).toBe(true);
     expect(contents).toEqual([]);
-    expect(result).toMatch(/DIVE_Jobs\/myproject1_name_mypipeline\.pipe_/);
+    expect(result).toMatch(/DIVE_Jobs\/myproject1_name_tktfgyv2g9_mypipeline\.pipe_/);
   });
 
   it('beginMediaImport image sequence success', async () => {

--- a/client/platform/desktop/backend/native/utils.ts
+++ b/client/platform/desktop/backend/native/utils.ts
@@ -91,7 +91,7 @@ async function createWorkingDirectory(settings: Settings, jsonMetaList: JsonMeta
   const jobFolderPath = path.join(settings.dataPath, JobsFolderName);
   // eslint won't recognize \. as valid escape
   // eslint-disable-next-line no-useless-escape
-  const safeDatasetName = jsonMetaList[0].name.replace(/[\.\s/]+/g, '_');
+  const safeDatasetName = jsonMetaList[0].id.replace(/[\.\s/]+/g, '_');
   const runFolderName = moment().format(`[${safeDatasetName}_${pipeline}]_MM-DD-yy_hh-mm-ss.SSS`);
   const runFolderPath = path.join(jobFolderPath, runFolderName);
   if (!fs.existsSync(jobFolderPath)) {

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -26,7 +26,7 @@ import {
  * Native functions that run entirely in the renderer
  */
 
-async function openFromDisk(datasetType: DatasetType | 'calibration' | 'annotation' | 'text', directory = false) {
+async function openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 'annotation' | 'text', directory = false) {
   let filters: FileFilter[] = [];
   const allFiles = { name: 'All Files', extensions: ['*'] };
   if (datasetType === 'video') {
@@ -53,7 +53,7 @@ async function openFromDisk(datasetType: DatasetType | 'calibration' | 'annotati
       allFiles,
     ];
   }
-  const props = (datasetType === 'image-sequence' || directory) ? 'openDirectory' : 'openFile';
+  const props = (['image-sequence', 'bulk'].includes(datasetType) || directory) ? 'openDirectory' : 'openFile';
   const results = await dialog.showOpenDialog({
     properties: [props],
     filters,
@@ -115,6 +115,10 @@ async function runTraining(
 
 function importMedia(path: string): Promise<DesktopMediaImportResponse> {
   return ipcRenderer.invoke('import-media', { path });
+}
+
+function bulkImportMedia(path: string): Promise<DesktopMediaImportResponse[]> {
+  return ipcRenderer.invoke('bulk-import-media', { path });
 }
 
 function deleteDataset(datasetId: string): Promise<boolean> {
@@ -228,6 +232,7 @@ export {
   exportConfiguration,
   finalizeImport,
   importMedia,
+  bulkImportMedia,
   deleteDataset,
   checkDataset,
   importAnnotationFile,

--- a/client/platform/desktop/frontend/components/BulkImportDialog.vue
+++ b/client/platform/desktop/frontend/components/BulkImportDialog.vue
@@ -12,19 +12,22 @@ const headers = [
     text: 'Dataset Name',
     align: 'start',
     sortable: false,
-    value: 'jsonMeta.name',
+    value: 'name',
+    width: '300',
   },
   {
     text: 'Path',
     align: 'start',
     sortable: false,
     value: 'path',
+    width: '800',
   },
   {
     text: 'Dataset Type',
     align: 'start',
     sortable: false,
     value: 'jsonMeta.type',
+    width: '150',
   },
   {
     text: 'Config',
@@ -136,8 +139,16 @@ export default defineComponent({
       disable-sort
       @input="updateSelected"
     >
+      <template #item.name="{ item }">
+        <div class="text-wrap" style="word-break: break-word;">
+          {{ item.jsonMeta.name }}
+        </div>
+      </template>
+
       <template #item.path="{ item }">
-        {{ formatPath(item) }}
+        <div class="text-wrap" style="word-break: break-word;">
+          {{ formatPath(item) }}
+        </div>
       </template>
 
       <template #item.config="{ item }">

--- a/client/platform/desktop/frontend/components/BulkImportDialog.vue
+++ b/client/platform/desktop/frontend/components/BulkImportDialog.vue
@@ -13,14 +13,12 @@ const headers = [
     align: 'start',
     sortable: false,
     value: 'name',
-    width: '300',
   },
   {
     text: 'Path',
     align: 'start',
     sortable: false,
     value: 'path',
-    width: '800',
   },
   {
     text: 'Dataset Type',
@@ -31,7 +29,7 @@ const headers = [
   },
   {
     text: 'Config',
-    align: 'start',
+    align: 'end',
     sortable: false,
     value: 'config',
   },

--- a/client/platform/desktop/frontend/components/BulkImportDialog.vue
+++ b/client/platform/desktop/frontend/components/BulkImportDialog.vue
@@ -117,7 +117,7 @@ export default defineComponent({
 <template>
   <v-card outlined class="import-card" style="overflow-x: hidden;">
     <v-card-title class="text-h5">
-      Bulk Import
+      Bulk Import (Selecting {{ selectedImports.length }} of {{ imports.length }})
     </v-card-title>
 
     <v-dialog :value="currentImport !== undefined" width="800">

--- a/client/platform/desktop/frontend/components/BulkImportDialog.vue
+++ b/client/platform/desktop/frontend/components/BulkImportDialog.vue
@@ -1,0 +1,184 @@
+<script lang="ts">
+import {
+  defineComponent, ref, PropType,
+  computed,
+} from 'vue';
+import { DesktopMediaImportResponse } from 'platform/desktop/constants';
+import { clone, cloneDeep } from 'lodash';
+import ImportDialog from './ImportDialog.vue';
+
+const headers = [
+  {
+    text: 'Dataset Name',
+    align: 'start',
+    sortable: false,
+    value: 'jsonMeta.name',
+  },
+  {
+    text: 'Path',
+    align: 'start',
+    sortable: false,
+    value: 'path',
+  },
+  {
+    text: 'Dataset Type',
+    align: 'start',
+    sortable: false,
+    value: 'jsonMeta.type',
+  },
+  {
+    text: 'Config',
+    align: 'start',
+    sortable: false,
+    value: 'config',
+  },
+];
+
+export default defineComponent({
+  name: 'BulkImportDialog',
+  components: {
+    ImportDialog,
+  },
+  props: {
+    importData: {
+      type: Array as PropType<DesktopMediaImportResponse[]>,
+      required: true,
+    },
+  },
+  setup(props, ctx) {
+    // Map imports to include generated "id" field, used in rendering.
+    const imports = ref(props.importData.map((im) => {
+      const cloned = cloneDeep(im);
+      cloned.jsonMeta.id = (Math.random() + 1).toString(36).substring(2);
+
+      return cloned;
+    }));
+
+    // The dataset import currently being configured
+    const currentImport = ref<DesktopMediaImportResponse>();
+
+    // Selected state and selected imports maintain the ordering of `imports`
+    const selectedState = ref(imports.value.map(() => true));
+    const selectedImports = computed(() => imports.value.filter((_, index) => selectedState.value[index]));
+    function updateSelected(val: DesktopMediaImportResponse[]) {
+      selectedState.value = imports.value.map((im) => val.includes(im));
+    }
+
+    function stripId(item: DesktopMediaImportResponse) {
+      const cloned = cloneDeep(item);
+      cloned.jsonMeta.id = '';
+      return item;
+    }
+
+    function finalizeImport() {
+      const finalImports = imports.value.filter((im) => selectedImports.value.includes(im)).map((im) => stripId(im));
+      ctx.emit('finalize-import', finalImports);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    function updateImportConfig(oldItem: DesktopMediaImportResponse, newItem: DesktopMediaImportResponse) {
+      const itemIndex = imports.value.indexOf(oldItem);
+
+      // Need to modify the imports array ref to contain the new item
+      const newArray = clone(imports.value);
+      newArray.splice(itemIndex, 1, newItem);
+      imports.value = newArray;
+
+      currentImport.value = undefined;
+    }
+
+    function formatPath(item: DesktopMediaImportResponse) {
+      let path = item.jsonMeta.originalBasePath;
+
+      if (item.jsonMeta.originalVideoFile !== '') {
+        path = `${path}/${item.jsonMeta.originalVideoFile}`;
+      }
+
+      return path;
+    }
+
+    return {
+      updateSelected,
+      updateImportConfig,
+      formatPath,
+      imports,
+      headers,
+      selectedImports,
+      currentImport,
+      finalizeImport,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-card outlined class="import-card" style="overflow-x: hidden;">
+    <v-card-title class="text-h5">
+      Bulk Import
+    </v-card-title>
+
+    <v-dialog :value="currentImport !== undefined" width="800">
+      <ImportDialog
+        v-if="currentImport !== undefined"
+        :import-data="currentImport"
+        :embedded="true"
+        @abort="currentImport = undefined"
+        @finalize-import="updateImportConfig(currentImport, $event)"
+      />
+    </v-dialog>
+
+    <v-data-table
+      :value="selectedImports"
+      :items="imports"
+      item-key="jsonMeta.id"
+      :headers="headers"
+      show-select
+      disable-sort
+      @input="updateSelected"
+    >
+      <template #item.path="{ item }">
+        {{ formatPath(item) }}
+      </template>
+
+      <template #item.config="{ item }">
+        <v-btn
+          icon
+          :disabled="!selectedImports.includes(item)"
+          @click="currentImport = item"
+        >
+          <v-icon>
+            mdi-cog
+          </v-icon>
+        </v-btn>
+      </template>
+    </v-data-table>
+
+    <v-card-text>
+      <div class="d-flex flex-row mt-4">
+        <v-spacer />
+        <v-btn
+          text
+          outlined
+          class="mr-5"
+          @click="$emit('abort')"
+        >
+          Cancel
+        </v-btn>
+        <v-btn
+          color="primary"
+          @click="finalizeImport"
+        >
+          Import Selected
+        </v-btn>
+      </div>
+    </v-card-text>
+  </v-card>
+</template>
+
+<style lang="scss">
+@import 'dive-common/components/styles/KeyValueTable.scss';
+
+.v-data-table__selected {
+  background: unset !important;
+}
+</style>

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -22,6 +22,11 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    // If being embedded into the bulk import dialog
+    embedded: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props) {
     const argCopy = ref(cloneDeep(props.importData));
@@ -321,7 +326,7 @@ export default defineComponent({
           :disabled="!ready || disabled"
           @click="$emit('finalize-import', argCopy)"
         >
-          Finish Import
+          {{ embedded ? "Save" : "Finish Import" }}
         </v-btn>
       </div>
     </v-card-text>

--- a/client/platform/desktop/frontend/components/Recent.vue
+++ b/client/platform/desktop/frontend/components/Recent.vue
@@ -63,11 +63,19 @@ export default defineComponent({
         return;
       }
 
-      if (dstype === 'bulk') {
-        pendingImportPayload.value = await request(() => api.bulkImportMedia(ret.filePaths[0]));
-      } else {
+      if (dstype !== 'bulk') {
         pendingImportPayload.value = [await request(() => api.importMedia(ret.filePaths[0]))];
+        return;
       }
+
+      const foundImports = await request(() => api.bulkImportMedia(ret.filePaths[0]));
+      if (!foundImports.length) {
+        prompt({ title: 'No datasets found', text: 'Please check that your import path is correct and try again.', positiveButton: 'Okay' });
+        pendingImportPayload.value = null;
+        return;
+      }
+
+      pendingImportPayload.value = foundImports;
     }
 
     /** Accept args from the dialog, as it may have modified some parts */

--- a/client/platform/desktop/frontend/components/Recent.vue
+++ b/client/platform/desktop/frontend/components/Recent.vue
@@ -30,12 +30,14 @@ import { setOrGetConversionJob } from '../store/jobs';
 import BrowserLink from './BrowserLink.vue';
 import NavigationBar from './NavigationBar.vue';
 import ImportDialog from './ImportDialog.vue';
+import BulkImportDialog from './BulkImportDialog.vue';
 
 export default defineComponent({
   components: {
     BrowserLink,
     ImportButton,
     ImportDialog,
+    BulkImportDialog,
     NavigationBar,
     ImportMultiCamDialog,
     TooltipBtn,
@@ -44,7 +46,8 @@ export default defineComponent({
   setup() {
     const router = useRouter();
     const importMultiCamDialog = ref(false);
-    const pendingImportPayload: Ref<DesktopMediaImportResponse | null> = ref(null);
+    const pendingImportPayload: Ref<DesktopMediaImportResponse[] | null> = ref(null);
+    const bulkImport = computed(() => (pendingImportPayload.value !== null && pendingImportPayload.value.length > 1));
     const searchText: Ref<string | null> = ref('');
     const stereo = ref(false);
     const multiCamOpenType: Ref<'image-sequence'|'video'> = ref('image-sequence');
@@ -54,11 +57,32 @@ export default defineComponent({
       error, loading: checkingMedia, request, reset: resetError,
     } = useRequest();
 
-    async function open(dstype: DatasetType | 'text', directory = false) {
+    async function open(dstype: DatasetType | 'bulk' | 'text', directory = false) {
       const ret = await api.openFromDisk(dstype, directory);
-      if (!ret.canceled) {
-        pendingImportPayload.value = await request(() => api.importMedia(ret.filePaths[0]));
+      if (ret.canceled) {
+        return;
       }
+
+      if (dstype === 'bulk') {
+        pendingImportPayload.value = await request(() => api.bulkImportMedia(ret.filePaths[0]));
+      } else {
+        pendingImportPayload.value = [await request(() => api.importMedia(ret.filePaths[0]))];
+      }
+    }
+
+    /** Accept args from the dialog, as it may have modified some parts */
+    async function finalizeBulkImport(argsArray: DesktopMediaImportResponse[]) {
+      importing.value = true;
+
+      const imports = await request(async () => Promise.all(argsArray.map((args) => api.finalizeImport(args))));
+      pendingImportPayload.value = null;
+
+      imports.forEach(async (jsonMeta) => {
+        const recentsMeta = await api.loadMetadata(jsonMeta.id);
+        setRecents(recentsMeta);
+      });
+
+      importing.value = false;
     }
 
     /** Accept args from the dialog, as it may have modified some parts */
@@ -89,7 +113,7 @@ export default defineComponent({
 
     async function multiCamImport(args: MultiCamImportArgs) {
       importMultiCamDialog.value = false;
-      pendingImportPayload.value = await request(() => api.importMultiCam(args));
+      pendingImportPayload.value = [await request(() => api.importMultiCam(args))];
     }
 
     async function confirmDeleteDataset(datasetId: string, datasetName: string) {
@@ -180,6 +204,7 @@ export default defineComponent({
       // methods
       acknowledgeVersion,
       open,
+      finalizeBulkImport,
       finalizeImport,
       multiCamImport,
       join,
@@ -196,6 +221,7 @@ export default defineComponent({
       stereo,
       filteredRecents,
       pendingImportPayload,
+      bulkImport,
       searchText,
       error,
       importing,
@@ -217,17 +243,25 @@ export default defineComponent({
     <v-dialog
       :value="pendingImportPayload !== null || importMultiCamDialog || checkingMedia"
       persistent
-      width="800"
+      :width="bulkImport ? 'auto' : '800'"
       overlay-opacity="0.95"
       max-width="80%"
     >
-      <ImportDialog
-        v-if="pendingImportPayload !== null"
-        :import-data="pendingImportPayload"
-        :disabled="importing"
-        @finalize-import="finalizeImport($event)"
-        @abort="pendingImportPayload = null"
-      />
+      <template v-if="pendingImportPayload !== null">
+        <BulkImportDialog
+          v-if="bulkImport"
+          :import-data="pendingImportPayload"
+          @finalize-import="finalizeBulkImport($event)"
+          @abort="pendingImportPayload = null"
+        />
+        <ImportDialog
+          v-else
+          :import-data="pendingImportPayload[0]"
+          :disabled="importing"
+          @finalize-import="finalizeImport($event)"
+          @abort="pendingImportPayload = null"
+        />
+      </template>
       <ImportMultiCamDialog
         v-else-if="importMultiCamDialog"
         :stereo="stereo"
@@ -319,6 +353,13 @@ export default defineComponent({
             md="6"
             sm="6"
           >
+            <ImportButton
+              name="Bulk Import"
+              icon="mdi-folder-multiple"
+              open-type="bulk"
+              class="my-3"
+              @open="open($event)"
+            />
             <ImportButton
               name="Open Image Sequence"
               icon="mdi-folder-open"

--- a/client/platform/desktop/frontend/components/Recent.vue
+++ b/client/platform/desktop/frontend/components/Recent.vue
@@ -243,7 +243,7 @@ export default defineComponent({
     <v-dialog
       :value="pendingImportPayload !== null || importMultiCamDialog || checkingMedia"
       persistent
-      :width="bulkImport ? 'auto' : '800'"
+      :width="bulkImport ? '1400' : '800'"
       overlay-opacity="0.95"
       max-width="80%"
     >


### PR DESCRIPTION
Closes #1455 

Allows for bulk importing of datasets with a new "Bulk Import" button. This is done by recursively searching for datasets, wrapping the existing import sequence. If a directory fails the import sequence, the function will recurse into that directory.