### PR TITLE
CPU DIVE

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -5,6 +5,9 @@
 # Docker Compose Stack configuration
 #
 COMPOSE_PROJECT_NAME=dive
+# Default to the full GPU-enabled worker stack.
+# Set COMPOSE_PROFILES=cpu for CPU-only worker mode.
+COMPOSE_PROFILES=gpu
 
 # MongoDB Configuration
 #

--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ DIVE uses [Girder](https://girder.readthedocs.io/en/stable/) for data management
 
 DIVE supports two Docker Compose modes:
 
-* **Default mode (no profile):** starts the web stack and the standard worker (`girder_worker_default`) for non-GPU/background tasks.
-* **GPU mode (`--profile gpu`):** also starts GPU workers (`girder_worker_pipelines`, `girder_worker_training`) for VIAME pipelines and training.
+* **Default mode (GPU-enabled):** starts the web stack, the standard worker, and GPU workers (`girder_worker_pipelines`, `girder_worker_training`) for VIAME pipelines and training.
+* **CPU-only mode (`--profile cpu`):** starts only the standard worker (`girder_worker_default`) and omits GPU workers.
 
 ### Commands
 
 ```bash
-# Default mode (no GPU workers)
+# Default mode (GPU-enabled workers)
 docker compose up -d
 
-# GPU mode (includes pipeline/training workers)
-docker compose --profile gpu up -d
+# CPU-only mode
+docker compose --profile cpu up -d
 ```
 
-When GPU workers are not running, the web UI and API automatically disable pipeline and training actions.
+When GPU workers are not running (for example, in CPU-only mode), the web UI and API automatically disable pipeline and training actions.
 
 ## Example Data
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ DIVE uses [Girder](https://girder.readthedocs.io/en/stable/) for data management
 * The client application is a standard [@vue/cli](https://cli.vuejs.org/) application.
 * The job runner is built on celery and [Girder Worker](https://girder-worker.readthedocs.io/en/latest/).  Command-line executables for VIAME and FFmpeg are built inside the worker docker image.
 
+## Docker Compose profiles
+
+DIVE supports two Docker Compose modes:
+
+* **Default mode (no profile):** starts the web stack and the standard worker (`girder_worker_default`) for non-GPU/background tasks.
+* **GPU mode (`--profile gpu`):** also starts GPU workers (`girder_worker_pipelines`, `girder_worker_training`) for VIAME pipelines and training.
+
+### Commands
+
+```bash
+# Default mode (no GPU workers)
+docker compose up -d
+
+# GPU mode (includes pipeline/training workers)
+docker compose --profile gpu up -d
+```
+
+When GPU workers are not running, the web UI and API automatically disable pipeline and training actions.
+
 ## Example Data
 
 ### Input

--- a/client/platform/web-girder/api/configuration.service.ts
+++ b/client/platform/web-girder/api/configuration.service.ts
@@ -46,6 +46,16 @@ export type GroupBy = 'user' | 'month' | undefined;
 
 export type AddOns = [string, string, string, boolean][];
 
+export interface DiveConfiguration {
+  distributedWorker?: string;
+  pipelinesEnabled?: boolean;
+  trainingEnabled?: boolean;
+}
+
+function getConfig() {
+  return girderRest.get<DiveConfiguration>('dive_configuration');
+}
+
 function getBrandData() {
   return girderRest.get<BrandData>('dive_configuration/brand_data');
 }
@@ -87,6 +97,7 @@ function getStats(dateRange?: DateRange, overrideDateTime?: string, groupBy?: Gr
 
 export {
   getBrandData,
+  getConfig,
   putBrandData,
   getPipelineList,
   getTrainingConfigurations,

--- a/client/platform/web-girder/main.ts
+++ b/client/platform/web-girder/main.ts
@@ -36,6 +36,7 @@ if (
 
 Promise.all([
   store.dispatch('Brand/loadBrand'),
+  store.dispatch('Config/load'),
   girderRest.fetchUser(),
 ]).then(() => {
   const vuetify = getVuetify(store.state.Brand.brandData?.vuetify);

--- a/client/platform/web-girder/store/Config.ts
+++ b/client/platform/web-girder/store/Config.ts
@@ -1,0 +1,38 @@
+import { Module } from 'vuex';
+
+import { getConfig } from 'platform/web-girder/api/configuration.service';
+import { RootState } from './types';
+
+export interface ConfigState {
+  distributedWorkerEnabled: boolean;
+  pipelinesEnabled: boolean;
+  trainingEnabled: boolean;
+}
+
+const configModule: Module<ConfigState, RootState> = {
+  namespaced: true,
+  state: {
+    distributedWorkerEnabled: false,
+    pipelinesEnabled: false,
+    trainingEnabled: false,
+  },
+  mutations: {
+    setCapabilities(state, payload: Partial<ConfigState>) {
+      state.distributedWorkerEnabled = payload.distributedWorkerEnabled ?? false;
+      state.pipelinesEnabled = payload.pipelinesEnabled ?? false;
+      state.trainingEnabled = payload.trainingEnabled ?? false;
+    },
+  },
+  actions: {
+    async load({ commit }) {
+      const { data } = await getConfig();
+      commit('setCapabilities', {
+        distributedWorkerEnabled: !!data.distributedWorker,
+        pipelinesEnabled: !!data.pipelinesEnabled,
+        trainingEnabled: !!data.trainingEnabled,
+      });
+    },
+  },
+};
+
+export default configModule;

--- a/client/platform/web-girder/store/index.ts
+++ b/client/platform/web-girder/store/index.ts
@@ -8,6 +8,7 @@ import Dataset from './Dataset';
 import Brand from './Brand';
 import User from './User';
 import Jobs, { init as JobsInit } from './Jobs';
+import Config from './Config';
 
 Vue.use(Vuex);
 
@@ -18,6 +19,7 @@ const store = new Vuex.Store<RootState>({
     Dataset,
     Jobs,
     User,
+    Config,
   },
 });
 

--- a/client/platform/web-girder/store/types.ts
+++ b/client/platform/web-girder/store/types.ts
@@ -47,6 +47,11 @@ export interface RootState {
   Dataset: DatasetState;
   Brand: BrandState;
   User: UserState;
+  Config: {
+    distributedWorkerEnabled: boolean;
+    pipelinesEnabled: boolean;
+    trainingEnabled: boolean;
+  };
 }
 
 export function useStore(): Store<RootState> {

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -74,6 +74,7 @@ export default defineComponent({
   },
   computed: {
     ...mapState('Location', ['selected', 'location']),
+    ...mapState('Config', ['pipelinesEnabled', 'trainingEnabled']),
     ...mapGetters('Location', ['locationIsViameFolder']),
     selectedViameFolderIds() {
       return this.selected.filter(
@@ -173,6 +174,7 @@ export default defineComponent({
                   :dataset-id="locationInputs.length === 1 ? locationInputs[0] : null"
                 />
                 <run-training-menu
+                  v-if="trainingEnabled"
                   v-bind="{
                     buttonOptions:
                       { ...buttonOptions, disabled: includesLargeImage },
@@ -181,6 +183,7 @@ export default defineComponent({
                   :selected-dataset-ids="locationInputs"
                 />
                 <run-pipeline-menu
+                  v-if="pipelinesEnabled"
                   v-bind="{
                     buttonOptions:
                       { ...buttonOptions, disabled: includesLargeImage },

--- a/client/platform/web-girder/views/Jobs.vue
+++ b/client/platform/web-girder/views/Jobs.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  defineComponent, ref, toRef, watch,
+  computed, defineComponent, ref, toRef, watch,
 } from 'vue';
 import { GirderJobList } from '@girder/components/src';
 import { setUsePrivateQueue } from 'platform/web-girder/api';
@@ -16,7 +16,9 @@ export default defineComponent({
     const restClient = useGirderRest();
     const store = useStore();
     const outstandingJobs = ref(0);
-    const distributedWorkerEnabled = ref(false);
+    const distributedWorkerEnabled = computed(
+      () => store.state.Config.distributedWorkerEnabled,
+    );
 
     watch(toRef(store.getters, 'Jobs/runningJobIds'), () => {
       restClient.get('job/queued').then(({ data }) => {
@@ -30,10 +32,6 @@ export default defineComponent({
       privateQueueEnabled.value = resp.data.user_private_queue_enabled;
       loading.value = false;
     }
-
-    restClient.get('dive_configuration').then((data) => {
-      distributedWorkerEnabled.value = !!(data.data.distributedWorker);
-    });
 
     restClient.fetchUser()
       .then((user) => {

--- a/client/platform/web-girder/views/NavigationBar.vue
+++ b/client/platform/web-girder/views/NavigationBar.vue
@@ -22,6 +22,7 @@ export default {
   computed: {
     ...mapGetters('Location', ['locationRoute']),
     ...mapState('Brand', ['brandData']),
+    ...mapState('Config', ['pipelinesEnabled', 'trainingEnabled']),
     isAdmin() {
       if (this.girderRest) {
         return this.girderRest?.user?.admin || false;
@@ -65,6 +66,7 @@ export default {
         </v-tab>
         <JobsTab />
         <v-tab
+          v-if="pipelinesEnabled || trainingEnabled"
           to="/trained-models"
         >
           Models <v-icon>mdi-brain</v-icon>

--- a/client/platform/web-girder/views/TrainedModels.vue
+++ b/client/platform/web-girder/views/TrainedModels.vue
@@ -6,6 +6,7 @@ import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { Pipelines, useApi, Pipe } from 'dive-common/apispec';
 import { DataTableHeader } from 'vuetify';
 import { useRouter } from 'vue-router/composables';
+import { useStore } from 'platform/web-girder/store/types';
 
 export default defineComponent({
   name: 'TrainedModels',
@@ -15,11 +16,16 @@ export default defineComponent({
     } = useApi();
     const { prompt } = usePrompt();
     const router = useRouter();
+    const store = useStore();
 
     const unsortedPipelines = ref({} as Pipelines);
     const search = ref('');
 
     onBeforeMount(async () => {
+      if (!store.state.Config.pipelinesEnabled && !store.state.Config.trainingEnabled) {
+        router.push('/');
+        return;
+      }
       unsortedPipelines.value = await getPipelineList();
     });
 

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -97,6 +97,7 @@ export default defineComponent({
     const viewerRef = ref();
     const store = useStore();
     const brandData = toRef(store.state.Brand, 'brandData');
+    const pipelinesEnabled = toRef(store.state.Config, 'pipelinesEnabled');
     const revisionNum = computed(() => {
       const parsed = Number.parseInt(props.revision, 10);
       if (Number.isNaN(parsed)) return undefined;
@@ -226,6 +227,7 @@ export default defineComponent({
       routeSet,
       largeImageWarning,
       typeList,
+      pipelinesEnabled,
     };
   },
 });
@@ -261,6 +263,7 @@ export default defineComponent({
     </template>
     <template #title-right>
       <RunPipelineMenu
+        v-if="pipelinesEnabled"
         v-bind="{ buttonOptions, menuOptions, typeList }"
         :selected-dataset-ids="[id]"
         :running-pipelines="runningPipelines"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,9 @@ services:
   girder_worker_default:
     # Merge base-worker object with this config
     << : *base-worker
+    profiles:
+      - gpu
+      - cpu
     deploy: {}
     volumes:
       # readwrite because this worker does addon updates

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-worker: &base-worker
   build:
     context: .
     dockerfile: docker/girder_worker.Dockerfile
-  image: kitware/viame-worker:${TAG:-latest}
+  image: kitware/dive-worker:${TAG:-latest}
   volumes:
     - addons:/tmp/addons:ro # readonly
   labels:
@@ -111,6 +111,12 @@ services:
   girder_worker_pipelines:
     # Merge base-worker object with this config
     << : *base-worker
+    profiles:
+      - gpu
+    build:
+      context: .
+      dockerfile: docker/girder_worker_gpu.Dockerfile
+    image: kitware/viame-worker:${TAG:-latest}
     restart: always
     deploy:
       resources:
@@ -137,6 +143,12 @@ services:
   girder_worker_training:
     # Merge base-worker object with this config
     << : *base-worker
+    profiles:
+      - gpu
+    build:
+      context: .
+      dockerfile: docker/girder_worker_gpu.Dockerfile
+    image: kitware/viame-worker:${TAG:-latest}
     restart: always
     deploy:
       resources:

--- a/docker/girder_worker.Dockerfile
+++ b/docker/girder_worker.Dockerfile
@@ -1,23 +1,12 @@
-# ========================
-# == SERVER BUILD STAGE ==
-# ========================
-# ====================
-# == FFMPEG FETCHER ==
-# ====================
-FROM python:3.8-bookworm AS ffmpeg-builder
-RUN wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
-RUN mkdir /tmp/ffextracted
-RUN tar -xvf ffmpeg.tar.xz -C /tmp/ffextracted --strip-components 1
-
-# =====================
-# == STANDARD WORKER ==
-# =====================
 FROM python:3.11-bookworm AS worker
 
-# install tini init system
-ENV TINI_VERSION=v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
+# install architecture-compatible tini and ffmpeg
+RUN apt-get update && \
+  apt-get install -qy tini ffmpeg && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# use distro-provided tini binary for current architecture
+RUN ln -sf /usr/bin/tini /tini
 
 
 
@@ -55,7 +44,9 @@ RUN uv sync --frozen --no-dev
 
 # Copy the built python installation
 # Copy ffmpeg
-COPY --from=ffmpeg-builder /tmp/ffextracted/ffmpeg /tmp/ffextracted/ffprobe /opt/dive/local/ffmpeg/
+RUN install -d /opt/dive/local/ffmpeg && \
+  ln -sf /usr/bin/ffmpeg /opt/dive/local/ffmpeg/ffmpeg && \
+  ln -sf /usr/bin/ffprobe /opt/dive/local/ffmpeg/ffprobe
 # Copy provision scripts
 COPY --chown=dive:dive docker/entrypoint_worker.sh /
 

--- a/docker/girder_worker_gpu.Dockerfile
+++ b/docker/girder_worker_gpu.Dockerfile
@@ -9,19 +9,28 @@ RUN wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-relea
 RUN mkdir /tmp/ffextracted
 RUN tar -xvf ffmpeg.tar.xz -C /tmp/ffextracted --strip-components 1
 
-# =====================
-# == STANDARD WORKER ==
-# =====================
-FROM python:3.11-bookworm AS worker
+# =================
+# == GPU WORKER ==
+# =================
+FROM kitware/viame:gpu-algorithms-web AS worker
+# VIAME install at /opt/noaa/viame/
+# VIAME pipelines at /opt/noaa/viame/configs/pipelines/
 
 # install tini init system
 ENV TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
+# Install python
+RUN export DEBIAN_FRONTEND=noninteractive && \
+  apt update && \
+  apt-get install software-properties-common -y && \
+  add-apt-repository ppa:deadsnakes/ppa && \
+  apt-get update && \
+  apt-get install -qy python3.11 libpython3.11 python3.11-venv libc6 build-essential cargo build-essential libssl-dev libffi-dev python3-libtiff libvips-dev libgdal-dev python3-dev npm && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 
-
-RUN ln -fs /usr/bin/python3.11 /usr/bin/python
+RUN ln -fs /usr/bin/python3.10 /usr/bin/python
 WORKDIR /opt/dive/src
 
 # Use a globally accessible uv binary (works before/after USER switch)
@@ -35,12 +44,9 @@ ENV PATH="/opt/dive/local/venv/bin:/usr/local/bin:$PATH"
 COPY server/pyproject.toml server/uv.lock /opt/dive/src/
 # Install dependencies only
 RUN uv sync --frozen --no-install-project --no-dev
-# Build girder client, including plugins like worker/jobs
-# RUN girder build
 
 # Copy full source code and install
 COPY server/ /opt/dive/src/
-    
 
 # Create user "dive" 1099:1099 to align with base image permissions.
 # https://github.com/VIAME/VIAME/blob/master/cmake/build_server_docker.sh#L123

--- a/docs/Deployment-Docker-Compose.md
+++ b/docs/Deployment-Docker-Compose.md
@@ -59,6 +59,25 @@ docker-compose -f docker-compose.yml up -d
 
 VIAME server will be running at [http://localhost:8010](http://localhost:8010/). You should see a page that looks like this. The default username and password is `admin:letmein`.
 
+### Docker Compose profile behavior
+
+There are two ways to run the stack:
+
+* **Default (no profile):** runs the web services and the standard worker only.
+* **GPU profile (`--profile gpu`):** additionally runs `girder_worker_pipelines` and `girder_worker_training`.
+
+Use these commands:
+
+```bash
+# Default mode (no GPU pipeline/training workers)
+docker-compose -f docker-compose.yml up -d
+
+# GPU mode (enable pipeline/training workers)
+docker-compose -f docker-compose.yml --profile gpu up -d
+```
+
+When the GPU profile is not enabled (or GPU workers are otherwise not connected), the UI and API automatically disable pipeline and training features.
+
 ![Login Page](images/General/login.png)
 
 ## Production deployment
@@ -94,10 +113,10 @@ It's possible to split your web server and task runner between multiple nodes.  
 docker-compose -f docker-compose.yml up -d girder rabbit
 
 ## On the GPU server(s)
-docker-compose -f docker-compose.yml up -d --no-deps girder_worker_pipelines girder_worker_training girder_worker_default
+docker-compose -f docker-compose.yml --profile gpu up -d --no-deps girder_worker_default girder_worker_pipelines girder_worker_training
 ```
 
-In order to run any jobs (video transcoding, pipelines, training, addon upgrades) the GPU server will need to be running.
+In this split setup, `girder_worker_default` handles standard queue jobs while the GPU workers handle pipeline/training queues. If GPU workers are offline, only non-GPU worker functionality remains available and pipeline/training actions are disabled.
 
 ## Addon management
 

--- a/docs/Deployment-Docker-Compose.md
+++ b/docs/Deployment-Docker-Compose.md
@@ -63,20 +63,20 @@ VIAME server will be running at [http://localhost:8010](http://localhost:8010/).
 
 There are two ways to run the stack:
 
-* **Default (no profile):** runs the web services and the standard worker only.
-* **GPU profile (`--profile gpu`):** additionally runs `girder_worker_pipelines` and `girder_worker_training`.
+* **Default (GPU-enabled):** runs the web services, the standard worker, and GPU workers.
+* **CPU profile (`--profile cpu`):** runs only the standard worker (`girder_worker_default`).
 
 Use these commands:
 
 ```bash
-# Default mode (no GPU pipeline/training workers)
+# Default mode (GPU-enabled pipeline/training workers)
 docker-compose -f docker-compose.yml up -d
 
-# GPU mode (enable pipeline/training workers)
-docker-compose -f docker-compose.yml --profile gpu up -d
+# CPU-only mode
+docker-compose -f docker-compose.yml --profile cpu up -d
 ```
 
-When the GPU profile is not enabled (or GPU workers are otherwise not connected), the UI and API automatically disable pipeline and training features.
+When GPU workers are not connected (for example, in CPU-only mode), the UI and API automatically disable pipeline and training features.
 
 ![Login Page](images/General/login.png)
 
@@ -113,7 +113,7 @@ It's possible to split your web server and task runner between multiple nodes.  
 docker-compose -f docker-compose.yml up -d girder rabbit
 
 ## On the GPU server(s)
-docker-compose -f docker-compose.yml --profile gpu up -d --no-deps girder_worker_default girder_worker_pipelines girder_worker_training
+docker-compose -f docker-compose.yml up -d --no-deps girder_worker_default girder_worker_pipelines girder_worker_training
 ```
 
 In this split setup, `girder_worker_default` handles standard queue jobs while the GPU workers handle pipeline/training queues. If GPU workers are offline, only non-GPU worker functionality remains available and pipeline/training actions are disabled.

--- a/docs/Deployment-Overview.md
+++ b/docs/Deployment-Overview.md
@@ -35,7 +35,7 @@ The easiest option to get started using VIAME is to [try our public server](Web-
 
 You may wish to run your own deployment of VIAME Web in your lab or a cloud environment.  Deploying VIAME Web is relatively straightforward with `docker-compose`.
 
-By default, Docker Compose starts DIVE without GPU pipeline/training workers. Use `--profile gpu` when launching Compose to enable pipeline/training worker containers.
+By default, Docker Compose starts DIVE with GPU pipeline/training workers enabled. Use `--profile cpu` when launching Compose to run CPU-only workers.
 
 | Environment | Instructions |
 |-------------|--------------|

--- a/docs/Deployment-Overview.md
+++ b/docs/Deployment-Overview.md
@@ -35,6 +35,8 @@ The easiest option to get started using VIAME is to [try our public server](Web-
 
 You may wish to run your own deployment of VIAME Web in your lab or a cloud environment.  Deploying VIAME Web is relatively straightforward with `docker-compose`.
 
+By default, Docker Compose starts DIVE without GPU pipeline/training workers. Use `--profile gpu` when launching Compose to enable pipeline/training worker containers.
+
 | Environment | Instructions |
 |-------------|--------------|
 **Local server** | If you already have SSH access to an existing server and `sudo` permissions, [proceed to the docker compose guide](Deployment-Docker-Compose.md).

--- a/server/README.md
+++ b/server/README.md
@@ -33,11 +33,11 @@ docker-compose build
 # Option 2) Pull pre-build images
 docker-compose pull
 
-# Start the project in default mode (no GPU workers)
+# Start the project in default mode (GPU-enabled workers)
 docker-compose up -d
 
-# Start the project with GPU workers enabled (pipelines + training)
-docker-compose --profile gpu up -d
+# Start the project in CPU-only mode
+docker-compose --profile cpu up -d
 
 # The web server has hot reload, so code changes will
 # immediately trigger a server restart.
@@ -57,8 +57,8 @@ Access the server at <http://localhost:8010>
 
 Docker Compose now separates workers by profile:
 
-* **No profile:** runs `girder_worker_default` only.
-* **`--profile gpu`:** runs `girder_worker_default` plus `girder_worker_pipelines` and `girder_worker_training`.
+* **Default mode:** runs `girder_worker_default` plus `girder_worker_pipelines` and `girder_worker_training`.
+* **`--profile cpu`:** runs `girder_worker_default` only.
 
 If GPU workers are not present, DIVE disables pipeline/training actions in the web interface and rejects related API job launch requests.
 

--- a/server/README.md
+++ b/server/README.md
@@ -33,8 +33,11 @@ docker-compose build
 # Option 2) Pull pre-build images
 docker-compose pull
 
-# Start the project
+# Start the project in default mode (no GPU workers)
 docker-compose up -d
+
+# Start the project with GPU workers enabled (pipelines + training)
+docker-compose --profile gpu up -d
 
 # The web server has hot reload, so code changes will
 # immediately trigger a server restart.
@@ -49,6 +52,15 @@ docker-compose up girder_worker_training
 ```
 
 Access the server at <http://localhost:8010>
+
+### Worker profiles and feature availability
+
+Docker Compose now separates workers by profile:
+
+* **No profile:** runs `girder_worker_default` only.
+* **`--profile gpu`:** runs `girder_worker_default` plus `girder_worker_pipelines` and `girder_worker_training`.
+
+If GPU workers are not present, DIVE disables pipeline/training actions in the web interface and rejects related API job launch requests.
 
 To work on the Vue client, see development instructions in `../client`.
 

--- a/server/dive_server/views_configuration.py
+++ b/server/dive_server/views_configuration.py
@@ -17,7 +17,7 @@ from girder.utility import setting_utilities
 from girder_jobs.models.job import Job
 import requests
 
-from dive_server import crud, crud_rpc
+from dive_server import crud, crud_rpc, worker_capabilities
 from dive_tasks import tasks
 from dive_utils import TRUTHY_META_VALUES, constants, models, types
 
@@ -72,9 +72,12 @@ class ConfigurationResource(Resource):
     @autoDescribeRoute(Description("Get Configuration Information"))
     def get_config(self):
         env = os.environ.copy()
-
         distributed_worker = env.get("RABBITMQ_DISTRIBUTED_WORKER")
-        return {'distributedWorker': distributed_worker}
+        capabilities = worker_capabilities.get_worker_capabilities()
+        return {
+            'distributedWorker': distributed_worker,
+            **capabilities,
+        }
 
     @access.public
     @autoDescribeRoute(Description("Get custom brand data"))
@@ -84,11 +87,16 @@ class ConfigurationResource(Resource):
     @access.user
     @autoDescribeRoute(Description("Get available pipeline configurations"))
     def get_pipelines(self, params):
+        if not worker_capabilities.get_worker_capabilities()['pipelinesEnabled']:
+            return {}
         return crud_rpc.load_pipelines(self.getCurrentUser())
 
     @access.user
     @autoDescribeRoute(Description("Get available training configs"))
     def get_training_configs(self, params):
+        capabilities = worker_capabilities.get_worker_capabilities()
+        if not capabilities['trainingEnabled']:
+            return {"training": {"configs": [], "default": ""}, "models": {}}
         static_job_configs: types.AvailableJobSchema = (
             Setting().get(constants.SETTINGS_CONST_JOBS_CONFIGS) or {}
         )

--- a/server/dive_server/views_rpc.py
+++ b/server/dive_server/views_rpc.py
@@ -12,7 +12,7 @@ from dive_utils import asbool, fromMeta
 from dive_utils.constants import DatasetMarker, FPSMarker, MarkForPostProcess, TypeMarker
 from dive_utils.types import PipelineDescription, TrainingModelTuneArgs
 
-from . import crud, crud_rpc
+from . import crud, crud_rpc, worker_capabilities
 
 
 class RpcResource(Resource):
@@ -58,6 +58,7 @@ class RpcResource(Resource):
         )
     )
     def run_pipeline_task(self, folder, forceTranscoded, pipeline: PipelineDescription, pipelineParams: dict[str, str]):
+        worker_capabilities.require_pipeline_worker()
         return crud_rpc.run_pipeline(self.getCurrentUser(), folder, pipeline, forceTranscoded, pipelineParams)
     
     @access.user
@@ -83,6 +84,7 @@ class RpcResource(Resource):
         )
     )
     def export_pipeline_onnx(self, modelFolderId, exportFolderId):
+        worker_capabilities.require_pipeline_worker()
         return crud_rpc.export_trained_pipeline(self.getCurrentUser(), modelFolderId, exportFolderId)
 
     @access.user
@@ -129,6 +131,7 @@ class RpcResource(Resource):
         )
     )
     def run_training(self, body, pipelineName, config, annotatedFramesOnly, forceTranscoded):
+        worker_capabilities.require_training_worker()
         user = self.getCurrentUser()
         token = Token().createToken(user=user, days=14)
         run_training_args = crud.get_validated_model(crud_rpc.RunTrainingArgs, **body)

--- a/server/dive_server/worker_capabilities.py
+++ b/server/dive_server/worker_capabilities.py
@@ -1,0 +1,76 @@
+import os
+from typing import Any, Dict
+from urllib.parse import quote, urljoin
+
+import requests
+from girder.exceptions import RestException
+
+from dive_utils import asbool
+
+
+def _queue_has_consumers(session: requests.Session, base_url: str, vhost: str, queue: str) -> bool:
+    queue_path = f"api/queues/{quote(vhost, safe='')}/{quote(queue, safe='')}"
+    response = session.get(urljoin(base_url.rstrip('/') + '/', queue_path), timeout=3)
+    response.raise_for_status()
+    queue_data: Dict[str, Any] = response.json()
+    return int(queue_data.get('consumers', 0)) > 0
+
+
+def _capability_override(name: str) -> bool | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    return asbool(value)
+
+
+def get_worker_capabilities() -> Dict[str, bool]:
+    pipeline_override = _capability_override('DIVE_ENABLE_PIPELINES')
+    training_override = _capability_override('DIVE_ENABLE_TRAINING')
+
+    # Optional explicit overrides are useful in deployments without RabbitMQ management API access.
+    if pipeline_override is not None or training_override is not None:
+        return {
+            'pipelinesEnabled': pipeline_override if pipeline_override is not None else False,
+            'trainingEnabled': training_override if training_override is not None else False,
+        }
+
+    base_url = os.environ.get('RABBITMQ_MANAGEMENT_URL', 'http://rabbit:15672/')
+    username = os.environ.get('RABBITMQ_MANAGEMENT_USERNAME', 'guest')
+    password = os.environ.get('RABBITMQ_MANAGEMENT_PASSWORD', 'guest')
+    vhost = os.environ.get('RABBITMQ_MANAGEMENT_VHOST', 'default')
+
+    capabilities = {
+        'pipelinesEnabled': False,
+        'trainingEnabled': False,
+    }
+
+    try:
+        with requests.Session() as session:
+            session.auth = (username, password)
+            capabilities['pipelinesEnabled'] = _queue_has_consumers(
+                session, base_url, vhost, 'pipelines'
+            )
+            capabilities['trainingEnabled'] = _queue_has_consumers(
+                session, base_url, vhost, 'training'
+            )
+    except requests.RequestException:
+        # If queue status cannot be checked, default to disabled for safety.
+        pass
+
+    return capabilities
+
+
+def require_pipeline_worker():
+    if not get_worker_capabilities()['pipelinesEnabled']:
+        raise RestException(
+            'Pipeline execution is unavailable because no pipeline workers are connected.',
+            code=503,
+        )
+
+
+def require_training_worker():
+    if not get_worker_capabilities()['trainingEnabled']:
+        raise RestException(
+            'Training is unavailable because no training workers are connected.',
+            code=503,
+        )


### PR DESCRIPTION
Configuration changes that allow for DIVE to be run without VIAME algorithms by not using `--profile cpu` when running docker compose.

This will prevent the pipeline/training containers from running and will disable endpoints related to running pipelines or training

The front-end will hide all pipeline/training instances from the interface when run in this mode.

There is a newer environment variable `COMPOSE_PROFILES` either gpu (default) or cpu for cpu only