### PR TITLE
update rabbit mq timeouts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS:-guest}
       - RABBITMQ_DEFAULT_VHOST=${RABBITMQ_DEFAULT_VHOST:-default}
       - RABBITMQ_DISTRIBUTED_WORKER=${RABBITMQ_DISTRIBUTED_WORKER:-0}
+      # Allow long pipeline/training jobs to run with acks_late (5 days; default is 30 minutes).
+      - "RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit consumer_timeout 432000000"
 
   mongo:
     image: mongo:5.0

--- a/server/dive_tasks/celeryconfig.py
+++ b/server/dive_tasks/celeryconfig.py
@@ -58,6 +58,6 @@ task_ignore_result = True
 
 # https://docs.celeryproject.org/en/stable/userguide/configuration.html#std-setting-task_reject_on_worker_lost
 # Run tasks at least once, rescheduling them if the worker crashes.
-# TODO: Required to pin to rabbitmq 3.8.14 because of https://github.com/Kitware/dive/issues/995
+# Late acks require RabbitMQ consumer_timeout to be raised (see docker-compose.yml).
 task_reject_on_worker_lost = True
 task_acks_late = True


### PR DESCRIPTION
Using newer version of rabbitmq I need to update the timeout.  Figured 5 days should be good for any longer running training tasks.