### PR TITLE
Allow use of labels.txt file on desktop

### DIFF
--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -400,6 +400,13 @@ async function train(
     command.push(runTrainingArgs.fineTuneModel.path);
   }
 
+  if (runTrainingArgs.labelText) {
+    const labelsPath = `${jobWorkDir}/labels.txt`;
+    fs.writeFileSync(labelsPath, runTrainingArgs.labelText);
+    command.push('--labels');
+    command.push(labelsPath);
+  }
+
   const job = observeChild(spawn(command.join(' '), {
     shell: viameConstants.shell,
     cwd: jobWorkDir,


### PR DESCRIPTION
Fix #1511 

### Changes

This adds a new, optional field to the training form on the desktop application where users can attach a `labels.txt` file to their training run.
<img width="1020" height="544" alt="image" src="https://github.com/user-attachments/assets/f5fc1711-cf8b-46d9-abe4-43bf4253e718" />

This file's contents are passed as text to the IPC call that spawns a training job. The contents are written as `labels.txt` in the pipeline folder and passed as an argument to the VIAME training call.
