### PR TITLE
Add custom run pipeline settings support

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -31,10 +31,26 @@ interface AnnotationSchemaList {
   sets: string[];
 }
 
+interface DiveParam {
+  label: string;
+  type: string;
+  type_props?: string[];
+  key: string;
+  default: string;
+}
+
+interface PipeMetadata {
+  description?: string;
+  inputType?: string;
+  outputType?: string;
+  diveParams?: DiveParam[];
+}
+
 interface Pipe {
   name: string;
   pipe: string;
   type: string;
+  metadata?: PipeMetadata;
   folderId?: string;
   ownerId?: string;
   ownerLogin?: string;
@@ -45,9 +61,14 @@ interface Category {
   pipes: Pipe[];
 }
 
+interface TrainingConfig {
+  name: string;
+  description?: string;
+}
+
 interface TrainingConfigs {
   training: {
-    configs: string[];
+    configs: TrainingConfig[];
     default: string;
   };
   models: Record<string, {
@@ -222,15 +243,18 @@ export {
   DatasetMetaMutable,
   DatasetMetaMutableKeys,
   DatasetType,
+  DiveParam,
   SubType,
   FrameImage,
   MultiTrackRecord,
   MultiGroupRecord,
   Pipe,
+  PipeMetadata,
   Pipelines,
   SaveDetectionsArgs,
   SaveAttributeArgs,
   SaveAttributeTrackFilterArgs,
+  TrainingConfig,
   TrainingConfigs,
   MultiCamMedia,
   MediaImportResponse,

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -13,6 +13,11 @@ type DatasetType = 'image-sequence' | 'video' | 'multi' | 'large-image';
 type MultiTrackRecord = Record<string, TrackData>;
 type MultiGroupRecord = Record<string, GroupData>;
 type SubType = 'stereo' | 'multicam' | null; // Additional type info used for UI display enabled pipelines
+type PipelineParamType = | 'bool'
+  | 'int' | 'positive_int' | 'strictly_positive_int' | 'range_int'
+  | 'float' | 'positive_float' | 'strictly_positive_float' | 'range_float'
+  | 'folder' | 'path'
+  | 'file';
 
 interface AnnotationSchema {
   version: number;
@@ -33,7 +38,7 @@ interface AnnotationSchemaList {
 
 interface DiveParam {
   label: string;
-  type: string;
+  type: PipelineParamType;
   type_props?: string[];
   key: string;
   default: string;
@@ -245,6 +250,7 @@ export {
   DatasetType,
   DiveParam,
   SubType,
+  PipelineParamType,
   FrameImage,
   MultiTrackRecord,
   MultiGroupRecord,

--- a/client/dive-common/components/PipelineParamsDialog.vue
+++ b/client/dive-common/components/PipelineParamsDialog.vue
@@ -1,0 +1,232 @@
+<script lang="ts">
+import { Pipe } from 'dive-common/apispec';
+import {
+  defineComponent,
+  PropType,
+  ref,
+  watch,
+} from 'vue';
+
+type ValidationRule = (value: string | number) => boolean | string;
+
+export default defineComponent({
+  name: 'PipelineParamsDialog',
+  props: {
+    value: { type: Boolean, required: true },
+    pipeline: { type: Object as PropType<Pipe | null>, default: null },
+    params: {
+      type: Object as PropType<Record<string, string>>,
+      default: () => ({}),
+    },
+  },
+  setup(props, { emit }) {
+    const localParams = ref<Record<string, string>>({ ...props.params });
+    const getIcon = (type: string) => {
+      switch (type) {
+        case 'bool': return 'mdi-toggle-switch-outline';
+        case 'int':
+        case 'positive_int':
+        case 'strictly_positive_int':
+        case 'range_int': return 'mdi-numeric';
+        case 'float':
+        case 'positive_float':
+        case 'strictly_positive_float':
+        case 'range_float': return 'mdi-decimal';
+        case 'folder':
+        case 'path': return 'mdi-folder-outline';
+        case 'file': return 'mdi-file-outline';
+        default: return 'mdi-alphabetical-variant';
+      }
+    };
+
+    watch(() => props.params, (newParams) => {
+      localParams.value = { ...newParams };
+    }, { deep: true });
+
+    const close = () => emit('input', false);
+
+    const confirm = () => {
+      emit('confirm', { ...localParams.value });
+    };
+
+    const rules: Record<string, ValidationRule> = {
+      integer: (value: string | number) => Number.isInteger(Number(value)) || 'Please enter a whole number',
+      positive: (value: string | number) => Number(value) >= 0 || 'Please enter a number ≥ 0',
+      strictlyPositive: (value: string | number) => Number(value) > 0 || 'Please enter a number > 0',
+    };
+
+    function getRules(type: string): ValidationRule[] {
+      const res = [];
+      if (type.includes('int')) {
+        res.push(rules.integer);
+      }
+
+      if (type.includes('strictly_positive')) {
+        res.push(rules.strictlyPositive);
+      } else if (type.includes('positive')) {
+        console.log('positive');
+        res.push(rules.positive);
+      }
+
+      return res;
+    }
+
+    const isFormValid = ref(false);
+
+    return {
+      localParams,
+      getIcon,
+      close,
+      confirm,
+      isFormValid,
+      getRules,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-dialog
+    :value="value"
+    max-width="600px"
+    scrollable
+    @input="$emit('input', $event)"
+  >
+    <v-card v-if="pipeline" class="rounded-lg">
+      <v-toolbar flat color="primary" dark dense>
+        <v-icon left>mdi-cog</v-icon>
+        <v-toolbar-title class="text-h6">
+          Pipeline Configuration
+        </v-toolbar-title>
+        <v-spacer />
+        <v-btn icon small @click="close">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </v-toolbar>
+
+      <v-card-text class="pa-4">
+        <div class="mb-6">
+          <div class="text-h5 font-weight-bold mb-1">
+            {{ pipeline.name }}
+          </div>
+          <div v-if="pipeline.metadata?.description" class="text-body-2 text--secondary">
+            {{ pipeline.metadata.description }}
+          </div>
+        </div>
+
+        <v-divider class="mb-4" />
+
+        <v-form v-model="isFormValid">
+          <div
+            v-for="param in pipeline.metadata?.diveParams"
+            :key="param.key"
+            class="mb-3"
+          >
+            <div class="d-flex align-center">
+              <v-icon small class="mr-2 text--secondary">
+                {{ getIcon(param.type) }}
+              </v-icon>
+              <label
+                :for="`input-${param.key}`"
+                class="text-caption font-weight-bold text-uppercase text--secondary"
+              >
+                {{ param.label }}
+              </label>
+            </div>
+
+            <template v-if="param.type === 'bool'">
+              <div class="d-flex align-center mt-2 ml-1">
+                <v-switch
+                  :id="`input-${param.key}`"
+                  v-model="localParams[param.key]"
+                  color="primary"
+                  hide-details
+                  class="mt-0 pt-0"
+                />
+              </div>
+            </template>
+
+            <template v-else-if="['int', 'positive_int', 'strictly_positive_int'].includes(param.type)">
+              <v-text-field
+                :id="`input-${param.key}`"
+                v-model.number="localParams[param.key]"
+                type="number"
+                outlined
+                dense
+                hide-details="auto"
+                class="mt-1"
+                :min="param.type === 'int' ? 'none' : 0"
+                :rules="getRules(param.type)"
+              />
+            </template>
+
+            <template v-else-if="['float', 'positive_float', 'strictly_positive_float'].includes(param.type)">
+              <v-text-field
+                :id="`input-${param.key}`"
+                v-model.number="localParams[param.key]"
+                type="number"
+                outlined
+                dense
+                hide-details="auto"
+                class="mt-1"
+                :min="param.type === 'float' ? 'none' : 0"
+                :rules="getRules(param.type)"
+              />
+            </template>
+
+            <template v-else-if="['range_int', 'range_float'].includes(param.type)">
+              <div class="d-flex align-center mt-2 px-2">
+                <v-slider
+                  v-model="localParams[param.key]"
+                  :min="param.type_props?.at(0) || 0"
+                  :max="param.type_props?.at(1) || 100"
+                  :step="param.type_props?.at(2) || 1"
+                  hide-details
+                >
+                  <template v-slot:append>
+                    <v-text-field
+                      v-model="localParams[param.key]"
+                      dense
+                      style="width: 100px; margin-top: -6px"
+                      type="number"
+                      :min="param.type_props?.at(0) || 0"
+                      :max="param.type_props?.at(1) || 100"
+                      :step="param.type_props?.at(2) || 1"
+                      :rules="getRules(param.type)"
+                      outlined
+                      hide-details
+                    />
+                  </template>
+                </v-slider>
+              </div>
+            </template>
+
+            <v-text-field
+              v-else
+              :id="`input-${param.key}`"
+              v-model="localParams[param.key]"
+              type="text"
+              outlined
+              dense
+              hide-details="auto"
+              class="mt-1"
+            />
+          </div>
+        </v-form>
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions class="pa-4 lighten-3">
+        <v-btn text color="grey darken-1" @click="close">
+          Cancel
+        </v-btn>
+        <v-spacer />
+        <v-btn color="primary" @click="confirm" :disabled="!isFormValid">
+          <v-icon left>mdi-play</v-icon>
+          Run Pipeline
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>

--- a/client/dive-common/components/PipelineParamsDialog.vue
+++ b/client/dive-common/components/PipelineParamsDialog.vue
@@ -64,7 +64,6 @@ export default defineComponent({
       if (type.includes('strictly_positive')) {
         res.push(rules.strictlyPositive);
       } else if (type.includes('positive')) {
-        console.log('positive');
         res.push(rules.positive);
       }
 

--- a/client/dive-common/components/PipelineParamsDialog.vue
+++ b/client/dive-common/components/PipelineParamsDialog.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Pipe } from 'dive-common/apispec';
+import { Pipe, PipelineParamType } from 'dive-common/apispec';
 import {
   defineComponent,
   PropType,
@@ -21,7 +21,7 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const localParams = ref<Record<string, string>>({ ...props.params });
-    const getIcon = (type: string) => {
+    const getIcon = (type: PipelineParamType): string => {
       switch (type) {
         case 'bool': return 'mdi-toggle-switch-outline';
         case 'int':
@@ -35,7 +35,7 @@ export default defineComponent({
         case 'folder':
         case 'path': return 'mdi-folder-outline';
         case 'file': return 'mdi-file-outline';
-        default: return 'mdi-alphabetical-variant';
+        default: return 'mdi-help-box-outline';
       }
     };
 
@@ -55,7 +55,7 @@ export default defineComponent({
       strictlyPositive: (value: string | number) => Number(value) > 0 || 'Please enter a number > 0',
     };
 
-    function getRules(type: string): ValidationRule[] {
+    function getRules(type: PipelineParamType): ValidationRule[] {
       const res = [];
       if (type.includes('int')) {
         res.push(rules.integer);

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -16,6 +16,7 @@ import {
 } from 'dive-common/apispec';
 import JobLaunchDialog from 'dive-common/components/JobLaunchDialog.vue';
 import JobConfigFilterTranscodeDialog from 'dive-common/components/JobConfigFilterTranscodeDialog.vue';
+import RunPipelineToast from 'dive-common/components/RunPipelineToast.vue';
 import {
   stereoPipelineMarker,
   multiCamPipelineMarkers,
@@ -24,6 +25,7 @@ import {
 } from 'dive-common/constants';
 import { useRequest } from 'dive-common/use';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
+import PipelineParamsDialog from 'dive-common/components/PipelineParamsDialog.vue';
 
 type MenuState = 'idle' | 'configuring';
 
@@ -33,6 +35,8 @@ export default defineComponent({
   components: {
     JobLaunchDialog,
     JobConfigFilterTranscodeDialog,
+    PipelineParamsDialog,
+    RunPipelineToast,
   },
 
   props: {
@@ -77,7 +81,6 @@ export default defineComponent({
     const { prompt } = usePrompt();
     const { runPipeline, getPipelineList } = useApi();
     const unsortedPipelines = ref({} as Pipelines);
-    const selectedPipe = ref(null as Pipe | null);
     const camNumberStringArray = computed(() => props.cameraNumbers.map((v) => v.toString()));
     const {
       request: _runPipelineRequest,
@@ -92,11 +95,32 @@ export default defineComponent({
     function cancelConfig() {
       menuState.value = 'idle';
     }
+    const showParamsDialog = ref(false);
+    const pipelineParams = ref<Record<string, string>>({});
+
+    function openDiveParamsDialog(pipeline: Pipe) {
+      selectedPipeline.value = pipeline;
+      const defaults: Record<string, string> = {};
+      pipeline?.metadata?.diveParams?.forEach((param) => {
+        defaults[param.key] = param.default;
+      });
+      pipelineParams.value = defaults;
+      showParamsDialog.value = true;
+    }
+
+    async function confirmPipelineExecution(updatedParams: Record<string, string>) {
+      const configById: Record<string, Record<string, string>> = {};
+      props.selectedDatasetIds.forEach((id) => {
+        configById[id] = updatedParams;
+      });
+      showParamsDialog.value = false;
+      await _runPipelineOnSelectedItemInner(selectedPipeline.value!, configById);
+    }
 
     const includesLargeImage = computed(() => props.typeList.includes(LargeImageType));
 
     const successMessage = computed(() => (
-      `Started ${selectedPipe.value?.name} on ${props.selectedDatasetIds.length} dataset(s).`));
+      `Started ${selectedPipeline.value?.name} on ${props.selectedDatasetIds.length} dataset(s).`));
 
     onBeforeMount(async () => {
       unsortedPipelines.value = await getPipelineList();
@@ -175,7 +199,7 @@ export default defineComponent({
       || stereoPipelineMarker === pipeline.type) {
         datasetIds = props.selectedDatasetIds.map((item) => item.substring(0, item.lastIndexOf('/')));
       }
-      selectedPipe.value = pipeline;
+      selectedPipeline.value = pipeline;
       await _runPipelineRequest(() => Promise.all(
         datasetIds.map((id) => {
           const additionalConfig = additionalConfigById ? additionalConfigById[id] : undefined;
@@ -185,6 +209,10 @@ export default defineComponent({
     }
 
     async function runPipelineOnSelectedItem(pipeline: Pipe) {
+      if (pipeline.metadata?.diveParams && pipeline.metadata?.diveParams?.length > 0) {
+        openDiveParamsDialog(pipeline);
+        return;
+      }
       if (!pipelineCreatesDatasetMarkers.includes(pipeline.type)) {
         _runPipelineOnSelectedItemInner(pipeline);
       } else {
@@ -248,6 +276,9 @@ export default defineComponent({
       cancelConfig,
       menuState,
       exitPipelineConfig,
+      pipelineParams,
+      showParamsDialog,
+      confirmPipelineExecution,
     };
   },
 });
@@ -383,15 +414,30 @@ export default defineComponent({
                   outlined
                   style="overflow-y: auto; max-height: 85vh"
                 >
-                  <v-list-item
+                  <v-tooltip
                     v-for="pipeline in pipelines[pipeType].pipes"
                     :key="`${pipeline.name}-${pipeline.pipe}`"
-                    @click="runPipelineOnSelectedItem(pipeline)"
+                    left
+                    :disabled="!pipeline?.metadata?.description"
+                    max-width="400"
+                    content-class="pipeline-description-tooltip"
                   >
-                    <v-list-item-title class="font-weight-regular">
-                      {{ pipeline.name }}
-                    </v-list-item-title>
-                  </v-list-item>
+                    <template #activator="{ on, attrs }">
+                      <v-list-item
+                        v-bind="attrs"
+                        v-on="on"
+                        @click="runPipelineOnSelectedItem(pipeline)"
+                      >
+                        <v-list-item-title class="font-weight-regular" style="display: flex; justify-content: space-between; align-items: center;">
+                          {{ pipeline.name }}
+                          <v-icon style="margin-left: 20px">
+                            {{ pipeline.metadata?.diveParams?.length ?? 0 > 0 ? 'mdi-application-cog-outline' : 'mdi-play-outline' }}
+                          </v-icon>
+                        </v-list-item-title>
+                      </v-list-item>
+                    </template>
+                    <RunPipelineToast :pipeline="pipeline" />
+                  </v-tooltip>
                 </v-list>
               </v-menu>
             </v-col>
@@ -412,6 +458,12 @@ export default defineComponent({
       :selected-dataset-ids="selectedDatasetIds"
       @cancel="cancelConfig"
       @submit="exitPipelineConfig"
+    />
+    <PipelineParamsDialog
+      v-model="showParamsDialog"
+      :pipeline="selectedPipeline"
+      :params="pipelineParams"
+      @confirm="confirmPipelineExecution"
     />
   </div>
 </template>

--- a/client/dive-common/components/RunPipelineToast.vue
+++ b/client/dive-common/components/RunPipelineToast.vue
@@ -1,0 +1,93 @@
+<script lang="ts">
+import { computed, defineComponent, PropType } from 'vue';
+import { Pipe } from 'dive-common/apispec';
+
+export default defineComponent({
+  name: 'RunPipelineToast',
+
+  props: {
+    pipeline: {
+      type: Object as PropType<Pipe>,
+      required: true,
+    },
+  },
+
+  setup(props) {
+    function getPipelineTypeIcon(type: string | undefined): string {
+      console.log(type);
+
+      if (!type) {
+        return '';
+      }
+
+      switch (type.toUpperCase()) {
+        case 'IMAGE':
+          return 'mdi-image';
+        case 'VIDEO':
+          return 'mdi-video-vintage';
+        case 'TEXT':
+          return 'mdi-format-text';
+        case 'BBOX':
+          return 'mdi-vector-square';
+        case 'FULL-SIZE-BBOX':
+          return 'mdi-square-outline';
+        case 'HEAD-TAIL':
+          return 'mdi-vector-line';
+        case 'MASK':
+          return 'mdi-vector-polygon';
+        case 'TRACK':
+          return 'mdi-gesture';
+        default:
+          return type;
+      }
+    }
+
+    console.log(props.pipeline);
+
+    const inputIcon = computed(() => getPipelineTypeIcon(props.pipeline.metadata?.inputType));
+    const outputIcon = computed(() => getPipelineTypeIcon(props.pipeline.metadata?.outputType));
+
+    return {
+      inputIcon,
+      outputIcon,
+    };
+  },
+});
+</script>
+
+<template>
+  <div>
+    <span>{{ pipeline.metadata?.description }}</span>
+    <div class="pipeline-type-indicators" v-if="pipeline.metadata?.inputType && pipeline.metadata?.outputType">
+      <v-icon>
+        {{ inputIcon }}
+      </v-icon>
+
+      <v-icon>
+        mdi-arrow-right
+      </v-icon>
+
+      <v-icon>
+        {{ outputIcon }}
+      </v-icon>
+    </div>
+  </div>
+</template>
+
+<style>
+.pipeline-description-tooltip.v-tooltip__content {
+  background: #3a3a3a !important;
+  opacity: 1 !important;
+}
+</style>
+
+<style scoped>
+.pipeline-type-indicators {
+  border-top: 1px solid #888888;
+  margin-top: 5px;
+  padding: 10px 0;
+  display: flex;
+  justify-content: left;
+  gap: 10px;
+}
+</style>

--- a/client/dive-common/components/RunPipelineToast.vue
+++ b/client/dive-common/components/RunPipelineToast.vue
@@ -14,8 +14,6 @@ export default defineComponent({
 
   setup(props) {
     function getPipelineTypeIcon(type: string | undefined): string {
-      console.log(type);
-
       if (!type) {
         return '';
       }
@@ -41,8 +39,6 @@ export default defineComponent({
           return type;
       }
     }
-
-    console.log(props.pipeline);
 
     const inputIcon = computed(() => getPipelineTypeIcon(props.pipeline.metadata?.inputType));
     const outputIcon = computed(() => getPipelineTypeIcon(props.pipeline.metadata?.outputType));

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -24,6 +24,7 @@ import {
   SaveAttributeTrackFilterArgs,
   Pipe,
   PipeMetadata,
+  PipelineParamType,
 } from 'dive-common/apispec';
 import * as viameSerializers from 'platform/desktop/backend/serializers/viame';
 import * as nistSerializers from 'platform/desktop/backend/serializers/nist';
@@ -105,7 +106,7 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
       if (diveMatch) {
         const [, label, rawArgs] = diveMatch;
         const args = rawArgs.split(',').map((arg) => arg.trim());
-        const type = args[0];
+        const type: PipelineParamType = args[0] as PipelineParamType;
         const pipelineTypeArgs = args.slice(1);
 
         const paramLineMatch = trimmed.match(/^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)/i);

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -17,12 +17,13 @@ import { TrackData } from 'vue-media-annotator/track';
 import { GroupData } from 'vue-media-annotator/Group';
 import {
   DatasetType, Pipelines, SaveDetectionsArgs,
-  FrameImage, DatasetMetaMutable, TrainingConfigs, SaveAttributeArgs,
+  FrameImage, DatasetMetaMutable, TrainingConfig, TrainingConfigs, SaveAttributeArgs,
   MultiCamMedia,
   DatasetMetaMutableKeys,
   AnnotationSchema,
   SaveAttributeTrackFilterArgs,
   Pipe,
+  PipeMetadata,
 } from 'dive-common/apispec';
 import * as viameSerializers from 'platform/desktop/backend/serializers/viame';
 import * as nistSerializers from 'platform/desktop/backend/serializers/nist';
@@ -65,6 +66,93 @@ const YAMLFileName = /^.*\.ya?ml$/i;
 async function readLines(filePath: string): Promise<string[]> {
   const rawBuffer = await fs.readFile(filePath, 'utf-8');
   return rawBuffer.toString().replace(/\r\n/g, '\n').split('\n');
+}
+
+/**
+ * Extract metadata from a .pipe file header.
+ */
+async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
+  const metadata: PipeMetadata = {};
+  metadata.diveParams = [];
+  try {
+    const lines = await readLines(filePath);
+    let inDescription = false;
+    let contextStack: string[] = [];
+    let fullDescription = '';
+
+    lines.forEach((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+
+      const processMatch = trimmed.match(/^process\s+([\w-]+)/i);
+      if (processMatch) {
+        contextStack = [processMatch[1]];
+        return;
+      }
+
+      const blockMatch = trimmed.match(/^block\s+([\w:-]+)/i);
+      if (blockMatch) {
+        contextStack.push(blockMatch[1]);
+        return;
+      }
+
+      if (trimmed.toLowerCase() === 'endblock') {
+        contextStack.pop();
+        return;
+      }
+
+      const diveMatch = line.match(/#\s*DIVE_PARAM\s*\[\s*"([^"]+)"\s*,\s*(.+)\s*\]/i);
+      if (diveMatch) {
+        const [, label, rawArgs] = diveMatch;
+        const args = rawArgs.split(',').map((arg) => arg.trim());
+        const type = args[0];
+        const pipelineTypeArgs = args.slice(1);
+
+        const paramLineMatch = trimmed.match(/^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)/i);
+        if (paramLineMatch) {
+          const localKey = paramLineMatch[1];
+          const defaultValue = paramLineMatch[2].trim();
+          const fullKey = [...contextStack, localKey].join(':');
+          metadata.diveParams!.push({
+            label,
+            type,
+            type_props: pipelineTypeArgs,
+            key: fullKey,
+            default: defaultValue,
+          });
+        }
+      }
+
+      // --- Description extraction (Multiline) ---
+      if (/^#\s*Description:\s*/i.test(line)) {
+        inDescription = true;
+        fullDescription = line.replace(/^#\s*Description:\s*/i, '').trim();
+        return;
+      }
+
+      if (inDescription) {
+        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output):/i.test(line) || !line.startsWith('#')) {
+          inDescription = false;
+        } else {
+          fullDescription += ` ${line.replace(/^#\s*/, '').trim()}`;
+          return;
+        }
+      }
+
+      // --- Input / Output extraction ---
+      if (/^#\s*Input:\s*/i.test(line)) {
+        metadata.inputType = line.split(':')[1]?.trim();
+      }
+      if (/^#\s*Output:\s*/i.test(line)) {
+        metadata.outputType = line.split(':')[1]?.trim();
+      }
+    });
+    metadata.description = fullDescription.trim() || undefined;
+  } catch (error) {
+    console.error(`Error while reading ${filePath} metadata`, error);
+  }
+
+  return metadata;
 }
 
 /**
@@ -356,7 +444,8 @@ async function getPipelineList(settings: Settings): Promise<Pipelines> {
 
   /* TODO: fetch trained pipelines */
   const ret: Pipelines = {};
-  pipes.forEach((p) => {
+
+  await Promise.all(pipes.map(async (p) => {
     const parts = cleanString(p.replace('.pipe', '')).split('_');
     let pipeType = parts[0];
     let pipeName = parts.slice(1).join(' ');
@@ -365,10 +454,16 @@ async function getPipelineList(settings: Settings): Promise<Pipelines> {
       pipeType = `${parts[parts.length - 2]}-cam`;
       pipeName = parts.join(' ');
     }
-    const pipeInfo = {
+
+    // Extract description and requirements from the pipe file
+    const pipeFilePath = npath.join(pipelinePath, p);
+    const metadata = await extractPipeMetadata(pipeFilePath);
+
+    const pipeInfo: Pipe = {
       name: pipeName,
       type: pipeType,
       pipe: p,
+      metadata,
     };
     if (pipeType in ret) {
       ret[pipeType].pipes.push(pipeInfo);
@@ -378,7 +473,7 @@ async function getPipelineList(settings: Settings): Promise<Pipelines> {
         description: '',
       };
     }
-  });
+  }));
 
   // Now lets add to it the trained pipelines by recursively looking in the dir
   const allowedTrainedPatterns = new RegExp([
@@ -460,10 +555,17 @@ async function getTrainingConfigs(settings: Settings): Promise<TrainingConfigs> 
   if (!exists) {
     throw new Error(`Path does not exist: ${pipelinePath}`);
   }
-  let configs = await fs.readdir(pipelinePath);
-  configs = configs
+  let configNames = await fs.readdir(pipelinePath);
+  configNames = configNames
     .filter((p) => (p.match(allowedPatterns) && !p.match(disallowedPatterns)))
     .sort((a, b) => (a === defaultTrainingConfiguration ? -1 : a.localeCompare(b)));
+
+  const configs: TrainingConfig[] = await Promise.all(configNames.map(async (name) => {
+    const configFilePath = npath.join(pipelinePath, name);
+    const { description } = (await extractPipeMetadata(configFilePath));
+    return { name, description };
+  }));
+
   // Get Model files in the pipeline directory
   const modelList = getFilesWithExtensions(pipelinePath, allowedModelExtensions);
   const models: TrainingConfigs['models'] = {};
@@ -476,7 +578,7 @@ async function getTrainingConfigs(settings: Settings): Promise<TrainingConfigs> 
   });
   return {
     training: {
-      default: configs[0],
+      default: configNames[0],
       configs,
     },
     models,

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -455,7 +455,7 @@ async function getPipelineList(settings: Settings): Promise<Pipelines> {
       pipeName = parts.join(' ');
     }
 
-    // Extract description and requirements from the pipe file
+    // Extract description and metadata from the pipe file
     const pipeFilePath = npath.join(pipelinePath, p);
     const metadata = await extractPipeMetadata(pipeFilePath);
 

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -255,8 +255,12 @@ async function runPipeline(
 
   // Add any custom pipeline parameters
   if (runPipelineArgs.pipelineParams) {
+    const escapeValue = (val: string) => {
+      // We replace " by \" and $ by \$ to avoid interpolation
+      return val.replace(/["$]/g, '\\$&');
+    };
     Object.entries(runPipelineArgs.pipelineParams).forEach(([key, value]) => {
-      command.push(`-s ${key}="${value}"`);
+      command.push(`-s ${key}="${escapeValue(value)}"`);
     });
   }
 

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -253,6 +253,13 @@ async function runPipeline(
     throw new Error('Attempting to run a multicam pipeline on non multicam data');
   }
 
+  // Add any custom pipeline parameters
+  if (runPipelineArgs.pipelineParams) {
+    Object.entries(runPipelineArgs.pipelineParams).forEach(([key, value]) => {
+      command.push(`-s ${key}="${value}"`);
+    });
+  }
+
   const job = observeChild(spawn(command.join(' '), {
     shell: viameConstants.shell,
     cwd: jobWorkDir,
@@ -392,7 +399,7 @@ async function exportTrainedPipeline(
 
   const files = fs.readdirSync(modelPipelineDir);
 
-  const foundExtension = extensions.find((ext) => 
+  const foundExtension = extensions.find((ext) =>
     files.some((file) => file.toLowerCase().endsWith(ext))
   );
 

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -255,10 +255,7 @@ async function runPipeline(
 
   // Add any custom pipeline parameters
   if (runPipelineArgs.pipelineParams) {
-    const escapeValue = (val: string) => {
-      // We replace " by \" and $ by \$ to avoid interpolation
-      return val.replace(/["$]/g, '\\$&');
-    };
+    const escapeValue = (val: string) => val.replace(/["$]/g, '\\$&');
     Object.entries(runPipelineArgs.pipelineParams).forEach(([key, value]) => {
       command.push(`-s ${key}="${escapeValue(value)}"`);
     });

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -172,6 +172,8 @@ export interface RunPipeline extends JobArgs {
   type: JobType.RunPipeline;
   datasetId: string;
   pipeline: Pipe;
+  /** Optional parameters to pass to the pipeline via -s flags */
+  pipelineParams?: Record<string, string>;
   outputDatasetName?: string;
 }
 

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -96,7 +96,7 @@ async function runPipeline(itemId: string, pipeline: Pipe, additionalConfig?: Re
     type: JobType.RunPipeline,
     pipeline,
     datasetId: itemId,
-    ...additionalConfig,
+    pipelineParams: additionalConfig,
   };
   gpuJobQueue.enqueue(args);
 }

--- a/client/platform/web-girder/api/rpc.service.ts
+++ b/client/platform/web-girder/api/rpc.service.ts
@@ -10,11 +10,12 @@ function postProcess(folderId: string, skipJobs = false, skipTranscoding = false
   });
 }
 
-function runPipeline(itemId: string, pipeline: Pipe) {
+function runPipeline(itemId: string, pipeline: Pipe, additionalConfig?: Record<string, string>) {
   return girderRest.post('dive_rpc/pipeline', null, {
     params: {
       folderId: itemId,
       pipeline,
+      pipelineParams: additionalConfig,
     },
   });
 }

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -20,7 +20,6 @@ from dive_tasks import tasks
 from dive_utils import TRUTHY_META_VALUES, asbool, constants, fromMeta, models, types
 from dive_utils.constants import TrainingModelExtensions
 from dive_utils.serializers import dive, kpf, kwcoco, viame
-from dive_utils.types import PipelineDescription
 
 from . import crud_dataset
 

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -191,12 +191,15 @@ def run_pipeline(
     folder: types.GirderModel,
     pipeline: types.PipelineDescription,
     force_transcoded=False,
+    pipeline_params: dict[str, str] = None,
 ) -> types.GirderModel:
     """
     Run a pipeline on a dataset.
 
     :param folder: The girder folder containing the dataset to run on.
     :param pipeline: The pipeline to run the dataset on.
+    :param force_transcoded: Force transcoding input.
+    :param pipeline_params: Dict of key values containing user specified settings.
     """
     verify_pipe(user, pipeline)
     crud.getCloneRoot(user, folder)
@@ -234,6 +237,7 @@ def run_pipeline(
         'user_id': str(user.get('_id', 'unknown')),
         'user_login': user.get('login', 'unknown'),
         'force_transcoded': force_transcoded,
+        'pipeline_params': pipeline_params,
     }
     newjob = tasks.run_pipeline.apply_async(
         queue=_get_queue_name(user, "pipelines"),

--- a/server/dive_server/views_rpc.py
+++ b/server/dive_server/views_rpc.py
@@ -52,7 +52,7 @@ class RpcResource(Resource):
         .jsonParam("pipeline", "The pipeline to run on the dataset", required=True)
         .jsonParam(
             "pipelineParams",
-            "Optional KWIVER -s parameter overrides from pipeline requirements",
+            "Optional KWIVER -s parameter overrides from pipeline specified parameters",
             required=False,
             default=None,
         )

--- a/server/dive_server/views_rpc.py
+++ b/server/dive_server/views_rpc.py
@@ -50,9 +50,15 @@ class RpcResource(Resource):
             required=False,
         )
         .jsonParam("pipeline", "The pipeline to run on the dataset", required=True)
+        .jsonParam(
+            "pipelineParams",
+            "Optional KWIVER -s parameter overrides from pipeline requirements",
+            required=False,
+            default=None,
+        )
     )
-    def run_pipeline_task(self, folder, forceTranscoded, pipeline: PipelineDescription):
-        return crud_rpc.run_pipeline(self.getCurrentUser(), folder, pipeline, forceTranscoded)
+    def run_pipeline_task(self, folder, forceTranscoded, pipeline: PipelineDescription, pipelineParams: dict[str, str]):
+        return crud_rpc.run_pipeline(self.getCurrentUser(), folder, pipeline, forceTranscoded, pipelineParams)
     
     @access.user
     @autoDescribeRoute(

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -8,6 +8,7 @@ from dive_utils.types import (
     AvailableJobSchema,
     PipelineCategory,
     PipelineDescription,
+    PipeMetadata,
     TrainingConfigurationSummary,
     TrainingModelDescription,
 )

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -34,22 +34,125 @@ DisallowedStaticPipelines = (
 )
 
 
+def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
+    metadata: PipeMetadata = {
+        "diveParams": []
+    }
+
+    context_stack: List[str] = []
+    in_description = False
+    full_description_parts: List[str] = []
+
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line_raw = line.rstrip('\n\r')
+                trimmed = line_raw.strip()
+                if not trimmed:
+                    continue
+
+                process_match = re.match(r'^process\s+([\w-]+)', trimmed, re.IGNORECASE)
+                if process_match:
+                    context_stack = [process_match.group(1)]
+                    continue
+
+                block_match = re.match(r'^block\s+([\w:-]+)', trimmed, re.IGNORECASE)
+                if block_match:
+                    context_stack.append(block_match.group(1))
+                    continue
+
+                if trimmed.lower() == 'endblock':
+                    if context_stack:
+                        context_stack.pop()
+                    continue
+
+                dive_match = re.search(r'#\s*DIVE_PARAM\s*\[\s*"([^"]+)"\s*,\s*(.+)\s*\]', line_raw, re.IGNORECASE)
+                if dive_match:
+                    label, raw_args = dive_match.groups()
+                    args = [arg.strip() for arg in raw_args.split(',')]
+                    param_type = args[0]
+                    pipeline_type_args = args[1:]
+
+                    param_line_match = re.match(r'^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)', trimmed,
+                                                re.IGNORECASE)
+                    if param_line_match:
+                        local_key = param_line_match.group(1)
+                        default_val = param_line_match.group(2).strip()
+                        full_key = ":".join(context_stack + [local_key])
+
+                        metadata["diveParams"].append({
+                            "label": label,
+                            "type": param_type,
+                            "type_props": pipeline_type_args,
+                            "key": full_key,
+                            "default": default_val
+                        })
+
+                # --- Description extraction (Multiline) ---
+                desc_start_match = re.match(r'^#\s*Description:\s*(.*)', line_raw, re.IGNORECASE)
+                if desc_start_match:
+                    in_description = True
+                    content = desc_start_match.group(1).strip()
+                    if content:
+                        full_description_parts.append(content)
+                    continue
+
+                if in_description:
+                    is_stop_condition = (
+                            re.match(r'^#\s*$', line_raw) or
+                            re.match(r'^#\s*=', line_raw) or
+                            re.match(r'^#\s*(Input|Output):', line_raw, re.IGNORECASE) or
+                            not line_raw.startswith('#')
+                    )
+
+                    if is_stop_condition:
+                        in_description = False
+                    else:
+                        continued_text = re.sub(r'^#\s*', '', line_raw).strip()
+                        if continued_text:
+                            full_description_parts.append(continued_text)
+
+                # --- Input / Output extraction ---
+                input_match = re.match(r'^#\s*Input:\s*(.*)', line_raw, re.IGNORECASE)
+                if input_match:
+                    metadata["inputType"] = input_match.group(1).strip()
+
+                output_match = re.match(r'^#\s*Output:\s*(.*)', line_raw, re.IGNORECASE)
+                if output_match:
+                    metadata["outputType"] = output_match.group(1).strip()
+
+        if full_description_parts:
+            metadata["description"] = " ".join(full_description_parts)
+        else:
+            metadata["description"] = None
+
+    except Exception as e:
+        print(f"Error while reading {file_path} metadata: {e}")
+
+    return metadata
+
+
 def load_static_pipelines(search_path: Path) -> Dict[str, PipelineCategory]:
     pipedict: Dict[str, PipelineCategory] = {}
 
     pipelist = [
-        path.name
+        path
         for path in search_path.glob("./*.pipe")
         if re.match(AllowedStaticPipelines, path.name)
         and not re.match(DisallowedStaticPipelines, path.name)
     ]
 
-    for pipe in pipelist:
+    for pipe_path in pipelist:
+        pipe = pipe_path.name
         pipe_type, *nameparts = pipe.replace(".pipe", "").split("_")
+
+        metadata = extract_pipe_metadata(pipe_path)
+
         pipe_info: PipelineDescription = {
             "name": " ".join(nameparts),
             "type": pipe_type,
             "pipe": pipe,
+            "metadata": metadata,
             "folderId": None,
         }
         print(f"Discovered pipe {pipe_info}")

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -263,7 +263,7 @@ def run_pipeline(self: Task, params: PipelineJob):
             command.append(f'-s detection_reader:file_name={quoted_input_file}')
             command.append(f'-s track_reader:file_name={quoted_input_file}')
 
-        # Apply user-provided pipeline parameter overrides from requirements
+        # Apply user-provided pipeline parameter overrides from pipeline params
         pipeline_params = params.get('pipeline_params')
         if pipeline_params:
             for key, value in pipeline_params.items():

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -263,6 +263,12 @@ def run_pipeline(self: Task, params: PipelineJob):
             command.append(f'-s detection_reader:file_name={quoted_input_file}')
             command.append(f'-s track_reader:file_name={quoted_input_file}')
 
+        # Apply user-provided pipeline parameter overrides from requirements
+        pipeline_params = params.get('pipeline_params')
+        if pipeline_params:
+            for key, value in pipeline_params.items():
+                command.append(f'-s {shlex.quote(key)}={shlex.quote(str(value))}')
+
         manager.updateStatus(JobStatus.RUNNING)
         popen_kwargs = {
             'args': " ".join(command),

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -4,10 +4,12 @@ from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 __all__ = [
+    "DiveParam",
     "GirderModel",
     "PipelineDescription",
     "PipelineJob",
     "PipelineCategory",
+    "PipeMetadata",
 ]
 
 
@@ -57,12 +59,28 @@ class TrainingModelTuneArgs(TrainingModelDescription):
         extra = 'forbid'
 
 
+class DiveParam(TypedDict):
+    label: str
+    type: str
+    type_props: list[str]
+    key: str
+    default: str
+
+
+class PipeMetadata(TypedDict):
+    description: Optional[str]
+    inputType: Optional[str]
+    outputType: Optional[str]
+    diveParams: Optional[list[DiveParam]]
+
+
 class PipelineDescription(TypedDict):
     """Describes a pipeline for running on datasets."""
 
     name: str  # friendly name
     type: str  # indicates whether this is a dynamic pipe.
     pipe: str  # unmodified pipe file name
+    metadata: Optional[PipeMetadata]  # some metadata about the pipeline
 
     # If the pipeline is stored in girder, this is
     # the ID of the folder containing the pipeline,
@@ -80,6 +98,7 @@ class PipelineJob(TypedDict):
     user_id: str  # user id who started the job
     user_login: str  # login of user who started the kjob
     force_transcoded: Optional[bool]  # Force using the transcoded version
+    pipeline_params: Optional[dict[str, str]]
 
 
 class TrainingJob(TypedDict):


### PR DESCRIPTION
This PR add the following improvements to the run pipeline menu:
- Add description when cursor hover a pipeline (based on @mattdawkins  work: [viame/master](https://github.com/Kitware/dive/tree/viame/master))
- Add pipeline input/output types when cursor hover a pipeline
- Add a popup to override default pipeline parameters.

<img width="1912" height="1073" alt="image" src="https://github.com/user-attachments/assets/03145085-7f33-4438-9d28-908cc9110269" />


<img width="1913" height="1074" alt="image" src="https://github.com/user-attachments/assets/4e8b71d5-5fc8-4e65-a2dc-7699ba4470e6" />

(The goal would be to limit the number of customizable settings, to not overload the UI).

Here are all possible values for parameters types:
- int
- positive_int
- strictly_positive_int
- range_int
- float
- positive_float
- strictly_positive_float
- range_float
- path
- file
- folder
- string

Except for `path`, `file` and `folder` types, which are only icons, there is form validation to ensure user inputs are valid.

Currently, customizable parameters are specified in .pipe files using the `# DIVE_PARAMS["label", type, arg1, arg2, ...]` comment suffix. There are current discussions on whether we should use dedicated files for this or not. However, changing how we read these metadata should not impact a lot of code of this PR.

**Note 1**: Some work of this PR was already done by @mattdawkins on the [viame/master](https://github.com/Kitware/dive/tree/viame/master) branch:

- Description overlay
- Support for passing pipeline params to VIAME using "-s" arguments

**Note 2**: On the main branch of VIAME, this PR will have no effects.
To test the PR, you will have to compile VIAME web docker on the `dive-params` branch.