### PR TITLE
resolving the confidence pair type for web

### DIFF
--- a/client/dive-common/components/TrackDetailsPanel.vue
+++ b/client/dive-common/components/TrackDetailsPanel.vue
@@ -242,12 +242,22 @@ export default defineComponent({
       });
     }
 
+    // Re-run when track confidence pairs change (see AttributesSubsection revision pattern)
+    const displayConfidencePairs = computed((): [string, number][] => {
+      const pairs: [string, number][] = [];
+      selectedTrackList.value.forEach((t) => {
+        if (t.revision.value) {
+          pairs.push(...t.confidencePairs);
+        }
+      });
+      return pairs.sort((a, b) => b[1] - a[1]);
+    });
+
     function setTrackType(type: string) {
       const track = selectedTrackList.value[0];
-      // Find the confidence value for this type in the track's confidence pairs
-      const existingPair = track.confidencePairs.find(([t]) => t === type);
-      const confidenceVal = existingPair ? existingPair[1] : 1;
-      track.setType(type, confidenceVal);
+      if (!track) return;
+      const currentType = track.confidencePairs[0]?.[0];
+      cameraStore.setTrackType(track.id, type, 1, currentType);
     }
 
     return {
@@ -291,6 +301,7 @@ export default defineComponent({
       unstageFromMerge,
       updateSelectedTracksType,
       setTrackType,
+      displayConfidencePairs,
     };
   },
 });
@@ -594,9 +605,7 @@ export default defineComponent({
       <confidence-subsection
         v-if="editingGroupIdRef === null"
         style="max-height:33vh;"
-        :confidence-pairs="
-          flatten(selectedTrackList.map((t) => t.confidencePairs)).sort((a, b) => b[1] - a[1])
-        "
+        :confidence-pairs="displayConfidencePairs"
         :disabled="selectedTrackList.length > 1"
         :user-modified="isUserModified"
         @set-type="setTrackType($event)"


### PR DESCRIPTION
resolves #1611 

Previously, it was using the existing confidence number instead of setting it to 1.  This updates the cod eon the web to handle it properly.