### PR TITLE
Add missing function argument to remove runtime error on linux desktop

### DIFF
--- a/client/platform/desktop/backend/server.ts
+++ b/client/platform/desktop/backend/server.ts
@@ -211,6 +211,8 @@ function fail(
   err: { status?: number; statusMessage?: string },
   req: express.Request,
   res: express.Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  next: express.NextFunction,
 ) {
   res.status(err.status || 500).json({ message: err.statusMessage || err });
 }


### PR DESCRIPTION
I get the following error on the latest release of DIVE when running a long-running stereo pipeline.

<img width="2553" height="788" alt="dive-what" src="https://github.com/user-attachments/assets/8b5cae08-2a6b-493b-aea0-6502c0d3bdc7" />

This is an Express error handler but it has the wrong signature. Express error handlers need 4 parameters: (err, req, res, next). With only 3 parameters, Express treats it as  a regular middleware and passes (req, res, next) - so the request object becomes err, the response object becomes req, and next becomes res.

Update(client/platform/desktop/backend/server.ts)
  Updated client/platform/desktop/backend/server.ts with 2 additions                   
       211      err: { status?: number; statusMessage?: string },
       212      req: express.Request,
       213      res: express.Response,
       214 +    // eslint-disable-next-line @typescript-eslint/no-unused-vars
       215 +    next: express.NextFunction,
       216    ) {
       217      res.status(err.status || 500).json({ message: err.statusMessage || err });
       218    }

The fix is adding the next parameter. In Express, error-handling middleware must have exactly 4 parameters (err, req, res, next) for Express to recognize it as an error handler. Without next, Express was treating fail as regular middleware and passing (req, res, next) instead of (err, req, res, next), causing res to be in the req position and the actual next function to be in the res position.

When the code then called res.status(500), it was actually calling next.status(500) - and next is a function, not a response object, which is why you got TypeError: n.status  is not a function.
