### PR TITLE
Save image enhancments

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -7,6 +7,7 @@ import { TrackData } from 'vue-media-annotator/track';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import { CustomStyle } from 'vue-media-annotator/StyleManager';
 import { AttributeTrackFilter } from 'vue-media-annotator/AttributeTrackFilterControls';
+import { ImageEnhancements } from 'vue-media-annotator/use/useImageEnhancements';
 
 type DatasetType = 'image-sequence' | 'video' | 'multi' | 'large-image';
 type MultiTrackRecord = Record<string, TrackData>;
@@ -132,10 +133,11 @@ interface DatasetMetaMutable {
   customTypeStyling?: Record<string, CustomStyle>;
   customGroupStyling?: Record<string, CustomStyle>;
   confidenceFilters?: Record<string, number>;
+  imageEnhancements?: ImageEnhancements;
   attributes?: Readonly<Record<string, Attribute>>;
   attributeTrackFilters?: Readonly<Record<string, AttributeTrackFilter>>;
 }
-const DatasetMetaMutableKeys = ['attributes', 'confidenceFilters', 'customTypeStyling', 'customGroupStyling', 'attributeTrackFilters'];
+const DatasetMetaMutableKeys = ['attributes', 'confidenceFilters', 'imageEnhancements', 'customTypeStyling', 'customGroupStyling', 'attributeTrackFilters'];
 
 interface DatasetMeta extends DatasetMetaMutable {
   id: Readonly<string>;

--- a/client/dive-common/components/ControlsContainer.vue
+++ b/client/dive-common/components/ControlsContainer.vue
@@ -50,6 +50,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    isDefaultImage: {
+      type: Boolean as PropType<boolean>,
+      required: true,
+    },
   },
   setup(_, { emit }) {
     const handler = useHandler();
@@ -148,7 +152,7 @@ export default defineComponent({
     dense
     style="position:absolute; bottom: 0px; padding: 0px; margin:0px;"
   >
-    <Controls>
+    <Controls :is-default-image="isDefaultImage">
       <template slot="timelineControls">
         <div style="min-width: 270px">
           <v-tooltip

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -165,8 +165,8 @@ export default defineComponent({
 
     const {
       imageEnhancements,
-      brightness,
-      intercept,
+      imageEnhancementOutputs,
+      isDefaultImage,
       setSVGFilters,
     } = useImageEnhancements();
 
@@ -852,8 +852,8 @@ export default defineComponent({
       originalFps: time.originalFps,
       context,
       readonlyState,
-      brightness,
-      intercept,
+      imageEnhancementOutputs,
+      isDefaultImage,
       /* large image methods */
       getTiles,
       getTileURL,
@@ -1131,8 +1131,8 @@ export default defineComponent({
                   frameRate,
                   originalFps,
                   camera,
-                  brightness,
-                  intercept,
+                  imageEnhancementOutputs,
+                  isDefaultImage,
                   getTiles,
                   getTileURL,
                 }"
@@ -1146,7 +1146,7 @@ export default defineComponent({
             ref="controlsRef"
             :collapsed.sync="controlsCollapsed"
             v-bind="{
-              lineChartData, eventChartData, groupChartData, datasetType,
+              lineChartData, eventChartData, groupChartData, datasetType, isDefaultImage,
             }"
           />
         </div>

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -555,6 +555,9 @@ async function saveMetadata(settings: Settings, datasetId: string, args: Dataset
   if (args.confidenceFilters) {
     existing.confidenceFilters = args.confidenceFilters;
   }
+  if (args.imageEnhancements) {
+    existing.imageEnhancements = args.imageEnhancements;
+  }
   if (args.customTypeStyling) {
     existing.customTypeStyling = args.customTypeStyling;
   }

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -4,6 +4,7 @@ import type {
 } from 'dive-common/apispec';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import { AttributeTrackFilter } from 'vue-media-annotator/AttributeTrackFilterControls';
+import { ImageEnhancements } from 'vue-media-annotator/use/useImageEnhancements';
 
 export const JsonMetaCurrentVersion = 1;
 export const SettingsCurrentVersion = 1;
@@ -116,6 +117,9 @@ export interface JsonMeta extends DatasetMetaMutable {
 
   // confidence filter threshold for exporting
   confidenceFilters?: Record<string, number>;
+
+  // image enhancement settings
+  imageEnhancement?: ImageEnhancements;
 
   // Stereo or multi-camera datasets with uniform type (all images, all video)
   multiCam: MultiCamDesktop | null;

--- a/client/src/components/ImageEnhancements.vue
+++ b/client/src/components/ImageEnhancements.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { defineComponent, ref } from 'vue';
-
 import { useHandler, useImageEnhancements } from '../provides';
 
 export default defineComponent({
@@ -9,17 +8,35 @@ export default defineComponent({
   setup() {
     const { setSVGFilters } = useHandler();
     const imageEnhancements = useImageEnhancements();
-    const range = ref([
-      (imageEnhancements.value.blackPoint ?? 0) * 255.0,
-      (imageEnhancements.value.whitePoint ?? 1) * 255.0,
-    ]);
+    const brightness = ref(imageEnhancements.value.brightness || 1);
+    const contrast = ref(imageEnhancements.value.contrast || 1);
+    const saturation = ref(imageEnhancements.value.saturation || 1);
+    const sharpen = ref(imageEnhancements.value.sharpen || 0);
 
     const modifyValue = () => {
-      setSVGFilters({ blackPoint: range.value[0] / 255.0, whitePoint: range.value[1] / 255.0 });
+      setSVGFilters({
+        brightness: brightness.value,
+        contrast: contrast.value,
+        saturation: saturation.value,
+        sharpen: sharpen.value,
+      });
     };
+
+    const reset = () => {
+      brightness.value = 1;
+      contrast.value = 1;
+      saturation.value = 1;
+      sharpen.value = 0;
+      modifyValue();
+    };
+
     return {
       modifyValue,
-      range,
+      reset,
+      brightness,
+      contrast,
+      saturation,
+      sharpen,
     };
   },
 });
@@ -31,22 +48,88 @@ export default defineComponent({
       Controls for adjusting images.
     </span>
     <v-divider class="my-3" />
-    <v-range-slider
-      v-model="range"
-      :min="0"
-      :max="255"
-      :step="1.0"
-      thumb-label="always"
-      label="Contrast:"
-      class="my-4"
-      @input="modifyValue"
-    />
+    <v-row>
+      <v-col cols="4">
+        <span class="text-caption">Brightness</span>
+      </v-col>
+      <v-col>
+        <v-slider
+          v-model="brightness"
+          :min="0"
+          :max="3"
+          :step="0.1"
+          hide-details
+          class="pa-0 ma-0"
+          @input="modifyValue()"
+        />
+      </v-col>
+      <v-col cols="2">
+        <span>{{ brightness.toFixed(1) }}</span>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4">
+        <span class="text-caption">Contrast</span>
+      </v-col>
+      <v-col>
+        <v-slider
+          v-model="contrast"
+          :min="0"
+          :max="3"
+          :step="0.1"
+          hide-details
+          class="pa-0 ma-0"
+          @input="modifyValue()"
+        />
+      </v-col>
+      <v-col cols="2">
+        <span>{{ contrast.toFixed(1) }}</span>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4">
+        <span class="text-caption">Saturation</span>
+      </v-col>
+      <v-col>
+        <v-slider
+          v-model="saturation"
+          :min="0"
+          :max="3"
+          :step="0.1"
+          hide-details
+          class="pa-0 ma-0"
+          @input="modifyValue()"
+        />
+      </v-col>
+      <v-col cols="2">
+        <span>{{ saturation.toFixed(1) }}</span>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="4">
+        <span class="text-caption">Sharpness</span>
+      </v-col>
+      <v-col>
+        <v-slider
+          v-model="sharpen"
+          :min="0"
+          :max="4"
+          :step="0.1"
+          hide-details
+          class="pa-0 ma-0"
+          @input="modifyValue()"
+        />
+      </v-col>
+      <v-col cols="2">
+        <span>{{ sharpen.toFixed(1) }}</span>
+      </v-col>
+    </v-row>
     <v-btn
       block
       depressed
       color="warning"
       class="my-2"
-      @click="range = [0, 255]; modifyValue()"
+      @click="reset()"
     >
       Reset
     </v-btn>

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -370,9 +370,11 @@ export default defineComponent({
           });
           // Set quadFeature and conditionally apply brightness filter
           local.quadFeature = quadFeatureLayer.createFeature('quad');
-          local.quadFeature.layer().node().css('filter', 'url(#imageEhancements)');
           data.ready = true;
           seek(0);
+          if (!props.isDefaultImage) {
+            local.quadFeature.layer().node().css('filter', 'url(#imageEhancements)');
+          }
         });
       }
     }

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -250,6 +250,9 @@ export default defineComponent({
       // Force the first frame to load on slow networks.
       // See https://github.com/Kitware/dive/issues/447 for more details.
       seek(0);
+      if (!props.isDefaultImage) {
+        quadFeatureLayer.node().css('filter', 'url(#imageEhancements)');
+      }
       data.ready = true;
       data.volume = video.volume;
       data.speed = video.playbackRate;

--- a/client/src/components/controls/Controls.vue
+++ b/client/src/components/controls/Controls.vue
@@ -8,7 +8,13 @@ import { clientSettings } from 'dive-common/store/settings';
 import { injectAggregateController } from '../annotators/useMediaController';
 
 export default defineComponent({
-  name: 'Control',
+  name: 'Controls',
+  props: {
+    isDefaultImage: {
+      type: Boolean as () => boolean,
+      required: true,
+    },
+  },
   setup() {
     const data = reactive({
       frame: 0,
@@ -289,14 +295,22 @@ export default defineComponent({
           >
             <v-icon>mdi-image-filter-center-focus</v-icon>
           </v-btn>
-          <v-btn
-            icon
-            small
-            title="Image Enhancements"
-            @click="toggleEnhancements"
+          <v-badge
+            :value="!isDefaultImage"
+            color="warning"
+            dot
+            overlap
+            bottom
           >
-            <v-icon>mdi-contrast-box</v-icon>
-          </v-btn>
+            <v-btn
+              icon
+              small
+              :title="!isDefaultImage ? 'Image Enhancements (Modified)' : 'Image Enhancements'"
+              @click="toggleEnhancements"
+            >
+              <v-icon>mdi-contrast-box</v-icon>
+            </v-btn>
+          </v-badge>
 
           <v-btn
             v-if="mediaController.cameras.value.length > 1"

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -174,7 +174,9 @@ export interface Handler {
   unstageFromMerge(ids: AnnotationId[]): void;
   /* Reload Annotation File */
   reloadAnnotations(): Promise<void>;
-  setSVGFilters({ blackPoint, whitePoint }: {blackPoint?: number; whitePoint?: number}): void;
+  setSVGFilters({
+    brightness, contrast, saturation, sharpen,
+  }: {brightness?: number; contrast?: number; saturation?: number; sharpen?: number}): void;
   /* unlink Camera Track */
   unlinkCameraTrack(trackId: AnnotationId, camera: string): void;
   /* link Camera Track */
@@ -331,7 +333,12 @@ function dummyState(): State {
     trackStyleManager: new StyleManager({ markChangesPending }),
     visibleModes: ref(['rectangle', 'text'] as VisibleAnnotationTypes[]),
     readOnlyMode: ref(false),
-    imageEnhancements: ref({}),
+    imageEnhancements: ref({
+      brightness: 1,
+      contrast: 1,
+      saturation: 1,
+      sharpen: 0,
+    }),
   };
 }
 

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -6,39 +6,70 @@ import {
 // Expecting this may be a placeholder for more complicated client side enhancements
 // or more image filters
 export interface ImageEnhancements {
-    blackPoint?: number;
-    whitePoint?: number;
+    brightness: number;
+    contrast: number;
+    saturation: number;
+    sharpen: number
+  }
+
+export interface ImageEnhancementOutputs {
+    brightness: { slope: number; intercept: number };
+    contrast: { slope: number; intercept: number };
+    saturation: { values: number };
+    sharpen: { kernelMatrix: string; divisor: number };
   }
 
 export default function useImageEnhancements() {
-  const imageEnhancements: Ref<ImageEnhancements> = ref({});
+  const imageEnhancements: Ref<ImageEnhancements> = ref({
+    brightness: 1,
+    contrast: 1,
+    saturation: 1,
+    sharpen: 0,
+  });
 
-  const setSVGFilters = ({ blackPoint, whitePoint }:
-    {blackPoint?: number; whitePoint?: number }) => {
-    VueSet(imageEnhancements.value, 'blackPoint', blackPoint);
-    VueSet(imageEnhancements.value, 'whitePoint', whitePoint);
+  const setSVGFilters = ({
+    brightness, contrast, saturation, sharpen,
+  }:
+    { brightness: number; contrast: number; saturation: number; sharpen: number }) => {
+    VueSet(imageEnhancements.value, 'brightness', brightness);
+    VueSet(imageEnhancements.value, 'contrast', contrast);
+    VueSet(imageEnhancements.value, 'saturation', saturation);
+    VueSet(imageEnhancements.value, 'sharpen', sharpen);
   };
 
-  const brightness = computed(() => {
-    if (imageEnhancements.value.blackPoint !== undefined
-        && imageEnhancements.value.whitePoint !== undefined) {
-      return (1 / (imageEnhancements.value.whitePoint - imageEnhancements.value.blackPoint));
-    }
-    return undefined;
-  });
-  const intercept = computed(() => {
-    if (imageEnhancements.value.blackPoint !== undefined
-        && imageEnhancements.value.whitePoint !== undefined) {
-      return (-imageEnhancements.value.blackPoint
-        / (imageEnhancements.value.whitePoint - imageEnhancements.value.blackPoint));
-    }
-    return undefined;
+  const brightness = computed(() => ({ slope: imageEnhancements.value.brightness, intercept: 0 }));
+
+  const contrast = computed(() => {
+    const value = imageEnhancements.value.contrast;
+    return { slope: value, intercept: 0.5 - 0.5 * (value) };
   });
 
+  const saturation = computed(() => ({ values: imageEnhancements.value.saturation }));
+
+  const sharpen = computed(() => {
+    const s = imageEnhancements.value.sharpen;
+    const center = (1 + 4 * s);
+    const kernel = [0, -s, 0, -s, center, -s, 0, -s, 0].map((n) => Number(n).toFixed(4)).join(' ');
+    return { kernelMatrix: kernel, divisor: 1 };
+  });
+
+  const imageEnhancementOutputs = computed(() => ({
+    brightness: brightness.value,
+    contrast: contrast.value,
+    saturation: saturation.value,
+    sharpen: sharpen.value,
+  }));
+
+  const isDefaultImage = computed(() => (
+    imageEnhancements.value.brightness === 1
+    && imageEnhancements.value.contrast === 1
+    && imageEnhancements.value.saturation === 1
+    && imageEnhancements.value.sharpen === 0
+  ));
   return {
     imageEnhancements,
-    brightness,
-    intercept,
+    imageEnhancementOutputs,
+    isDefaultImage,
     setSVGFilters,
   };
 }

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -66,10 +66,21 @@ export default function useImageEnhancements() {
     && imageEnhancements.value.saturation === 1
     && imageEnhancements.value.sharpen === 0
   ));
+
+  const setImageEnhancements = (enhancements: ImageEnhancements) => {
+    imageEnhancements.value = {
+      brightness: enhancements.brightness,
+      contrast: enhancements.contrast,
+      saturation: enhancements.saturation,
+      sharpen: enhancements.sharpen,
+    };
+  };
+
   return {
     imageEnhancements,
     imageEnhancementOutputs,
     isDefaultImage,
     setSVGFilters,
+    setImageEnhancements,
   };
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4262,9 +4262,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599, caniuse-lite@^1.0.30001688:
-  version "1.0.30001695"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz"
-  integrity sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==
+  version "1.0.30001743"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz"
+  integrity sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -141,6 +141,7 @@ interface DatasetMetaMutable {
   customTypeStyling?: Record<string, CustomStyle>;
   customGroupStyling?: Record<string, CustomStyle>;
   confidenceFilters?: Record<string, number>;
+  imageEnhancments?: ImageEnhancements;
   attributes?: Readonly<Record<string, Attribute>>;
 }
 ```

--- a/server/README.md
+++ b/server/README.md
@@ -128,6 +128,7 @@ Image chips that compose a video are stored as girder items in a folder.  Videos
 * `fps` (number) annotation framerate, not to be confused with video raw framerate
 * `ffprobe_info` (JSON) output of ffprobe for raw input video
 * `confidenceFilters` (JSON) map of filter name to float in [0, 1]
+* `imageEnhancements` (JSON) values for image enhancements (brightness, contrast, saturation, sharpen)
 * `customTypeStyline` (JSON) map of class name to GeoJS display attributes.
 * `foreign_media_id` (string) For "cloned" datasets, this is an objectId pointer to the source media
 

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -277,6 +277,7 @@ def upload_exported_zipped_dataset(
         "customTypeStyling": meta.get("customTypeStyling", None),
         "customGroupStyling": meta.get("customGroupStyling", None),
         "confidenceFilters": meta.get("confidenceFilters", None),
+        "imageEnhancements": meta.get("imageEnhancements", None),
         "fps": meta["fps"],
         "version": meta["version"],
     }

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -113,6 +113,7 @@ FPSMarker = "fps"
 OriginalFPSMarker = "originalFps"
 OriginalFPSStringMarker = "originalFpsString"
 ConfidenceFiltersMarker = "confidenceFilters"
+ImageEnhancementsMarker = "imageEnhancements"
 AnnotationFileFutureProcessMarker = "importAnnotationFile"
 
 # Other constants

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -232,6 +232,7 @@ class MetadataMutable(BaseModel):
     customTypeStyling: Optional[Dict[str, CustomStyle]]
     customGroupStyling: Optional[Dict[str, CustomStyle]]
     confidenceFilters: Optional[Dict[str, float]]
+    imageEnhancements: Optional[Dict[str, Any]]
     attributes: Optional[Dict[str, Attribute]]
     attributeTrackFilters: Optional[Dict[str, AttributeTrackFilter]]
     fps: Optional[float]


### PR DESCRIPTION
resolves #1510

Requires #1526 to be merged first

- Adds `imageEnhancements` to the metadata mutable (this is metadata stored in the DIVEDataset Folder Metadata that can be modified by a user)
- On back-end and front-end put the required references to imageEnhancements so it can be properly saved and loaded
- There is a debounce method on saving the imageEnhancements so that endpoint isn't hammered during sliding or other changes.  It makes it so once it is complete it will send the request to the save the updated parameters.
- Updated Loading for Media Views (Video, Image, Large-Image was already okay) to set the SVG filter if the data is not the default image.