### PR TITLE
Add required flag to DIVE_PARAM

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -46,6 +46,8 @@ interface DiveParam {
   type_props?: string[];
   key: string;
   default: string;
+  /** True if the user must supply a value before the pipeline can run. */
+  required?: boolean;
 }
 
 interface PipeMetadata {

--- a/client/dive-common/components/PipelineParamsDialog.vue
+++ b/client/dive-common/components/PipelineParamsDialog.vue
@@ -55,8 +55,14 @@ export default defineComponent({
       strictlyPositive: (value: string | number) => Number(value) > 0 || 'Please enter a number > 0',
     };
 
-    function getRules(type: PipelineParamType): ValidationRule[] {
-      const res = [];
+    function getRules(type: PipelineParamType, required = false): ValidationRule[] {
+      const res: ValidationRule[] = [];
+      if (required) {
+        res.push((value) => {
+          if (value === undefined || value === null || value === '') return 'Required';
+          return true;
+        });
+      }
       if (type.includes('int')) {
         res.push(rules.integer);
       }
@@ -131,7 +137,7 @@ export default defineComponent({
                 :for="`input-${param.key}`"
                 class="text-caption font-weight-bold text-uppercase text--secondary"
               >
-                {{ param.label }}
+                {{ param.label }}<span v-if="param.required" class="error--text"> *</span>
               </label>
             </div>
 
@@ -157,7 +163,7 @@ export default defineComponent({
                 hide-details="auto"
                 class="mt-1"
                 :min="param.type === 'int' ? 'none' : 0"
-                :rules="getRules(param.type)"
+                :rules="getRules(param.type, param.required)"
               />
             </template>
 
@@ -171,7 +177,7 @@ export default defineComponent({
                 hide-details="auto"
                 class="mt-1"
                 :min="param.type === 'float' ? 'none' : 0"
-                :rules="getRules(param.type)"
+                :rules="getRules(param.type, param.required)"
               />
             </template>
 
@@ -193,7 +199,7 @@ export default defineComponent({
                       :min="param.type_props?.at(0) || 0"
                       :max="param.type_props?.at(1) || 100"
                       :step="param.type_props?.at(2) || 1"
-                      :rules="getRules(param.type)"
+                      :rules="getRules(param.type, param.required)"
                       outlined
                       hide-details
                     />
@@ -211,6 +217,7 @@ export default defineComponent({
               dense
               hide-details="auto"
               class="mt-1"
+              :rules="getRules(param.type, param.required)"
             />
           </div>
         </v-form>

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -479,11 +479,8 @@ export default defineComponent({
                                 :aria-label="`Configure ${pipeline.name}`"
                                 @click.stop="openDiveParamsDialog(pipeline)"
                               >
-                                <v-icon>mdi-application-cog-outline</v-icon>
+                                <v-icon>mdi-cog-outline</v-icon>
                               </v-btn>
-                              <v-icon v-else>
-                                mdi-play-outline
-                              </v-icon>
                             </span>
                           </v-list-item-title>
                         </v-list-item>

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -29,6 +29,7 @@ import { filterPipelinesForDatasets } from 'dive-common/pipelineMenuFilters';
 import {
   pipelineDisabledForMissingCalibration,
 } from 'dive-common/pipelineCalibration';
+import { pipelineHasParams, pipelineRequiresParams } from 'dive-common/pipelineParams';
 import pipelineTypeDisplay from 'dive-common/pipelineTypeDisplay';
 import { useRequest } from 'dive-common/use';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
@@ -244,7 +245,9 @@ export default defineComponent({
       if (isPipelineDisabledForCalibration(pipeline)) {
         return;
       }
-      if (pipeline.metadata?.diveParams && pipeline.metadata?.diveParams?.length > 0) {
+      // Only required params block the run; optional ones already hold the
+      // .pipe file's own values, and stay reachable from the gear.
+      if (pipelineRequiresParams(pipeline)) {
         openDiveParamsDialog(pipeline);
         return;
       }
@@ -302,6 +305,8 @@ export default defineComponent({
       confirmPipelineExecution,
       isPipelineDisabledForCalibration,
       pipelineTooltipDisabled,
+      openDiveParamsDialog,
+      pipelineHasParams,
     };
   },
 });
@@ -463,10 +468,21 @@ export default defineComponent({
                               <PipelineCalibrationWarningIcon
                                 v-if="isPipelineDisabledForCalibration(pipeline)"
                               />
-                              <v-icon style="font-size: 1.5em;">
-                                <template v-if="pipeline.metadata?.diveParams?.length ?? 0 > 0">
-                                  mdi-cog-outline
-                                </template>
+                              <!-- The gear is its own hit target: clicking it
+                                configures, clicking anywhere else on the entry
+                                runs with the pipeline's own defaults. -->
+                              <v-btn
+                                v-if="pipelineHasParams(pipeline)"
+                                icon
+                                small
+                                class="pipeline-params-button"
+                                :aria-label="`Configure ${pipeline.name}`"
+                                @click.stop="openDiveParamsDialog(pipeline)"
+                              >
+                                <v-icon>mdi-application-cog-outline</v-icon>
+                              </v-btn>
+                              <v-icon v-else>
+                                mdi-play-outline
                               </v-icon>
                             </span>
                           </v-list-item-title>
@@ -517,6 +533,12 @@ export default defineComponent({
 .pipeline-submenu-list {
   max-height: 60vh;
   overflow-y: auto;
+}
+
+/* Keep the gear's hit area comfortably clear of the pipeline name, so a click
+   meant for the name does not land on the button. */
+.pipeline-params-button {
+  margin-left: 20px;
 }
 
 .pipeline-category-col--last {

--- a/client/dive-common/pipelineParams.spec.ts
+++ b/client/dive-common/pipelineParams.spec.ts
@@ -1,0 +1,63 @@
+import type { Pipe } from 'dive-common/apispec';
+import { pipelineHasParams, pipelineRequiresParams } from './pipelineParams';
+
+/** Build a Pipe; omitting diveParams yields a pipeline with no metadata. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function pipe(diveParams?: any[]): Pipe {
+  return {
+    name: 'Test Pipeline',
+    pipe: 'test.pipe',
+    type: 'detector',
+    ...(diveParams === undefined ? {} : { metadata: { diveParams } }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+const optionalParam = {
+  label: 'Threshold', type: 'float', key: 'detector:thresh', default: '0.5',
+};
+const requiredParam = {
+  label: 'Model', type: 'string', key: 'detector:model', default: '', required: true,
+};
+
+describe('pipelineHasParams', () => {
+  it('is false when the pipeline has no metadata at all', () => {
+    expect(pipelineHasParams(pipe())).toBe(false);
+  });
+
+  it('is false for an empty param list', () => {
+    expect(pipelineHasParams(pipe([]))).toBe(false);
+  });
+
+  it('is true when the pipeline exposes params', () => {
+    expect(pipelineHasParams(pipe([optionalParam]))).toBe(true);
+  });
+});
+
+describe('pipelineRequiresParams', () => {
+  it('is false when the pipeline has no metadata at all', () => {
+    expect(pipelineRequiresParams(pipe())).toBe(false);
+  });
+
+  it('is false for an empty param list', () => {
+    expect(pipelineRequiresParams(pipe([]))).toBe(false);
+  });
+
+  // The point of the change: optional params must not force the dialog, so a
+  // plain click runs the pipeline with the .pipe file's own values.
+  it('is false when every param is optional', () => {
+    expect(pipelineRequiresParams(pipe([optionalParam, { ...optionalParam, key: 'b' }]))).toBe(false);
+  });
+
+  it('is false when required is explicitly false', () => {
+    expect(pipelineRequiresParams(pipe([{ ...optionalParam, required: false }]))).toBe(false);
+  });
+
+  it('is true when any single param is required', () => {
+    expect(pipelineRequiresParams(pipe([optionalParam, requiredParam]))).toBe(true);
+  });
+
+  it('is true when the only param is required', () => {
+    expect(pipelineRequiresParams(pipe([requiredParam]))).toBe(true);
+  });
+});

--- a/client/dive-common/pipelineParams.ts
+++ b/client/dive-common/pipelineParams.ts
@@ -1,0 +1,21 @@
+import type { Pipe } from 'dive-common/apispec';
+
+/**
+ * Whether the pipeline exposes any DIVE_PARAM values for the user to tune.
+ * These are reachable from the gear on the pipeline's menu entry.
+ */
+export function pipelineHasParams(pipe: Pipe): boolean {
+  return (pipe.metadata?.diveParams?.length ?? 0) > 0;
+}
+
+/**
+ * Whether the pipeline cannot run until the user supplies values.
+ *
+ * Only params flagged `required` force the dialog. Every other param already
+ * carries the value written in the .pipe file, so running without opening the
+ * dialog is the same as accepting those defaults -- which is why a plain click
+ * on the entry runs rather than configures.
+ */
+export function pipelineRequiresParams(pipe: Pipe): boolean {
+  return pipe.metadata?.diveParams?.some((param) => param.required === true) ?? false;
+}

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -78,6 +78,129 @@ async function readLines(filePath: string): Promise<string[]> {
   return rawBuffer.toString().replace(/\r\n/g, '\n').split('\n');
 }
 
+type DiveParam = NonNullable<PipeMetadata['diveParams']>[number];
+
+/**
+ * Parse DIVE_PARAM declarations and include directives from pipe lines.
+ */
+function parseDiveParamLines(lines: string[]) {
+  const params: DiveParam[] = [];
+  const includes: string[] = [];
+  let contextStack: string[] = [];
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    const includeMatch = trimmed.match(/^include\s+(\S+)/i);
+    if (includeMatch) {
+      includes.push(includeMatch[1]);
+      return;
+    }
+
+    const processMatch = trimmed.match(/^process\s+([\w-]+)/i);
+    if (processMatch) {
+      contextStack = [processMatch[1]];
+      return;
+    }
+
+    const blockMatch = trimmed.match(/^block\s+([\w:-]+)/i);
+    if (blockMatch) {
+      contextStack.push(blockMatch[1]);
+      return;
+    }
+
+    if (trimmed.toLowerCase() === 'endblock') {
+      contextStack.pop();
+      return;
+    }
+
+    // `config <key>` opens a config block; its entries are keyed under the
+    // block name (e.g. `config global` + `:scale` -> `global:scale`).
+    const configBlockMatch = trimmed.match(/^config\s+([\w:.-]+)\s*(?:#.*)?$/i);
+    if (configBlockMatch) {
+      contextStack = configBlockMatch[1].split(':');
+      return;
+    }
+
+    const diveMatch = line.match(/#\s*DIVE_PARAM\s*\[\s*"([^"]+)"\s*,\s*(.+)\s*\]/i);
+    if (diveMatch) {
+      const [, label, rawArgs] = diveMatch;
+      const args = rawArgs.split(',').map((arg) => arg.trim());
+      const type: PipelineParamType = args[0] as PipelineParamType;
+      const restArgs = args.slice(1);
+      // `required` is a flag keyword — strip it from type_props,
+      // everything else stays positional for the type.
+      const isRequired = restArgs.some((a) => a.toLowerCase() === 'required');
+      const pipelineTypeArgs = restArgs.filter((a) => a.toLowerCase() !== 'required');
+
+      // `config <key> = <value>` — absolute kwiver key, no process/block prefix
+      // applied. Used for global / cross-referenced settings.
+      const configMatch = trimmed.match(/^config\s+([\w:.-]+)\s*=\s*([^#]+)/i);
+      // Otherwise a regular per-process/block parameter assignment.
+      const paramLineMatch = !configMatch
+        ? trimmed.match(/^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)/i)
+        : null;
+
+      let fullKey: string | null = null;
+      let defaultValue: string | null = null;
+      if (configMatch) {
+        const [, key, value] = configMatch;
+        fullKey = key;
+        defaultValue = value.trim();
+      } else if (paramLineMatch) {
+        fullKey = [...contextStack, paramLineMatch[1]].join(':');
+        defaultValue = paramLineMatch[2].trim();
+      }
+
+      if (fullKey !== null && defaultValue !== null) {
+        params.push({
+          label,
+          type,
+          type_props: pipelineTypeArgs,
+          key: fullKey,
+          default: defaultValue,
+          ...(isRequired ? { required: true } : {}),
+        });
+      }
+    }
+  });
+  return { params, includes };
+}
+
+/**
+ * Collect DIVE_PARAMs from a pipe and, recursively, from its includes.
+ *
+ * Wrapper pipes inherit the params of the pipes they include; a file's own
+ * declarations override inherited ones for the same key, matching kwiver's
+ * config override order. Includes that cannot be read next to the including
+ * file (e.g. $ENV{...} paths resolved by kwiver's own search path) simply
+ * contribute no params.
+ */
+async function collectDiveParams(
+  filePath: string,
+  collected: Map<string, DiveParam>,
+  visited: Set<string>,
+): Promise<void> {
+  const resolved = npath.resolve(filePath);
+  if (visited.has(resolved)) {
+    return;
+  }
+  visited.add(resolved);
+  let lines: string[];
+  try {
+    lines = await readLines(resolved);
+  } catch {
+    return;
+  }
+  const { params, includes } = parseDiveParamLines(lines);
+  // eslint-disable-next-line no-restricted-syntax
+  for (const include of includes.filter((f) => !f.includes('$'))) {
+    // eslint-disable-next-line no-await-in-loop
+    await collectDiveParams(npath.join(npath.dirname(resolved), include), collected, visited);
+  }
+  params.forEach((p) => collected.set(p.key, p));
+}
+
 /**
  * Extract metadata from a .pipe file header.
  */
@@ -85,81 +208,17 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
   const metadata: PipeMetadata = {};
   metadata.diveParams = [];
   try {
+    const collected = new Map<string, DiveParam>();
+    await collectDiveParams(filePath, collected, new Set());
+    metadata.diveParams = Array.from(collected.values());
+
     const lines = await readLines(filePath);
     let inDescription = false;
-    let contextStack: string[] = [];
     let fullDescription = '';
 
     lines.forEach((line) => {
       const trimmed = line.trim();
       if (!trimmed) return;
-
-      const processMatch = trimmed.match(/^process\s+([\w-]+)/i);
-      if (processMatch) {
-        contextStack = [processMatch[1]];
-        return;
-      }
-
-      const blockMatch = trimmed.match(/^block\s+([\w:-]+)/i);
-      if (blockMatch) {
-        contextStack.push(blockMatch[1]);
-        return;
-      }
-
-      if (trimmed.toLowerCase() === 'endblock') {
-        contextStack.pop();
-        return;
-      }
-
-      // `config <key>` opens a config block; its entries are keyed under the
-      // block name (e.g. `config global` + `:scale` -> `global:scale`).
-      const configBlockMatch = trimmed.match(/^config\s+([\w:.-]+)\s*(?:#.*)?$/i);
-      if (configBlockMatch) {
-        contextStack = configBlockMatch[1].split(':');
-        return;
-      }
-
-      const diveMatch = line.match(/#\s*DIVE_PARAM\s*\[\s*"([^"]+)"\s*,\s*(.+)\s*\]/i);
-      if (diveMatch) {
-        const [, label, rawArgs] = diveMatch;
-        const args = rawArgs.split(',').map((arg) => arg.trim());
-        const type: PipelineParamType = args[0] as PipelineParamType;
-        const restArgs = args.slice(1);
-        // `required` is a flag keyword — strip it from type_props,
-        // everything else stays positional for the type.
-        const isRequired = restArgs.some((a) => a.toLowerCase() === 'required');
-        const pipelineTypeArgs = restArgs.filter((a) => a.toLowerCase() !== 'required');
-
-        // `config <key> = <value>` — absolute kwiver key, no process/block prefix
-        // applied. Used for global / cross-referenced settings.
-        const configMatch = trimmed.match(/^config\s+([\w:.-]+)\s*=\s*([^#]+)/i);
-        // Otherwise a regular per-process/block parameter assignment.
-        const paramLineMatch = !configMatch
-          ? trimmed.match(/^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)/i)
-          : null;
-
-        let fullKey: string | null = null;
-        let defaultValue: string | null = null;
-        if (configMatch) {
-          const [, key, value] = configMatch;
-          fullKey = key;
-          defaultValue = value.trim();
-        } else if (paramLineMatch) {
-          fullKey = [...contextStack, paramLineMatch[1]].join(':');
-          defaultValue = paramLineMatch[2].trim();
-        }
-
-        if (fullKey !== null && defaultValue !== null) {
-          metadata.diveParams!.push({
-            label,
-            type,
-            type_props: pipelineTypeArgs,
-            key: fullKey,
-            default: defaultValue,
-            ...(isRequired ? { required: true } : {}),
-          });
-        }
-      }
 
       // --- Description extraction (Multiline) ---
       if (/^#\s*Description:\s*/i.test(line)) {

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -116,19 +116,39 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
         const [, label, rawArgs] = diveMatch;
         const args = rawArgs.split(',').map((arg) => arg.trim());
         const type: PipelineParamType = args[0] as PipelineParamType;
-        const pipelineTypeArgs = args.slice(1);
+        const restArgs = args.slice(1);
+        // `required` is a flag keyword — strip it from type_props,
+        // everything else stays positional for the type.
+        const isRequired = restArgs.some((a) => a.toLowerCase() === 'required');
+        const pipelineTypeArgs = restArgs.filter((a) => a.toLowerCase() !== 'required');
 
-        const paramLineMatch = trimmed.match(/^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)/i);
-        if (paramLineMatch) {
-          const localKey = paramLineMatch[1];
-          const defaultValue = paramLineMatch[2].trim();
-          const fullKey = [...contextStack, localKey].join(':');
+        // `config <key> = <value>` — absolute kwiver key, no process/block prefix
+        // applied. Used for global / cross-referenced settings.
+        const configMatch = trimmed.match(/^config\s+([\w:.-]+)\s*=\s*([^#]+)/i);
+        // Otherwise a regular per-process/block parameter assignment.
+        const paramLineMatch = !configMatch
+          ? trimmed.match(/^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)/i)
+          : null;
+
+        let fullKey: string | null = null;
+        let defaultValue: string | null = null;
+        if (configMatch) {
+          const [, key, value] = configMatch;
+          fullKey = key;
+          defaultValue = value.trim();
+        } else if (paramLineMatch) {
+          fullKey = [...contextStack, paramLineMatch[1]].join(':');
+          defaultValue = paramLineMatch[2].trim();
+        }
+
+        if (fullKey !== null && defaultValue !== null) {
           metadata.diveParams!.push({
             label,
             type,
             type_props: pipelineTypeArgs,
             key: fullKey,
             default: defaultValue,
+            ...(isRequired ? { required: true } : {}),
           });
         }
       }

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -111,6 +111,14 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
         return;
       }
 
+      // `config <key>` opens a config block; its entries are keyed under the
+      // block name (e.g. `config global` + `:scale` -> `global:scale`).
+      const configBlockMatch = trimmed.match(/^config\s+([\w:.-]+)\s*(?:#.*)?$/i);
+      if (configBlockMatch) {
+        contextStack = configBlockMatch[1].split(':');
+        return;
+      }
+
       const diveMatch = line.match(/#\s*DIVE_PARAM\s*\[\s*"([^"]+)"\s*,\s*(.+)\s*\]/i);
       if (diveMatch) {
         const [, label, rawArgs] = diveMatch;

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -87,6 +87,16 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                         context_stack.pop()
                     continue
 
+                # `config <key>` opens a config block; its entries are keyed
+                # under the block name (e.g. `config global` + `:scale` ->
+                # `global:scale`).
+                config_block_match = re.match(
+                    r'^config\s+([\w:.-]+)\s*(?:#.*)?$', trimmed, re.IGNORECASE
+                )
+                if config_block_match:
+                    context_stack = config_block_match.group(1).split(':')
+                    continue
+
                 dive_match = re.search(
                     r'#\s*DIVE_PARAM\s*\[\s*"([^"]+)"\s*,\s*(.+)\s*\]', line_raw, re.IGNORECASE
                 )

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional
 
 from dive_utils.constants import TrainingModelExtensions
 from dive_utils.types import (
+    DiveParam,
     AvailableJobSchema,
     PipelineCategory,
     PipelineDescription,
@@ -57,10 +58,128 @@ def parse_pipe_type_and_name(pipe_stem: str) -> tuple[str, str]:
     return pipe_type, ' '.join(parts[1:])
 
 
+def _parse_dive_param_lines(lines: List[str]) -> "tuple[List[DiveParam], List[str]]":
+    """Parse DIVE_PARAM declarations and include directives from pipe lines."""
+    params: List[DiveParam] = []
+    includes: List[str] = []
+    context_stack: List[str] = []
+    for line_raw in lines:
+        trimmed = line_raw.strip()
+        if not trimmed:
+            continue
+
+        include_match = re.match(r'^include\s+(\S+)', trimmed, re.IGNORECASE)
+        if include_match:
+            includes.append(include_match.group(1))
+            continue
+
+        process_match = re.match(r'^process\s+([\w-]+)', trimmed, re.IGNORECASE)
+        if process_match:
+            context_stack = [process_match.group(1)]
+            continue
+
+        block_match = re.match(r'^block\s+([\w:-]+)', trimmed, re.IGNORECASE)
+        if block_match:
+            context_stack.append(block_match.group(1))
+            continue
+
+        if trimmed.lower() == 'endblock':
+            if context_stack:
+                context_stack.pop()
+            continue
+
+        # `config <key>` opens a config block; its entries are keyed
+        # under the block name (e.g. `config global` + `:scale` ->
+        # `global:scale`).
+        config_block_match = re.match(
+            r'^config\s+([\w:.-]+)\s*(?:#.*)?$', trimmed, re.IGNORECASE
+        )
+        if config_block_match:
+            context_stack = config_block_match.group(1).split(':')
+            continue
+
+        dive_match = re.search(
+            r'#\s*DIVE_PARAM\s*\[\s*"([^"]+)"\s*,\s*(.+)\s*\]', line_raw, re.IGNORECASE
+        )
+        if dive_match:
+            label, raw_args = dive_match.groups()
+            args = [arg.strip() for arg in raw_args.split(',')]
+            param_type = args[0]
+            rest_args = args[1:]
+            # `required` is a flag keyword — strip it from type_props,
+            # everything else stays positional for the type.
+            is_required = any(a.lower() == 'required' for a in rest_args)
+            pipeline_type_args = [a for a in rest_args if a.lower() != 'required']
+
+            # `config <key> = <value>` — absolute kwiver key, no
+            # process/block prefix. Used for global / cross-referenced
+            # settings.
+            config_match = re.match(r'^config\s+([\w:.-]+)\s*=\s*([^#]+)', trimmed, re.IGNORECASE)
+            # Otherwise a regular per-process/block parameter assignment.
+            param_line_match = (
+                re.match(r'^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)', trimmed, re.IGNORECASE)
+                if not config_match else None
+            )
+
+            full_key = None
+            default_val = None
+            if config_match:
+                full_key = config_match.group(1)
+                default_val = config_match.group(2).strip()
+            elif param_line_match:
+                local_key = param_line_match.group(1)
+                default_val = param_line_match.group(2).strip()
+                full_key = ":".join(context_stack + [local_key])
+
+            if full_key is not None and default_val is not None:
+                param_dict: DiveParam = {
+                    "label": label,
+                    "type": param_type,
+                    "type_props": pipeline_type_args,
+                    "key": full_key,
+                    "default": default_val,
+                }
+                if is_required:
+                    param_dict["required"] = True
+                params.append(param_dict)
+    return params, includes
+
+
+def _collect_dive_params(
+    file_path: Path, collected: "Dict[str, DiveParam]", visited: set
+) -> None:
+    """Collect DIVE_PARAMs from a pipe and, recursively, from its includes.
+
+    Wrapper pipes inherit the params of the pipes they include; a file's own
+    declarations override inherited ones for the same key, matching kwiver's
+    config override order. Includes that cannot be read next to the including
+    file (e.g. $ENV{...} paths resolved by kwiver's own search path) simply
+    contribute no params.
+    """
+    resolved = file_path.resolve()
+    if resolved in visited:
+        return
+    visited.add(resolved)
+    try:
+        with open(resolved, 'r', encoding='utf-8') as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return
+    params, includes = _parse_dive_param_lines(lines)
+    for include in includes:
+        if '$' not in include:
+            _collect_dive_params(resolved.parent / include, collected, visited)
+    for param in params:
+        collected[param["key"]] = param
+
+
 def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
     metadata: PipeMetadata = {"diveParams": []}
 
-    context_stack: List[str] = []
+    collected: Dict[str, DiveParam] = {}
+    _collect_dive_params(file_path, collected, set())
+    metadata["diveParams"] = list(collected.values())
+
     in_description = False
     full_description_parts: List[str] = []
 
@@ -71,76 +190,6 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                 trimmed = line_raw.strip()
                 if not trimmed:
                     continue
-
-                process_match = re.match(r'^process\s+([\w-]+)', trimmed, re.IGNORECASE)
-                if process_match:
-                    context_stack = [process_match.group(1)]
-                    continue
-
-                block_match = re.match(r'^block\s+([\w:-]+)', trimmed, re.IGNORECASE)
-                if block_match:
-                    context_stack.append(block_match.group(1))
-                    continue
-
-                if trimmed.lower() == 'endblock':
-                    if context_stack:
-                        context_stack.pop()
-                    continue
-
-                # `config <key>` opens a config block; its entries are keyed
-                # under the block name (e.g. `config global` + `:scale` ->
-                # `global:scale`).
-                config_block_match = re.match(
-                    r'^config\s+([\w:.-]+)\s*(?:#.*)?$', trimmed, re.IGNORECASE
-                )
-                if config_block_match:
-                    context_stack = config_block_match.group(1).split(':')
-                    continue
-
-                dive_match = re.search(
-                    r'#\s*DIVE_PARAM\s*\[\s*"([^"]+)"\s*,\s*(.+)\s*\]', line_raw, re.IGNORECASE
-                )
-                if dive_match:
-                    label, raw_args = dive_match.groups()
-                    args = [arg.strip() for arg in raw_args.split(',')]
-                    param_type = args[0]
-                    rest_args = args[1:]
-                    # `required` is a flag keyword — strip it from type_props,
-                    # everything else stays positional for the type.
-                    is_required = any(a.lower() == 'required' for a in rest_args)
-                    pipeline_type_args = [a for a in rest_args if a.lower() != 'required']
-
-                    # `config <key> = <value>` — absolute kwiver key, no
-                    # process/block prefix. Used for global / cross-referenced
-                    # settings.
-                    config_match = re.match(r'^config\s+([\w:.-]+)\s*=\s*([^#]+)', trimmed, re.IGNORECASE)
-                    # Otherwise a regular per-process/block parameter assignment.
-                    param_line_match = (
-                        re.match(r'^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)', trimmed, re.IGNORECASE)
-                        if not config_match else None
-                    )
-
-                    full_key = None
-                    default_val = None
-                    if config_match:
-                        full_key = config_match.group(1)
-                        default_val = config_match.group(2).strip()
-                    elif param_line_match:
-                        local_key = param_line_match.group(1)
-                        default_val = param_line_match.group(2).strip()
-                        full_key = ":".join(context_stack + [local_key])
-
-                    if full_key is not None and default_val is not None:
-                        param_dict = {
-                            "label": label,
-                            "type": param_type,
-                            "type_props": pipeline_type_args,
-                            "key": full_key,
-                            "default": default_val,
-                        }
-                        if is_required:
-                            param_dict["required"] = True
-                        metadata["diveParams"].append(param_dict)
 
                 # --- Description extraction (Multiline) ---
                 desc_start_match = re.match(r'^#\s*Description:\s*(.*)', line_raw, re.IGNORECASE)

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -94,27 +94,43 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                     label, raw_args = dive_match.groups()
                     args = [arg.strip() for arg in raw_args.split(',')]
                     param_type = args[0]
-                    pipeline_type_args = args[1:]
+                    rest_args = args[1:]
+                    # `required` is a flag keyword — strip it from type_props,
+                    # everything else stays positional for the type.
+                    is_required = any(a.lower() == 'required' for a in rest_args)
+                    pipeline_type_args = [a for a in rest_args if a.lower() != 'required']
 
-                    param_line_match = re.match(
-                        r'^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)',
-                        trimmed,
-                        re.IGNORECASE,
+                    # `config <key> = <value>` — absolute kwiver key, no
+                    # process/block prefix. Used for global / cross-referenced
+                    # settings.
+                    config_match = re.match(r'^config\s+([\w:.-]+)\s*=\s*([^#]+)', trimmed, re.IGNORECASE)
+                    # Otherwise a regular per-process/block parameter assignment.
+                    param_line_match = (
+                        re.match(r'^(?:relativepath\s+)?(?::)?([\w:-]+)\s*=?\s*([^#]+)', trimmed, re.IGNORECASE)
+                        if not config_match else None
                     )
-                    if param_line_match:
+
+                    full_key = None
+                    default_val = None
+                    if config_match:
+                        full_key = config_match.group(1)
+                        default_val = config_match.group(2).strip()
+                    elif param_line_match:
                         local_key = param_line_match.group(1)
                         default_val = param_line_match.group(2).strip()
                         full_key = ":".join(context_stack + [local_key])
 
-                        metadata["diveParams"].append(
-                            {
-                                "label": label,
-                                "type": param_type,
-                                "type_props": pipeline_type_args,
-                                "key": full_key,
-                                "default": default_val,
-                            }
-                        )
+                    if full_key is not None and default_val is not None:
+                        param_dict = {
+                            "label": label,
+                            "type": param_type,
+                            "type_props": pipeline_type_args,
+                            "key": full_key,
+                            "default": default_val,
+                        }
+                        if is_required:
+                            param_dict["required"] = True
+                        metadata["diveParams"].append(param_dict)
 
                 # --- Description extraction (Multiline) ---
                 desc_start_match = re.match(r'^#\s*Description:\s*(.*)', line_raw, re.IGNORECASE)

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -64,12 +64,14 @@ class TrainingModelTuneArgs(TrainingModelDescription):
         extra = 'forbid'
 
 
-class DiveParam(TypedDict):
+class DiveParam(TypedDict, total=False):
     label: str
     type: str
     type_props: list[str]
     key: str
     default: str
+    # True if the pipeline can't run until the user supplies a value
+    required: bool
 
 
 class PipeMetadata(TypedDict):


### PR DESCRIPTION
## Summary

Pipelines can now mark a \`DIVE_PARAM\` as required so the user can't run the pipeline until they supply a value, and \`config <key>\` lines (kwiver globals) can be DIVE_PARAM targets — same syntax, parser-side recognition only.

## Spec

\`\`\`
:my:key = 0.5  # DIVE_PARAM ["My label", float, required]

config global:fps = 5  # DIVE_PARAM ["FPS", int, required]
\`\`\`

\`required\` is a flag keyword in the DIVE_PARAM comma list — stripped from \`type_props\`, sets \`required: true\` on the param.

## Coverage

- Top-level assignments (\`:key = value\`) — keyed under \`process:block...:key\` from surrounding \`process\` / \`block\` context.
- Nested \`block\` declarations — context stack pushes/pops per \`block\` / \`endblock\`, so e.g. \`process tracker → block matcher → block weights → :iou\` keys as \`tracker:matcher:weights:iou\`.
- \`config <absolute:key> = <value>\` — absolute kwiver key, no process/block prefix applied. Used for globals referenced from multiple sites.

## Changes

- \`apispec.ts\` / \`server/dive_utils/types.py\`: \`required?: boolean\` on \`DiveParam\`.
- \`pipeline_discovery.py\` (server) + \`platform/desktop/backend/native/common.ts\` (desktop): recognise the \`required\` keyword in the type-props list, plus \`config <key> = <value>\` lines as DIVE_PARAM targets.
- \`PipelineParamsDialog\`: red \`*\` on the label, vuetify rule on the input that blocks the Run button when empty.