### PR TITLE
Add bulk pipeline interface

### DIFF
--- a/client/platform/desktop/frontend/components/MultiPipeline.vue
+++ b/client/platform/desktop/frontend/components/MultiPipeline.vue
@@ -1,0 +1,213 @@
+<script setup lang="ts">
+import {
+  computed,
+  onBeforeMount,
+  ref,
+  Ref,
+  watch,
+} from 'vue';
+import { DataTableHeader } from 'vuetify';
+import { Pipe, Pipelines, useApi } from 'dive-common/apispec';
+import { itemsPerPageOptions } from 'dive-common/constants';
+import { clientSettings } from 'dive-common/store/settings';
+import { datasets, JsonMetaCache } from '../store/dataset';
+
+const { getPipelineList } = useApi();
+const unsortedPipelines = ref({} as Pipelines);
+const selectedPipelineType: Ref<string | null> = ref(null);
+const pipelineTypes = computed(() => Object.keys(unsortedPipelines.value));
+const selectedPipeline: Ref<Pipe | null> = ref(null);
+const pipesForSelectedType = computed(() => {
+  if (!selectedPipelineType.value) {
+    return null;
+  }
+  return unsortedPipelines.value[selectedPipelineType.value].pipes;
+});
+watch(selectedPipelineType, () => {
+  // Clear the selected pipeline if the chosen type changes
+  selectedPipeline.value = null;
+});
+
+const headersTmpl: DataTableHeader[] = [
+  {
+    text: 'Dataset',
+    value: 'name',
+    sortable: true,
+  },
+  {
+    text: 'Type',
+    value: 'type',
+    sortable: true,
+    width: 160,
+  },
+  {
+    text: 'fps',
+    value: 'fps',
+    sortable: true,
+    width: 80,
+  },
+];
+const availableDatasetHeaders = headersTmpl.concat(
+  {
+    text: 'Include',
+    value: 'include',
+    sortable: false,
+    width: 80,
+  },
+);
+const stagedDatasetHeaders: DataTableHeader[] = headersTmpl.concat([
+  {
+    text: 'Remove',
+    value: 'remove',
+    sortable: false,
+    width: 80,
+  },
+]);
+function getAvailableItems(): JsonMetaCache[] {
+  if (!selectedPipelineType.value || !selectedPipeline.value) {
+    return [];
+  }
+  return Object.values(datasets.value);
+}
+const availableItems: Ref<JsonMetaCache[]> = ref([]);
+const availableDatasetSearch = ref('');
+const stagedDatasetIds: Ref<string[]> = ref([]);
+const stagedDatasets = computed(() => availableItems.value.filter((item: JsonMetaCache) => stagedDatasetIds.value.includes(item.id)));
+watch(selectedPipeline, () => {
+  availableItems.value = getAvailableItems();
+});
+function toggleStaged(item: JsonMetaCache) {
+  if (stagedDatasetIds.value.includes(item.id)) {
+    stagedDatasetIds.value = stagedDatasetIds.value.filter((id: string) => id !== item.id);
+  } else {
+    stagedDatasetIds.value.push(item.id);
+  }
+}
+
+function runPipelineForDatasets() {
+  console.log('Running pipeline...');
+}
+
+onBeforeMount(async () => {
+  unsortedPipelines.value = await getPipelineList();
+  availableItems.value = getAvailableItems();
+});
+
+</script>
+
+<template>
+  <div>
+    <div class="mb-4">
+      <v-card-title class="text-h4">
+        Run a pipeline on multiple datasets
+      </v-card-title>
+      <v-card-text>Choose a pipeline to run, then select datasets.</v-card-text>
+    </div>
+    <div class="mb-4">
+      <v-card-title class="text-h4">
+        Choose a VIAME pipeline
+      </v-card-title>
+      <v-card-text>
+        <v-row>
+          <v-col cols="6">
+            <v-select
+              v-model="selectedPipelineType"
+              :items="pipelineTypes"
+              outlined
+              persistent-hint
+              dense
+              label="Pipeline Type"
+              hint="Select which type of pipeline to run"
+            />
+          </v-col>
+          <v-col>
+            <v-select
+              v-model="selectedPipeline"
+              :items="pipesForSelectedType"
+              :disabled="!selectedPipelineType"
+              item-text="name"
+              outlined
+              persistent-hint
+              dense
+              label="Pipeline"
+              hint="Select the pipeline to run"
+            />
+          </v-col>
+        </v-row>
+      </v-card-text>
+      <div v-if="selectedPipeline">
+        <v-card-title>Datasets staged for selected pipeline</v-card-title>
+        <v-data-table
+          dense
+          v-bind="{ headers: stagedDatasetHeaders, items: stagedDatasets }"
+          :items-per-page.sync="clientSettings.rowsPerPage"
+          hide-default-footer
+          :hide-default-header="stagedDatasets.length === 0"
+          no-data-text="Select datasets from the table below"
+        >
+          <template #[`item.remove`]="{ item }">
+            <v-btn
+              color="error"
+              x-small
+              @click="toggleStaged(item)"
+            >
+              <v-icon>mdi-minus</v-icon>
+            </v-btn>
+          </template>
+        </v-data-table>
+      </div>
+      <v-row class="mt-7">
+        <v-spacer />
+        <v-col cols="auto">
+          <v-btn
+            :disabled="stagedDatasets.length === 0"
+            color="primary"
+            @click="runPipelineForDatasets"
+          >
+            Run pipeline for ({{ stagedDatasets.length }}) Datasets
+          </v-btn>
+        </v-col>
+      </v-row>
+    </div>
+    <div
+      v-if="selectedPipeline"
+      class="mb-4"
+    >
+      <v-card-title class="text-h4">
+        Available datasets
+      </v-card-title>
+      <v-card-text>These datasets are compatible with the chosen pipeline.</v-card-text>
+      <v-row class="mb-2">
+        <v-col cols="6">
+          <v-text-field
+            v-model="availableDatasetSearch"
+            append-icon="mdi-magnify"
+            label="Search"
+            single-line
+            hide-details
+          />
+        </v-col>
+      </v-row>
+      <v-data-table
+        dense
+        v-bind="{ headers: availableDatasetHeaders, items: availableItems }"
+        :footer-props="{ itemsPerPageOptions }"
+        :items-per-page.sync="clientSettings.rowsPerPage"
+        :search="availableDatasetSearch"
+        no-data-text="No compatible datasets found for the selected pipeline."
+      >
+        <template #[`item.include`]="{ item }">
+          <v-btn
+            :key="item.name"
+            :disabled="stagedDatasetIds.includes(item.id)"
+            color="success"
+            x-small
+            @click="toggleStaged(item)"
+          >
+            <v-icon>mdi-plus</v-icon>
+          </v-btn>
+        </template>
+      </v-data-table>
+    </div>
+  </div>
+</template>

--- a/client/platform/desktop/frontend/components/NavigationBar.vue
+++ b/client/platform/desktop/frontend/components/NavigationBar.vue
@@ -28,6 +28,9 @@ export default defineComponent({
       <v-tab :to="{ name: 'training' }">
         Training<v-icon>mdi-brain</v-icon>
       </v-tab>
+      <v-tab :to="{ name: 'pipeline' }">
+        Pipeline<v-icon>mdi-pipe</v-icon>
+      </v-tab>
       <v-tab :to="{ name: 'settings' }">
         Settings<v-icon>mdi-cog</v-icon>
       </v-tab>

--- a/client/platform/desktop/frontend/components/PipelinePage.vue
+++ b/client/platform/desktop/frontend/components/PipelinePage.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import NavigationBar from './NavigationBar.vue';
+import MultiPipeline from './MultiPipeline.vue';
+</script>
+
+<template>
+  <v-main>
+    <navigation-bar />
+    <v-container>
+      <multi-pipeline />
+    </v-container>
+  </v-main>
+</template>

--- a/client/platform/desktop/router.ts
+++ b/client/platform/desktop/router.ts
@@ -6,6 +6,7 @@ import Recent from './frontend/components/Recent.vue';
 import Settings from './frontend/components/Settings.vue';
 import TrainingPage from './frontend/components/TrainingPage.vue';
 import ViewerLoader from './frontend/components/ViewerLoader.vue';
+import PipelinePage from './frontend/components/PipelinePage.vue';
 
 Vue.use(Router);
 
@@ -25,6 +26,11 @@ export default new Router({
       path: '/training',
       name: 'training',
       component: TrainingPage,
+    },
+    {
+      path: '/pipeline',
+      name: 'pipeline',
+      component: PipelinePage,
     },
     {
       path: '/jobs',


### PR DESCRIPTION
Fix #1512

### Changes (Desktop only)

Following the precedent of the Multi-Training tab, a new tab has been added to the Dive Desktop navigation bar, called "Pipeline."
<img width="498" height="70" alt="image" src="https://github.com/user-attachments/assets/095377cb-e0c2-48ba-ba57-561109853dee" />

This tab contains an interface similar to that of the multi-training interface, but with the ability to run a specified pipeline over multiple datasets.

#### Intended Workflow

##### Step 1. Choose a pipeline type

This is handled by a simple dropdown menu. This must be done first to enable the pipeline select to become enabled.
<img width="1158" height="305" alt="image" src="https://github.com/user-attachments/assets/231ce7ad-d0a3-43fc-9db2-e20c4a70d475" />

_Limitation: The pipeline types "2-cam" and "3-cam" are filtered out for now to reduce the complexity of selecting datasets._

##### Step 2. Choose a pipeline

Once a pipeline type is chosen, the "Pipeline" dropdown will allow users to select a specific pipeline of that type. Once this is done, the available datasets appear for selection. 

<img width="1155" height="805" alt="image" src="https://github.com/user-attachments/assets/bf4200f3-786f-46af-8081-d7fe78f77701" />

Because the pipeline/type pipeline are chosen first, we have additional control over what datasets are presented for staging. For example, measurement pipelines only allow users to select from stereo datasets.

<img width="1169" height="808" alt="image" src="https://github.com/user-attachments/assets/c972c871-3234-47c5-b2bd-d65f4b4ef9de" />

##### Step 3. Stage datasets
Much like how datasets are staged/unstaged for multi-training, users can add from the available datasets table, and remove from the staged datasets table as needed.

<img width="1151" height="805" alt="image" src="https://github.com/user-attachments/assets/6bb7ea50-7069-4d24-9944-ebfb7ec1cf2e" />

##### Step 4. Run pipelines

Clicking the button will create a request for each selected dataset. If all requests come back to the frontend with no issues, the user will be moved to the Jobs tab to monitor the jobs that they just started. If any requests come back with issues, the user will be shown a prompt informing them that some of the pipelines did not start.