### PR TITLE
Use newer viame runners for training and inference as opposed to kwiver call

### DIFF
--- a/client/platform/desktop/backend/native/linux.ts
+++ b/client/platform/desktop/backend/native/linux.ts
@@ -40,7 +40,7 @@ const DefaultSettings: Settings = {
 
 const ViameLinuxConstants = {
   setup: 'setup_viame.sh',
-  trainingExe: 'viame_train_detector',
+  trainingExe: 'viame',
   kwiverExe: 'kwiver',
   shell: '/bin/bash',
 };
@@ -57,10 +57,10 @@ async function validateViamePath(settings: Settings): Promise<true | string> {
     return `${setupScriptPath} does not exist`;
   }
 
-  const trainingScriptPath = npath.join(settings.viamePath, 'bin', ViameLinuxConstants.trainingExe);
-  const trainingExists = await fs.pathExists(trainingScriptPath);
-  if (!trainingExists) {
-    return `${trainingScriptPath} does not exist`;
+  const viameExePath = npath.join(settings.viamePath, 'bin', ViameLinuxConstants.trainingExe);
+  const viameExists = await fs.pathExists(viameExePath);
+  if (!viameExists) {
+    return `${viameExePath} does not exist`;
   }
 
   const kwiverExistsOnPath = observeChild(spawn(

--- a/client/platform/desktop/backend/native/linux.ts
+++ b/client/platform/desktop/backend/native/linux.ts
@@ -40,8 +40,7 @@ const DefaultSettings: Settings = {
 
 const ViameLinuxConstants = {
   setup: 'setup_viame.sh',
-  trainingExe: 'viame',
-  kwiverExe: 'kwiver',
+  viameExe: 'viame',
   shell: '/bin/bash',
 };
 
@@ -57,22 +56,22 @@ async function validateViamePath(settings: Settings): Promise<true | string> {
     return `${setupScriptPath} does not exist`;
   }
 
-  const viameExePath = npath.join(settings.viamePath, 'bin', ViameLinuxConstants.trainingExe);
+  const viameExePath = npath.join(settings.viamePath, 'bin', ViameLinuxConstants.viameExe);
   const viameExists = await fs.pathExists(viameExePath);
   if (!viameExists) {
     return `${viameExePath} does not exist`;
   }
 
-  const kwiverExistsOnPath = observeChild(spawn(
-    `${sourceString(settings)} && which ${ViameLinuxConstants.kwiverExe}`,
+  const viameOnPath = observeChild(spawn(
+    `${sourceString(settings)} && which ${ViameLinuxConstants.viameExe}`,
     { shell: '/bin/bash' },
   ));
   return new Promise((resolve) => {
-    kwiverExistsOnPath.on('exit', (code) => {
+    viameOnPath.on('exit', (code) => {
       if (code === 0) {
         resolve(true);
       } else {
-        resolve('kwiver failed to initialize');
+        resolve('viame failed to initialize');
       }
     });
   });

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -181,7 +181,7 @@ async function runPipeline(
     }
     command = [
       `${viameConstants.setupScriptAbs} &&`,
-      `"${viameConstants.kwiverExe}" runner`,
+      `"${viameConstants.trainingExe}" runner`,
       '-s "input:video_reader:type=vidl_ffmpeg"',
       `-p "${pipelinePath}"`,
       `-s downsampler:target_frame_rate=${meta.fps}`,
@@ -205,7 +205,7 @@ async function runPipeline(
     await fs.writeFile(manifestFile, fileData);
     command = [
       `${viameConstants.setupScriptAbs} &&`,
-      `"${viameConstants.kwiverExe}" runner`,
+      `"${viameConstants.trainingExe}" runner`,
       `-p "${pipelinePath}"`,
     ];
     if (!stereoOrMultiCam) {
@@ -422,7 +422,8 @@ async function exportTrainedPipeline(
 
   const command = [
     `${viameConstants.setupScriptAbs} &&`,
-    `"${viameConstants.kwiverExe}" runner ${exportPipelinePath}`,
+    `"${viameConstants.trainingExe}" runner`,
+    `-p "${exportPipelinePath}"`,
     `-s "onnx_convert:model_path=${weightsPath}"`,
     `-s "onnx_convert:onnx_model_prefix=${converterOutput}"`,
   ];
@@ -553,7 +554,7 @@ async function train(
 
   const command = [
     `${viameConstants.setupScriptAbs} &&`,
-    `"${viameConstants.trainingExe}"`,
+    `"${viameConstants.trainingExe}" train`,
     `--input-list "${inputFolderFileList}"`,
     `--input-truth "${groundTruthFileList}"`,
     `--config "${configFilePath}"`,

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -33,8 +33,8 @@ const DiveJobManifestName = 'dive_job_manifest.json';
 
 export interface ViameConstants {
   setupScriptAbs: string; // abs path setup comman
-  trainingExe: string; // name of training binary on PATH
-  kwiverExe: string; // name of kwiver binary on PATH
+  /** Basename of unified VIAME CLI in `bin/` (e.g. `viame` or `viame.exe`). */
+  viameExe: string;
   shell: string | boolean; // shell arg for spawn
 }
 
@@ -181,7 +181,7 @@ async function runPipeline(
     }
     command = [
       `${viameConstants.setupScriptAbs} &&`,
-      `"${viameConstants.trainingExe}" runner`,
+      `"${viameConstants.viameExe}" runner`,
       '-s "input:video_reader:type=vidl_ffmpeg"',
       `-p "${pipelinePath}"`,
       `-s downsampler:target_frame_rate=${meta.fps}`,
@@ -205,7 +205,7 @@ async function runPipeline(
     await fs.writeFile(manifestFile, fileData);
     command = [
       `${viameConstants.setupScriptAbs} &&`,
-      `"${viameConstants.trainingExe}" runner`,
+      `"${viameConstants.viameExe}" runner`,
       `-p "${pipelinePath}"`,
     ];
     if (!stereoOrMultiCam) {
@@ -422,7 +422,7 @@ async function exportTrainedPipeline(
 
   const command = [
     `${viameConstants.setupScriptAbs} &&`,
-    `"${viameConstants.trainingExe}" runner`,
+    `"${viameConstants.viameExe}" runner`,
     `-p "${exportPipelinePath}"`,
     `-s "onnx_convert:model_path=${weightsPath}"`,
     `-s "onnx_convert:onnx_model_prefix=${converterOutput}"`,
@@ -554,7 +554,7 @@ async function train(
 
   const command = [
     `${viameConstants.setupScriptAbs} &&`,
-    `"${viameConstants.trainingExe}" train`,
+    `"${viameConstants.viameExe}" train`,
     `--input-list "${inputFolderFileList}"`,
     `--input-truth "${groundTruthFileList}"`,
     `--config "${configFilePath}"`,

--- a/client/platform/desktop/backend/native/windows.ts
+++ b/client/platform/desktop/backend/native/windows.ts
@@ -38,7 +38,7 @@ const DefaultSettings: Settings = {
 
 const ViameWindowsConstants = {
   setup: 'setup_viame.bat',
-  trainingExe: 'viame_train_detector.exe',
+  trainingExe: 'viame.exe',
   kwiverExe: 'kwiver.exe',
   shell: true,
 };

--- a/client/platform/desktop/backend/native/windows.ts
+++ b/client/platform/desktop/backend/native/windows.ts
@@ -38,8 +38,7 @@ const DefaultSettings: Settings = {
 
 const ViameWindowsConstants = {
   setup: 'setup_viame.bat',
-  trainingExe: 'viame.exe',
-  kwiverExe: 'kwiver.exe',
+  viameExe: 'viame.exe',
   shell: true,
 };
 
@@ -62,23 +61,30 @@ async function validateViamePath(settings: Settings): Promise<true | string> {
     return `${setupScriptPath} does not exist`;
   }
 
+  const viameExePath = npath.join(settings.viamePath, 'bin', ViameWindowsConstants.viameExe);
+  const viameExists = await fs.pathExists(viameExePath);
+  if (!viameExists) {
+    return `${viameExePath} does not exist`;
+  }
+
   const modifiedCommand = `"${setupScriptPath.replace(/\\/g, '\\')}"`;
-  const kwiverExistsOnPath = observeChild(spawn(`${modifiedCommand} && kwiver.exe help`, {
-    shell: true,
-  }));
+  const viameOnPath = observeChild(spawn(
+    `${modifiedCommand} && ${ViameWindowsConstants.viameExe} help`,
+    { shell: true },
+  ));
   return new Promise((resolve) => {
-    kwiverExistsOnPath.on('exit', (code) => {
+    viameOnPath.on('exit', (code) => {
       if (code === 0) {
         resolve(true);
       } else {
-        resolve('kwiver failed to initialize');
+        resolve('viame failed to initialize');
       }
     });
   });
 }
 
 // Mock the validate call when starting jobs because it just takes too long to run.
-// TODO: maybe perform a lightweight check or some other test that doesn't spawn() kwiver
+// TODO: maybe perform a lightweight check or some other test that doesn't spawn() viame
 const validateFake = () => Promise.resolve(true as const);
 
 async function runPipeline(

--- a/client/platform/desktop/frontend/components/Settings.vue
+++ b/client/platform/desktop/frontend/components/Settings.vue
@@ -242,17 +242,17 @@ export default defineComponent({
             === false ? 'info' : settingsAreValid === true ? 'success' : 'warning'"
         >
           <span v-if="settingsAreValid === false">
-            Checking for Kwiver
+            Checking for VIAME
             <v-progress-linear
               indeterminate
               color="yellow darken-2"
             />
           </span>
           <span v-else-if="settingsAreValid === true">
-            Kwiver initialization succeeded
+            VIAME initialization succeeded
           </span>
           <span v-else>
-            Could not initialize kwiver: {{ settingsAreValid }}
+            Could not initialize VIAME: {{ settingsAreValid }}
           </span>
         </v-alert>
 

--- a/docs/Command-Line-Tools.md
+++ b/docs/Command-Line-Tools.md
@@ -2,7 +2,7 @@
 
 !!! note
 
-    This page is **not related** to the VIAME command line (i.e. `kwiver`, `viame_train_detector`)
+    This page is **not related** to the VIAME command line (i.e. `kwiver`, `viame`)
 
 Some of the DIVE data conversion features are exposed through `dive`.  
 

--- a/docs/Command-Line-Tools.md
+++ b/docs/Command-Line-Tools.md
@@ -2,7 +2,7 @@
 
 !!! note
 
-    This page is **not related** to the VIAME command line (i.e. `kwiver`, `viame`)
+    This page is **not related** to the VIAME install command line (e.g. `viame`, `kwiver`)
 
 Some of the DIVE data conversion features are exposed through `dive`.  
 

--- a/docs/Deployment-Docker-Compose.md
+++ b/docs/Deployment-Docker-Compose.md
@@ -179,7 +179,7 @@ This image contains a celery worker to run VIAME pipelines and transcoding jobs.
 | WORKER_CONCURRENCY | `# of CPU cores` | max concurrnet jobs. **Lower this if you run training** |
 | WORKER_GPU_UUID | null | leave empty to use all GPUs.  Specify UUID to use specific device |
 | CELERY_BROKER_URL | `amqp://guest:guest@default/` | rabbitmq connection string. Ignored in standalone mode. |
-| KWIVER_DEFAULT_LOG_LEVEL | `warn` | kwiver log level |
+| KWIVER_DEFAULT_LOG_LEVEL | `warn` | Log level for VIAME pipeline jobs (env name unchanged; used by the Kwiver logging stack) |
 | DIVE_USERNAME | null | Username to start private queue processor. Providing this enables standalone mode. |
 | DIVE_PASSWORD | null | Password for private queue processor. Providing this enables standalone mode. |
 | DIVE_API_URL  | `https://viame.kitware.com/api/v1` | Remote URL to authenticate against |

--- a/docs/Deployment-Overview.md
+++ b/docs/Deployment-Overview.md
@@ -63,7 +63,7 @@ Instead of running the whole web stack, it's possible to deploy a worker by itse
 * You must [toggle your private queue](https://viame.kitware.com/#jobs)
 * When you launch jobs (like transcoding, pipelines, or training), they go into a special queue just for your user account.
 * You are responsible for running a worker.  Your worker is a Celery process that will connect to our public RabbitMQ server.
-* Jobs submitted through the interface at viame.kitware.com will run on your compute resources.  This involves automatically downloading the video or images and annotation files, running a kwiver pipeline, and uploading the results.
+* Jobs submitted through the interface at viame.kitware.com will run on your compute resources.  This involves automatically downloading the video or images and annotation files, running a VIAME pipeline (via the `viame` CLI), and uploading the results.
 
 To set up a private worker, continue to the [Provisioning Google Cloud](Deployment-Provision.md) page for `Scenario 3`.
 

--- a/docs/Deployment-Provision.md
+++ b/docs/Deployment-Provision.md
@@ -111,7 +111,7 @@ These are all the variables that can be provided with `--extra-vars`.
 | DIVE_PASSWORD | null | Required for scenario 3. Password for private queue processor |
 | WORKER_CONCURRENCY | `2` | Optional for scenario 3. Max concurrnet jobs. **Change this to 1 if you run training** |
 | DIVE_API_URL  | `https://viame.kitware.com/api/v1` | Optional for scenario 3. Remote URL to authenticate against. |
-| KWIVER_DEFAULT_LOG_LEVEL | `warn` | Optional for scenario 3. kwiver log level |
+| KWIVER_DEFAULT_LOG_LEVEL | `warn` | Optional for scenario 3. Log level for VIAME pipeline jobs (same env name as the Kwiver stack) |
 
 ### Run Ansible
 
@@ -159,10 +159,10 @@ docker run --gpus=all --rm nvidia/cuda:11.0-base nvidia-smi
 # Test regular nvidia runtime
 nvidia-smi
 
-# For Scenario 2 and 3, check KWIVER installation
+# For Scenario 2 and 3, check that the VIAME CLI is available (DIVE jobs use `viame runner` / `viame train`)
 cd /opt/noaa/viame
 source setup_viame.sh
-kwiver
+viame --help
 
 # For Scenario 3, you can check to see if the worker is started
 # You should see "celery@identifier ready." in the logs

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -81,8 +81,8 @@ class Config:
         assert self.viame_install_path.exists(), "VIAME Base install directory missing."
         self.viame_setup_script = self.viame_install_path / "setup_viame.sh"
         assert self.viame_setup_script.is_file(), "VIAME Setup Script missing"
-        self.viame_training_executable = self.viame_install_path / "bin" / "viame_train_detector"
-        assert self.viame_training_executable.is_file(), "VIAME Training Executable missing"
+        self.viame_training_executable = self.viame_install_path / "bin" / "viame"
+        assert self.viame_training_executable.is_file(), "VIAME Executable missing"
 
         # The subdirectory within VIAME_INSTALL_PATH where pipelines can be found
         self.pipeline_subdir = 'configs/pipelines'
@@ -232,7 +232,7 @@ def run_pipeline(self: Task, params: PipelineJob):
             command = [
                 f". {shlex.quote(str(conf.viame_setup_script))} &&",
                 f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
-                "kwiver runner",
+                "viame runner",
                 "-s input:video_reader:type=vidl_ffmpeg",
                 f"-p {shlex.quote(str(pipeline_path))}",
                 f"-s input:video_filename={shlex.quote(input_media_list[0])}",
@@ -246,7 +246,7 @@ def run_pipeline(self: Task, params: PipelineJob):
             command = [
                 f". {shlex.quote(str(conf.viame_setup_script))} &&",
                 f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
-                "kwiver runner",
+                "viame runner",
                 f"-p {shlex.quote(str(pipeline_path))}",
                 f"-s input:video_filename={shlex.quote(str(img_list_path))}",
                 f"-s detector_writer:file_name={shlex.quote(detector_output_file)}",
@@ -333,8 +333,8 @@ def export_trained_pipeline(self: Task, params: ExportTrainedPipelineJob):
         command = [
             f". {shlex.quote(str(conf.viame_setup_script))} &&",
             f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
-            "kwiver runner",
-            f"{shlex.quote(str(convert_to_onnx_pipeline_path))}",
+            "viame runner",
+            f"-p {shlex.quote(str(convert_to_onnx_pipeline_path))}",
             f"-s onnx_convert:model_path={shlex.quote(str(model_file))}",
             f"-s onnx_convert:onnx_model_prefix={shlex.quote(str(onnx_path))}"
         ]
@@ -355,7 +355,7 @@ def export_trained_pipeline(self: Task, params: ExportTrainedPipelineJob):
 
 @app.task(bind=True, acks_late=True, ignore_result=True)
 def train_pipeline(self: Task, params: TrainingJob):
-    """Train a pipeline by making a call to viame_train_detector"""
+    """Train a pipeline by making a call to viame train"""
     conf = Config()
     context: dict = {}
     manager: JobManager = patch_manager(self.job_manager)
@@ -384,7 +384,7 @@ def train_pipeline(self: Task, params: TrainingJob):
     config_file = pipeline_base_path / config
     # List of (input folder, ground truth file) pairs for creating input lists
     input_groundtruth_list: List[Tuple[Path, Path]] = []
-    # root_data_dir is the directory passed to `viame_train_detector`
+    # root_data_dir is the directory passed to `viame train`
     with tempfile.TemporaryDirectory() as _working_directory, suppress(utils.CanceledError):
         _working_directory_path = Path(_working_directory)
         input_path = utils.make_directory(_working_directory_path / 'input')
@@ -417,7 +417,7 @@ def train_pipeline(self: Task, params: TrainingJob):
         command = [
             f". {shlex.quote(str(conf.viame_setup_script))} &&",
             f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
-            shlex.quote(str(conf.viame_training_executable)),
+            f"{shlex.quote(str(conf.viame_training_executable))} train",
             "--input-list",
             shlex.quote(str(input_folder_file_list)),
             "--input-truth",

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -81,8 +81,8 @@ class Config:
         assert self.viame_install_path.exists(), "VIAME Base install directory missing."
         self.viame_setup_script = self.viame_install_path / "setup_viame.sh"
         assert self.viame_setup_script.is_file(), "VIAME Setup Script missing"
-        self.viame_training_executable = self.viame_install_path / "bin" / "viame"
-        assert self.viame_training_executable.is_file(), "VIAME Executable missing"
+        self.viame_executable = self.viame_install_path / "bin" / "viame"
+        assert self.viame_executable.is_file(), "VIAME Executable missing"
 
         # The subdirectory within VIAME_INSTALL_PATH where pipelines can be found
         self.pipeline_subdir = 'configs/pipelines'
@@ -417,7 +417,7 @@ def train_pipeline(self: Task, params: TrainingJob):
         command = [
             f". {shlex.quote(str(conf.viame_setup_script))} &&",
             f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
-            f"{shlex.quote(str(conf.viame_training_executable))} train",
+            f"{shlex.quote(str(conf.viame_executable))} train",
             "--input-list",
             shlex.quote(str(input_folder_file_list)),
             "--input-truth",


### PR DESCRIPTION
## Summary

Use \`viame runner\` (a thin wrapper that pre-loads VIAME's environment) instead of bare \`kwiver runner\` for pipeline execution and ONNX export, matching the runner used by the rest of the desktop pipeline tooling.

## Changes vs main

- \`server/dive_tasks/tasks.py\`: pipeline runs (video and image-sequence paths) and \`export_trained_pipeline\` now invoke \`viame runner -p <pipe>\` instead of \`kwiver runner <pipe>\`.
- \`client/platform/desktop/backend/native/viame.ts\`, \`linux.ts\`, \`windows.ts\`: replace \`kwiver runner\` with \`viame runner\` and update \`-p\` syntax in the desktop equivalents.
- \`docs/Command-Line-Tools.md\`: doc reference updated to match.

\`viame runner\` is identical to \`kwiver runner\` from a pipeline-execution standpoint but already sources the VIAME setup script and resolves binary paths against the VIAME install, which removes a class of "binary not found" / partially-loaded-environment failures we hit on Windows and on minimal Linux installs.