### PR TITLE
update the model param request to properly fail

### DIFF
--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -357,7 +357,7 @@ def train_pipeline(self: Task, params: TrainingJob):
     config = params['config']
     annotated_frames_only = params['annotated_frames_only']
     label_text = params['label_txt']
-    model = params['model']
+    model = params.get('model', None)
     force_transcoded = params.get('force_transcoded', False)
 
     pipeline_base_path = Path(conf.get_extracted_pipeline_path())


### PR DESCRIPTION
The param["model"] was an optional field and wasn't accessed properly.