### PR TITLE
swap addons downloading to pipelines container for access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,8 @@ services:
     << : *base-worker
     profiles:
       - gpu
+    volumes:
+      - addons:/tmp/addons:rw
     build:
       context: .
       dockerfile: docker/girder_worker_gpu.Dockerfile

--- a/server/dive_server/views_configuration.py
+++ b/server/dive_server/views_configuration.py
@@ -182,13 +182,17 @@ class ConfigurationResource(Resource):
         )
     )
     def upgrade_pipelines(self, force: bool, urls: List[str]):
+        worker_capabilities.require_pipeline_worker()
         token = Token().createToken(user=self.getCurrentUser(), days=1)
         Setting().set(constants.SETTINGS_CONST_JOBS_CONFIGS, None)
-        tasks.upgrade_pipelines.delay(
-            urls=urls,
-            force=force,
-            girder_job_title="Upgrade Pipelines",
-            girder_client_token=str(token["_id"]),
+        tasks.upgrade_pipelines.apply_async(
+            queue='pipelines',
+            kwargs=dict(
+                urls=urls,
+                force=force,
+                girder_job_title="Upgrade Pipelines",
+                girder_client_token=str(token["_id"]),
+            ),
         )
 
     @access.admin


### PR DESCRIPTION
When I updated to having a non-CUDA worker containers I also made that container not install VIAME so it could be used just for ffmpeg and other minor tasks.  This then caused an issue where it doesn't have /opt/noaa/viame for addon installation.

- Moved the addon downloading to the pipeline containers (that has /opt/noaa/viame)
- Updated the addon volume to be read-write for the pipeline container so that addon task can be run properly.