### PR TITLE
Max N Count Support

### DIFF
--- a/client/dive-common/components/TrackSettingsPanel.vue
+++ b/client/dive-common/components/TrackSettingsPanel.vue
@@ -30,6 +30,8 @@ export default defineComponent({
       interpolate: 'Whether new tracks should have interpolation enabled by default',
       continuous: 'Immediately stay in detection creation mode after creating a new track.  Hit Esc to exit.',
       prompt: 'Prompt user before deleting a track?',
+      filterTracksByFrame: 'Filter the track list by those with detections in the current frame',
+      autoZoom: 'Automatically zoom to the track when selected',
     });
     const modes = ref(['Track', 'Detection']);
     // Add unknown as the default type to the typeList
@@ -278,6 +280,45 @@ export default defineComponent({
               </v-icon>
             </template>
             <span>{{ help.prompt }}</span>
+          </v-tooltip>
+        </v-col>
+      </v-row>
+      <v-divider class="my-2" />
+      <div class="subheading">
+        Track List Settings
+      </div>
+      <v-row
+        align="end"
+        dense
+      >
+        <v-col class="py-1">
+          <v-switch
+            v-model="clientSettings.trackSettings.trackListSettings.filterDetectionsByFrame"
+            class="my-0 ml-1 pt-0"
+            dense
+            label="Filter Detections By Frame"
+            hide-details
+          />
+        </v-col>
+        <v-col
+          cols="2"
+          class="py-1"
+          align="right"
+        >
+          <v-tooltip
+            open-delay="200"
+            max-width="200"
+            bottom
+          >
+            <template #activator="{ on }">
+              <v-icon
+                small
+                v-on="on"
+              >
+                mdi-help
+              </v-icon>
+            </template>
+            <span>{{ help.filterTracksByFrame }}</span>
           </v-tooltip>
         </v-col>
       </v-row>

--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -22,6 +22,8 @@ export default defineComponent({
       import: 'Import multiple Types',
       showEmptyTypes: 'View types that are not used currently.',
       lockTypes: 'Only allows the use of defined types.',
+      preventCascadeTypes: 'When a track has multiple types, this will prevent the type from displaying if the max type is not visible in the type list',
+      filterTypesByFrame: 'Filters the type list by only types that are visible in the current frame',
     });
     const importInstructions = ref('Please provide a list of types (separated by a new line) that you would like to import');
     const importDialog = ref(false);
@@ -177,6 +179,68 @@ export default defineComponent({
                 </v-icon>
               </template>
               <span>{{ help.lockTypes }}</span>
+            </v-tooltip>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col class="py-1">
+            <v-switch
+              v-model="clientSettings.typeSettings.preventCascadeTypes"
+              label="Prevent Cascade Types"
+              class="my-0 ml-1 pt-0"
+              dense
+              hide-details
+            />
+          </v-col>
+          <v-col
+            cols="2"
+            class="py-1"
+            align="right"
+          >
+            <v-tooltip
+              open-delay="200"
+              bottom
+            >
+              <template #activator="{ on }">
+                <v-icon
+                  small
+                  v-on="on"
+                >
+                  mdi-help
+                </v-icon>
+              </template>
+              <span>{{ help.preventCascadeTypes }}</span>
+            </v-tooltip>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col class="py-1">
+            <v-switch
+              v-model="clientSettings.typeSettings.filterTypesByFrame"
+              label="Filter Types by Frame"
+              class="my-0 ml-1 pt-0"
+              dense
+              hide-details
+            />
+          </v-col>
+          <v-col
+            cols="2"
+            class="py-1"
+            align="right"
+          >
+            <v-tooltip
+              open-delay="200"
+              bottom
+            >
+              <template #activator="{ on }">
+                <v-icon
+                  small
+                  v-on="on"
+                >
+                  mdi-help
+                </v-icon>
+              </template>
+              <span>{{ help.filterTypesByFrame }}</span>
             </v-tooltip>
           </v-col>
         </v-row>

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -6,6 +6,8 @@ interface AnnotationSettings {
   typeSettings: {
     showEmptyTypes: boolean;
     lockTypes: boolean;
+    preventCascadeTypes?: boolean;
+    filterTypesByFrame?: boolean;
   };
   trackSettings: {
     newTrackSettings: {
@@ -24,6 +26,10 @@ interface AnnotationSettings {
     deletionSettings: {
       promptUser: boolean;
     };
+    trackListSettings: {
+      autoZoom?: boolean;
+      filterDetectionsByFrame?: boolean;
+    }
   };
   groupSettings: {
     newGroupSettings: {
@@ -53,6 +59,10 @@ const defaultSettings: AnnotationSettings = {
     deletionSettings: {
       promptUser: true,
     },
+    trackListSettings: {
+      autoZoom: false,
+      filterDetectionsByFrame: false,
+    },
   },
   groupSettings: {
     newGroupSettings: {
@@ -62,6 +72,7 @@ const defaultSettings: AnnotationSettings = {
   typeSettings: {
     showEmptyTypes: false,
     lockTypes: false,
+    preventCascadeTypes: false,
   },
   rowsPerPage: 20,
   annotationFPS: 10,

--- a/client/src/TrackFilterControls.ts
+++ b/client/src/TrackFilterControls.ts
@@ -1,5 +1,6 @@
 import { computed, Ref, ref } from 'vue';
 import { cloneDeep } from 'lodash';
+import { clientSettings } from 'dive-common/store/settings';
 import { AnnotationId } from './BaseAnnotation';
 import BaseFilterControls, { AnnotationWithContext, FilterControlsParams } from './BaseFilterControls';
 import type Group from './Group';
@@ -51,7 +52,7 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
            */
           enabledInGroupFilters = groups.some((group) => filteredGroupsSet.has(group.id));
         }
-        const confidencePairIndex = annotation.confidencePairs
+        let confidencePairIndex = annotation.confidencePairs
           .findIndex(([confkey, confval]) => {
             const confidenceThresh = Math.max(
               confidenceFiltersVal[confkey] || 0,
@@ -59,6 +60,18 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
             );
             return confval >= confidenceThresh && checkedSet.has(confkey);
           });
+        if (clientSettings.typeSettings.preventCascadeTypes) {
+          const [confkey, confval] = annotation.confidencePairs[0];
+          const confidenceThresh = Math.max(
+            confidenceFiltersVal[confkey] || 0,
+            confidenceFiltersVal.default,
+          );
+          if (checkedSet.has(confkey) && confval > confidenceThresh) {
+            confidencePairIndex = 0;
+          } else {
+            confidencePairIndex = -1;
+          }
+        }
         /* include annotations where at least 1 confidence pair is above
          * the threshold and part of the checked type set */
         if (

--- a/client/src/components/GroupList.vue
+++ b/client/src/components/GroupList.vue
@@ -67,7 +67,7 @@ export default defineComponent({
         }
         return [];
       }),
-      selectNext: () => null,
+      trackSelect: () => null,
     });
 
     const virtualListItems = computed(() => {

--- a/client/src/components/TrackList.vue
+++ b/client/src/components/TrackList.vue
@@ -1,11 +1,13 @@
 <script lang="ts">
 import {
-  defineComponent, reactive, computed, Ref,
+  defineComponent, reactive, computed, Ref, ref,
+  watch,
 } from 'vue';
 
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { AnnotationId } from 'vue-media-annotator/BaseAnnotation';
 
+import { clientSettings } from 'dive-common/store/settings';
 import {
   useEditingMode,
   useHandler,
@@ -65,12 +67,36 @@ export default defineComponent({
     const { frame: frameRef } = useTime();
     const multiSelectList = useMultiSelectList();
     const {
-      trackSelectNext, trackSplit, removeTrack, trackAdd,
+      trackSplit, removeTrack, trackAdd, trackSelect,
     } = useHandler();
 
     const data = reactive({
       itemHeight: 70, // in pixelx
       settingsActive: false,
+    });
+
+    const filterDetectionsByFrame = ref(clientSettings.trackSettings.trackListSettings.filterDetectionsByFrame);
+    watch(
+      () => clientSettings.trackSettings.trackListSettings.filterDetectionsByFrame,
+      (newValue) => {
+        filterDetectionsByFrame.value = newValue;
+      },
+    );
+
+    const finalFilteredTracks = computed(() => {
+      if (filterDetectionsByFrame.value) {
+        return filteredTracksRef.value.filter((track) => {
+          const possibleTrack = cameraStore.getAnyPossibleTrack(track.annotation.id);
+          if (possibleTrack) {
+            const [feature] = possibleTrack.getFeature(frameRef.value);
+            if (feature && feature.keyframe) {
+              return true;
+            }
+          }
+          return false;
+        });
+      }
+      return filteredTracksRef.value;
     });
 
     const virtualListItems = computed(() => {
@@ -79,7 +105,7 @@ export default defineComponent({
       const checkedTrackIds = checkedTrackIdsRef.value;
       const editingMode = editingModeRef.value;
       const allTypes = allTypesRef.value;
-      return filteredTracksRef.value.map((filtered) => ({
+      return finalFilteredTracks.value.map((filtered) => ({
         filteredTrack: filtered,
         selectedTrackId,
         checkedTrackIds,
@@ -99,13 +125,22 @@ export default defineComponent({
 
     const getAnnotation = (id: AnnotationId) => cameraStore.getAnyPossibleTrack(id);
 
+    watch(
+      () => filteredTracksRef.value,
+      (newValue) => {
+        if (newValue.length === 0) {
+          trackSelect(null, false);
+        }
+      },
+    );
+
     const virtualScroll = useVirtualScrollTo({
       itemHeight: data.itemHeight,
       getAnnotation,
-      filteredListRef: filteredTracksRef,
+      filteredListRef: finalFilteredTracks,
       selectedIdRef: selectedTrackIdRef,
       multiSelectList,
-      selectNext: trackSelectNext,
+      trackSelect,
     });
 
     function getItemProps(item: typeof virtualListItems.value[number]) {

--- a/client/src/use/useVirtualScrollTo.ts
+++ b/client/src/use/useVirtualScrollTo.ts
@@ -11,14 +11,14 @@ export default function useVirtualScrollTo({
   filteredListRef,
   selectedIdRef,
   multiSelectList,
-  selectNext,
+  trackSelect,
 }: {
   itemHeight: Readonly<number>;
   getAnnotation: (id: AnnotationId) => Track | Group | undefined;
   filteredListRef: Ref<AnnotationWithContext<Track | Group>[]>;
   selectedIdRef: Ref<Readonly<AnnotationId | null>>;
   multiSelectList: Ref<Readonly<AnnotationId[]>>;
-  selectNext: (id: AnnotationId) => void;
+  trackSelect: (id: AnnotationId | null, edit: boolean) => void;
 }) {
   const virtualList = ref(null as null | Vue);
 
@@ -56,10 +56,30 @@ export default function useVirtualScrollTo({
     direction: 'up' | 'down',
   ): void {
     if (virtualList.value !== null && element === virtualList.value.$el) {
-      if (direction === 'up') {
-        selectNext(-1);
+      if (filteredListRef.value.length === 0) {
+        return;
+      }
+      const index = filteredListRef.value.findIndex((item) => item.annotation.id === selectedIdRef.value);
+      if (index === -1 && direction === 'up') {
+        const newId = filteredListRef.value[filteredListRef.value.length - 1].annotation.id;
+        trackSelect(newId, false);
+      } else if (index === -1 && direction === 'down') {
+        const newId = filteredListRef.value[0].annotation.id;
+        trackSelect(newId, false);
+      } else if (direction === 'up') {
+        if (index > 0) {
+          trackSelect(filteredListRef.value[index - 1].annotation.id, false);
+        } else {
+          const newId = filteredListRef.value[filteredListRef.value.length - 1].annotation.id;
+          trackSelect(newId, false);
+        }
       } else if (direction === 'down') {
-        selectNext(1);
+        if (index === filteredListRef.value.length - 1) {
+          trackSelect(filteredListRef.value[0].annotation.id, false);
+        } else {
+          const newId = filteredListRef.value[index + 1].annotation.id;
+          trackSelect(newId, false);
+        }
       }
       keyEvent.preventDefault();
     }


### PR DESCRIPTION
resolves #1492 

TODO:
- [ ] Filtering the Track List based on the current frame visible
- [ ] Updating selection of track using the keyboard shortcuts in the track list so it only jumps to the next track in the track list
- [ ] Filter the Type list so it will show only the types for the current frame
- [ ] Add option to prevent cascading types.  I.E it uses only the highest tracktype and will be removed if it it goes below that trackType.
- [ ] Add an optional button to the types that will jump to the frame with the highest Count for the type.  This button would be off by default but in the client settings it can be turned on and enabled.
- [ ] Add a Help icon to the type and track list to indicate the current settings with filtering and other settings to make it clear what is happening
- [ ] Update the filtering on types and tracks to make it so it is only active when the video/media is not 'playing'.  This may require placing it in the UsetimeObserver instead of the media annotator because the time observer is easier to pass around.
- [ ] The auto zoom track options for the tracklist with some additional settings (ZoomTime: we may want more than a snapping to the position, ZoomBounds: the spacing around the bbox for the item to zoom in)
- [ ] Make a way to full screen the video or toggle between full screen and the basic view.