### PR TITLE
Stereo bugfixes

### DIFF
--- a/client/dive-common/components/MultiCamTools.vue
+++ b/client/dive-common/components/MultiCamTools.vue
@@ -2,15 +2,19 @@
 import { computed, defineComponent, ref } from 'vue';
 import {
   useCameraStore,
-  useEditingMode, useHandler, useSelectedCamera,
-  useSelectedTrackId, useTime, useTrackFilters,
+  useEditingMode,
+  useHandler,
+  useSelectedCamera,
+  useSelectedTrackId,
+  useTime,
+  useTrackFilters,
 } from 'vue-media-annotator/provides';
 import TooltipBtn from 'vue-media-annotator/components/TooltipButton.vue';
 import { AnnotationId } from 'vue-media-annotator/BaseAnnotation';
 
 interface CameraTrackData {
-    trackExists: boolean;
-    annotationExists: boolean;
+  trackExists: boolean;
+  annotationExists: boolean;
 }
 export default defineComponent({
   name: 'MultiCamTools',
@@ -33,28 +37,32 @@ export default defineComponent({
       const trackKeyPair: Record<string, CameraTrackData> = {};
       _depend(); // Used for remove detections/tracks from a camera
       /* EnabledTracksRef depedency triggers update when the sortedTracks updates based
-      * on track links/unlinks.  It doesn't work on same frame camera track deletions because
-      * nothing is updated in the sortedTracks dependencies when that happens
-      */
-      if (selectedTrackId.value !== null && selectedCamera.value
-      && enabledTracksRef.value.length > 0) {
+       * on track links/unlinks.  It doesn't work on same frame camera track deletions because
+       * nothing is updated in the sortedTracks dependencies when that happens
+       */
+      if (
+        selectedTrackId.value !== null
+        && selectedCamera.value
+        && enabledTracksRef.value.length > 0
+      ) {
         cameraStore.camMap.value.forEach((camera, key) => {
           const trackExists = camera.trackStore.getPossible(selectedTrackId.value as AnnotationId);
-          const completeTrackExists = (trackExists !== undefined
-          && trackExists.features.length > 0);
+          const completeTrackExists = trackExists !== undefined && trackExists.features.length > 0;
           trackKeyPair[key] = {
             trackExists: completeTrackExists,
-            annotationExists: completeTrackExists && camera.trackStore.get(
-                selectedTrackId.value as AnnotationId,
-            )?.getFeature(frame.value)[0] !== null,
+            annotationExists:
+              completeTrackExists
+              && camera.trackStore
+                .get(selectedTrackId.value as AnnotationId)
+                ?.getFeature(frame.value)[0] !== null,
           };
         });
       }
       return trackKeyPair;
     });
-    const existingCount = computed(() => Object.values(
-      tracks.value,
-    ).filter((item) => item.trackExists).length);
+    const existingCount = computed(
+      () => Object.values(tracks.value).filter((item) => item.trackExists).length,
+    );
     // Delete annotation for selected camera/frame
     const deleteAnnotation = async (camera: string, trackId: number) => {
       canary.value = !canary.value;
@@ -88,7 +96,7 @@ export default defineComponent({
     /** So for linking cameras we need to kick it out of the selectedTrack and choose a track within
      * the selected camera to merge with it.  We need to make sure that the merged
      * track only exists on the sleected camera
-    **/
+     **/
     const startLinking = (camera: string) => {
       //We can't join the other track while in editing mode so we need to disable it
       if (inEditingMode.value) {
@@ -124,82 +132,81 @@ export default defineComponent({
     <v-divider class="my-3" />
     <v-divider class="my-3" />
     <div v-if="selectedTrackId !== null">
-      <span> Selected Track: {{ selectedTrackId }}  Frame: {{ frame }}</span>
+      <span> Selected Track: {{ selectedTrackId }} Frame: {{ frame }}</span>
       <div>
-        <div
-          v-for="camera in cameras"
-          :key="camera"
-        >
+        <div v-for="camera in cameras" :key="camera" class="pt-3">
           <v-row>
             <h2 :class="{ selected: camera === selectedCamera }">
               {{ camera }}
             </h2>
           </v-row>
           <v-divider />
-          <v-row class="pl-2">
-            <h3> Detection: </h3>
-            <tooltip-btn
-              icon="mdi-star"
-              :disabled="!tracks[camera].annotationExists"
-              :tooltip-text="`Delete detection for camera: ${camera}`"
-              @click="deleteAnnotation(camera, selectedTrackId)"
-            />
-            <tooltip-btn
-              v-if="tracks[camera].annotationExists"
-              icon="mdi-pencil-box-outline"
-              :tooltip-text="`Edit detection for camera: ${camera}`"
-              @click="editOrCreateAnnotation(camera)"
-            />
-            <tooltip-btn
-              v-else-if="!tracks[camera].annotationExists"
-              icon="mdi-shape-square-plus"
-              :tooltip-text="`Add detection for camera: ${camera}`"
-              @click="editOrCreateAnnotation(camera)"
-            />
+          <v-row align="center" justify="space-between" class="mt-4 mb-2">
+            <h3 class="mb-0">Detection:</h3>
+            <div class="d-flex gap-2">
+              <tooltip-btn
+                icon="mdi-star"
+                :disabled="!tracks[camera].annotationExists"
+                :tooltip-text="`Delete detection for camera: ${camera}`"
+                @click="deleteAnnotation(camera, selectedTrackId)"
+              />
+              <tooltip-btn
+                v-if="tracks[camera].annotationExists"
+                icon="mdi-pencil-box-outline"
+                :tooltip-text="`Edit detection for camera: ${camera}`"
+                @click="editOrCreateAnnotation(camera)"
+              />
+              <tooltip-btn
+                v-else
+                icon="mdi-shape-square-plus"
+                :tooltip-text="`Add detection for camera: ${camera}`"
+                @click="editOrCreateAnnotation(camera)"
+              />
+            </div>
           </v-row>
-          <v-divider class="pl-2" />
-          <v-row class="pl-2">
-            <h3> Track: </h3>
-            <tooltip-btn
-              color="error"
-              icon="mdi-delete"
-              :disabled="!tracks[camera].trackExists"
-              :tooltip-text="`Delete Track for camera: ${camera}`"
-              @click="deleteTrack(camera, selectedTrackId)"
-            />
-            <tooltip-btn
-              v-if="tracks[camera].trackExists"
-              color="error"
-              icon="mdi-link-variant-minus"
-              :disabled="existingCount === 1"
-              :tooltip-text="`Unlink Track for camera: ${camera}`"
-              @click="handler.unlinkCameraTrack(selectedTrackId, camera)"
-            />
-            <tooltip-btn
-              v-else-if="!tracks[camera].trackExists"
-              icon="mdi-link-variant-plus"
-              :tooltip-text="`Link Track to this camera: ${camera}`"
-              @click="startLinking(camera)"
-            />
+
+          <v-divider class="my-2" />
+
+          <v-row align="center" justify="space-between" class="mt-2 mb-4">
+            <h3 class="mb-0">Track:</h3>
+            <div class="d-flex gap-2">
+              <tooltip-btn
+                color="error"
+                icon="mdi-delete"
+                :disabled="!tracks[camera].trackExists"
+                :tooltip-text="`Delete Track for camera: ${camera}`"
+                @click="deleteTrack(camera, selectedTrackId)"
+              />
+              <tooltip-btn
+                v-if="tracks[camera].trackExists"
+                color="error"
+                icon="mdi-link-variant-minus"
+                :disabled="existingCount === 1"
+                :tooltip-text="`Unlink Track for camera: ${camera}`"
+                @click="handler.unlinkCameraTrack(selectedTrackId, camera)"
+              />
+              <tooltip-btn
+                v-else
+                icon="mdi-link-variant-plus"
+                :tooltip-text="`Link Track to this camera: ${camera}`"
+                @click="startLinking(camera)"
+              />
+            </div>
           </v-row>
+
           <v-divider />
         </div>
       </div>
     </div>
-    <div
-      v-else
-      class="text-body-2"
-    >
+    <div v-else class="text-body-2">
       <p>No track selected.</p>
-      <p>
-        This panel is used for:
-        <ul>
-          <li>Viewing which cameras have tracks/detections for the selected trackId</li>
-          <li>Deleting detection and/or tracks from a camera </li>
-          <li>Splitting off tracks from an existing camera</li>
-          <li>Linking tracks from difference cameras to the same trackId</li>
-        </ul>
-      </p>
+      <p>This panel is used for:</p>
+      <ul>
+        <li>Viewing which cameras have tracks/detections for the selected trackId</li>
+        <li>Deleting detection and/or tracks from a camera</li>
+        <li>Splitting off tracks from an existing camera</li>
+        <li>Linking tracks from difference cameras to the same trackId</li>
+      </ul>
       <p>Select a track to populate this editor.</p>
     </div>
   </div>

--- a/client/dive-common/components/TrackDetailsPanel.vue
+++ b/client/dive-common/components/TrackDetailsPanel.vue
@@ -105,8 +105,8 @@ export default defineComponent({
     const selectedTrackList = computed(() => {
       if (multiSelectList.value.length > 0) {
         return multiSelectList.value.map(
-          (trackId) => cameraStore.getTrack(trackId, selectedCamera.value),
-        );
+          (trackId) => cameraStore.getAnyPossibleTrack(trackId),
+        ).filter((t) => t !== undefined);
       }
       if (selectedTrackIdRef.value !== null) {
         return [cameraStore.getAnyTrack(selectedTrackIdRef.value)];

--- a/client/dive-common/recipes/headtail.ts
+++ b/client/dive-common/recipes/headtail.ts
@@ -161,7 +161,7 @@ export default class HeadTail implements Recipe {
         let geom = linestring.geometry;
         const head = track.getFeatureGeometry(frameNum, { type: 'Point', key: HeadPointKey });
         const tail = track.getFeatureGeometry(frameNum, { type: 'Point', key: TailPointKey });
-        const currentFeature = track.features.find((item) => item.frame === frameNum);
+        const currentFeature = track.features.find((item) => item && item.frame === frameNum);
         let bounds: RectBounds | null = null;
         if (currentFeature && currentFeature.bounds) {
           bounds = currentFeature.bounds;

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -61,7 +61,7 @@ async function runPipeline(
 
   //TODO: TEMPORARY FIX FOR DEMO PURPOSES
   let requiresInput = false;
-  if ((/utility_|filter_|transcode_/g).test(pipeline.pipe)) {
+  if ((/utility_|filter_|transcode_|measurement_/g).test(pipeline.pipe)) {
     requiresInput = true;
   }
   let groundTruthFileName;

--- a/client/src/components/annotators/useMediaController.ts
+++ b/client/src/components/annotators/useMediaController.ts
@@ -203,11 +203,15 @@ export function useMediaController() {
     });
 
     function setCursor(newCursor: string) {
-      state[camera].cursor = `${newCursor}`;
+      if (state[camera]) {
+        state[camera].cursor = `${newCursor}`;
+      }
     }
 
     function setImageCursor(newCursor: string) {
-      state[camera].imageCursor = `${newCursor}`;
+      if (state[camera]) {
+        state[camera].imageCursor = `${newCursor}`;
+      }
     }
 
     function centerOn(coords: { x: number; y: number; z: number }) {

--- a/client/src/use/useLineChart.ts
+++ b/client/src/use/useLineChart.ts
@@ -75,7 +75,7 @@ export default function useLineChart({
       const { annotation: track } = filtered;
       if (clientSettings.timelineCountSettings.defaultView === 'detections') {
         const trackObj = getTracksMerged(track.id);
-        const frames = trackObj.features.filter((item) => item.keyframe).map((item) => item.frame);
+        const frames = trackObj.features.filter((item) => item && item.keyframe).map((item) => item.frame);
         const segments = framesToSegments(frames);
         segments.forEach((segment) => {
           const ibegin = segment[0];


### PR DESCRIPTION
resolves #1520 
resolves #1522 

- Fixes some errors where feature frame on Desktop had some undefined values causing head-tail creation to fail.  Similar issue in the useLineChart functionality.
- The cursor setting when reloading annotations while in multi-camera caused a brief issue so I guarded against that.
- Updated the input field to add measurement pipelines.  detections will now be injected into any pipeline that has measurements.
- Minor adjustment to multi-select so that it will properly select across multiple cameras
- Update the CSS for the multiCameraTools so it renders properly.