### PR TITLE
Vue3 Upgrade - Phase 0

### DIFF
--- a/client/dive-common/components/DeleteControls.vue
+++ b/client/dive-common/components/DeleteControls.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import { EditAnnotationTypes } from 'vue-media-annotator/layers/';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'DeleteControls',
 
   props: {

--- a/client/dive-common/components/NavigationTitle.vue
+++ b/client/dive-common/components/NavigationTitle.vue
@@ -1,5 +1,7 @@
 <script>
-export default {
+import { defineComponent } from 'vue';
+
+export default defineComponent({
   name: 'NavigationTitle',
   props: {
     name: {
@@ -12,7 +14,7 @@ export default {
       return process.env.VUE_APP_GIT_HASH;
     },
   },
-};
+});
 </script>
 
 <template>

--- a/client/dive-common/components/UserGuideButton.vue
+++ b/client/dive-common/components/UserGuideButton.vue
@@ -1,7 +1,8 @@
 <script>
+import { defineComponent } from 'vue';
 import UserGuideDialog from 'dive-common/components/UserGuideDialog.vue';
 
-export default {
+export default defineComponent({
   components: {
     UserGuideDialog,
   },
@@ -17,7 +18,7 @@ export default {
       userGuideLink: 'https://kitware.github.io/dive/',
     };
   },
-};
+});
 </script>
 <template>
   <div>

--- a/client/dive-common/recipes/headtail.ts
+++ b/client/dive-common/recipes/headtail.ts
@@ -1,4 +1,6 @@
-import Vue, { ref, Ref } from 'vue';
+import { ref, Ref } from 'vue';
+
+import EventBus, { createEventBus } from 'dive-common/utils/eventBus';
 
 import Track from 'vue-media-annotator/track';
 import Recipe, { UpdateResponse } from 'vue-media-annotator/recipe';
@@ -35,14 +37,14 @@ export default class HeadTail implements Recipe {
 
   private startWithHead: boolean;
 
-  bus: Vue;
+  bus: EventBus;
 
   toggleable: Ref<boolean>;
 
   icon: Ref<string>;
 
   constructor() {
-    this.bus = new Vue();
+    this.bus = createEventBus();
     this.startWithHead = true;
     this.active = ref(false);
     this.name = 'HeadTail';

--- a/client/dive-common/recipes/polygonbase.ts
+++ b/client/dive-common/recipes/polygonbase.ts
@@ -1,5 +1,7 @@
 import { cloneDeep } from 'lodash';
-import Vue, { ref, Ref } from 'vue';
+import { ref, Ref } from 'vue';
+
+import EventBus, { createEventBus } from 'dive-common/utils/eventBus';
 
 import { removePoint } from 'vue-media-annotator/utils';
 import Track from 'vue-media-annotator/track';
@@ -17,10 +19,10 @@ export default class PolygonBoundsExpand implements Recipe {
 
   toggleable: Ref<boolean>;
 
-  bus: Vue;
+  bus: EventBus;
 
   constructor() {
-    this.bus = new Vue();
+    this.bus = createEventBus();
     this.active = ref(false);
     this.name = 'PolygonBase';
     this.toggleable = ref(true);

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -169,8 +169,16 @@ function saveSettings() {
   }
 }
 
+function normalizeRowsPerPage(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  return defaultSettings.rowsPerPage;
+}
+
 function hydrate(obj: Partial<AnnotationSettings>): AnnotationSettings {
   const hydrated = merge(cloneDeep(defaultSettings), obj);
+  hydrated.rowsPerPage = normalizeRowsPerPage(hydrated.rowsPerPage);
   hydrated.autoSaveSettings.delaySeconds = Math.max(
     MIN_AUTO_SAVE_DELAY_SECONDS,
     Number(hydrated.autoSaveSettings.delaySeconds) || defaultSettings.autoSaveSettings.delaySeconds,

--- a/client/dive-common/utils/eventBus.spec.ts
+++ b/client/dive-common/utils/eventBus.spec.ts
@@ -1,0 +1,34 @@
+// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
+import {
+  describe, expect, it, vi,
+} from 'vitest';
+
+import { createEventBus } from './eventBus';
+
+describe('EventBus', () => {
+  it('supports $on, $emit, and $off', () => {
+    const bus = createEventBus();
+    const handler = vi.fn();
+
+    bus.$on('test', handler);
+    bus.$emit('test', 1, 'two');
+    bus.$off('test', handler);
+    bus.$emit('test', 3);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(1, 'two');
+  });
+
+  it('supports multiple handlers for the same event', () => {
+    const bus = createEventBus();
+    const first = vi.fn();
+    const second = vi.fn();
+
+    bus.$on('multi', first);
+    bus.$on('multi', second);
+    bus.$emit('multi', 'payload');
+
+    expect(first).toHaveBeenCalledWith('payload');
+    expect(second).toHaveBeenCalledWith('payload');
+  });
+});

--- a/client/dive-common/utils/eventBus.ts
+++ b/client/dive-common/utils/eventBus.ts
@@ -1,0 +1,30 @@
+type Handler = (...args: unknown[]) => void;
+
+/**
+ * Minimal event bus replacing `new Vue()` for cross-module events.
+ * API mirrors Vue 2's instance event methods for easier Vue 3 migration.
+ */
+export default class EventBus {
+  private handlers = new Map<string, Set<Handler>>();
+
+  $on(event: string, handler: Handler): void {
+    if (!this.handlers.has(event)) {
+      this.handlers.set(event, new Set());
+    }
+    this.handlers.get(event)!.add(handler);
+  }
+
+  $off(event: string, handler: Handler): void {
+    this.handlers.get(event)?.delete(handler);
+  }
+
+  $emit(event: string, ...args: unknown[]): void {
+    this.handlers.get(event)?.forEach((handler) => {
+      handler(...args);
+    });
+  }
+}
+
+export function createEventBus(): EventBus {
+  return new EventBus();
+}

--- a/client/package.json
+++ b/client/package.json
@@ -138,6 +138,7 @@
       "vue/no-lone-template": "off",
       "vuejs-accessibility/mouse-events-have-key-events": "off",
       "vuejs-accessibility/click-events-have-key-events": "off",
+      "vue/no-v-model-argument": "off",
       "vue/no-mutating-props": "off",
       "no-promise-executor-return": "off",
       "no-shadow": "off",

--- a/client/platform/web-girder/eventBus.ts
+++ b/client/platform/web-girder/eventBus.ts
@@ -1,3 +1,3 @@
-import Vue from 'vue';
+import { createEventBus } from 'dive-common/utils/eventBus';
 
-export default new Vue();
+export default createEventBus();

--- a/client/platform/web-girder/views/AdminPage.vue
+++ b/client/platform/web-girder/views/AdminPage.vue
@@ -1,4 +1,5 @@
 <script>
+import { defineComponent } from 'vue';
 
 import AddOns from './Admin/Addons.vue';
 import AdminRecents from './Admin/AdminRecents.vue';
@@ -8,7 +9,7 @@ import AdminBranding from './Admin/AdminBranding.vue';
 import AdminStats from './Admin/AdminStats.vue';
 import AdminUpdate from './Admin/AdminUpdate.vue';
 
-export default {
+export default defineComponent({
   name: 'AdminPage',
   components: {
     AddOns,
@@ -27,7 +28,7 @@ export default {
       currentTab: null,
     };
   },
-};
+});
 </script>
 
 <template>

--- a/client/platform/web-girder/views/DataBrowser.vue
+++ b/client/platform/web-girder/views/DataBrowser.vue
@@ -32,7 +32,7 @@ export default defineComponent({
     const uploading = ref(false);
     const uploaderDialog = ref(false);
     const {
-      location, selected, locationIsViameFolder, setRouteFromLocation,
+      location, selected, locationIsViameFolder, setRouteFromLocation, setSelected,
     } = useLocation();
     const jobs = useJobs();
 
@@ -69,6 +69,12 @@ export default defineComponent({
       && !selected.value.length
     ));
 
+    function updateRowsPerPage(count: number) {
+      if (typeof count === 'number' && Number.isFinite(count) && count > 0) {
+        clientSettings.rowsPerPage = count;
+      }
+    }
+
     eventBus.$on('refresh-data-browser', handleNotification);
     onBeforeUnmount(() => {
       eventBus.$off('refresh-data-browser', handleNotification);
@@ -92,6 +98,8 @@ export default defineComponent({
       getMultiCamTooltip,
       handleNotification,
       setLocation,
+      setSelected,
+      updateRowsPerPage,
       updateUploading,
     };
   },
@@ -101,14 +109,16 @@ export default defineComponent({
 <template>
   <DiveGirderBrowser
     ref="fileManager"
-    v-model="selected"
+    :value="selected"
     :selectable="!locationIsViameFolder"
     :new-folder-enabled="
       !selected.length && !locationIsViameFolder
     "
     :location="location"
-    :items-per-page.sync="clientSettings.rowsPerPage"
+    :items-per-page="clientSettings.rowsPerPage"
     :items-per-page-options="itemsPerPageOptions"
+    @input="setSelected"
+    @update:itemsPerPage="updateRowsPerPage"
     @update:location="setLocation($event)"
   >
     <template #headerwidget>

--- a/client/platform/web-girder/views/DataDetails.vue
+++ b/client/platform/web-girder/views/DataDetails.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 import {
   GirderDetailList,
   mixins,
@@ -72,7 +72,7 @@ export const DefaultInfoKeys = [
   },
 ];
 
-export default Vue.extend({
+export default defineComponent({
   components: {
     GirderDetailList,
   },

--- a/client/platform/web-girder/views/DataSharedBreadCrumb.vue
+++ b/client/platform/web-girder/views/DataSharedBreadCrumb.vue
@@ -1,7 +1,8 @@
 <script>
+import { defineComponent } from 'vue';
 import { createLocationValidator, getLocationType } from '@girder/components/src';
 
-export default {
+export default defineComponent({
   inject: ['girderRest'],
   props: {
     location: {
@@ -97,7 +98,7 @@ export default {
       };
     },
   },
-};
+});
 </script>
 
 <template>

--- a/client/platform/web-girder/views/DiveGirderBrowser.vue
+++ b/client/platform/web-girder/views/DiveGirderBrowser.vue
@@ -1,5 +1,5 @@
 <script>
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
 import {
   GirderDataBrowser,
@@ -13,7 +13,7 @@ import {
 } from '@girder/components/src';
 import DataSharedBreadCrumb from './DataSharedBreadCrumb.vue';
 
-export default Vue.extend({
+export default defineComponent({
   components: {
     GirderAccessControl,
     GirderBreadcrumb,

--- a/client/platform/web-girder/views/UploadGirder.vue
+++ b/client/platform/web-girder/views/UploadGirder.vue
@@ -1,5 +1,5 @@
 <script>
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 import { mixins } from '@girder/components/src';
 import { clone } from 'lodash';
 import { getResponseError } from 'vue-media-annotator/utils';
@@ -10,7 +10,7 @@ import {
 import { makeViameFolder, postProcess } from 'platform/web-girder/api';
 import { GirderUploadManager } from 'platform/web-girder/utils';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'GirderUpload',
   mixins: [mixins.fileUploader, mixins.sizeFormatter, mixins.progressReporter],
   inject: ['girderRest'],

--- a/client/src/components/TooltipButton.vue
+++ b/client/src/components/TooltipButton.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'TooltipButton',
 
   props: {

--- a/client/src/components/annotators/useMediaController.ts
+++ b/client/src/components/annotators/useMediaController.ts
@@ -3,17 +3,19 @@
 import geo, { GeoEvent } from 'geojs';
 import * as d3 from 'd3';
 
-import Vue, {
+import {
   ref, reactive, provide, toRef, Ref, UnwrapRef, computed,
 } from 'vue';
 import { map, over } from 'lodash';
+
+import { createEventBus } from 'dive-common/utils/eventBus';
 
 import { use } from '../../provides';
 import type { AggregateMediaController, MediaController } from './mediaControllerType';
 
 const AggregateControllerSymbol = Symbol('aggregate-controller');
 const CameraInitializerSymbol = Symbol('camera-initializer');
-const bus = new Vue();
+const bus = createEventBus();
 let allowCameraTrigger = true; // Used to prevent infinite loop on Camera Sync
 
 interface MediaControllerReactiveData {

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -1,5 +1,5 @@
 <script>
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 import { throttle, debounce, sortBy } from 'lodash';
 import * as d3 from 'd3';
 
@@ -12,7 +12,7 @@ function intersect(range1, range2) {
   return [max[0], min[1] < max[1] ? min[1] : max[1]];
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'EventChart',
   props: {
     startFrame: {

--- a/client/src/components/controls/LineChart.vue
+++ b/client/src/components/controls/LineChart.vue
@@ -1,9 +1,9 @@
 <script>
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 import { throttle } from 'lodash';
 import * as d3 from 'd3';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'LineChart',
   props: {
     startFrame: {

--- a/client/src/layers/BaseLayer.ts
+++ b/client/src/layers/BaseLayer.ts
@@ -1,5 +1,7 @@
 /*eslint class-methods-use-this: "off"*/
-import Vue, { Ref } from 'vue';
+import { Ref } from 'vue';
+
+import EventBus, { createEventBus } from 'dive-common/utils/eventBus';
 
 import { MediaController } from '../components/annotators/mediaControllerType';
 import { StateStyles, TypeStyling } from '../StyleManager';
@@ -65,7 +67,7 @@ export default abstract class BaseLayer<D> {
 
   selectedIndex: number[]; // sparse array
 
-  bus: Vue;
+  bus: EventBus;
 
   constructor({
     annotator,
@@ -79,7 +81,7 @@ export default abstract class BaseLayer<D> {
     this.style = {};
     this.featureLayer = null;
     this.selectedIndex = [];
-    this.bus = new Vue();
+    this.bus = createEventBus();
     this.initialize();
   }
 

--- a/client/src/layers/LassoSelectionLayer.ts
+++ b/client/src/layers/LassoSelectionLayer.ts
@@ -1,4 +1,4 @@
-import Vue from 'vue';
+import EventBus, { createEventBus } from 'dive-common/utils/eventBus';
 
 import { MediaController } from '../components/annotators/mediaControllerType';
 import type { AnnotationId } from '../BaseAnnotation';
@@ -28,7 +28,7 @@ interface SearchableFeature {
 export default class LassoSelectionLayer {
   private annotator: MediaController;
 
-  public bus: Vue;
+  public bus: EventBus;
 
   private enabled = true;
 
@@ -69,7 +69,7 @@ export default class LassoSelectionLayer {
     this.searchFeatures = searchFeatures;
     this.isBlocked = isBlocked;
     this.onDrawingChange = onDrawingChange;
-    this.bus = new Vue();
+    this.bus = createEventBus();
     this.boundMouseDown = (evt) => this.onMouseDown(evt);
     this.boundDocumentMove = (evt) => this.onDocumentMouseMove(evt);
     this.boundDocumentUp = (evt) => this.onDocumentMouseUp(evt);


### PR DESCRIPTION
- Replace all `Vue.extend` definitions to use Vue 2.7 defineComponent and composition API references
- Any references to the EventBus need to be modified in prep for eventual upgrading to Vue 3 with its own custom eventBus

