### PR TITLE
Allow stereo cal file to be optional

### DIFF
--- a/client/dive-common/components/ImportMultiCamDialog.vue
+++ b/client/dive-common/components/ImportMultiCamDialog.vue
@@ -491,7 +491,7 @@ export default defineComponent({
         </v-btn>
         <v-btn
           color="primary"
-          :disabled="!nextSteps || (stereo && !calibrationFile)"
+          :disabled="!nextSteps"
           @click="prepForImport"
         >
           Begin Import

--- a/client/platform/desktop/backend/native/multiCamImport.ts
+++ b/client/platform/desktop/backend/native/multiCamImport.ts
@@ -202,7 +202,7 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
   }
 
   if (jsonMeta.multiCam?.cameras && jsonMeta.multiCam.cameras.left
-    && jsonMeta.multiCam.cameras.right && jsonMeta.multiCam.calibration) {
+    && jsonMeta.multiCam.cameras.right) {
     jsonMeta.subType = 'stereo';
   } else if (jsonMeta.multiCam) {
     jsonMeta.subType = 'multicam';


### PR DESCRIPTION
There are a couple use cases where you might want to load stereo imagery but no calibration file. In particular, if you don't have a calibration file yet and you want to run a pipeline to generate a calibration file.