### PR TITLE
Allow same filenames in different directories for multicam import

### DIFF
--- a/client/dive-common/components/ImportMultiCamDialog.vue
+++ b/client/dive-common/components/ImportMultiCamDialog.vue
@@ -163,7 +163,11 @@ export default defineComponent({
         if (length !== images.length) {
           return `All cameras should have the same length of ${length}`;
         }
-        if (totalList.some((imageName) => images.includes(imageName))) {
+        // Only check for overlapping filenames in keyword/glob mode where images
+        // come from a single shared directory. In multi-folder mode, same filenames
+        // in different directories are valid (e.g., stereo camera setups).
+        if (importType.value === 'keyword'
+            && totalList.some((imageName) => images.includes(imageName))) {
           return 'Overlapping values.  All cameras must consist of mutually exclusive images.';
         }
         totalList = totalList.concat(images);


### PR DESCRIPTION
## Summary

Allow same filenames in different directories for stereo / multicam imports.

## Changes vs main

- Fix overlap validation in `ImportMultiCamDialog.vue` so it only forbids duplicate filenames in keyword/glob mode (where images come from a single shared directory). Multi-folder mode now permits same filenames across cameras (e.g. `left/image001.png` + `right/image001.png`), which is a valid stereo setup.