### PR TITLE
[feature] ONNX Export

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -34,6 +34,7 @@ interface Pipe {
   name: string;
   pipe: string;
   type: string;
+  folderId?: string
 }
 
 interface Category {
@@ -142,6 +143,8 @@ interface DatasetMeta extends DatasetMetaMutable {
 interface Api {
   getPipelineList(): Promise<Pipelines>;
   runPipeline(itemId: string, pipeline: Pipe): Promise<unknown>;
+  deleteTrainedPipeline(pipeline: Pipe): Promise<void>;
+  exportTrainedPipeline(path: string, pipeline: Pipe): Promise<unknown>;
 
   getTrainingConfigurations(): Promise<TrainingConfigs>;
   runTraining(

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -34,7 +34,9 @@ interface Pipe {
   name: string;
   pipe: string;
   type: string;
-  folderId?: string
+  folderId?: string;
+  ownerId?: string;
+  ownerLogin?: string;
 }
 
 interface Category {

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -35,7 +35,8 @@ export default function register() {
     return ret;
   });
   ipcMain.handle('delete-trained-pipeline', async (event, args: Pipe) => {
-    return await common.deleteTrainedPipeline(args);
+    const ret = await common.deleteTrainedPipeline(args);
+    return ret;
   })
   ipcMain.handle('get-training-configs', async () => {
     const ret = await common.getTrainingConfigs(settings.get());

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -2,9 +2,11 @@ import OS from 'os';
 import http from 'http';
 import { ipcMain } from 'electron';
 import { MultiCamImportArgs } from 'dive-common/apispec';
+import type { Pipe } from 'dive-common/apispec';
 import {
   DesktopJobUpdate, RunPipeline, RunTraining, Settings, ExportDatasetArgs,
   DesktopMediaImportResponse,
+  ExportTrainedPipeline,
 } from 'platform/desktop/constants';
 
 import linux from './native/linux';
@@ -32,6 +34,9 @@ export default function register() {
     const ret = await common.getPipelineList(settings.get());
     return ret;
   });
+  ipcMain.handle('delete-trained-pipeline', async (event, args: Pipe) => {
+    return await common.deleteTrainedPipeline(args);
+  })
   ipcMain.handle('get-training-configs', async () => {
     const ret = await common.getTrainingConfigs(settings.get());
     return ret;
@@ -121,6 +126,12 @@ export default function register() {
       event.sender.send('job-update', update);
     };
     return currentPlatform.runPipeline(settings.get(), args, updater);
+  });
+  ipcMain.handle('export-trained-pipeline', async (event, args: ExportTrainedPipeline) => {
+    const updater = (update: DesktopJobUpdate) => {
+      event.sender.send('job-update', update);
+    };
+    return currentPlatform.exportTrainedPipeline(settings.get(), args, updater);
   });
   ipcMain.handle('run-training', async (event, args: RunTraining) => {
     const updater = (update: DesktopJobUpdate) => {

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -22,6 +22,7 @@ import {
   DatasetMetaMutableKeys,
   AnnotationSchema,
   SaveAttributeTrackFilterArgs,
+  Pipe,
 } from 'dive-common/apispec';
 import * as viameSerializers from 'platform/desktop/backend/serializers/viame';
 import * as nistSerializers from 'platform/desktop/backend/serializers/nist';
@@ -442,6 +443,16 @@ async function getTrainingConfigs(settings: Settings): Promise<TrainingConfigs> 
     default: configs[0],
     configs,
   };
+}
+
+/**
+ * delete a trained pipeline
+ */
+async function deleteTrainedPipeline(pipeline: Pipe): Promise<void> {
+  if (pipeline.type !== 'trained') throw new Error(`${pipeline.name} is not a trained pipeline`);
+
+  const parent = npath.parse(pipeline.pipe).dir;
+  await fs.remove(parent);
 }
 
 /**
@@ -1195,6 +1206,7 @@ export {
   exportDataset,
   finalizeMediaImport,
   getPipelineList,
+  deleteTrainedPipeline,
   getTrainingConfigs,
   getProjectDir,
   getValidatedProjectDir,

--- a/client/platform/desktop/backend/native/linux.ts
+++ b/client/platform/desktop/backend/native/linux.ts
@@ -96,8 +96,8 @@ async function exportTrainedPipeline(
 ): Promise<DesktopJob> {
   return viame.exportTrainedPipeline(settings, exportTrainedPipelineArgs, updater, validateViamePath, {
     ...ViameLinuxConstants,
-    setupScriptAbs: sourceString(settings)
-  })
+    setupScriptAbs: sourceString(settings),
+  });
 }
 
 async function train(

--- a/client/platform/desktop/backend/native/linux.ts
+++ b/client/platform/desktop/backend/native/linux.ts
@@ -13,6 +13,7 @@ import {
   NvidiaSmiReply,
   RunTraining,
   DesktopJobUpdater,
+  ExportTrainedPipeline,
 } from 'platform/desktop/constants';
 import { observeChild } from 'platform/desktop/backend/native/processManager';
 import * as viame from './viame';
@@ -88,6 +89,17 @@ async function runPipeline(
   });
 }
 
+async function exportTrainedPipeline(
+  settings: Settings,
+  exportTrainedPipelineArgs: ExportTrainedPipeline,
+  updater: DesktopJobUpdater,
+): Promise<DesktopJob> {
+  return viame.exportTrainedPipeline(settings, exportTrainedPipelineArgs, updater, validateViamePath, {
+    ...ViameLinuxConstants,
+    setupScriptAbs: sourceString(settings)
+  })
+}
+
 async function train(
   settings: Settings,
   runTrainingArgs: RunTraining,
@@ -132,6 +144,7 @@ export default {
   DefaultSettings,
   nvidiaSmi,
   runPipeline,
+  exportTrainedPipeline,
   train,
   validateViamePath,
 };

--- a/client/platform/desktop/backend/native/utils.ts
+++ b/client/platform/desktop/backend/native/utils.ts
@@ -101,6 +101,20 @@ async function createWorkingDirectory(settings: Settings, jsonMetaList: JsonMeta
   return runFolderPath;
 }
 
+async function createCustomWorkingDirectory(settings: Settings, prefix: string, pipeline: string) {
+  const jobFolderPath = path.join(settings.dataPath, JobsFolderName);
+  // Formating prefix if for any reason the prefix is input by the user in the futur
+  // eslint-disable-next-line no-useless-escape
+  const safePrefix = prefix.replace(/[\.\s/]+/g, '_');
+  const runFolderName = moment().format(`[${safePrefix}_${pipeline}]_MM-DD-yy_hh-mm-ss.SSS`);
+  const runFolderPath = path.join(jobFolderPath, runFolderName);
+  if (!fs.existsSync(jobFolderPath)) {
+    await fs.mkdir(jobFolderPath);
+  }
+  await fs.mkdir(runFolderPath);
+  return runFolderPath;
+}
+
 /* same as os.path.splitext */
 function splitExt(input: string): [string, string] {
   const ext = path.extname(input);
@@ -112,6 +126,7 @@ export {
   getBinaryPath,
   jobFileEchoMiddleware,
   createWorkingDirectory,
+  createCustomWorkingDirectory,
   spawnResult,
   splitExt,
 };

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -285,6 +285,9 @@ async function exportTrainedPipeline(settings: Settings,
   job.on('exit', async (code) => {
     if (code === 0) {
       if (fs.existsSync(converterOutput)) {
+        if (fs.existsSync(path)) {
+          fs.unlinkSync(path);
+        }
         // We move instead of copying because .onnx files can be huge
         fs.moveSync(converterOutput, path);
       } else {

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -230,6 +230,10 @@ async function exportTrainedPipeline(settings: Settings,
   }
 
   const exportPipelinePath = npath.join(settings.viamePath, PipelineRelativeDir, "convert_to_onnx.pipe");
+  if (!fs.existsSync(npath.join(exportPipelinePath))) {
+    throw new Error("Your VIAME version doesn't support ONNX export. You have to update it to a newer version to be able to export models.");
+  }
+  
   const modelPipelineDir = npath.parse(pipeline.pipe).dir;
   let weightsPath: string;
   if (fs.existsSync(npath.join(modelPipelineDir, 'yolo.weights'))) {

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -5,6 +5,7 @@ import fs from 'fs-extra';
 import {
   Settings, DesktopJob, RunPipeline, RunTraining,
   DesktopJobUpdater,
+  ExportTrainedPipeline,
 } from 'platform/desktop/constants';
 import { cleanString } from 'platform/desktop/sharedUtils';
 import { serialize } from 'platform/desktop/backend/serializers/viame';
@@ -213,6 +214,75 @@ async function runPipeline(
 }
 
 /**
+ * a node.js implementation of dive_tasks.tasks.export_trained_model
+ */
+async function exportTrainedPipeline(settings: Settings,
+  exportTrainedPipelineArgs: ExportTrainedPipeline,
+  updater: DesktopJobUpdater,
+  validateViamePath: (settings: Settings) => Promise<true | string>,
+  viameConstants: ViameConstants,
+): Promise<DesktopJob> {
+  const { path, pipeline } = exportTrainedPipelineArgs;
+
+  const isValid = await validateViamePath(settings);
+  if (isValid !== true) {
+    throw new Error(isValid);
+  }
+
+  const exportPipelinePath = npath.join(settings.viamePath, PipelineRelativeDir, "convert_to_onnx.pipe");
+  const modelPipelineDir = npath.parse(pipeline.pipe).dir;
+  let weightsPath: string;
+  if (fs.existsSync(npath.join(modelPipelineDir, 'yolo.weights'))) {
+    weightsPath = npath.join(modelPipelineDir, 'yolo.weights');
+  } else {
+    throw new Error("Your pipeline has no trained weights (yolo.weights is missing)");
+  }
+
+  const command = [
+    `${viameConstants.setupScriptAbs} &&`,
+    `"${viameConstants.kwiverExe}" runner ${exportPipelinePath}`,
+    `-s "onnx_convert:model_path=${weightsPath}"`,
+    `-s "onnx_convert:onnx_model_prefix=${path}"`,
+  ];
+
+  const job = observeChild(spawn(command.join(' '), {
+    shell: viameConstants.shell,
+    cwd: undefined,
+  }));
+
+  const jobBase: DesktopJob = {
+    key: `pipeline_${job.pid}`,
+    command: command.join(' '),
+    jobType: 'export',
+    pid: job.pid,
+    args: exportTrainedPipelineArgs,
+    title: `${exportTrainedPipelineArgs.pipeline.name} to ONNX`,
+    datasetIds: [],
+    exitCode: job.exitCode,
+    startTime: new Date(),
+  };
+
+  updater({
+    ...jobBase,
+    body: [''],
+  });
+
+  job.stdout.on('data', jobFileEchoMiddleware(jobBase, updater));
+  job.stderr.on('data', jobFileEchoMiddleware(jobBase, updater));
+
+  job.on('exit', async (code) => {
+    updater({
+      ...jobBase,
+      body: [''],
+      exitCode: code,
+      endTime: new Date(),
+    });
+  });
+
+  return jobBase;
+}
+
+/**
  * a node.js implementation of dive_tasks.tasks.run_training
  */
 async function train(
@@ -356,5 +426,6 @@ async function train(
 
 export {
   runPipeline,
+  exportTrainedPipeline,
   train,
 };

--- a/client/platform/desktop/backend/native/windows.ts
+++ b/client/platform/desktop/backend/native/windows.ts
@@ -12,6 +12,7 @@ import {
   Settings, SettingsCurrentVersion,
   DesktopJob, RunPipeline, NvidiaSmiReply, RunTraining,
   DesktopJobUpdater,
+  ExportTrainedPipeline,
 } from 'platform/desktop/constants';
 import * as viame from './viame';
 
@@ -86,6 +87,17 @@ async function runPipeline(
   updater: DesktopJobUpdater,
 ): Promise<DesktopJob> {
   return viame.runPipeline(settings, runPipelineArgs, updater, validateFake, {
+    ...ViameWindowsConstants,
+    setupScriptAbs: `"${npath.join(settings.viamePath, ViameWindowsConstants.setup)}"`,
+  });
+}
+
+async function exportTrainedPipeline(
+  settings: Settings,
+  exportTrainedPipelineArgs: ExportTrainedPipeline,
+  updater: DesktopJobUpdater,
+): Promise<DesktopJob> {
+  return viame.exportTrainedPipeline(settings, exportTrainedPipelineArgs, updater, validateFake, {
     ...ViameWindowsConstants,
     setupScriptAbs: `"${npath.join(settings.viamePath, ViameWindowsConstants.setup)}"`,
   });
@@ -168,6 +180,7 @@ export default {
   DefaultSettings,
   validateViamePath,
   runPipeline,
+  exportTrainedPipeline,
   train,
   nvidiaSmi,
   initialize,

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -151,6 +151,11 @@ export interface RunPipeline {
   pipeline: Pipe;
 }
 
+export interface ExportTrainedPipeline {
+  path: string;
+  pipeline: Pipe;
+}
+
 /** TODO promote to apispec */
 export interface RunTraining {
   // datasets to run training on
@@ -176,17 +181,17 @@ export interface DesktopJob {
   // command that was run
   command: string;
   // jobType identify type of job
-  jobType: 'pipeline' | 'training' | 'conversion';
+  jobType: 'pipeline' | 'training' | 'conversion' | 'export';
   // title whatever humans should see this job called
   title: string;
   // arguments to creation
-  args: RunPipeline | RunTraining | ConversionArgs;
+  args: RunPipeline | RunTraining | ExportTrainedPipeline | ConversionArgs;
   // datasetIds of the involved datasets
   datasetIds: string[];
   // pid of the process spawned
   pid: number;
   // workingDir of the job's output
-  workingDir: string;
+  workingDir?: string;
   // exitCode if set, the job exited already
   exitCode: number | null;
   // startTime time of process initialization

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -191,7 +191,7 @@ export interface DesktopJob {
   // pid of the process spawned
   pid: number;
   // workingDir of the job's output
-  workingDir?: string;
+  workingDir: string;
   // exitCode if set, the job exited already
   exitCode: number | null;
   // startTime time of process initialization

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -18,7 +18,7 @@ import {
 } from 'dive-common/constants';
 import {
   DesktopJob, DesktopMetadata, JsonMeta, NvidiaSmiReply,
-  RunPipeline, RunTraining, ExportDatasetArgs, ExportConfigurationArgs,
+  RunPipeline, RunTraining, ExportTrainedPipeline, ExportDatasetArgs, ExportConfigurationArgs,
   DesktopMediaImportResponse,
 } from 'platform/desktop/constants';
 
@@ -96,6 +96,14 @@ async function runPipeline(itemId: string, pipeline: Pipe): Promise<DesktopJob> 
   return ipcRenderer.invoke('run-pipeline', args);
 }
 
+async function exportTrainedPipeline(path: string, pipeline: Pipe): Promise<DesktopJob> {
+  const args: ExportTrainedPipeline = {
+    path,
+    pipeline,
+  };
+  return ipcRenderer.invoke('export-trained-pipeline', args);
+}
+
 async function runTraining(
   folderIds: string[],
   pipelineName: string,
@@ -111,6 +119,10 @@ async function runTraining(
     labelText,
   };
   return ipcRenderer.invoke('run-training', args);
+}
+
+async function deleteTrainedPipeline(pipeline: Pipe): Promise<void> {
+  return ipcRenderer.invoke('delete-trained-pipeline', pipeline);
 }
 
 function importMedia(path: string): Promise<DesktopMediaImportResponse> {
@@ -219,7 +231,9 @@ export {
   /* Standard Specification APIs */
   loadMetadata,
   getPipelineList,
+  deleteTrainedPipeline,
   runPipeline,
+  exportTrainedPipeline,
   getTrainingConfigurations,
   runTraining,
   saveMetadata,

--- a/client/platform/desktop/frontend/components/Jobs.vue
+++ b/client/platform/desktop/frontend/components/Jobs.vue
@@ -34,7 +34,7 @@ export default defineComponent({
     }
 
     async function openPath(job: DesktopJob) {
-      shell.openPath(job.workingDir);
+      if (job.workingDir) shell.openPath(job.workingDir);
     }
 
     return {
@@ -103,8 +103,13 @@ export default defineComponent({
                 <v-col cols="8">
                   <v-card-title class="primary--text text--lighten-3 text-decoration-none pt-0">
                     {{ job.job.jobType }}:
-                    {{ datasets[job.job.datasetIds[0]]
-                      ? datasets[job.job.datasetIds[0]].name : job.job.datasetIds.join(', ') }}
+                    <template v-if="job.job.datasetIds.length > 0">
+                      {{ datasets[job.job.datasetIds[0]]
+                        ? datasets[job.job.datasetIds[0]].name : job.job.datasetIds.join(', ') }}
+                    </template>
+                    <template v-else>
+                      {{ job.job.title }}
+                    </template>
                   </v-card-title>
                   <v-card-subtitle>
                     <table class="key-value-table">
@@ -116,7 +121,7 @@ export default defineComponent({
                         <td>PID</td>
                         <td>{{ job.job.pid }}</td>
                       </tr>
-                      <tr>
+                      <tr v-if="job.job.datasetIds.length > 0">
                         <td>datasets</td>
                         <td>
                           <span
@@ -132,7 +137,7 @@ export default defineComponent({
                           </span>
                         </td>
                       </tr>
-                      <tr>
+                      <tr v-if="job.job.workingDir">
                         <td>work dir</td>
                         <td>
                           <span

--- a/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
+++ b/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
@@ -148,11 +148,22 @@ export default defineComponent({
         });
         if (!location.canceled && location.filePath) {
           await exportTrainedPipeline(location.filePath!, item);
+          const goToJobsPage = !await prompt({
+            title: 'Export Started',
+            text: 'You can check the export status in the Jobs tab.',
+            negativeButton: 'View',
+            positiveButton: 'OK',
+            confirm: true,
+          });
+          if (goToJobsPage) {
+            router.push('/jobs');
+          }
         }
       } catch (err) {
         console.log(err);
-        let text = 'Unable to export model';
-        if (err.response?.status === 403) text = 'You do not have permission to export the selected resource(s).';
+        const errorTemplate = 'Unable to export model';
+        let text = `${errorTemplate}: ${err}`;
+        if (err.response?.status === 403) text = `${errorTemplate}: You do not have permission to export the selected resource(s).`;
         prompt({
           title: 'Export Failed',
           text,

--- a/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
+++ b/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
@@ -146,7 +146,6 @@ export default defineComponent({
           title: 'Export Model',
           defaultPath: npath.join(app.getPath('home'), 'model.onnx'),
         });
-        console.log(location);
         if (!location.canceled && location.filePath) {
           await exportTrainedPipeline(location.filePath!, item);
         }
@@ -365,7 +364,6 @@ export default defineComponent({
         v-bind="{ headers: models.headers, items: models.items.value }"
         no-data-text="You don't have any trained model"
       >
-
         <template #[`item.export`]="{ item }">
           <v-btn
             :key="item.name"
@@ -387,10 +385,8 @@ export default defineComponent({
             <v-icon>mdi-trash-can</v-icon>
           </v-btn>
         </template>
-
       </v-data-table>
     </div>
-
   </div>
 </template>
 

--- a/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
+++ b/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
@@ -5,22 +5,27 @@ import {
   computed, defineComponent, onBeforeMount, set, del, reactive, ref,
 } from 'vue';
 import {
-  DatasetMeta, Pipelines, TrainingConfigs, useApi,
+  DatasetMeta, Pipelines, TrainingConfigs, useApi, Pipe,
 } from 'dive-common/apispec';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { itemsPerPageOptions, simplifyTrainingName } from 'dive-common/constants';
 import { clientSettings } from 'dive-common/store/settings';
 
 import { useRouter } from 'vue-router/composables';
+import npath from 'path';
+import { dialog, app } from '@electron/remote';
 import { datasets } from '../store/dataset';
 
 export default defineComponent({
   setup() {
-    const { getPipelineList, getTrainingConfigurations, runTraining } = useApi();
+    const {
+      getPipelineList, deleteTrainedPipeline, getTrainingConfigurations, runTraining, exportTrainedPipeline,
+    } = useApi();
     const { prompt } = usePrompt();
     const router = useRouter();
 
     const unsortedPipelines = ref({} as Pipelines);
+
     onBeforeMount(async () => {
       unsortedPipelines.value = await getPipelineList();
     });
@@ -28,6 +33,13 @@ export default defineComponent({
     const trainedPipelines = computed(() => {
       if (unsortedPipelines.value.trained) {
         return unsortedPipelines.value.trained.pipes.map((item) => item.name);
+      }
+      return [];
+    });
+
+    const trainedModels = computed(() => {
+      if (unsortedPipelines.value.trained) {
+        return unsortedPipelines.value.trained.pipes;
       }
       return [];
     });
@@ -67,6 +79,14 @@ export default defineComponent({
       },
     ];
 
+    const trainedHeadersTmpl: DataTableHeader[] = [
+      {
+        text: 'Model',
+        value: 'name',
+        sortable: true,
+      },
+    ];
+
     onBeforeMount(async () => {
       const configs = await getTrainingConfigurations();
       data.trainingConfigurations = configs;
@@ -95,6 +115,53 @@ export default defineComponent({
         && data.trainingOutputName
     ));
 
+    async function deleteModel(item: Pipe) {
+      const confirmDelete = await prompt({
+        title: `Delete "${item.name}" model`,
+        text: 'Are you sure you want to delete this model?',
+        positiveButton: 'Delete',
+        negativeButton: 'Cancel',
+        confirm: true,
+      });
+
+      if (confirmDelete) {
+        try {
+          await deleteTrainedPipeline(item);
+          unsortedPipelines.value = await getPipelineList();
+        } catch (err) {
+          let text = 'Unable to delete model';
+          if (err.response?.status === 403) text = 'You do not have permission to delete the selected resource(s).';
+          prompt({
+            title: 'Delete Failed',
+            text,
+            positiveButton: 'OK',
+          });
+        }
+      }
+    }
+
+    async function exportModel(item: Pipe) {
+      try {
+        const location = await dialog.showSaveDialog({
+          title: 'Export Model',
+          defaultPath: npath.join(app.getPath('home'), 'model.onnx'),
+        });
+        console.log(location);
+        if (!location.canceled && location.filePath) {
+          await exportTrainedPipeline(location.filePath!, item);
+        }
+      } catch (err) {
+        console.log(err);
+        let text = 'Unable to export model';
+        if (err.response?.status === 403) text = 'You do not have permission to export the selected resource(s).';
+        prompt({
+          title: 'Export Failed',
+          text,
+          positiveButton: 'OK',
+        });
+      }
+    }
+
     async function runTrainingOnFolder() {
       try {
         await runTraining(
@@ -120,12 +187,28 @@ export default defineComponent({
     return {
       data,
       toggleStaged,
+      deleteModel,
+      exportModel,
       simplifyTrainingName,
       isReadyToTrain,
       runTrainingOnFolder,
       nameRules,
       itemsPerPageOptions,
       clientSettings,
+      models: {
+        items: trainedModels,
+        headers: trainedHeadersTmpl.concat({
+          text: 'Export',
+          value: 'export',
+          sortable: false,
+          width: 80,
+        }, {
+          text: 'Delete',
+          value: 'delete',
+          sortable: false,
+          width: 80,
+        }),
+      },
       available: {
         items: availableItems,
         headers: headersTmpl.concat({
@@ -269,6 +352,45 @@ export default defineComponent({
         </template>
       </v-data-table>
     </div>
+
+    <div>
+      <v-card-title class="text-h4">
+        Trained models
+      </v-card-title>
+      <v-card-text>
+        Here are all your trained models
+      </v-card-text>
+      <v-data-table
+        dense
+        v-bind="{ headers: models.headers, items: models.items.value }"
+        no-data-text="You don't have any trained model"
+      >
+
+        <template #[`item.export`]="{ item }">
+          <v-btn
+            :key="item.name"
+            color="info"
+            x-small
+            @click="exportModel(item)"
+          >
+            <v-icon>mdi-export</v-icon>
+          </v-btn>
+        </template>
+
+        <template #[`item.delete`]="{ item }">
+          <v-btn
+            :key="item.name"
+            color="error"
+            x-small
+            @click="deleteModel(item)"
+          >
+            <v-icon>mdi-trash-can</v-icon>
+          </v-btn>
+        </template>
+
+      </v-data-table>
+    </div>
+
   </div>
 </template>
 

--- a/client/platform/web-girder/App.vue
+++ b/client/platform/web-girder/App.vue
@@ -12,7 +12,9 @@ import { useStore } from 'platform/web-girder/store/types';
 import type { GirderMetadata } from './constants';
 import {
   getPipelineList,
+  deleteTrainedPipeline,
   runPipeline,
+  exportTrainedPipeline,
   getTrainingConfigurations,
   runTraining,
   saveMetadata,
@@ -41,7 +43,9 @@ export default defineComponent({
 
     provideApi({
       getPipelineList: unwrap(getPipelineList),
+      deleteTrainedPipeline: unwrap(deleteTrainedPipeline),
       runPipeline: unwrap(runPipeline),
+      exportTrainedPipeline: unwrap(exportTrainedPipeline),
       getTrainingConfigurations: unwrap(getTrainingConfigurations),
       runTraining: unwrap(runTraining),
       loadDetections,

--- a/client/platform/web-girder/api/rpc.service.ts
+++ b/client/platform/web-girder/api/rpc.service.ts
@@ -38,10 +38,10 @@ function deleteTrainedPipeline(pipeline: Pipe) {
 }
 
 function exportTrainedPipeline(path: string, pipeline: Pipe) {
-  console.log(pipeline);
   return girderRest.post('dive_rpc/export', null, {
     params: {
-      folderId: path,
+      modelFolderId: pipeline.folderId,
+      exportFolderId: path,
     },
   });
 }

--- a/client/platform/web-girder/api/rpc.service.ts
+++ b/client/platform/web-girder/api/rpc.service.ts
@@ -33,6 +33,19 @@ function runTraining(
   });
 }
 
+function deleteTrainedPipeline(pipeline: Pipe) {
+  return girderRest.delete(`folder/${pipeline.folderId}`);
+}
+
+function exportTrainedPipeline(path: string, pipeline: Pipe) {
+  console.log(pipeline);
+  return girderRest.post('dive_rpc/export', null, {
+    params: {
+      folderId: path,
+    },
+  });
+}
+
 function convertLargeImage(folderId: string) {
   return girderRest.post(`dive_rpc/convert_large_image/${folderId}`, null, {});
 }
@@ -42,4 +55,6 @@ export {
   postProcess,
   runPipeline,
   runTraining,
+  deleteTrainedPipeline,
+  exportTrainedPipeline,
 };

--- a/client/platform/web-girder/router.ts
+++ b/client/platform/web-girder/router.ts
@@ -4,6 +4,7 @@ import Router, { Route } from 'vue-router';
 import girderRest from './plugins/girder';
 import Home from './views/Home.vue';
 import Jobs from './views/Jobs.vue';
+import TrainedModels from './views/TrainedModels.vue';
 import Login from './views/Login.vue';
 import RouterPage from './views/RouterPage.vue';
 import AdminPage from './views/AdminPage.vue';
@@ -89,6 +90,12 @@ const router = new Router({
           path: 'jobs',
           name: 'jobs',
           component: Jobs,
+          beforeEnter,
+        },
+        {
+          path: 'trained-models',
+          name: 'trained-models',
+          component: TrainedModels,
           beforeEnter,
         },
         {

--- a/client/platform/web-girder/views/Export.vue
+++ b/client/platform/web-girder/views/Export.vue
@@ -79,6 +79,16 @@ export default defineComponent({
       }
     }
 
+    const isDownloadButtonDisplayed = computed(() => {
+      const datasetsSelected = props.datasetIds.length > 0;
+      const filesSelected = props.fileIds.length > 0;
+
+      return datasetsSelected !== filesSelected;
+    });
+
+    const isDatasetDownload = computed(() => props.datasetIds.length > 0 && props.fileIds.length === 0);
+    const isFilesDownload = computed(() => props.fileIds.length > 0 && props.datasetIds.length === 0);
+
     const menuOpen = ref(false);
     const excludeBelowThreshold = ref(true);
     const excludeUncheckedTypes = ref(false);
@@ -198,7 +208,7 @@ export default defineComponent({
     });
 
     async function prepareExport() {
-      if (props.fileIds.length >= 1) {
+      if (isFilesDownload.value) {
         menuOpen.value = false;
         await doExport({ url: exportUrls.value && exportUrls.value.exportAllUrl });
       } else {
@@ -220,6 +230,9 @@ export default defineComponent({
       savePrompt,
       singleDataSetId,
       doExport,
+      isDownloadButtonDisplayed,
+      isDatasetDownload,
+      isFilesDownload,
     };
   },
 });
@@ -240,7 +253,7 @@ export default defineComponent({
           <v-btn
             class="ma-0"
             v-bind="buttonOptions"
-            :disabled="!(datasetIds.length > 0 && fileIds.length === 0 || datasetIds.length === 0 && fileIds.length > 0)"
+            :disabled="!isDownloadButtonDisplayed"
             v-on="{ ...tooltipOn, ...menuOn }"
 
             @click="prepareExport()"
@@ -255,12 +268,13 @@ export default defineComponent({
               Download
             </span>
             <v-spacer />
-            <v-icon v-if="menuOptions.right">
+            <v-icon v-if="menuOptions.right && isDatasetDownload">
               mdi-chevron-right
             </v-icon>
           </v-btn>
         </template>
-        <span>Download media and annotations</span>
+        <span v-if="isDatasetDownload">Download media and annotations</span>
+        <span v-else-if="isFilesDownload">Download selected files</span>
       </v-tooltip>
     </template>
     <template>

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -82,6 +82,11 @@ export default defineComponent({
         ({ _modelType, meta }) => _modelType === 'folder' && meta && meta.annotate,
       ).map(({ _id }) => _id);
     },
+    selectedFileIds() {
+      return this.selected.filter(
+        (element) => element._modelType === 'item',
+      ).map(({ _id }) => _id);
+    },
     includesLargeImage() {
       return (this.selected.filter(
         ({ meta }) => meta && meta.type === 'large-image',
@@ -181,6 +186,7 @@ export default defineComponent({
                 <export
                   v-bind="{ buttonOptions, menuOptions }"
                   :dataset-ids="locationInputs"
+                  :file-ids="selectedFileIds"
                 />
                 <v-btn
                   :disabled="!selected.length"

--- a/client/platform/web-girder/views/Jobs.vue
+++ b/client/platform/web-girder/views/Jobs.vue
@@ -104,7 +104,7 @@ export default defineComponent({
               v-on="on"
             >
               <v-icon small>
-                mdi-eye
+                mdi-folder
               </v-icon>
             </v-btn>
           </template>

--- a/client/platform/web-girder/views/Jobs.vue
+++ b/client/platform/web-girder/views/Jobs.vue
@@ -78,7 +78,7 @@ export default defineComponent({
               depressed
               :to="{ name: 'viewer', params: { id: item.dataset_id } }"
               color="info"
-              class="ml-0"
+              class="mr-2"
               v-on="on"
             >
               <v-icon small>
@@ -88,6 +88,29 @@ export default defineComponent({
           </template>
           <span>Launch dataset viewer</span>
         </v-tooltip>
+
+        <v-tooltip
+          v-if="item.type == 'export' && item.statusText == 'Success'"
+          bottom
+        >
+          <template #activator="{ on, attrs }">
+            <v-btn
+              v-bind="attrs"
+              x-small
+              depressed
+              :href="`/#/folder/${JSON.parse(item.kwargs).params.input_folder}`"
+              color="info"
+              class="mr-2"
+              v-on="on"
+            >
+              <v-icon small>
+                mdi-eye
+              </v-icon>
+            </v-btn>
+          </template>
+          <span>Navigate to exported file</span>
+        </v-tooltip>
+
         <v-tooltip bottom>
           <template #activator="{ on, attrs }">
             <v-btn
@@ -96,7 +119,7 @@ export default defineComponent({
               depressed
               :href="`/girder/#job/${item._id}`"
               color="info"
-              class="mx-2"
+              class="mr-2"
               v-on="on"
             >
               <v-icon small>

--- a/client/platform/web-girder/views/NavigationBar.vue
+++ b/client/platform/web-girder/views/NavigationBar.vue
@@ -65,6 +65,11 @@ export default {
         </v-tab>
         <JobsTab />
         <v-tab
+          :to="'/trained-models'"
+        >
+          Models <v-icon>mdi-brain</v-icon>
+        </v-tab>
+        <v-tab
           v-if="isAdmin"
           :to="`/admin`"
         >

--- a/client/platform/web-girder/views/NavigationBar.vue
+++ b/client/platform/web-girder/views/NavigationBar.vue
@@ -65,13 +65,13 @@ export default {
         </v-tab>
         <JobsTab />
         <v-tab
-          :to="'/trained-models'"
+          to="/trained-models"
         >
           Models <v-icon>mdi-brain</v-icon>
         </v-tab>
         <v-tab
           v-if="isAdmin"
-          :to="`/admin`"
+          to="/admin"
         >
           Admin <v-icon>mdi-badge-account</v-icon>
         </v-tab>

--- a/client/platform/web-girder/views/TrainedModels.vue
+++ b/client/platform/web-girder/views/TrainedModels.vue
@@ -1,0 +1,129 @@
+<script lang="ts">
+import {
+  computed, defineComponent, onBeforeMount, ref,
+} from 'vue';
+import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
+import { Pipelines, useApi, Pipe } from 'dive-common/apispec';
+import { DataTableHeader } from 'vuetify';
+import { useRouter } from 'vue-router/composables';
+
+export default defineComponent({
+  name: 'TrainedModels',
+  setup() {
+    const {
+      getPipelineList, deleteTrainedPipeline, exportTrainedPipeline,
+    } = useApi();
+    const { prompt } = usePrompt();
+    const router = useRouter();
+
+    const unsortedPipelines = ref({} as Pipelines);
+
+    onBeforeMount(async () => {
+      unsortedPipelines.value = await getPipelineList();
+    });
+
+    const trainedModels = computed(() => {
+      if (unsortedPipelines.value.trained) {
+        return unsortedPipelines.value.trained.pipes;
+      }
+      return [];
+    });
+
+    async function deleteModel(item: Pipe) {
+      const confirmDelete = await prompt({
+        title: `Delete "${item.name}" model`,
+        text: 'Are you sure you want to delete this model?',
+        positiveButton: 'Delete',
+        negativeButton: 'Cancel',
+        confirm: true,
+      });
+
+      if (confirmDelete) {
+        try {
+          await deleteTrainedPipeline(item);
+          unsortedPipelines.value = await getPipelineList();
+        } catch (err) {
+          let text = 'Unable to delete model';
+          if (err.response?.status === 403) text = 'You do not have permission to run training on the selected resource(s).';
+          prompt({
+            title: 'Delete Failed',
+            text,
+            positiveButton: 'OK',
+          });
+        }
+      }
+    }
+
+    async function exportModel(item: Pipe) {
+      await exportTrainedPipeline(item.folderId!, item);
+      router.push('/jobs');
+    }
+
+    const trainedHeadersTmpl: DataTableHeader[] = [
+      {
+        text: 'Model',
+        value: 'name',
+        sortable: true,
+      },
+      {
+        text: 'Export',
+        value: 'export',
+        sortable: false,
+        width: 80,
+      }, {
+        text: 'Delete',
+        value: 'delete',
+        sortable: false,
+        width: 80,
+      },
+    ];
+
+    return {
+      deleteModel,
+      exportModel,
+      items: trainedModels,
+      headers: trainedHeadersTmpl,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-container :fluid="$vuetify.breakpoint.mdAndDown">
+    <v-card class="trained-models-wrapper mt-4 pa-6">
+      <v-data-table
+        v-bind="{ headers: headers, items: items }"
+        no-data-text="You don't have any trained model"
+      >
+        <template #[`item.export`]="{ item }">
+          <v-btn
+            :key="item.name"
+            color="info"
+            small
+            @click="exportModel(item)"
+          >
+            <v-icon>mdi-export</v-icon>
+          </v-btn>
+        </template>
+
+        <template #[`item.delete`]="{ item }">
+          <v-btn
+            :key="item.name"
+            color="error"
+            small
+            @click="deleteModel(item)"
+          >
+            <v-icon>mdi-trash-can</v-icon>
+          </v-btn>
+        </template>
+      </v-data-table>
+    </v-card>
+  </v-container>
+</template>
+
+<style lang="scss" scoped>
+.trained-models-wrapper {
+  max-width: 1200px;
+  margin: auto;
+}
+</style>

--- a/client/platform/web-girder/views/TrainedModels.vue
+++ b/client/platform/web-girder/views/TrainedModels.vue
@@ -17,6 +17,7 @@ export default defineComponent({
     const router = useRouter();
 
     const unsortedPipelines = ref({} as Pipelines);
+    const search = ref('');
 
     onBeforeMount(async () => {
       unsortedPipelines.value = await getPipelineList();
@@ -59,11 +60,26 @@ export default defineComponent({
       router.push('/jobs');
     }
 
+    async function browseModel(item: Pipe) {
+      router.push(`/folder/${item.folderId}`);
+    }
+
     const trainedHeadersTmpl: DataTableHeader[] = [
       {
         text: 'Model',
         value: 'name',
         sortable: true,
+      },
+      {
+        text: 'Owner',
+        value: 'ownerLogin',
+        sortable: true,
+      },
+      {
+        text: 'Browse',
+        value: 'browse',
+        sortable: false,
+        width: 80,
       },
       {
         text: 'Export',
@@ -81,8 +97,10 @@ export default defineComponent({
     return {
       deleteModel,
       exportModel,
+      browseModel,
       items: trainedModels,
       headers: trainedHeadersTmpl,
+      search,
     };
   },
 });
@@ -91,10 +109,40 @@ export default defineComponent({
 <template>
   <v-container :fluid="$vuetify.breakpoint.mdAndDown">
     <v-card class="trained-models-wrapper mt-4 pa-6">
+      <v-card-title> Trained models </v-card-title>
+      <v-card-text>
+        <p>
+          Below is a list of trained models that you own or are shared with you.<br>
+          It doesn't include pretrained models provided by VIAME.
+        </p>
+      </v-card-text>
+
+      <template v-if="items.length > 0">
+        <v-text-field
+          v-model="search"
+          label="Search..."
+          prepend-inner-icon="mdi-magnify"
+          density="compact"
+          variant="solo-filled"
+          single-line />
+      </template>
+
       <v-data-table
         v-bind="{ headers: headers, items: items }"
         no-data-text="You don't have any trained model"
+        :search="search"
       >
+        <template #[`item.browse`]="{ item }">
+          <v-btn
+            :key="item.name"
+            color="info"
+            small
+            @click="browseModel(item)"
+          >
+            <v-icon>mdi-folder</v-icon>
+          </v-btn>
+        </template>
+
         <template #[`item.export`]="{ item }">
           <v-btn
             :key="item.name"

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -64,10 +64,33 @@ def _load_dynamic_pipelines(user: types.GirderUserModel) -> Dict[str, types.Pipe
     """Add any additional dynamic pipelines to the existing pipeline list."""
     pipelines: Dict[str, types.PipelineCategory] = {}
     pipelines[constants.TrainedPipelineCategory] = {"pipes": [], "description": ""}
-    for folder in Folder().findWithPermissions(
-        query={f"meta.{constants.TrainedPipelineMarker}": {'$in': TRUTHY_META_VALUES}},
-        user=user,
-    ):
+    
+    trained_pipelines_query = {f"meta.{constants.TrainedPipelineMarker}": {'$in': TRUTHY_META_VALUES}}
+    query = {'$and': [trained_pipelines_query, Folder().permissionClauses(user, AccessType.READ)]}
+    models = [
+        {'$match': query},
+        {
+            '$facet': {
+                'results': [
+                    {
+                        '$lookup': {
+                            'from': 'user',
+                            'localField': 'creatorId',
+                            'foreignField': '_id',
+                            'as': 'ownerLogin',
+                        },
+                    },
+                    {'$set': {'ownerLogin': {'$first': '$ownerLogin'}}},
+                    {'$set': {'ownerLogin': '$ownerLogin.login'}},
+                ],
+                'totalCount': [{'$count': 'count'}],
+            },
+        },
+    ]
+    response = next(Folder().collection.aggregate(models))
+    folders = [Folder().filter(doc, additionalKeys=['ownerLogin']) for doc in response['results']]
+
+    for folder in folders:
         pipename = None
         for item in Folder().childItems(folder):
             if item['name'].endswith('.pipe') and not item['name'].startswith('embedded_'):
@@ -83,6 +106,8 @@ def _load_dynamic_pipelines(user: types.GirderUserModel) -> Dict[str, types.Pipe
                         "type": constants.TrainedPipelineCategory,
                         "pipe": pipename,
                         "folderId": str(folder["_id"]),
+                        "ownerLogin": folder["ownerLogin"],
+                        "ownerId": folder["creatorId"],
                     }
                 )
     return pipelines
@@ -203,16 +228,18 @@ def run_pipeline(
 
 def export_trained_pipeline(
     user: types.GirderUserModel,
-    folder: types.GirderModel
+    model_folder: types.GirderModel,
+    export_folder: types.GirderModel,
 ) -> types.GirderModel:
-    folder_id_str = str(folder["_id"])
+    model_folder_id_str = str(model_folder["_id"])
+    export_folder_id_str = str(export_folder['_id'])
     token = Token().createToken(user=user, days=14)
 
     job_is_private = user.get(constants.UserPrivateQueueEnabledMarker, False)
 
     params: types.PipelineJob = {
-        "input_folder": folder_id_str,
-        "output_folder": folder_id_str,
+        "input_folder": model_folder_id_str,
+        "output_folder": export_folder_id_str,
         "output_name": "model.onnx",
         'user_id': str(user.get('_id', 'unknown')),
         'user_login': user.get('login', 'unknown'),
@@ -221,7 +248,7 @@ def export_trained_pipeline(
         queue=_get_queue_name(user, "pipelines"),
         kwargs=dict(
             params=params,
-            girder_job_title=f"Exporting {str(folder['name'])} to ONNX",
+            girder_job_title=f"Exporting {str(model_folder['name'])} to ONNX",
             girder_client_token=str(token["_id"]),
             girder_job_type="private" if job_is_private else "export",
         ),
@@ -232,7 +259,7 @@ def export_trained_pipeline(
     newjob.job[constants.JOBCONST_CREATOR] = str(user['_id'])
     # Allow any users with access to the input data to also
     # see and possibly manage the job
-    Job().copyAccessPolicies(folder, newjob.job)
+    Job().copyAccessPolicies(model_folder, newjob.job)
     Job().save(newjob.job)
     # Inform Client of new Job added in inactive state
     Notification().createNotification(

--- a/server/dive_server/views_rpc.py
+++ b/server/dive_server/views_rpc.py
@@ -58,16 +58,26 @@ class RpcResource(Resource):
     @autoDescribeRoute(
         Description("Export pipeline to ONNX")
         .modelParam(
-            "folderId",
-            description="Folder id that contains the model to export",
+            "modelFolderId",
+            destName='modelFolderId',
+            description="Folder id in which the model to export is located",
+            model=Folder,
+            paramType="query",
+            required=True,
+            level=AccessType.READ,
+        )
+        .modelParam(
+            "exportFolderId",
+            destName='exportFolderId',
+            description="Folder id to which the model will be exported",
             model=Folder,
             paramType="query",
             required=True,
             level=AccessType.WRITE,
         )
     )
-    def export_pipeline_onnx(self, folder):
-        return crud_rpc.export_trained_pipeline(self.getCurrentUser(), folder)
+    def export_pipeline_onnx(self, modelFolderId, exportFolderId):
+        return crud_rpc.export_trained_pipeline(self.getCurrentUser(), modelFolderId, exportFolderId)
 
     @access.user
     @autoDescribeRoute(

--- a/server/dive_server/views_rpc.py
+++ b/server/dive_server/views_rpc.py
@@ -23,6 +23,7 @@ class RpcResource(Resource):
         self.resourceName = resourceName
 
         self.route("POST", ("pipeline",), self.run_pipeline_task)
+        self.route("POST", ("export",), self.export_pipeline_onnx)
         self.route("POST", ("train",), self.run_training)
         self.route("POST", ("postprocess", ":id"), self.postprocess)
         self.route("POST", ("convert_dive", ":id"), self.convert_dive)
@@ -52,6 +53,21 @@ class RpcResource(Resource):
     )
     def run_pipeline_task(self, folder, forceTranscoded, pipeline: PipelineDescription):
         return crud_rpc.run_pipeline(self.getCurrentUser(), folder, pipeline, forceTranscoded)
+    
+    @access.user
+    @autoDescribeRoute(
+        Description("Export pipeline to ONNX")
+        .modelParam(
+            "folderId",
+            description="Folder id that contains the model to export",
+            model=Folder,
+            paramType="query",
+            required=True,
+            level=AccessType.WRITE,
+        )
+    )
+    def export_pipeline_onnx(self, folder):
+        return crud_rpc.export_trained_pipeline(self.getCurrentUser(), folder)
 
     @access.user
     @autoDescribeRoute(

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -77,6 +77,16 @@ class TrainingJob(TypedDict):
     force_transcoded: Optional[bool]  # Force using the transcoded version
 
 
+class ExportTrainedPipelineJob(TypedDict):
+    """Describes the parameters for exporting a pipeline"""
+
+    input_folder: str  # Where the model to export is
+    output_folder: str  # Where to upload results
+    output_name: str  # Name of the exported file
+    user_id: str  # user id who started the job
+    user_login: str  # login of user who started the job
+
+
 class TrainingConfigurationSummary(TypedDict):
     configs: List[str]
     default: Optional[str]


### PR DESCRIPTION
The main objective of this PR was to add a 'ONNX export' button to export trained models on the platform.

Changes:

- Export to ONNX function is available on Dive Web & Desktop. 
- Added a tab to list, delete and export all trained pipelines. 
- Added the possibility to download single or multiple files from the browser on Dive web.
- Fixed alignment issue on Jobs list on Dive web.

Web:
![image](https://github.com/user-attachments/assets/3e6a1725-fa8d-4451-b57c-e6cd97b82c48)

Desktop:
![image](https://github.com/user-attachments/assets/94b3f559-b64a-48c0-9a54-cbe83827c482)

On Desktop, you can directly select the location where you want to save the ONNX model.

On Web, the exported model will appear in the original model directory. You can click on the eye in the Job list to go directly there. 