### PR TITLE
Advanced image enhancements

### DIFF
--- a/client/dive-common/components/ControlsContainer.vue
+++ b/client/dive-common/components/ControlsContainer.vue
@@ -50,6 +50,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    isDefaultImage: {
+      type: Boolean as PropType<boolean>,
+      required: true,
+    },
   },
   setup(_, { emit }) {
     const handler = useHandler();
@@ -148,7 +152,7 @@ export default defineComponent({
     dense
     style="position:absolute; bottom: 0px; padding: 0px; margin:0px;"
   >
-    <Controls>
+    <Controls :is-default-image="isDefaultImage">
       <template slot="timelineControls">
         <div style="min-width: 270px">
           <v-tooltip

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -165,8 +165,8 @@ export default defineComponent({
 
     const {
       imageEnhancements,
-      brightness,
-      intercept,
+      imageEnhancementOutputs,
+      isDefaultImage,
       setSVGFilters,
     } = useImageEnhancements();
 
@@ -852,8 +852,8 @@ export default defineComponent({
       originalFps: time.originalFps,
       context,
       readonlyState,
-      brightness,
-      intercept,
+      imageEnhancementOutputs,
+      isDefaultImage,
       /* large image methods */
       getTiles,
       getTileURL,
@@ -1131,8 +1131,8 @@ export default defineComponent({
                   frameRate,
                   originalFps,
                   camera,
-                  brightness,
-                  intercept,
+                  imageEnhancementOutputs,
+                  isDefaultImage,
                   getTiles,
                   getTileURL,
                 }"
@@ -1146,7 +1146,7 @@ export default defineComponent({
             ref="controlsRef"
             :collapsed.sync="controlsCollapsed"
             v-bind="{
-              lineChartData, eventChartData, groupChartData, datasetType,
+              lineChartData, eventChartData, groupChartData, datasetType, isDefaultImage,
             }"
           />
         </div>

--- a/client/src/components/ImageEnhancements.vue
+++ b/client/src/components/ImageEnhancements.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { defineComponent, ref } from 'vue';
-
 import { useHandler, useImageEnhancements } from '../provides';
 
 export default defineComponent({
@@ -9,17 +8,35 @@ export default defineComponent({
   setup() {
     const { setSVGFilters } = useHandler();
     const imageEnhancements = useImageEnhancements();
-    const range = ref([
-      (imageEnhancements.value.blackPoint ?? 0) * 255.0,
-      (imageEnhancements.value.whitePoint ?? 1) * 255.0,
-    ]);
+    const brightness = ref(imageEnhancements.value.brightness || 1);
+    const contrast = ref(imageEnhancements.value.contrast || 1);
+    const saturation = ref(imageEnhancements.value.saturation || 1);
+    const sharpen = ref(imageEnhancements.value.sharpen || 0);
 
     const modifyValue = () => {
-      setSVGFilters({ blackPoint: range.value[0] / 255.0, whitePoint: range.value[1] / 255.0 });
+      setSVGFilters({
+        brightness: brightness.value,
+        contrast: contrast.value,
+        saturation: saturation.value,
+        sharpen: sharpen.value,
+      });
     };
+
+    const reset = () => {
+      brightness.value = 1;
+      contrast.value = 1;
+      saturation.value = 1;
+      sharpen.value = 0;
+      modifyValue();
+    };
+
     return {
       modifyValue,
-      range,
+      reset,
+      brightness,
+      contrast,
+      saturation,
+      sharpen,
     };
   },
 });
@@ -31,22 +48,88 @@ export default defineComponent({
       Controls for adjusting images.
     </span>
     <v-divider class="my-3" />
-    <v-range-slider
-      v-model="range"
-      :min="0"
-      :max="255"
-      :step="1.0"
-      thumb-label="always"
-      label="Contrast:"
-      class="my-4"
-      @input="modifyValue"
-    />
+    <v-row>
+      <v-col cols="4">
+        <span class="text-caption">Brightness</span>
+      </v-col>
+      <v-col>
+        <v-slider
+          v-model="brightness"
+          :min="0"
+          :max="3"
+          :step="0.1"
+          hide-details
+          class="pa-0 ma-0"
+          @input="modifyValue()"
+        />
+      </v-col>
+      <v-col cols="2">
+        <span>{{ brightness.toFixed(1) }}</span>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4">
+        <span class="text-caption">Contrast</span>
+      </v-col>
+      <v-col>
+        <v-slider
+          v-model="contrast"
+          :min="0"
+          :max="3"
+          :step="0.1"
+          hide-details
+          class="pa-0 ma-0"
+          @input="modifyValue()"
+        />
+      </v-col>
+      <v-col cols="2">
+        <span>{{ contrast.toFixed(1) }}</span>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4">
+        <span class="text-caption">Saturation</span>
+      </v-col>
+      <v-col>
+        <v-slider
+          v-model="saturation"
+          :min="0"
+          :max="3"
+          :step="0.1"
+          hide-details
+          class="pa-0 ma-0"
+          @input="modifyValue()"
+        />
+      </v-col>
+      <v-col cols="2">
+        <span>{{ saturation.toFixed(1) }}</span>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4">
+        <span class="text-caption">Sharpness</span>
+      </v-col>
+      <v-col>
+        <v-slider
+          v-model="sharpen"
+          :min="0"
+          :max="4"
+          :step="0.1"
+          hide-details
+          class="pa-0 ma-0"
+          @input="modifyValue()"
+        />
+      </v-col>
+      <v-col cols="2">
+        <span>{{ sharpen.toFixed(1) }}</span>
+      </v-col>
+    </v-row>
     <v-btn
       block
       depressed
       color="warning"
       class="my-2"
-      @click="range = [0, 255]; modifyValue()"
+      @click="reset()"
     >
       Reset
     </v-btn>

--- a/client/src/components/controls/Controls.vue
+++ b/client/src/components/controls/Controls.vue
@@ -8,7 +8,13 @@ import { clientSettings } from 'dive-common/store/settings';
 import { injectAggregateController } from '../annotators/useMediaController';
 
 export default defineComponent({
-  name: 'Control',
+  name: 'Controls',
+  props: {
+    isDefaultImage: {
+      type: Boolean as () => boolean,
+      required: true,
+    },
+  },
   setup() {
     const data = reactive({
       frame: 0,
@@ -289,14 +295,22 @@ export default defineComponent({
           >
             <v-icon>mdi-image-filter-center-focus</v-icon>
           </v-btn>
-          <v-btn
-            icon
-            small
-            title="Image Enhancements"
-            @click="toggleEnhancements"
+          <v-badge
+            :value="!isDefaultImage"
+            color="warning"
+            dot
+            overlap
+            bottom
           >
-            <v-icon>mdi-contrast-box</v-icon>
-          </v-btn>
+            <v-btn
+              icon
+              small
+              :title="!isDefaultImage ? 'Image Enhancements (Modified)' : 'Image Enhancements'"
+              @click="toggleEnhancements"
+            >
+              <v-icon>mdi-contrast-box</v-icon>
+            </v-btn>
+          </v-badge>
 
           <v-btn
             v-if="mediaController.cameras.value.length > 1"

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -174,7 +174,9 @@ export interface Handler {
   unstageFromMerge(ids: AnnotationId[]): void;
   /* Reload Annotation File */
   reloadAnnotations(): Promise<void>;
-  setSVGFilters({ blackPoint, whitePoint }: {blackPoint?: number; whitePoint?: number}): void;
+  setSVGFilters({
+    brightness, contrast, saturation, sharpen,
+  }: {brightness?: number; contrast?: number; saturation?: number; sharpen?: number}): void;
   /* unlink Camera Track */
   unlinkCameraTrack(trackId: AnnotationId, camera: string): void;
   /* link Camera Track */
@@ -331,7 +333,12 @@ function dummyState(): State {
     trackStyleManager: new StyleManager({ markChangesPending }),
     visibleModes: ref(['rectangle', 'text'] as VisibleAnnotationTypes[]),
     readOnlyMode: ref(false),
-    imageEnhancements: ref({}),
+    imageEnhancements: ref({
+      brightness: 1,
+      contrast: 1,
+      saturation: 1,
+      sharpen: 0,
+    }),
   };
 }
 

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -6,39 +6,70 @@ import {
 // Expecting this may be a placeholder for more complicated client side enhancements
 // or more image filters
 export interface ImageEnhancements {
-    blackPoint?: number;
-    whitePoint?: number;
+    brightness: number;
+    contrast: number;
+    saturation: number;
+    sharpen: number
+  }
+
+export interface ImageEnhancementOutputs {
+    brightness: { slope: number; intercept: number };
+    contrast: { slope: number; intercept: number };
+    saturation: { values: number };
+    sharpen: { kernelMatrix: string; divisor: number };
   }
 
 export default function useImageEnhancements() {
-  const imageEnhancements: Ref<ImageEnhancements> = ref({});
+  const imageEnhancements: Ref<ImageEnhancements> = ref({
+    brightness: 1,
+    contrast: 1,
+    saturation: 1,
+    sharpen: 0,
+  });
 
-  const setSVGFilters = ({ blackPoint, whitePoint }:
-    {blackPoint?: number; whitePoint?: number }) => {
-    VueSet(imageEnhancements.value, 'blackPoint', blackPoint);
-    VueSet(imageEnhancements.value, 'whitePoint', whitePoint);
+  const setSVGFilters = ({
+    brightness, contrast, saturation, sharpen,
+  }:
+    { brightness: number; contrast: number; saturation: number; sharpen: number }) => {
+    VueSet(imageEnhancements.value, 'brightness', brightness);
+    VueSet(imageEnhancements.value, 'contrast', contrast);
+    VueSet(imageEnhancements.value, 'saturation', saturation);
+    VueSet(imageEnhancements.value, 'sharpen', sharpen);
   };
 
-  const brightness = computed(() => {
-    if (imageEnhancements.value.blackPoint !== undefined
-        && imageEnhancements.value.whitePoint !== undefined) {
-      return (1 / (imageEnhancements.value.whitePoint - imageEnhancements.value.blackPoint));
-    }
-    return undefined;
-  });
-  const intercept = computed(() => {
-    if (imageEnhancements.value.blackPoint !== undefined
-        && imageEnhancements.value.whitePoint !== undefined) {
-      return (-imageEnhancements.value.blackPoint
-        / (imageEnhancements.value.whitePoint - imageEnhancements.value.blackPoint));
-    }
-    return undefined;
+  const brightness = computed(() => ({ slope: imageEnhancements.value.brightness, intercept: 0 }));
+
+  const contrast = computed(() => {
+    const value = imageEnhancements.value.contrast;
+    return { slope: value, intercept: 0.5 - 0.5 * (value) };
   });
 
+  const saturation = computed(() => ({ values: imageEnhancements.value.saturation }));
+
+  const sharpen = computed(() => {
+    const s = imageEnhancements.value.sharpen;
+    const center = (1 + 4 * s);
+    const kernel = [0, -s, 0, -s, center, -s, 0, -s, 0].map((n) => Number(n).toFixed(4)).join(' ');
+    return { kernelMatrix: kernel, divisor: 1 };
+  });
+
+  const imageEnhancementOutputs = computed(() => ({
+    brightness: brightness.value,
+    contrast: contrast.value,
+    saturation: saturation.value,
+    sharpen: sharpen.value,
+  }));
+
+  const isDefaultImage = computed(() => (
+    imageEnhancements.value.brightness === 1
+    && imageEnhancements.value.contrast === 1
+    && imageEnhancements.value.saturation === 1
+    && imageEnhancements.value.sharpen === 0
+  ));
   return {
     imageEnhancements,
-    brightness,
-    intercept,
+    imageEnhancementOutputs,
+    isDefaultImage,
     setSVGFilters,
   };
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4262,9 +4262,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599, caniuse-lite@^1.0.30001688:
-  version "1.0.30001695"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz"
-  integrity sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==
+  version "1.0.30001743"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz"
+  integrity sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"


### PR DESCRIPTION
Solves part of #1510 

- Updates image enhancements to have independent sliders for:
    - Brightness
    - Contrast
    - Saturation
    - Sharpen
- Sharpen is a little different because it's using a FeConvolveMatrix with the nearest pixels to attempt a similar effect to sharpening.
- imageEnhancementOutputs is a collection of the above values and is passe to the annotators for implementation inthe SVG filters
- isDefaultImage is true when the default values are being used
    - This is used to provide a little orange dot at the bottom right of the imageEnhancements Icon/Button.

A Subsquent PR is going to hook this data into the saving system where it will be saved similar to the confidence threshold.  This would allow anyone to adjust the image settings and have it persist so others see the same thing. 


https://github.com/user-attachments/assets/0d040bd4-5490-494f-a843-773fa3c9be16



