### PR TITLE
Percentile stretch Image Enhancement option

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -298,6 +298,12 @@ interface Api {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getTileURL?(itemId: string, x: number, y: number, level: number, query: Record<string, any>):
    string;
+  getTileHistogram?(itemId: string, options?: {
+    bins?: number;
+    frame?: number;
+    width?: number;
+    height?: number;
+  }): Promise<unknown>;
   importAnnotationFile(id: string, path: string, file?: File,
     additive?: boolean, additivePrepend?: string, set?: string): Promise<boolean | string[]>;
   // Desktop-only calibration persistence functions

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -134,9 +134,11 @@ export interface MultiCamImportFolderArgs {
   sourceList: Record<string, {
     sourcePath: string;
     trackFile: string;
+    /** Per-camera media type when cameras differ (e.g. EO JPG + IR TIFF on web). */
+    type?: 'image-sequence' | 'video' | 'large-image';
   }>; // path/track file per camera
   calibrationFile?: string; // NPZ calibation matrix file
-  type: 'image-sequence' | 'video';
+  type: 'image-sequence' | 'video' | 'large-image';
 }
 
 export interface MultiCamImportKeywordArgs {

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -7,7 +7,7 @@ import { TrackData } from 'vue-media-annotator/track';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import { CustomStyle } from 'vue-media-annotator/StyleManager';
 import { AttributeTrackFilter } from 'vue-media-annotator/AttributeTrackFilterControls';
-import { ImageEnhancements } from 'vue-media-annotator/use/useImageEnhancements';
+import { ImageEnhancements, PercentileStretch } from 'vue-media-annotator/use/useImageEnhancements';
 
 type DatasetType = 'image-sequence' | 'video' | 'multi' | 'large-image';
 type MultiTrackRecord = Record<string, TrackData>;
@@ -526,4 +526,5 @@ export {
   TrainingConfigs,
   MultiCamMedia,
   MediaImportResponse,
+  PercentileStretch,
 };

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -7,7 +7,8 @@ import { TrackData } from 'vue-media-annotator/track';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import { CustomStyle } from 'vue-media-annotator/StyleManager';
 import { AttributeTrackFilter } from 'vue-media-annotator/AttributeTrackFilterControls';
-import { ImageEnhancements, PercentileStretch } from 'vue-media-annotator/use/useImageEnhancements';
+import { ImageEnhancements } from 'vue-media-annotator/use/useImageEnhancements';
+import type { PercentileStretch } from 'vue-media-annotator/use/useImageEnhancements';
 
 type DatasetType = 'image-sequence' | 'video' | 'multi' | 'large-image';
 type MultiTrackRecord = Record<string, TrackData>;
@@ -526,5 +527,6 @@ export {
   TrainingConfigs,
   MultiCamMedia,
   MediaImportResponse,
-  PercentileStretch,
 };
+
+export type { PercentileStretch };

--- a/client/dive-common/components/ControlsContainer.vue
+++ b/client/dive-common/components/ControlsContainer.vue
@@ -322,7 +322,7 @@ export default defineComponent({
       <template #middle>
         <div :class="{ 'middle-content-bottom': bottomLayout }">
           <file-name-time-display
-            v-if="datasetType === 'image-sequence' || datasetType === 'large-image'"
+            v-if="datasetType === 'image-sequence' || datasetType === 'large-image' || datasetType === 'multi'"
             :class="bottomLayout ? 'filename-toolbar' : 'text-middle px-3'"
             display-type="filename"
             :truncate-filename="bottomLayout"

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamAddType.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamAddType.vue
@@ -15,7 +15,7 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const newSetName = ref('');
-    const alphaNumeric = /^[a-zA-Z0-9]*$/;
+    const alphaNumeric = /^[a-zA-Z0-9_]*$/;
     const enabled = ref(false);
 
     const addNewSet = () => {
@@ -55,7 +55,7 @@ export default defineComponent({
         v-model="newSetName"
         :rules="[
           v => !!v || 'Name is required',
-          v => alphaNumeric.test(v) || 'Letters and Numbers only',
+          v => alphaNumeric.test(v) || 'Letters, numbers, and underscores only',
           v => !v.includes(' ') || 'No spaces',
           v => !nameList.includes(v) || 'No duplicate Names']"
         label="name"

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamDialog.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamDialog.vue
@@ -123,7 +123,7 @@ export default defineComponent({
         </v-alert>
       </div>
 
-      <div v-if="nextSteps && importType !== 'subfolders'">
+      <div v-if="showFinalizeStep">
         <v-alert
           type="info"
           outlined

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamSubfolders.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamSubfolders.vue
@@ -59,8 +59,9 @@ export default defineComponent({
       class="mb-3"
     >
       Choose a parent folder with either one subfolder per camera (2 or 3 subfolders)
-      or separate video files in the folder (2 or 3 videos). Names come from the subfolder
-      or video file name (letters and numbers only).
+      or separate video files in the folder (2 or 3 videos). Subfolders without image or
+      video files are ignored. Names come from the subfolder or video file name
+      (letters, numbers, and underscores).
     </v-alert>
     <v-row
       no-gutters

--- a/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.spec.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.spec.ts
@@ -3,14 +3,20 @@ import { describe, expect, it } from 'vitest';
 
 import {
   applyParentPathToAssignments,
+  filterSubfolderGroupsWithMedia,
   groupFilesByImmediateSubfolder,
   groupParentFolderByCamera,
   groupRootLevelVideoFiles,
+  inferSubfolderImportType,
+  isEoSubfolderName,
+  isImageFileName,
+  isMediaFileName,
   isValidCameraName,
   isVideoFileName,
   organizeSubfolderCameras,
   orderSubfolderCameraNames,
   parentFolderLabelFromAbsolutePaths,
+  preferEoSubfolderFirst,
   preferLeftSubfolderFirst,
   pickDefaultMulticamCamera,
   sortSubfolderCameraNames,
@@ -18,12 +24,13 @@ import {
 } from './multicamSubfolderLayout';
 
 describe('isValidCameraName', () => {
-  it('accepts alphanumeric names', () => {
+  it('accepts alphanumeric names and underscores', () => {
     expect(isValidCameraName('cam1')).toBe(true);
     expect(isValidCameraName('LeftCam')).toBe(true);
+    expect(isValidCameraName('2021_EO_SHORT')).toBe(true);
   });
 
-  it('rejects spaces and punctuation', () => {
+  it('rejects spaces and punctuation other than underscore', () => {
     expect(isValidCameraName('Port Cam')).toBe(false);
     expect(isValidCameraName('cam-1')).toBe(false);
   });
@@ -132,7 +139,13 @@ describe('organizeSubfolderCameras', () => {
 
   it('rejects invalid folder names', () => {
     const result = organizeSubfolderCameras(['good', 'bad name']);
-    expect(result.error).toMatch(/letters and numbers only/);
+    expect(result.error).toMatch(/letters, numbers, and underscores only/);
+  });
+
+  it('accepts folder names with underscores', () => {
+    const result = organizeSubfolderCameras(['2021_EO_SHORT', '2021_IR_SHORT']);
+    expect(result.error).toBeNull();
+    expect(result.assignments.map((a) => a.cameraName)).toEqual(['2021_EO_SHORT', '2021_IR_SHORT']);
   });
 
   it('rejects duplicate folder names', () => {
@@ -186,6 +199,37 @@ describe('groupRootLevelVideoFiles', () => {
   });
 });
 
+describe('isImageFileName', () => {
+  it('recognizes common image extensions', () => {
+    expect(isImageFileName('frame.jpg')).toBe(true);
+    expect(isImageFileName('frame.tif')).toBe(true);
+    expect(isImageFileName('notes.txt')).toBe(false);
+  });
+});
+
+describe('isMediaFileName', () => {
+  it('selects image or video extensions based on media type', () => {
+    expect(isMediaFileName('frame.jpg', 'image-sequence')).toBe(true);
+    expect(isMediaFileName('clip.mp4', 'video')).toBe(true);
+    expect(isMediaFileName('clip.mp4', 'image-sequence')).toBe(false);
+    expect(isMediaFileName('transform.h5', 'image-sequence')).toBe(false);
+  });
+});
+
+describe('filterSubfolderGroupsWithMedia', () => {
+  const mk = (path: string) => ({ webkitRelativePath: path, name: path.split('/').pop() } as File);
+
+  it('drops subfolders that only contain non-media files', () => {
+    const groups = groupFilesByImmediateSubfolder([
+      mk('example_seal_data/2021_EO_SHORT/a.jpg'),
+      mk('example_seal_data/2021_IR_SHORT/a.tif'),
+      mk('example_seal_data/transformations/Kotz.h5'),
+    ], 'example_seal_data');
+    const filtered = filterSubfolderGroupsWithMedia(groups, 'image-sequence');
+    expect([...filtered.keys()].sort()).toEqual(['2021_EO_SHORT', '2021_IR_SHORT']);
+  });
+});
+
 describe('groupParentFolderByCamera', () => {
   const mk = (path: string) => ({ webkitRelativePath: path, name: path.split('/').pop() } as File);
 
@@ -194,7 +238,7 @@ describe('groupParentFolderByCamera', () => {
       mk('set/left/a.mp4'),
       mk('set/right/b.mp4'),
       mk('set/left_cam.mp4'),
-    ], { allowRootLevelVideos: true }, 'set');
+    ], { allowRootLevelVideos: true, mediaType: 'video' }, 'set');
     expect([...groups.keys()].sort()).toEqual(['left', 'right']);
   });
 
@@ -215,6 +259,18 @@ describe('groupParentFolderByCamera', () => {
       mk('stereo/right.mp4'),
     ], undefined, 'stereo');
     expect(groups.size).toBe(0);
+  });
+
+  it('ignores non-media subfolders when discovering cameras', () => {
+    const groups = groupParentFolderByCamera([
+      mk('example_seal_data/2021_EO_SHORT/a.jpg'),
+      mk('example_seal_data/2021_IR_SHORT/a.tif'),
+      mk('example_seal_data/transformations/Kotz.h5'),
+    ], { mediaType: 'image-sequence' }, 'example_seal_data');
+    expect([...groups.keys()].sort()).toEqual(['2021_EO_SHORT', '2021_IR_SHORT']);
+    const organized = organizeSubfolderCameras([...groups.keys()]);
+    expect(organized.error).toBeNull();
+    expect(organized.assignments.map((a) => a.cameraName)).toEqual(['2021_EO_SHORT', '2021_IR_SHORT']);
   });
 });
 
@@ -267,6 +323,60 @@ describe('groupFilesByImmediateSubfolder', () => {
 describe('sortSubfolderCameraNames', () => {
   it('sorts STAR, CENTER, PORT', () => {
     expect(sortSubfolderCameraNames(['PORT', 'CENTER', 'STAR'])).toEqual(['STAR', 'CENTER', 'PORT']);
+  });
+});
+
+describe('preferEoSubfolderFirst', () => {
+  it('moves EO-named folders before IR and others', () => {
+    expect(preferEoSubfolderFirst(['2021_IR_SHORT', '2021_EO_SHORT'])).toEqual([
+      '2021_EO_SHORT',
+      '2021_IR_SHORT',
+    ]);
+  });
+
+  it('leaves order unchanged when EO is already first', () => {
+    expect(preferEoSubfolderFirst(['2021_EO_SHORT', '2021_IR_SHORT'])).toEqual([
+      '2021_EO_SHORT',
+      '2021_IR_SHORT',
+    ]);
+  });
+});
+
+describe('pickDefaultMulticamCamera EO/IR', () => {
+  it('prefers EO as default display when present', () => {
+    expect(pickDefaultMulticamCamera(['2021_IR_SHORT', '2021_EO_SHORT'])).toBe('2021_EO_SHORT');
+  });
+});
+
+describe('inferSubfolderImportType', () => {
+  const mk = (name: string) => ({ name } as File);
+
+  it('uses large-image for all-TIFF subfolders on web', () => {
+    expect(inferSubfolderImportType([
+      mk('a.tif'),
+      mk('b.tiff'),
+    ], { largeImageForTiff: true })).toBe('large-image');
+  });
+
+  it('keeps image-sequence for mixed or JPG folders', () => {
+    expect(inferSubfolderImportType([
+      mk('a.jpg'),
+      mk('b.jpg'),
+    ], { largeImageForTiff: true })).toBe('image-sequence');
+    expect(inferSubfolderImportType([
+      mk('a.tif'),
+      mk('b.jpg'),
+    ], { largeImageForTiff: true })).toBe('image-sequence');
+  });
+});
+
+describe('organizeSubfolderCameras seal example', () => {
+  it('orders EO before IR and picks EO as default', () => {
+    const result = organizeSubfolderCameras(['2021_IR_SHORT', '2021_EO_SHORT']);
+    expect(result.error).toBeNull();
+    expect(result.assignments.map((a) => a.cameraName)).toEqual(['2021_EO_SHORT', '2021_IR_SHORT']);
+    expect(result.defaultDisplay).toBe('2021_EO_SHORT');
+    expect(isEoSubfolderName(result.defaultDisplay)).toBe(true);
   });
 });
 

--- a/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.ts
@@ -19,13 +19,74 @@ export interface OrganizeSubfolderCamerasResult {
 }
 
 /** Same rules as manual "Add Camera" in ImportMultiCamDialog/ImportMultiCamAddType. */
-export const CAMERA_NAME_PATTERN = /^[a-zA-Z0-9]+$/;
+export const CAMERA_NAME_PATTERN = /^[a-zA-Z0-9_]+$/;
+
+/** Image extensions accepted for parent-folder subfolder discovery (aligned with desktop import). */
+export const fileImageTypes = [
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'tif',
+  'tiff',
+  'bmp',
+  'sgi',
+  'pgm',
+  'avif',
+];
 
 /** Preferred camera order when subfolders use these names (case-insensitive). */
 export const PREFERRED_SUBFOLDER_ORDER = ['STAR', 'CENTER', 'PORT'] as const;
 
 /** Camera names that should be the default display when present (case-insensitive). */
 export const DEFAULT_DISPLAY_NAME_ALIASES = ['center', 'middle'] as const;
+
+export function isTiffFileName(fileName: string): boolean {
+  const parts = fileName.split('.');
+  if (parts.length < 2) {
+    return false;
+  }
+  const ext = parts.pop()?.toLowerCase() ?? '';
+  return ext === 'tif' || ext === 'tiff';
+}
+
+/** True when the subfolder/camera name denotes an electro-optical (EO) sensor. */
+export function isEoSubfolderName(name: string): boolean {
+  return /(^|_)EO(_|$)/i.test(name);
+}
+
+/** True when the subfolder/camera name denotes an infrared (IR) sensor. */
+export function isIrSubfolderName(name: string): boolean {
+  return /(^|_)IR(_|$)/i.test(name);
+}
+
+/** Move an EO-named folder to the front when present (before IR and other cameras). */
+export function preferEoSubfolderFirst(names: string[]): string[] {
+  const eoIndex = names.findIndex((name) => isEoSubfolderName(name));
+  if (eoIndex <= 0) {
+    return names;
+  }
+  const eo = names[eoIndex];
+  return [eo, ...names.filter((_, index) => index !== eoIndex)];
+}
+
+/**
+ * Infer import type for one camera subfolder. On web, all-TIFF folders become large-image
+ * so 16-bit tiles and percentile stretch work in the viewer.
+ */
+export function inferSubfolderImportType(
+  files: Pick<File, 'name'>[],
+  options?: { largeImageForTiff?: boolean },
+): 'image-sequence' | 'large-image' {
+  const media = filterMediaFiles(files, 'image-sequence');
+  if (!media.length) {
+    return 'image-sequence';
+  }
+  if (options?.largeImageForTiff && media.every((file) => isTiffFileName(file.name))) {
+    return 'large-image';
+  }
+  return 'image-sequence';
+}
 
 /**
  * Pick the default multicam display camera: prefer "center" / "middle", else the middle
@@ -43,6 +104,11 @@ export function pickDefaultMulticamCamera(
   const byAlias = cameraNames.find((name) => centerAliases.has(name.toLowerCase()));
   if (byAlias) {
     return byAlias;
+  }
+
+  const eo = cameraNames.find((name) => isEoSubfolderName(name));
+  if (eo) {
+    return eo;
   }
 
   if (options?.preferLeftForStereo) {
@@ -110,9 +176,9 @@ export function orderSubfolderCameraNames(
     });
   }
   if (options?.preferLeftFirst) {
-    return preferLeftSubfolderFirst(ordered);
+    ordered = preferLeftSubfolderFirst(ordered);
   }
-  return ordered;
+  return preferEoSubfolderFirst(ordered);
 }
 
 export function isValidCameraName(name: string): boolean {
@@ -173,7 +239,7 @@ export function organizeSubfolderCameras(
     return {
       ...empty,
       error: (
-        `Subfolder names must be letters and numbers only (no spaces): ${invalid.join(', ')}. `
+        `Subfolder names must be letters, numbers, and underscores only (no spaces): ${invalid.join(', ')}. `
         + 'Rename folders on disk or edit camera names after import.'
       ),
     };
@@ -288,6 +354,44 @@ export function isVideoFileName(fileName: string): boolean {
   return fileVideoTypes.includes(ext);
 }
 
+export function isImageFileName(fileName: string): boolean {
+  const parts = fileName.split('.');
+  if (parts.length < 2) {
+    return false;
+  }
+  const ext = parts.pop()?.toLowerCase() ?? '';
+  return fileImageTypes.includes(ext);
+}
+
+export function isMediaFileName(
+  fileName: string,
+  mediaType: 'image-sequence' | 'video',
+): boolean {
+  return mediaType === 'video' ? isVideoFileName(fileName) : isImageFileName(fileName);
+}
+
+export function filterMediaFiles(
+  fileList: Pick<File, 'name'>[],
+  mediaType: 'image-sequence' | 'video',
+): Pick<File, 'name'>[] {
+  return fileList.filter((file) => isMediaFileName(file.name, mediaType));
+}
+
+/** Drop subfolder groups that do not contain importable image or video files. */
+export function filterSubfolderGroupsWithMedia(
+  groups: Map<string, File[]>,
+  mediaType: 'image-sequence' | 'video',
+): Map<string, File[]> {
+  const filtered = new Map<string, File[]>();
+  groups.forEach((files, folderName) => {
+    const mediaFiles = filterMediaFiles(files, mediaType) as File[];
+    if (mediaFiles.length) {
+      filtered.set(folderName, mediaFiles);
+    }
+  });
+  return filtered;
+}
+
 /** Display label for a video camera in parent-folder import (includes file extension when known). */
 export function subfolderVideoDisplayLabel(
   sourcePath: string,
@@ -339,10 +443,17 @@ export function groupRootLevelVideoFiles(
  */
 export function groupParentFolderByCamera(
   fileList: File[],
-  options?: { allowRootLevelVideos?: boolean },
+  options?: {
+    allowRootLevelVideos?: boolean;
+    mediaType?: 'image-sequence' | 'video';
+  },
   root = '',
 ): Map<string, File[]> {
-  const subfolderGroups = groupFilesByImmediateSubfolder(fileList, root);
+  const mediaType = options?.mediaType ?? 'image-sequence';
+  const subfolderGroups = filterSubfolderGroupsWithMedia(
+    groupFilesByImmediateSubfolder(fileList, root),
+    mediaType,
+  );
   if (subfolderGroups.size >= 2) {
     return subfolderGroups;
   }

--- a/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
@@ -18,6 +18,7 @@ import {
   applyParentPathToAssignments,
   commonPathPrefix,
   groupParentFolderByCamera,
+  inferSubfolderImportType,
   isValidCameraName,
   organizeSubfolderCameras,
   parentFolderLabelFromAbsolutePaths,
@@ -60,7 +61,11 @@ export function useImportMultiCamDialog(
     findParentFolderCalibrationFile,
   } = useApi();
   const importType: Ref<MulticamImportType> = ref('');
-  const folderList: Ref<Record<string, { sourcePath: string; trackFile: string }>> = ref({});
+  const folderList: Ref<Record<string, {
+    sourcePath: string;
+    trackFile: string;
+    type?: DatasetType;
+  }>> = ref({});
   const parentFolderName = ref('');
   const subfolderLayoutLabel = ref('');
   const keywordFolder = ref('');
@@ -272,6 +277,19 @@ export function useImportMultiCamDialog(
     return false;
   });
 
+  const showFinalizeStep = computed(() => {
+    if (importType.value === 'subfolders') {
+      return false;
+    }
+    if (importType.value === 'multi') {
+      return camerasReady.value;
+    }
+    if (importType.value === 'keyword') {
+      return nextSteps.value;
+    }
+    return false;
+  });
+
   async function openParentFolder() {
     const ret = await openFromDisk(props.dataType, true);
     if (ret.canceled) {
@@ -295,6 +313,7 @@ export function useImportMultiCamDialog(
         parentPath = ret.root || commonPathPrefix(paths);
         grouped = groupParentFolderByCamera(ret.fileList, {
           allowRootLevelVideos: props.dataType === VideoType,
+          mediaType,
         }, parentPath);
         folderNames = [...grouped.keys()];
       } else {
@@ -374,7 +393,13 @@ export function useImportMultiCamDialog(
             files,
           ),
         );
-        Vue.set(folderList.value, cameraName, { sourcePath, trackFile: '' });
+        Vue.set(folderList.value, cameraName, {
+          sourcePath,
+          trackFile: '',
+          type: props.registerSubfolderCameras && props.dataType !== VideoType
+            ? inferSubfolderImportType(files, { largeImageForTiff: true })
+            : props.dataType,
+        });
         // eslint-disable-next-line no-await-in-loop -- import each camera media sequentially
         const mediaPayload = await props.importMedia(sourcePath);
         Vue.set(pendingImportPayloads.value, cameraName, mediaPayload);
@@ -393,7 +418,7 @@ export function useImportMultiCamDialog(
       return;
     }
     if (!isValidCameraName(newKey)) {
-      throw new Error('Camera name must be letters and numbers only');
+      throw new Error('Camera name must be letters, numbers, and underscores only');
     }
     if (folderList.value[newKey]) {
       throw new Error(`Camera name "${newKey}" already exists`);
@@ -496,6 +521,13 @@ export function useImportMultiCamDialog(
         }
         folderList.value[folder].trackFile = '';
         const { sourcePath } = folderList.value[folder];
+        if (props.registerSubfolderCameras && ret.fileList?.length) {
+          props.registerSubfolderCameras([{
+            cameraName: folder,
+            sourcePath,
+            files: ret.fileList,
+          }]);
+        }
         Vue.set(
           pendingImportPayloads.value,
           folder,
@@ -564,7 +596,12 @@ export function useImportMultiCamDialog(
       const sourceList: MultiCamImportFolderArgs['sourceList'] = {};
       orderedCameraKeys.value.forEach((key) => {
         if (folderList.value[key]) {
-          sourceList[key] = folderList.value[key];
+          const { sourcePath, trackFile, type } = folderList.value[key];
+          sourceList[key] = {
+            sourcePath,
+            trackFile,
+            ...(type ? { type } : {}),
+          };
         }
       });
       const args: MultiCamImportFolderArgs = {
@@ -593,7 +630,7 @@ export function useImportMultiCamDialog(
   ];
 
   function syncSuggestedDatasetNameFromCameraPaths() {
-    if (!listParentFolderCameras || importType.value !== 'multi') {
+    if (importType.value !== 'multi') {
       return;
     }
     const paths = Object.values(folderList.value)
@@ -685,6 +722,7 @@ export function useImportMultiCamDialog(
     datasetNameRules,
     errorMessage,
     nextSteps,
+    showFinalizeStep,
     open,
     openParentFolder,
     prepForImport,

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -62,6 +62,12 @@ import type {
 import clientSettingsSetup, { clientSettings, isStereoInteractiveModeEnabled } from 'dive-common/store/settings';
 import { useApi, FrameImage, DatasetType } from 'dive-common/apispec';
 import { orderedMultiCamCameraNames } from 'dive-common/multicamDisplay';
+import {
+  computeOutputs,
+  computeIsDefault,
+  defaultImageEnhancements,
+  ImageEnhancements,
+} from 'vue-media-annotator/use/useImageEnhancements';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import context from 'dive-common/store/context';
 import { MarkChangesPendingFilter } from 'vue-media-annotator/BaseFilterControls';
@@ -291,7 +297,7 @@ export default defineComponent({
 
     const {
       imageEnhancements,
-      imageEnhancementOutputs,
+      imageEnhancementsByCamera,
       isDefaultImage,
       setImageEnhancements,
       setSVGFilters,
@@ -616,14 +622,39 @@ export default defineComponent({
       });
     }
 
-    function saveImageEnhancements() {
-      saveMetadata(datasetId.value, {
-        imageEnhancements: imageEnhancements.value,
-      });
-    }
-    const debouncedSaveImageEnhancements = debounce(saveImageEnhancements, 1000, { trailing: true });
+    const debouncedSaves: Record<string, ReturnType<typeof debounce>> = {};
 
-    watch(imageEnhancements, debouncedSaveImageEnhancements, { deep: true });
+    function getCameraId(camera: string): string {
+      return multiCamList.value.length > 1
+        ? `${baseMulticamDatasetId.value}/${camera}`
+        : datasetId.value;
+    }
+
+    function getDebouncedSave(camera: string) {
+      if (!debouncedSaves[camera]) {
+        debouncedSaves[camera] = debounce(
+          () => saveMetadata(
+            getCameraId(camera),
+            { imageEnhancements: imageEnhancementsByCamera.value[camera] },
+          ),
+          1000,
+          { trailing: true },
+        );
+      }
+      return debouncedSaves[camera];
+    }
+
+    watch(imageEnhancements, () => {
+      imageEnhancementsByCamera.value[selectedCamera.value] = imageEnhancements.value;
+      getDebouncedSave(selectedCamera.value)();
+    }, { deep: true });
+
+    watch(selectedCamera, (newCam, oldCam) => {
+      debouncedSaves[oldCam]?.flush();
+      setImageEnhancements(
+        imageEnhancementsByCamera.value[newCam] ?? { ...defaultImageEnhancements },
+      );
+    });
 
     // Auto-save annotations when enabled, but never while editing a track.
     // Delay is configurable in settings and applied dynamically.
@@ -917,9 +948,7 @@ export default defineComponent({
         }
         trackFilters.setConfidenceFilters(meta.confidenceFilters);
         trackFilters.setTimeFilters(meta.timeFilters ?? null);
-        if (meta.imageEnhancements) {
-          setImageEnhancements(meta.imageEnhancements);
-        }
+        /* imageEnhancements are loaded per-camera below */
         datasetName.value = meta.name;
         subType.value = meta.subType || null;
         initTime({
@@ -937,6 +966,9 @@ export default defineComponent({
           datasetType.value = subCameraMeta.type as DatasetType;
 
           imageData.value[camera] = cloneDeep(subCameraMeta.imageData) as FrameImage[];
+          imageEnhancementsByCamera.value[camera] = subCameraMeta.imageEnhancements
+            ? { ...subCameraMeta.imageEnhancements as ImageEnhancements }
+            : { ...defaultImageEnhancements };
           if (subCameraMeta.videoUrl) {
             videoUrl.value[camera] = subCameraMeta.videoUrl;
           }
@@ -1042,6 +1074,9 @@ export default defineComponent({
         if (meta.attributeTrackFilters) {
           trackFilters.loadTrackAttributesFilter(Object.values(meta.attributeTrackFilters));
         }
+        setImageEnhancements(
+          imageEnhancementsByCamera.value[selectedCamera.value] ?? { ...defaultImageEnhancements },
+        );
         progress.loaded = true;
         // If multiCam add Tools and remove group Tools
         if (cameraStore.camMap.value.size > 1) {
@@ -1078,6 +1113,9 @@ export default defineComponent({
     const reloadAnnotations = async () => {
       progress.loaded = false;
       discardChanges();
+      Object.values(debouncedSaves).forEach((fn) => fn.cancel());
+      Object.keys(debouncedSaves).forEach((k) => delete debouncedSaves[k]);
+      imageEnhancementsByCamera.value = {};
       cameraStore.clearAll();
       mediaControllerClear();
       await loadData();
@@ -1112,6 +1150,7 @@ export default defineComponent({
     });
     onBeforeUnmount(() => {
       debouncedAutoSave.cancel();
+      Object.values(debouncedSaves).forEach((fn) => fn.flush());
       if (controlsRef.value) observer.unobserve(controlsRef.value.$el);
     });
 
@@ -1326,6 +1365,18 @@ export default defineComponent({
       }
     }
 
+    function cameraEnhOutputs(camera: string) {
+      return computeOutputs(
+        imageEnhancementsByCamera.value[camera] ?? defaultImageEnhancements,
+      );
+    }
+
+    function isCameraDefault(camera: string): boolean {
+      return computeIsDefault(
+        imageEnhancementsByCamera.value[camera] ?? defaultImageEnhancements,
+      );
+    }
+
     return {
       /* props */
       aggregateController,
@@ -1379,8 +1430,9 @@ export default defineComponent({
       originalFps: time.originalFps,
       context,
       readonlyState,
-      imageEnhancementOutputs,
       isDefaultImage,
+      cameraEnhOutputs,
+      isCameraDefault,
       disableAnnotationFilters,
       trackStyleManager,
       visible,
@@ -1738,8 +1790,8 @@ export default defineComponent({
                   frameRate,
                   originalFps,
                   camera,
-                  imageEnhancementOutputs,
-                  isDefaultImage,
+                  imageEnhancementOutputs: cameraEnhOutputs(camera),
+                  isDefaultImage: isCameraDefault(camera),
                   getTiles,
                   getTileURL,
                   filterId: `imageEnhancements-${camera}`,
@@ -1835,8 +1887,8 @@ export default defineComponent({
                   frameRate,
                   originalFps,
                   camera,
-                  imageEnhancementOutputs,
-                  isDefaultImage,
+                  imageEnhancementOutputs: cameraEnhOutputs(camera),
+                  isDefaultImage: isCameraDefault(camera),
                   getTiles,
                   getTileURL,
                   filterId: `imageEnhancements-${camera}`,

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -1742,6 +1742,7 @@ export default defineComponent({
                   isDefaultImage,
                   getTiles,
                   getTileURL,
+                  filterId: `imageEnhancements-${camera}`,
                 }"
                 @large-image-warning="$emit('large-image-warning', true)"
               >
@@ -1838,6 +1839,7 @@ export default defineComponent({
                   isDefaultImage,
                   getTiles,
                   getTileURL,
+                  filterId: `imageEnhancements-${camera}`,
                 }"
                 @large-image-warning="$emit('large-image-warning', true)"
               >

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -171,6 +171,7 @@ export default defineComponent({
     const imageData = ref({ singleCam: [] } as Record<string, FrameImage[]>);
     const rawImageData = ref({ singleCam: [] } as Record<string, FrameImage[]>);
     const datasetType: Ref<DatasetType> = ref('image-sequence');
+    const cameraTypesByCamera: Ref<Record<string, DatasetType>> = ref({});
     const datasetName = ref('');
     const subType = ref(null as string | null);
     const saveInProgress = ref(false);
@@ -764,7 +765,8 @@ export default defineComponent({
       histogramRequestToken = requestToken;
       setPercentileHistogramLoading(true);
       try {
-        if (datasetType.value === 'large-image' && rawFrame.id && getTileHistogram) {
+        const cameraType = cameraTypesByCamera.value[camera] ?? datasetType.value;
+        if (cameraType === 'large-image' && rawFrame.id && getTileHistogram) {
           const response = await getTileHistogram(rawFrame.id, { bins: 256 });
           if (histogramRequestToken !== requestToken) return;
           setPercentileHistogram(
@@ -1131,6 +1133,7 @@ export default defineComponent({
         /* imageEnhancements are loaded per-camera below */
         datasetName.value = meta.name;
         subType.value = meta.subType || null;
+        datasetType.value = meta.type as DatasetType;
         initTime({
           frameRate: meta.fps,
           originalFps: meta.originalFps || null,
@@ -1143,7 +1146,10 @@ export default defineComponent({
           }
           // eslint-disable-next-line no-await-in-loop
           const subCameraMeta = await loadMetadata(cameraId);
-          datasetType.value = subCameraMeta.type as DatasetType;
+          VueSet(cameraTypesByCamera.value, camera, subCameraMeta.type as DatasetType);
+          if (multiCamList.value.length <= 1) {
+            datasetType.value = subCameraMeta.type as DatasetType;
+          }
 
           VueSet(imageEnhancementsByCamera.value, camera, subCameraMeta.imageEnhancements
             ? { ...subCameraMeta.imageEnhancements as ImageEnhancements }
@@ -1311,6 +1317,7 @@ export default defineComponent({
       Object.keys(debouncedApplyUrlsByCam).forEach((k) => delete debouncedApplyUrlsByCam[k]);
       Object.keys(previousStretchByCam).forEach((k) => delete previousStretchByCam[k]);
       imageEnhancementsByCamera.value = {};
+      cameraTypesByCamera.value = {};
       percentileStretchSupportedByCamera.value = {};
       setPercentileStretchSupported(false);
       setPercentileHistogram(null);
@@ -1569,6 +1576,17 @@ export default defineComponent({
       }
     }
 
+    function cameraAnnotatorComponent(camera: string): string {
+      const type = cameraTypesByCamera.value[camera] ?? datasetType.value;
+      if (type === 'image-sequence') {
+        return 'image-annotator';
+      }
+      if (type === 'video') {
+        return 'video-annotator';
+      }
+      return 'large-image-annotator';
+    }
+
     function cameraEnhOutputs(camera: string) {
       return computeOutputs(
         imageEnhancementsByCamera.value[camera] ?? defaultImageEnhancements,
@@ -1614,6 +1632,7 @@ export default defineComponent({
       clientSettings,
       datasetName,
       datasetType,
+      cameraAnnotatorComponent,
       subType,
       editingTrack,
       editingMode,
@@ -1990,10 +2009,7 @@ export default defineComponent({
               @mouseup.right="changeCamera(camera, $event)"
             >
               <component
-                :is="datasetType === 'image-sequence' ? 'image-annotator'
-                  : datasetType === 'video'
-                    ? 'video-annotator'
-                    : 'large-image-annotator'"
+                :is="cameraAnnotatorComponent(camera)"
                 v-if="(imageData[camera].length || videoUrl[camera]) && progress.loaded"
                 ref="subPlaybackComponent"
                 class="fill-height"
@@ -2090,8 +2106,7 @@ export default defineComponent({
               @mouseup.right="changeCamera(camera, $event)"
             >
               <component
-                :is="datasetType === 'image-sequence' ? 'image-annotator'
-                  : datasetType === 'video' ? 'video-annotator' : 'large-image-annotator'"
+                :is="cameraAnnotatorComponent(camera)"
                 v-if="(imageData[camera].length || videoUrl[camera]) && progress.loaded"
                 ref="subPlaybackComponent"
                 class="fill-height"

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -66,7 +66,9 @@ import {
   computeOutputs,
   computeIsDefault,
   defaultImageEnhancements,
+  effectiveImageEnhancements,
   ImageEnhancements,
+  metadataSupportsPercentileStretch,
 } from 'vue-media-annotator/use/useImageEnhancements';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import context from 'dive-common/store/context';
@@ -299,9 +301,22 @@ export default defineComponent({
     const {
       imageEnhancements,
       imageEnhancementsByCamera,
+      percentileStretchSupported,
       setImageEnhancements,
       setSVGFilters,
+      setPercentileStretchSupported,
     } = useImageEnhancements();
+
+    const isDesktopApp = typeof window !== 'undefined' && 'diveDesktop' in window;
+    const percentileStretchSupportedByCamera: Ref<Record<string, boolean>> = ref({});
+
+    function cameraSupportsPercentileStretch(camera: string): boolean {
+      return percentileStretchSupportedByCamera.value[camera] ?? false;
+    }
+
+    function syncPercentileStretchSupported(camera: string) {
+      setPercentileStretchSupported(cameraSupportsPercentileStretch(camera));
+    }
 
     const segmentationRecipe = new SegmentationPointClick();
     const segmentationCursorLoading = computed(
@@ -670,16 +685,24 @@ export default defineComponent({
 
     function stretchKey(camera: string): string {
       const enh = imageEnhancementsByCamera.value[camera];
-      const s = enh?.percentileStretch;
+      const effective = effectiveImageEnhancements(
+        enh ?? defaultImageEnhancements,
+        cameraSupportsPercentileStretch(camera),
+      );
+      const s = effective.percentileStretch;
       return s ? `${s.lowPercentile}:${s.highPercentile}` : 'none';
     }
 
     function applyDisplayUrls(camera: string) {
       const raw = rawImageData.value[camera] ?? [];
       const enh = imageEnhancementsByCamera.value[camera];
+      const effective = effectiveImageEnhancements(
+        enh ?? defaultImageEnhancements,
+        cameraSupportsPercentileStretch(camera),
+      );
       let frames: FrameImage[];
-      if (enh?.percentileStretch) {
-        const { lowPercentile, highPercentile } = enh.percentileStretch;
+      if (effective.percentileStretch) {
+        const { lowPercentile, highPercentile } = effective.percentileStretch;
         frames = raw.map((item, index) => ({
           ...item,
           url: toDisplayUrl(item.url, camera, index, lowPercentile, highPercentile),
@@ -725,6 +748,7 @@ export default defineComponent({
       setImageEnhancements(
         imageEnhancementsByCamera.value[newCam] ?? { ...defaultImageEnhancements },
       );
+      syncPercentileStretchSupported(newCam);
       // cancel the save that watch(imageEnhancements) schedules when setImageEnhancements
       // replaces the ref — loading a camera's stored state is not a user-initiated change
       nextTick(() => { debouncedSaves[newCam]?.cancel(); });
@@ -1042,6 +1066,11 @@ export default defineComponent({
           VueSet(imageEnhancementsByCamera.value, camera, subCameraMeta.imageEnhancements
             ? { ...subCameraMeta.imageEnhancements as ImageEnhancements }
             : { ...defaultImageEnhancements });
+          VueSet(
+            percentileStretchSupportedByCamera.value,
+            camera,
+            isDesktopApp && metadataSupportsPercentileStretch(subCameraMeta),
+          );
           VueSet(rawImageData.value, camera, cloneDeep(subCameraMeta.imageData) as FrameImage[]);
           applyDisplayUrls(camera);
           if (subCameraMeta.videoUrl) {
@@ -1152,6 +1181,7 @@ export default defineComponent({
         setImageEnhancements(
           imageEnhancementsByCamera.value[selectedCamera.value] ?? { ...defaultImageEnhancements },
         );
+        syncPercentileStretchSupported(selectedCamera.value);
         progress.loaded = true;
         // If multiCam add Tools and remove group Tools
         if (cameraStore.camMap.value.size > 1) {
@@ -1194,6 +1224,8 @@ export default defineComponent({
       Object.keys(debouncedApplyUrlsByCam).forEach((k) => delete debouncedApplyUrlsByCam[k]);
       Object.keys(previousStretchByCam).forEach((k) => delete previousStretchByCam[k]);
       imageEnhancementsByCamera.value = {};
+      percentileStretchSupportedByCamera.value = {};
+      setPercentileStretchSupported(false);
       cameraStore.clearAll();
       mediaControllerClear();
       await loadData();
@@ -1290,6 +1322,7 @@ export default defineComponent({
         visibleModes,
         readOnlyMode: readonlyState,
         imageEnhancements,
+        percentileStretchSupported,
       },
       globalHandler,
       useAttributeFilters,
@@ -1452,7 +1485,10 @@ export default defineComponent({
 
     function isCameraDefault(camera: string): boolean {
       return computeIsDefault(
-        imageEnhancementsByCamera.value[camera] ?? defaultImageEnhancements,
+        effectiveImageEnhancements(
+          imageEnhancementsByCamera.value[camera] ?? defaultImageEnhancements,
+          cameraSupportsPercentileStretch(camera),
+        ),
       );
     }
 

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -299,7 +299,6 @@ export default defineComponent({
     const {
       imageEnhancements,
       imageEnhancementsByCamera,
-      isDefaultImage,
       setImageEnhancements,
       setSVGFilters,
     } = useImageEnhancements();
@@ -646,7 +645,9 @@ export default defineComponent({
     }
 
     function toDisplayUrl(rawUrl: string, low: number, high: number): string {
-      const path = new URLSearchParams(rawUrl.split('?')[1]).get('path') ?? '';
+      const queryStr = rawUrl.split('?')[1];
+      const path = (queryStr ? new URLSearchParams(queryStr).get('path') : null) ?? '';
+      if (!path) console.error('[toDisplayUrl] could not extract path from URL:', rawUrl);
       return `/api/media/display?path=${encodeURIComponent(path)}&low=${low}&high=${high}`;
     }
 
@@ -671,11 +672,20 @@ export default defineComponent({
       } else {
         frames = raw;
       }
-      VueSet(imageData.value, camera, frames);
+      if (imageData.value[camera] !== frames) {
+        VueSet(imageData.value, camera, frames);
+      }
       previousStretchByCam[camera] = stretchKey(camera);
     }
 
-    const debouncedApplyDisplayUrls = debounce(applyDisplayUrls, 500, { trailing: true });
+    const debouncedApplyUrlsByCam: Record<string, ReturnType<typeof debounce>> = {};
+
+    function getDebouncedApplyDisplayUrls(camera: string) {
+      if (!debouncedApplyUrlsByCam[camera]) {
+        debouncedApplyUrlsByCam[camera] = debounce(applyDisplayUrls, 500, { trailing: true });
+      }
+      return debouncedApplyUrlsByCam[camera];
+    }
 
     watch(imageEnhancements, () => {
       const camera = selectedCamera.value;
@@ -687,10 +697,10 @@ export default defineComponent({
       if (current !== previous) {
         const isToggle = (current === 'none') !== (previous === 'none');
         if (isToggle) {
-          debouncedApplyDisplayUrls.cancel();
+          getDebouncedApplyDisplayUrls(camera).cancel();
           applyDisplayUrls(camera);
         } else {
-          debouncedApplyDisplayUrls(camera);
+          getDebouncedApplyDisplayUrls(camera)(camera);
         }
       }
     }, { deep: true });
@@ -1165,7 +1175,8 @@ export default defineComponent({
       discardChanges();
       Object.values(debouncedSaves).forEach((fn) => fn.cancel());
       Object.keys(debouncedSaves).forEach((k) => delete debouncedSaves[k]);
-      debouncedApplyDisplayUrls.cancel();
+      Object.values(debouncedApplyUrlsByCam).forEach((fn) => fn.cancel());
+      Object.keys(debouncedApplyUrlsByCam).forEach((k) => delete debouncedApplyUrlsByCam[k]);
       Object.keys(previousStretchByCam).forEach((k) => delete previousStretchByCam[k]);
       imageEnhancementsByCamera.value = {};
       cameraStore.clearAll();
@@ -1202,7 +1213,7 @@ export default defineComponent({
     });
     onBeforeUnmount(() => {
       debouncedAutoSave.cancel();
-      debouncedApplyDisplayUrls.cancel();
+      Object.values(debouncedApplyUrlsByCam).forEach((fn) => fn.cancel());
       Object.values(debouncedSaves).forEach((fn) => fn.flush());
       if (controlsRef.value) observer.unobserve(controlsRef.value.$el);
     });
@@ -1483,7 +1494,6 @@ export default defineComponent({
       originalFps: time.originalFps,
       context,
       readonlyState,
-      isDefaultImage,
       cameraEnhOutputs,
       isCameraDefault,
       disableAnnotationFilters,
@@ -1859,7 +1869,7 @@ export default defineComponent({
             ref="controlsRef"
             :collapsed.sync="controlsCollapsed"
             v-bind="{
-              lineChartData, eventChartData, groupChartData, datasetType, isDefaultImage,
+              lineChartData, eventChartData, groupChartData, datasetType, isDefaultImage: isCameraDefault(selectedCamera),
             }"
           />
         </div>
@@ -1961,7 +1971,7 @@ export default defineComponent({
             :event-chart-data="eventChartData"
             :group-chart-data="groupChartData"
             :dataset-type="datasetType"
-            :is-default-image="isDefaultImage"
+            :is-default-image="isCameraDefault(selectedCamera)"
             :client-settings="clientSettings"
             :track-filters="trackFilters"
             :attributes="attributes"

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -69,6 +69,7 @@ import {
   effectiveImageEnhancements,
   ImageEnhancements,
   metadataSupportsPercentileStretch,
+  PercentileHistogram,
 } from 'vue-media-annotator/use/useImageEnhancements';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import context from 'dive-common/store/context';
@@ -302,9 +303,13 @@ export default defineComponent({
       imageEnhancements,
       imageEnhancementsByCamera,
       percentileStretchSupported,
+      percentileHistogram,
+      percentileHistogramLoading,
       setImageEnhancements,
       setSVGFilters,
       setPercentileStretchSupported,
+      setPercentileHistogram,
+      setPercentileHistogramLoading,
     } = useImageEnhancements();
 
     const isDesktopApp = typeof window !== 'undefined' && 'diveDesktop' in window;
@@ -681,6 +686,22 @@ export default defineComponent({
       return `${apiBase}/media/display?id=${id}&frame=${frame}&low=${low}&high=${high}`;
     }
 
+    function toHistogramUrl(
+      rawUrl: string,
+      camera: string,
+      frame: number,
+      low: number,
+      high: number,
+    ): string {
+      let apiBase = '/api';
+      try {
+        const parsed = new URL(rawUrl);
+        apiBase = `${parsed.origin}/api`;
+      } catch { /* rawUrl is relative (web platform) — keep /api */ }
+      const id = encodeURIComponent(getCameraId(camera));
+      return `${apiBase}/media/histogram?id=${id}&frame=${frame}&low=${low}&high=${high}`;
+    }
+
     const previousStretchByCam: Record<string, string> = {};
 
     function stretchKey(camera: string): string {
@@ -716,7 +737,49 @@ export default defineComponent({
       previousStretchByCam[camera] = stretchKey(camera);
     }
 
+    let histogramRequestToken = 0;
+
+    async function fetchSelectedCameraHistogram() {
+      const camera = selectedCamera.value;
+      const frame = time.frame.value;
+      const rawFrames = rawImageData.value[camera] ?? [];
+      if (!progress.loaded || !cameraSupportsPercentileStretch(camera) || frame < 0 || frame >= rawFrames.length) {
+        histogramRequestToken += 1;
+        setPercentileHistogram(null);
+        setPercentileHistogramLoading(false);
+        return;
+      }
+      const rawFrame = rawFrames[frame];
+      if (!rawFrame?.url) {
+        histogramRequestToken += 1;
+        setPercentileHistogram(null);
+        setPercentileHistogramLoading(false);
+        return;
+      }
+      // Bins depend only on the source frame; percentile markers are derived client-side.
+      const requestToken = histogramRequestToken + 1;
+      histogramRequestToken = requestToken;
+      setPercentileHistogramLoading(true);
+      try {
+        const response = await fetch(toHistogramUrl(rawFrame.url, camera, frame, 1, 99));
+        if (!response.ok) {
+          throw new Error(`Histogram request failed with status ${response.status}`);
+        }
+        const payload = await response.json() as PercentileHistogram;
+        if (histogramRequestToken !== requestToken) return;
+        setPercentileHistogram(payload);
+      } catch {
+        if (histogramRequestToken !== requestToken) return;
+        setPercentileHistogram(null);
+      } finally {
+        if (histogramRequestToken === requestToken) {
+          setPercentileHistogramLoading(false);
+        }
+      }
+    }
+
     const debouncedApplyUrlsByCam: Record<string, ReturnType<typeof debounce>> = {};
+    const debouncedFetchHistogram = debounce(fetchSelectedCameraHistogram, 200, { trailing: true });
 
     function getDebouncedApplyDisplayUrls(camera: string) {
       if (!debouncedApplyUrlsByCam[camera]) {
@@ -745,14 +808,21 @@ export default defineComponent({
 
     watch(selectedCamera, (newCam, oldCam) => {
       debouncedSaves[oldCam]?.flush();
+      debouncedFetchHistogram.cancel();
       setImageEnhancements(
         imageEnhancementsByCamera.value[newCam] ?? { ...defaultImageEnhancements },
       );
       syncPercentileStretchSupported(newCam);
+      fetchSelectedCameraHistogram().catch(() => {});
       // cancel the save that watch(imageEnhancements) schedules when setImageEnhancements
       // replaces the ref — loading a camera's stored state is not a user-initiated change
       nextTick(() => { debouncedSaves[newCam]?.cancel(); });
     });
+
+    watch(
+      [() => time.frame.value, percentileStretchSupported],
+      () => { debouncedFetchHistogram(); },
+    );
 
     // Auto-save annotations when enabled, but never while editing a track.
     // Delay is configurable in settings and applied dynamically.
@@ -1183,6 +1253,7 @@ export default defineComponent({
         );
         syncPercentileStretchSupported(selectedCamera.value);
         progress.loaded = true;
+        fetchSelectedCameraHistogram().catch(() => {});
         // If multiCam add Tools and remove group Tools
         if (cameraStore.camMap.value.size > 1) {
           context.unregister({
@@ -1226,6 +1297,8 @@ export default defineComponent({
       imageEnhancementsByCamera.value = {};
       percentileStretchSupportedByCamera.value = {};
       setPercentileStretchSupported(false);
+      setPercentileHistogram(null);
+      setPercentileHistogramLoading(false);
       cameraStore.clearAll();
       mediaControllerClear();
       await loadData();
@@ -1261,6 +1334,7 @@ export default defineComponent({
     onBeforeUnmount(() => {
       debouncedAutoSave.cancel();
       Object.values(debouncedApplyUrlsByCam).forEach((fn) => fn.cancel());
+      debouncedFetchHistogram.cancel();
       Object.values(debouncedSaves).forEach((fn) => fn.flush());
       if (controlsRef.value) observer.unobserve(controlsRef.value.$el);
     });
@@ -1323,6 +1397,8 @@ export default defineComponent({
         readOnlyMode: readonlyState,
         imageEnhancements,
         percentileStretchSupported,
+        percentileHistogram,
+        percentileHistogramLoading,
       },
       globalHandler,
       useAttributeFilters,

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -163,6 +163,7 @@ export default defineComponent({
     } = useMediaController();
     const { time, updateTime, initialize: initTime } = useTimeObserver();
     const imageData = ref({ singleCam: [] } as Record<string, FrameImage[]>);
+    const rawImageData = ref({ singleCam: [] } as Record<string, FrameImage[]>);
     const datasetType: Ref<DatasetType> = ref('image-sequence');
     const datasetName = ref('');
     const subType = ref(null as string | null);
@@ -644,9 +645,54 @@ export default defineComponent({
       return debouncedSaves[camera];
     }
 
+    function toDisplayUrl(rawUrl: string, low: number, high: number): string {
+      const path = new URLSearchParams(rawUrl.split('?')[1]).get('path') ?? '';
+      return `/api/media/display?path=${encodeURIComponent(path)}&low=${low}&high=${high}`;
+    }
+
+    const previousStretchByCam: Record<string, string> = {};
+
+    function stretchKey(camera: string): string {
+      const enh = imageEnhancementsByCamera.value[camera];
+      const s = enh?.percentileStretch;
+      return s ? `${s.lowPercentile}:${s.highPercentile}` : 'none';
+    }
+
+    function applyDisplayUrls(camera: string) {
+      const raw = rawImageData.value[camera] ?? [];
+      const enh = imageEnhancementsByCamera.value[camera];
+      let frames: FrameImage[];
+      if (enh?.percentileStretch) {
+        const { lowPercentile, highPercentile } = enh.percentileStretch;
+        frames = raw.map((item) => ({
+          ...item,
+          url: toDisplayUrl(item.url, lowPercentile, highPercentile),
+        }));
+      } else {
+        frames = raw;
+      }
+      VueSet(imageData.value, camera, frames);
+      previousStretchByCam[camera] = stretchKey(camera);
+    }
+
+    const debouncedApplyDisplayUrls = debounce(applyDisplayUrls, 500, { trailing: true });
+
     watch(imageEnhancements, () => {
-      VueSet(imageEnhancementsByCamera.value, selectedCamera.value, imageEnhancements.value);
-      getDebouncedSave(selectedCamera.value)();
+      const camera = selectedCamera.value;
+      VueSet(imageEnhancementsByCamera.value, camera, imageEnhancements.value);
+      getDebouncedSave(camera)();
+
+      const current = stretchKey(camera);
+      const previous = previousStretchByCam[camera] ?? 'none';
+      if (current !== previous) {
+        const isToggle = (current === 'none') !== (previous === 'none');
+        if (isToggle) {
+          debouncedApplyDisplayUrls.cancel();
+          applyDisplayUrls(camera);
+        } else {
+          debouncedApplyDisplayUrls(camera);
+        }
+      }
     }, { deep: true });
 
     watch(selectedCamera, (newCam, oldCam) => {
@@ -968,10 +1014,11 @@ export default defineComponent({
           const subCameraMeta = await loadMetadata(cameraId);
           datasetType.value = subCameraMeta.type as DatasetType;
 
-          imageData.value[camera] = cloneDeep(subCameraMeta.imageData) as FrameImage[];
           VueSet(imageEnhancementsByCamera.value, camera, subCameraMeta.imageEnhancements
             ? { ...subCameraMeta.imageEnhancements as ImageEnhancements }
             : { ...defaultImageEnhancements });
+          VueSet(rawImageData.value, camera, cloneDeep(subCameraMeta.imageData) as FrameImage[]);
+          applyDisplayUrls(camera);
           if (subCameraMeta.videoUrl) {
             videoUrl.value[camera] = subCameraMeta.videoUrl;
           }
@@ -1118,6 +1165,8 @@ export default defineComponent({
       discardChanges();
       Object.values(debouncedSaves).forEach((fn) => fn.cancel());
       Object.keys(debouncedSaves).forEach((k) => delete debouncedSaves[k]);
+      debouncedApplyDisplayUrls.cancel();
+      Object.keys(previousStretchByCam).forEach((k) => delete previousStretchByCam[k]);
       imageEnhancementsByCamera.value = {};
       cameraStore.clearAll();
       mediaControllerClear();
@@ -1153,6 +1202,7 @@ export default defineComponent({
     });
     onBeforeUnmount(() => {
       debouncedAutoSave.cancel();
+      debouncedApplyDisplayUrls.cancel();
       Object.values(debouncedSaves).forEach((fn) => fn.flush());
       if (controlsRef.value) observer.unobserve(controlsRef.value.$el);
     });

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -68,8 +68,11 @@ import {
   defaultImageEnhancements,
   effectiveImageEnhancements,
   ImageEnhancements,
-  metadataSupportsPercentileStretch,
+  resolvePercentileStretchSupported,
+  parseGirderHistogramResponse,
+  girderHistogramToPercentileHistogram,
   PercentileHistogram,
+  PercentileStretch,
 } from 'vue-media-annotator/use/useImageEnhancements';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import context from 'dive-common/store/context';
@@ -173,7 +176,7 @@ export default defineComponent({
     const saveInProgress = ref(false);
     const videoUrl: Ref<Record<string, string>> = ref({});
     const {
-      loadDetections, loadMetadata, saveMetadata, getTiles, getTileURL,
+      loadDetections, loadMetadata, saveMetadata, getTiles, getTileURL, getTileHistogram,
     } = useApi();
     const progress = reactive({
       // Loaded flag prevents annotator window from populating
@@ -313,6 +316,7 @@ export default defineComponent({
     } = useImageEnhancements();
 
     const isDesktopApp = typeof window !== 'undefined' && 'diveDesktop' in window;
+    const supportsLargeImageTileStretch = !!getTileHistogram;
     const percentileStretchSupportedByCamera: Ref<Record<string, boolean>> = ref({});
 
     function cameraSupportsPercentileStretch(camera: string): boolean {
@@ -756,11 +760,19 @@ export default defineComponent({
         setPercentileHistogramLoading(false);
         return;
       }
-      // Bins depend only on the source frame; percentile markers are derived client-side.
       const requestToken = histogramRequestToken + 1;
       histogramRequestToken = requestToken;
       setPercentileHistogramLoading(true);
       try {
+        if (datasetType.value === 'large-image' && rawFrame.id && getTileHistogram) {
+          const response = await getTileHistogram(rawFrame.id, { bins: 256 });
+          if (histogramRequestToken !== requestToken) return;
+          setPercentileHistogram(
+            girderHistogramToPercentileHistogram(parseGirderHistogramResponse(response)),
+          );
+          return;
+        }
+        // Bins depend only on the source frame; percentile markers are derived client-side.
         const response = await fetch(toHistogramUrl(rawFrame.url, camera, frame, 1, 99));
         if (!response.ok) {
           throw new Error(`Histogram request failed with status ${response.status}`);
@@ -1139,7 +1151,11 @@ export default defineComponent({
           VueSet(
             percentileStretchSupportedByCamera.value,
             camera,
-            isDesktopApp && metadataSupportsPercentileStretch(subCameraMeta),
+            resolvePercentileStretchSupported(
+              subCameraMeta,
+              isDesktopApp,
+              supportsLargeImageTileStretch,
+            ),
           );
           VueSet(rawImageData.value, camera, cloneDeep(subCameraMeta.imageData) as FrameImage[]);
           applyDisplayUrls(camera);
@@ -1568,6 +1584,14 @@ export default defineComponent({
       );
     }
 
+    function cameraPercentileStretch(camera: string): PercentileStretch | null {
+      const effective = effectiveImageEnhancements(
+        imageEnhancementsByCamera.value[camera] ?? defaultImageEnhancements,
+        cameraSupportsPercentileStretch(camera),
+      );
+      return effective.percentileStretch ?? null;
+    }
+
     return {
       /* props */
       aggregateController,
@@ -1623,6 +1647,7 @@ export default defineComponent({
       readonlyState,
       cameraEnhOutputs,
       isCameraDefault,
+      cameraPercentileStretch,
       disableAnnotationFilters,
       trackStyleManager,
       visible,
@@ -1984,6 +2009,7 @@ export default defineComponent({
                   isDefaultImage: isCameraDefault(camera),
                   getTiles,
                   getTileURL,
+                  percentileStretch: cameraPercentileStretch(camera),
                   filterId: `imageEnhancements-${camera}`,
                 }"
                 @large-image-warning="$emit('large-image-warning', true)"
@@ -2081,6 +2107,7 @@ export default defineComponent({
                   isDefaultImage: isCameraDefault(camera),
                   getTiles,
                   getTileURL,
+                  percentileStretch: cameraPercentileStretch(camera),
                   filterId: `imageEnhancements-${camera}`,
                 }"
                 @large-image-warning="$emit('large-image-warning', true)"

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import {
   defineComponent, ref, toRef, computed, Ref,
-  reactive, watch, inject, provide, nextTick, onBeforeUnmount, PropType,
+  reactive, watch, inject, provide, nextTick, onBeforeUnmount, PropType, set as VueSet,
 } from 'vue';
 import type { Vue } from 'vue/types/vue';
 import type Vuetify from 'vuetify/lib';
@@ -645,7 +645,7 @@ export default defineComponent({
     }
 
     watch(imageEnhancements, () => {
-      imageEnhancementsByCamera.value[selectedCamera.value] = imageEnhancements.value;
+      VueSet(imageEnhancementsByCamera.value, selectedCamera.value, imageEnhancements.value);
       getDebouncedSave(selectedCamera.value)();
     }, { deep: true });
 
@@ -654,6 +654,9 @@ export default defineComponent({
       setImageEnhancements(
         imageEnhancementsByCamera.value[newCam] ?? { ...defaultImageEnhancements },
       );
+      // cancel the save that watch(imageEnhancements) schedules when setImageEnhancements
+      // replaces the ref — loading a camera's stored state is not a user-initiated change
+      nextTick(() => { debouncedSaves[newCam]?.cancel(); });
     });
 
     // Auto-save annotations when enabled, but never while editing a track.
@@ -966,9 +969,9 @@ export default defineComponent({
           datasetType.value = subCameraMeta.type as DatasetType;
 
           imageData.value[camera] = cloneDeep(subCameraMeta.imageData) as FrameImage[];
-          imageEnhancementsByCamera.value[camera] = subCameraMeta.imageEnhancements
+          VueSet(imageEnhancementsByCamera.value, camera, subCameraMeta.imageEnhancements
             ? { ...subCameraMeta.imageEnhancements as ImageEnhancements }
-            : { ...defaultImageEnhancements };
+            : { ...defaultImageEnhancements });
           if (subCameraMeta.videoUrl) {
             videoUrl.value[camera] = subCameraMeta.videoUrl;
           }

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -648,7 +648,15 @@ export default defineComponent({
       const queryStr = rawUrl.split('?')[1];
       const path = (queryStr ? new URLSearchParams(queryStr).get('path') : null) ?? '';
       if (!path) console.error('[toDisplayUrl] could not extract path from URL:', rawUrl);
-      return `/api/media/display?path=${encodeURIComponent(path)}&low=${low}&high=${high}`;
+      // For desktop the raw URL is absolute (http://127.0.0.1:PORT/api/media?path=...).
+      // Reuse its origin so requests go directly to the Express backend, not through the
+      // Vite proxy which doesn't know the randomly-assigned backend port.
+      let apiBase = '/api';
+      try {
+        const parsed = new URL(rawUrl);
+        apiBase = `${parsed.origin}/api`;
+      } catch { /* rawUrl is relative (web platform) — keep /api */ }
+      return `${apiBase}/media/display?path=${encodeURIComponent(path)}&low=${low}&high=${high}`;
     }
 
     const previousStretchByCam: Record<string, string> = {};

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -644,10 +644,16 @@ export default defineComponent({
       return debouncedSaves[camera];
     }
 
-    function toDisplayUrl(rawUrl: string, low: number, high: number): string {
-      const queryStr = rawUrl.split('?')[1];
-      const path = (queryStr ? new URLSearchParams(queryStr).get('path') : null) ?? '';
-      if (!path) console.error('[toDisplayUrl] could not extract path from URL:', rawUrl);
+    function toDisplayUrl(
+      rawUrl: string,
+      camera: string,
+      frame: number,
+      low: number,
+      high: number,
+    ): string {
+      // The backend resolves the ORIGINAL source image from (dataset id, frame index)
+      // rather than the transcoded path in rawUrl, so it can stretch the original 16-bit
+      // TIFF instead of the 8-bit PNG that import-time transcoding produced.
       // For desktop the raw URL is absolute (http://127.0.0.1:PORT/api/media?path=...).
       // Reuse its origin so requests go directly to the Express backend, not through the
       // Vite proxy which doesn't know the randomly-assigned backend port.
@@ -656,7 +662,8 @@ export default defineComponent({
         const parsed = new URL(rawUrl);
         apiBase = `${parsed.origin}/api`;
       } catch { /* rawUrl is relative (web platform) — keep /api */ }
-      return `${apiBase}/media/display?path=${encodeURIComponent(path)}&low=${low}&high=${high}`;
+      const id = encodeURIComponent(getCameraId(camera));
+      return `${apiBase}/media/display?id=${id}&frame=${frame}&low=${low}&high=${high}`;
     }
 
     const previousStretchByCam: Record<string, string> = {};
@@ -673,9 +680,9 @@ export default defineComponent({
       let frames: FrameImage[];
       if (enh?.percentileStretch) {
         const { lowPercentile, highPercentile } = enh.percentileStretch;
-        frames = raw.map((item) => ({
+        frames = raw.map((item, index) => ({
           ...item,
-          url: toDisplayUrl(item.url, lowPercentile, highPercentile),
+          url: toDisplayUrl(item.url, camera, index, lowPercentile, highPercentile),
         }));
       } else {
         frames = raw;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3203,9 +3203,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3227,9 +3224,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3251,9 +3245,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3275,9 +3266,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3299,9 +3287,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3323,9 +3308,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/client/platform/desktop/backend/media/displayProcessing.ts
+++ b/client/platform/desktop/backend/media/displayProcessing.ts
@@ -3,6 +3,14 @@ import PNG from 'pngjs';
 
 type RasterArray = Uint8Array | Uint16Array | Int16Array | Float32Array | Float64Array;
 
+export interface DisplayHistogram {
+  bins: number[];
+  lowValue: number;
+  highValue: number;
+  sourceMin: number;
+  sourceMax: number;
+}
+
 interface TiffImage {
   getWidth(): number;
   getHeight(): number;
@@ -13,8 +21,10 @@ interface TiffFile {
 }
 
 const MAX_DISPLAY_CACHE_ENTRIES = 64;
+const HISTOGRAM_BIN_COUNT = 256;
 
 const displayPngCache = new Map<string, Buffer>();
+const displayHistogramCache = new Map<string, DisplayHistogram>();
 
 function touchDisplayCacheEntry(key: string, value: Buffer): void {
   displayPngCache.delete(key);
@@ -22,6 +32,15 @@ function touchDisplayCacheEntry(key: string, value: Buffer): void {
   if (displayPngCache.size > MAX_DISPLAY_CACHE_ENTRIES) {
     const oldest = displayPngCache.keys().next().value as string | undefined;
     if (oldest) displayPngCache.delete(oldest);
+  }
+}
+
+function touchHistogramCacheEntry(key: string, value: DisplayHistogram): void {
+  displayHistogramCache.delete(key);
+  displayHistogramCache.set(key, value);
+  if (displayHistogramCache.size > MAX_DISPLAY_CACHE_ENTRIES) {
+    const oldest = displayHistogramCache.keys().next().value as string | undefined;
+    if (oldest) displayHistogramCache.delete(oldest);
   }
 }
 
@@ -141,6 +160,64 @@ function computeFrameBounds(
 }
 
 const inFlightDecodes = new Map<string, Promise<Buffer>>();
+const inFlightHistograms = new Map<string, Promise<DisplayHistogram>>();
+
+function computeSourceBounds(band: RasterArray): { sourceMin: number; sourceMax: number } {
+  if (band instanceof Uint8Array) return { sourceMin: 0, sourceMax: 255 };
+  if (band instanceof Uint16Array) return { sourceMin: 0, sourceMax: 65535 };
+  if (band.length === 0) return { sourceMin: 0, sourceMax: 1 };
+
+  let sourceMin = Number.POSITIVE_INFINITY;
+  let sourceMax = Number.NEGATIVE_INFINITY;
+  for (let i = 0; i < band.length; i += 1) {
+    const v = Number(band[i]);
+    if (v < sourceMin) sourceMin = v;
+    if (v > sourceMax) sourceMax = v;
+  }
+  if (!Number.isFinite(sourceMin) || !Number.isFinite(sourceMax)) {
+    return { sourceMin: 0, sourceMax: 1 };
+  }
+  return { sourceMin, sourceMax };
+}
+
+function buildHistogramBins(
+  band: RasterArray,
+  sourceMin: number,
+  sourceMax: number,
+  binCount = HISTOGRAM_BIN_COUNT,
+): number[] {
+  const bins = new Uint32Array(binCount);
+  if (band.length === 0) {
+    return Array.from(bins);
+  }
+
+  if (band instanceof Uint8Array && binCount === 256) {
+    for (let i = 0; i < band.length; i += 1) bins[band[i]] += 1;
+    return Array.from(bins);
+  }
+
+  if (band instanceof Uint16Array && binCount === 256) {
+    for (let i = 0; i < band.length; i += 1) {
+      bins[Math.floor(band[i] / 256)] += 1;
+    }
+    return Array.from(bins);
+  }
+
+  const range = sourceMax - sourceMin;
+  if (range <= 0) {
+    bins[0] = band.length;
+    return Array.from(bins);
+  }
+
+  for (let i = 0; i < band.length; i += 1) {
+    const v = Number(band[i]);
+    const normalized = (v - sourceMin) / range;
+    const idx = Math.max(0, Math.min(binCount - 1, Math.floor(normalized * (binCount - 1))));
+    bins[idx] += 1;
+  }
+
+  return Array.from(bins);
+}
 
 /**
  * Decode a TIFF file, compute per-frame percentile bounds, apply a linear stretch,
@@ -185,4 +262,46 @@ export async function getDisplayPng(
 
   inFlightDecodes.set(key, decodePromise);
   return decodePromise;
+}
+
+export async function getDisplayHistogram(
+  tiffPath: string,
+  lowPercentile: number,
+  highPercentile: number,
+  mtimeMs: number,
+): Promise<DisplayHistogram> {
+  const key = `${tiffPath}::${lowPercentile}::${highPercentile}::${mtimeMs}`;
+  const cached = displayHistogramCache.get(key);
+  if (cached) {
+    touchHistogramCacheEntry(key, cached);
+    return cached;
+  }
+
+  const inflight = inFlightHistograms.get(key);
+  if (inflight) return inflight;
+
+  const histogramPromise = (async () => {
+    const tiff = await openTiff(tiffPath);
+    const image = await tiff.getImage();
+    const rasters = await image.readRasters({
+      samples: [0],
+      interleave: false,
+    }) as RasterArray[];
+    const band = (rasters[0] ?? new Uint8Array(0)) as RasterArray;
+    const { min, max } = computeFrameBounds(band, lowPercentile, highPercentile);
+    const { sourceMin, sourceMax } = computeSourceBounds(band);
+    const bins = buildHistogramBins(band, sourceMin, sourceMax);
+    const payload: DisplayHistogram = {
+      bins,
+      lowValue: min,
+      highValue: max,
+      sourceMin,
+      sourceMax,
+    };
+    touchHistogramCacheEntry(key, payload);
+    return payload;
+  })().finally(() => inFlightHistograms.delete(key));
+
+  inFlightHistograms.set(key, histogramPromise);
+  return histogramPromise;
 }

--- a/client/platform/desktop/backend/media/displayProcessing.ts
+++ b/client/platform/desktop/backend/media/displayProcessing.ts
@@ -50,7 +50,7 @@ export function linearStretchToU8(
   const out = new Uint8Array(raw.length);
   const range = max - min;
   if (range <= 0) {
-    out.fill(raw.length > 0 && Number(raw[0]) > min ? 255 : 0);
+    out.fill(128); // flat field — no contrast, display as mid-gray
     return out;
   }
   for (let i = 0; i < raw.length; i += 1) {
@@ -60,7 +60,7 @@ export function linearStretchToU8(
   return out;
 }
 
-function encodePngRgba(width: number, height: number, rgba: Uint8Array): Buffer {
+export function encodePngRgba(width: number, height: number, rgba: Uint8Array): Buffer {
   type PngInstance = { data: Uint8Array };
   type PngConstructor = {
     new(opts: { width: number; height: number }): PngInstance;
@@ -100,21 +100,33 @@ function computeFrameBounds(
 ): { min: number; max: number } {
   if (band.length === 0) return { min: 0, max: 65535 };
 
-  const histogram = new Uint32Array(65536);
+  // Float rasters can have arbitrary value ranges; integer histogram binning loses
+  // precision and collapses sub-integer values (e.g. radiance 0.003–0.012) to a
+  // single bin. Use a sort-based percentile on a typed-array copy instead.
+  if (band instanceof Float32Array || band instanceof Float64Array) {
+    const sorted = band.slice().sort() as Float32Array | Float64Array;
+    const n = sorted.length;
+    const lowIdx = Math.min(n - 1, Math.floor(n * (lowPercentile / 100)));
+    const highIdx = Math.min(n - 1, Math.floor(n * (highPercentile / 100)));
+    return { min: sorted[lowIdx], max: sorted[highIdx] };
+  }
+
+  // Integer path: Uint8 → 256 bins, Uint16 → 65536 bins, indexed directly by value.
+  const binCount = band instanceof Uint8Array ? 256 : 65536;
+  const histogram = new Uint32Array(binCount);
   for (let i = 0; i < band.length; i += 1) {
-    const v = Math.max(0, Math.min(65535, Math.round(Number(band[i]))));
-    histogram[v] += 1;
+    histogram[band[i]] += 1;
   }
 
   const lowTarget = Math.floor(band.length * (lowPercentile / 100));
   const highTarget = Math.floor(band.length * (highPercentile / 100));
 
   let min = 0;
-  let max = 65535;
+  let max = binCount - 1;
   let cumulative = 0;
   let foundMin = false;
 
-  for (let v = 0; v < 65536; v += 1) {
+  for (let v = 0; v < binCount; v += 1) {
     cumulative += histogram[v];
     if (!foundMin && cumulative >= lowTarget) {
       min = v;
@@ -131,14 +143,16 @@ function computeFrameBounds(
 
 /**
  * Decode a TIFF file, compute per-frame percentile bounds, apply a linear stretch,
- * and return a grayscale PNG buffer. Cached by (path, lowPercentile, highPercentile).
+ * and return a grayscale PNG buffer. Cached by (path, lowPercentile, highPercentile, mtimeMs);
+ * the mtime component ensures stale entries are evicted when a file is replaced on disk.
  */
 export async function getDisplayPng(
   tiffPath: string,
   lowPercentile: number,
   highPercentile: number,
+  mtimeMs: number,
 ): Promise<Buffer> {
-  const key = `${tiffPath}::${lowPercentile}::${highPercentile}`;
+  const key = `${tiffPath}::${lowPercentile}::${highPercentile}::${mtimeMs}`;
   const cached = displayPngCache.get(key);
   if (cached) {
     touchDisplayCacheEntry(key, cached);

--- a/client/platform/desktop/backend/media/displayProcessing.ts
+++ b/client/platform/desktop/backend/media/displayProcessing.ts
@@ -125,7 +125,9 @@ function computeFrameBounds(
 
   for (let v = 0; v < binCount; v += 1) {
     cumulative += histogram[v];
-    if (!foundMin && cumulative >= lowTarget) {
+    // `cumulative > 0` guards the lowTarget === 0 case (tiny images), where
+    // `cumulative >= 0` would otherwise pin min to bin 0 before any pixel is seen.
+    if (!foundMin && cumulative > 0 && cumulative >= lowTarget) {
       min = v;
       foundMin = true;
     }

--- a/client/platform/desktop/backend/media/displayProcessing.ts
+++ b/client/platform/desktop/backend/media/displayProcessing.ts
@@ -1,0 +1,164 @@
+import fs from 'fs-extra';
+import { fromArrayBuffer } from 'geotiff';
+import PNG from 'pngjs';
+
+type RasterArray = Uint8Array | Uint16Array | Float32Array | Float64Array;
+
+interface TiffImage {
+  getWidth(): number;
+  getHeight(): number;
+  readRasters(opts: Record<string, unknown>): Promise<unknown>;
+}
+interface TiffFile {
+  getImage(index?: number): Promise<TiffImage>;
+}
+
+const MAX_DISPLAY_CACHE_ENTRIES = 64;
+
+const displayPngCache = new Map<string, Buffer>();
+
+function touchDisplayCacheEntry(key: string, value: Buffer): void {
+  displayPngCache.delete(key);
+  displayPngCache.set(key, value);
+  if (displayPngCache.size > MAX_DISPLAY_CACHE_ENTRIES) {
+    const oldest = displayPngCache.keys().next().value as string | undefined;
+    if (oldest) displayPngCache.delete(oldest);
+  }
+}
+
+/** Map raster samples to display bytes by clamping to [0, 255] (no dynamic range stretch). */
+export function normalizeToU8(
+  raw: RasterArray,
+  out: Uint8Array,
+  offset = 0,
+  stride = 1,
+): void {
+  const n = Math.min(raw.length, Math.floor((out.length - offset) / stride));
+  if (n === 0) return;
+  const outView = out;
+  for (let i = 0; i < n; i += 1) {
+    outView[offset + i * stride] = Math.max(0, Math.min(255, Math.round(Number(raw[i]))));
+  }
+}
+
+/** Linearly stretch raster values from [min, max] to [0, 255]. */
+export function linearStretchToU8(
+  raw: RasterArray,
+  min: number,
+  max: number,
+): Uint8Array {
+  const out = new Uint8Array(raw.length);
+  const range = max - min;
+  if (range <= 0) {
+    out.fill(raw.length > 0 && Number(raw[0]) > min ? 255 : 0);
+    return out;
+  }
+  for (let i = 0; i < raw.length; i += 1) {
+    const v = (Number(raw[i]) - min) / range;
+    out[i] = Math.max(0, Math.min(255, Math.round(v * 255)));
+  }
+  return out;
+}
+
+function encodePngRgba(width: number, height: number, rgba: Uint8Array): Buffer {
+  type PngInstance = { data: Uint8Array };
+  type PngConstructor = {
+    new(opts: { width: number; height: number }): PngInstance;
+    sync: { write(png: PngInstance): Buffer };
+  };
+  const pngModule = PNG as unknown as { PNG?: PngConstructor };
+  const PngCtor = pngModule.PNG ?? (PNG as unknown as PngConstructor);
+  const png = new PngCtor({ width, height });
+  png.data.set(rgba);
+  return PngCtor.sync.write(png);
+}
+
+function encodeGrayscalePng(pixels: Uint8Array, width: number, height: number): Buffer {
+  const rgba = new Uint8Array(width * height * 4);
+  for (let i = 0; i < pixels.length; i += 1) {
+    const v = pixels[i];
+    const dst = i * 4;
+    rgba[dst] = v;
+    rgba[dst + 1] = v;
+    rgba[dst + 2] = v;
+    rgba[dst + 3] = 255;
+  }
+  return encodePngRgba(width, height, rgba);
+}
+
+async function openTiff(tiffPath: string): Promise<TiffFile> {
+  const buf = await fs.readFile(tiffPath);
+  const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  return fromArrayBuffer(ab) as unknown as TiffFile;
+}
+
+/** Find the pixel values at lowPercentile and highPercentile within a single band. */
+function computeFrameBounds(
+  band: RasterArray,
+  lowPercentile: number,
+  highPercentile: number,
+): { min: number; max: number } {
+  if (band.length === 0) return { min: 0, max: 65535 };
+
+  const histogram = new Uint32Array(65536);
+  for (let i = 0; i < band.length; i += 1) {
+    const v = Math.max(0, Math.min(65535, Math.round(Number(band[i]))));
+    histogram[v] += 1;
+  }
+
+  const lowTarget = Math.floor(band.length * (lowPercentile / 100));
+  const highTarget = Math.floor(band.length * (highPercentile / 100));
+
+  let min = 0;
+  let max = 65535;
+  let cumulative = 0;
+  let foundMin = false;
+
+  for (let v = 0; v < 65536; v += 1) {
+    cumulative += histogram[v];
+    if (!foundMin && cumulative >= lowTarget) {
+      min = v;
+      foundMin = true;
+    }
+    if (cumulative >= highTarget) {
+      max = v;
+      break;
+    }
+  }
+
+  return { min, max };
+}
+
+/**
+ * Decode a TIFF file, compute per-frame percentile bounds, apply a linear stretch,
+ * and return a grayscale PNG buffer. Cached by (path, lowPercentile, highPercentile).
+ */
+export async function getDisplayPng(
+  tiffPath: string,
+  lowPercentile: number,
+  highPercentile: number,
+): Promise<Buffer> {
+  const key = `${tiffPath}::${lowPercentile}::${highPercentile}`;
+  const cached = displayPngCache.get(key);
+  if (cached) {
+    touchDisplayCacheEntry(key, cached);
+    return cached;
+  }
+
+  const tiff = await openTiff(tiffPath);
+  const image = await tiff.getImage();
+  const width = image.getWidth();
+  const height = image.getHeight();
+
+  const rasters = await image.readRasters({
+    samples: [0],
+    interleave: false,
+  }) as RasterArray[];
+  const band = (rasters[0] ?? new Uint8Array(0)) as RasterArray;
+
+  const { min, max } = computeFrameBounds(band, lowPercentile, highPercentile);
+  const stretched = linearStretchToU8(band, min, max);
+  const pngBuf = encodeGrayscalePng(stretched, width, height);
+  touchDisplayCacheEntry(key, pngBuf);
+  return pngBuf;
+}

--- a/client/platform/desktop/backend/media/displayProcessing.ts
+++ b/client/platform/desktop/backend/media/displayProcessing.ts
@@ -1,8 +1,7 @@
-import fs from 'fs-extra';
-import { fromArrayBuffer } from 'geotiff';
+import { fromFile } from 'geotiff';
 import PNG from 'pngjs';
 
-type RasterArray = Uint8Array | Uint16Array | Float32Array | Float64Array;
+type RasterArray = Uint8Array | Uint16Array | Int16Array | Float32Array | Float64Array;
 
 interface TiffImage {
   getWidth(): number;
@@ -87,9 +86,7 @@ function encodeGrayscalePng(pixels: Uint8Array, width: number, height: number): 
 }
 
 async function openTiff(tiffPath: string): Promise<TiffFile> {
-  const buf = await fs.readFile(tiffPath);
-  const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
-  return fromArrayBuffer(ab) as unknown as TiffFile;
+  return fromFile(tiffPath) as unknown as TiffFile;
 }
 
 /** Find the pixel values at lowPercentile and highPercentile within a single band. */
@@ -100,10 +97,10 @@ function computeFrameBounds(
 ): { min: number; max: number } {
   if (band.length === 0) return { min: 0, max: 65535 };
 
-  // Float rasters can have arbitrary value ranges; integer histogram binning loses
-  // precision and collapses sub-integer values (e.g. radiance 0.003–0.012) to a
-  // single bin. Use a sort-based percentile on a typed-array copy instead.
-  if (band instanceof Float32Array || band instanceof Float64Array) {
+  // Float rasters and signed integers need sort-based percentile: histogram bins are
+  // indexed by value, which breaks for negatives (Int16) and loses sub-integer
+  // precision for floats.
+  if (band instanceof Float32Array || band instanceof Float64Array || band instanceof Int16Array) {
     const sorted = band.slice().sort() as Float32Array | Float64Array;
     const n = sorted.length;
     const lowIdx = Math.min(n - 1, Math.floor(n * (lowPercentile / 100)));
@@ -141,10 +138,13 @@ function computeFrameBounds(
   return { min, max };
 }
 
+const inFlightDecodes = new Map<string, Promise<Buffer>>();
+
 /**
  * Decode a TIFF file, compute per-frame percentile bounds, apply a linear stretch,
  * and return a grayscale PNG buffer. Cached by (path, lowPercentile, highPercentile, mtimeMs);
  * the mtime component ensures stale entries are evicted when a file is replaced on disk.
+ * Concurrent requests for the same key share one decode promise instead of duplicating work.
  */
 export async function getDisplayPng(
   tiffPath: string,
@@ -159,20 +159,28 @@ export async function getDisplayPng(
     return cached;
   }
 
-  const tiff = await openTiff(tiffPath);
-  const image = await tiff.getImage();
-  const width = image.getWidth();
-  const height = image.getHeight();
+  const inflight = inFlightDecodes.get(key);
+  if (inflight) return inflight;
 
-  const rasters = await image.readRasters({
-    samples: [0],
-    interleave: false,
-  }) as RasterArray[];
-  const band = (rasters[0] ?? new Uint8Array(0)) as RasterArray;
+  const decodePromise = (async () => {
+    const tiff = await openTiff(tiffPath);
+    const image = await tiff.getImage();
+    const width = image.getWidth();
+    const height = image.getHeight();
 
-  const { min, max } = computeFrameBounds(band, lowPercentile, highPercentile);
-  const stretched = linearStretchToU8(band, min, max);
-  const pngBuf = encodeGrayscalePng(stretched, width, height);
-  touchDisplayCacheEntry(key, pngBuf);
-  return pngBuf;
+    const rasters = await image.readRasters({
+      samples: [0],
+      interleave: false,
+    }) as RasterArray[];
+    const band = (rasters[0] ?? new Uint8Array(0)) as RasterArray;
+
+    const { min, max } = computeFrameBounds(band, lowPercentile, highPercentile);
+    const stretched = linearStretchToU8(band, min, max);
+    const pngBuf = encodeGrayscalePng(stretched, width, height);
+    touchDisplayCacheEntry(key, pngBuf);
+    return pngBuf;
+  })().finally(() => inFlightDecodes.delete(key));
+
+  inFlightDecodes.set(key, decodePromise);
+  return decodePromise;
 }

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -1550,6 +1550,41 @@ async function getLargeImagePath(settings: Settings, datasetId: string): Promise
   }
 }
 
+/**
+ * Resolve the absolute path of the ORIGINAL (pre-transcode) image for a frame.
+ *
+ * The percentile-stretch / display path must read the original source image
+ * (e.g. a 16-bit IR TIFF), NOT the 8-bit PNG produced by import-time transcoding
+ * (`transcodedImageFiles`), which has already discarded the dynamic range the
+ * stretch is meant to recover. `imageData` URLs sent to the client point at the
+ * transcoded copies, so the client passes a frame index and we map it back to
+ * the original here. Returns null if the frame is out of range or unavailable.
+ */
+async function getDisplayImagePath(
+  settings: Settings,
+  datasetId: string,
+  frame: number,
+): Promise<string | null> {
+  try {
+    const projectDirData = await getValidatedProjectDir(settings, datasetId);
+    const meta = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+    const originals = meta.originalImageFiles ?? [];
+    if (!Number.isInteger(frame) || frame < 0 || frame >= originals.length) {
+      console.warn(
+        `[display] getDisplayImagePath: frame ${frame} out of range for dataset "${datasetId}" (${originals.length} images)`,
+      );
+      return null;
+    }
+    const entry = originals[frame];
+    // originalImageFiles entries are relative to originalBasePath, except for
+    // image-list imports where they are absolute and originalBasePath is ''.
+    return npath.isAbsolute(entry) ? entry : npath.join(meta.originalBasePath, entry);
+  } catch (err) {
+    console.warn(`[display] getDisplayImagePath: error for dataset "${datasetId}":`, err);
+    return null;
+  }
+}
+
 async function openLink(url: string) {
   shell.openExternal(url);
 }
@@ -2036,6 +2071,7 @@ export {
   getProjectDir,
   getValidatedProjectDir,
   getLargeImagePath,
+  getDisplayImagePath,
   loadMetadata,
   loadJsonMetadata,
   loadAnnotationFile,

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -1048,8 +1048,42 @@ function isVideoFilePath(filePath: string): boolean {
 }
 
 /**
+ * Return true when a subfolder contains at least one importable image or video file.
+ */
+async function subfolderContainsMedia(
+  subfolderPath: string,
+  mediaType: 'image-sequence' | 'video',
+): Promise<boolean> {
+  if (!await fs.pathExists(subfolderPath)) {
+    return false;
+  }
+  const stat = await fs.stat(subfolderPath);
+  if (!stat.isDirectory()) {
+    return mediaType === 'video' && isVideoFilePath(subfolderPath);
+  }
+  if (mediaType === 'image-sequence') {
+    const found = await findImagesInFolder(subfolderPath);
+    return found.imagePaths.length > 0;
+  }
+  const entries = await fs.readdir(subfolderPath, { withFileTypes: true });
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    if (!entry.isFile()) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    const fullPath = npath.join(subfolderPath, entry.name);
+    if (isVideoFilePath(fullPath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Discover cameras under a parent folder: immediate subfolders, or separate video files
  * in the parent when importing video and there are no subfolders.
+ * Subfolders without importable media (e.g. calibration or transform data) are skipped.
  */
 async function listParentFolderCameras(
   parentPath: string,
@@ -1058,13 +1092,22 @@ async function listParentFolderCameras(
   const subfolders = await listImmediateSubfolders(parentPath);
   const separator = parentPath.includes('\\') ? '\\' : '/';
   const normalized = parentPath.replace(/[\\/]+$/, '');
-  if (subfolders.length >= 2) {
-    return subfolders.map((name) => ({
+  const mediaSubfolders: string[] = [];
+  for (let i = 0; i < subfolders.length; i += 1) {
+    const name = subfolders[i];
+    const fullPath = `${normalized}${separator}${name}`;
+    // eslint-disable-next-line no-await-in-loop
+    if (await subfolderContainsMedia(fullPath, mediaType)) {
+      mediaSubfolders.push(name);
+    }
+  }
+  if (mediaSubfolders.length >= 2) {
+    return mediaSubfolders.map((name) => ({
       name,
       sourcePath: `${normalized}${separator}${name}`,
     }));
   }
-  if (mediaType === 'video' && subfolders.length === 0) {
+  if (mediaType === 'video' && mediaSubfolders.length === 0) {
     const children = await fs.readdir(parentPath, { withFileTypes: true });
     const videoPaths: string[] = [];
     children.forEach((entry) => {
@@ -1082,7 +1125,7 @@ async function listParentFolderCameras(
       sourcePath: fullPath,
     }));
   }
-  return subfolders.map((name) => ({
+  return mediaSubfolders.map((name) => ({
     name,
     sourcePath: `${normalized}${separator}${name}`,
   }));

--- a/client/platform/desktop/backend/server.ts
+++ b/client/platform/desktop/backend/server.ts
@@ -13,6 +13,7 @@ import { SaveAttributeArgs, SaveAttributeTrackFilterArgs, SaveDetectionsArgs } f
 import settings from './state/settings';
 import * as common from './native/common';
 import * as geotiffTiles from './tiles/geotiffTiles';
+import * as displayProcessing from './media/displayProcessing';
 
 const app = express();
 app.use(express.json({ limit: '250MB' }));
@@ -175,6 +176,37 @@ apirouter.get('/dataset/:id/:camera?/tiles', async (req, res, next) => {
     res.json(meta);
   } catch (err) {
     console.error('[tiles] GET tiles metadata error:', err);
+    (err as { status?: number }).status = 500;
+    next(err);
+  }
+  return null;
+});
+
+/* Serve a TIFF with per-frame percentile stretch applied, returned as a grayscale PNG */
+apirouter.get('/media/display', async (req, res, next) => {
+  const { path: reqPath, low: reqLow, high: reqHigh } = req.query;
+  if (!reqPath || Array.isArray(reqPath) || !reqLow || !reqHigh) {
+    return next({ status: 400, statusMessage: 'path, low, and high query params are required' });
+  }
+  const filePath = reqPath.toString();
+  const low = parseFloat(reqLow.toString());
+  const high = parseFloat(reqHigh.toString());
+  if (Number.isNaN(low) || Number.isNaN(high)) {
+    return next({ status: 400, statusMessage: 'low and high must be numbers' });
+  }
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) {
+      return next({ status: 404, statusMessage: `Not a file: ${filePath}` });
+    }
+  } catch {
+    return next({ status: 404, statusMessage: `File not found: ${filePath}` });
+  }
+  try {
+    const pngBuf = await displayProcessing.getDisplayPng(filePath, low, high);
+    res.setHeader('Content-Type', 'image/png');
+    res.send(pngBuf);
+  } catch (err) {
     (err as { status?: number }).status = 500;
     next(err);
   }

--- a/client/platform/desktop/backend/server.ts
+++ b/client/platform/desktop/backend/server.ts
@@ -247,6 +247,54 @@ apirouter.get('/media/display', async (req, res, next) => {
   return null;
 });
 
+/**
+ * Return a compact histogram (256 bins) for the ORIGINAL source image frame.
+ * Bounds are computed with the same percentile parameters as /media/display.
+ */
+apirouter.get('/media/histogram', async (req, res, next) => {
+  const {
+    id: reqId, frame: reqFrame, low: reqLow, high: reqHigh,
+  } = req.query;
+  if (!reqId || Array.isArray(reqId) || reqFrame === undefined || Array.isArray(reqFrame)
+      || !reqLow || !reqHigh || Array.isArray(reqLow) || Array.isArray(reqHigh)) {
+    return next({ status: 400, statusMessage: 'id, frame, low, and high query params are required' });
+  }
+  const datasetId = reqId.toString();
+  const frame = parseInt(reqFrame.toString(), 10);
+  const low = parseFloat(reqLow.toString());
+  const high = parseFloat(reqHigh.toString());
+  if (Number.isNaN(frame)) {
+    return next({ status: 400, statusMessage: 'frame must be an integer' });
+  }
+  if (Number.isNaN(low) || Number.isNaN(high)) {
+    return next({ status: 400, statusMessage: 'low and high must be numbers' });
+  }
+  if (low >= high) {
+    return next({ status: 400, statusMessage: 'low must be less than high' });
+  }
+  try {
+    const filePath = await common.getDisplayImagePath(settings.get(), datasetId, frame);
+    if (!filePath) {
+      return next({ status: 404, statusMessage: `No source image for dataset ${datasetId} frame ${frame}` });
+    }
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) {
+      return next({ status: 404, statusMessage: `Not a file: ${filePath}` });
+    }
+    if (!tiffExtensions.includes(npath.extname(filePath).toLowerCase())) {
+      return next({ status: 400, statusMessage: 'Histogram only supported for TIFF source images' });
+    }
+    const histogram = await displayProcessing.getDisplayHistogram(filePath, low, high, stat.mtimeMs);
+    return res.json(histogram);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return next({ status: 404, statusMessage: 'Source image file not found' });
+    }
+    (err as { status?: number }).status = 500;
+    return next(err);
+  }
+});
+
 /* STREAM media */
 apirouter.get('/media', (req, res, next) => {
   let { path } = req.query;

--- a/client/platform/desktop/backend/server.ts
+++ b/client/platform/desktop/backend/server.ts
@@ -1,5 +1,6 @@
 import type { AddressInfo } from 'net';
 import http from 'http';
+import npath from 'path';
 
 import cors from 'cors';
 import mime from 'mime-types';
@@ -182,16 +183,35 @@ apirouter.get('/dataset/:id/:camera?/tiles', async (req, res, next) => {
   return null;
 });
 
-/* Serve a TIFF with per-frame percentile stretch applied, returned as a grayscale PNG */
+const tiffExtensions = ['.tif', '.tiff'];
+
+/**
+ * Serve a per-frame percentile stretch of an image, returned as a grayscale PNG.
+ *
+ * The stretch must run against the ORIGINAL source image (e.g. a 16-bit IR TIFF),
+ * not the 8-bit PNG produced by import-time transcoding — that copy has already
+ * lost the dynamic range the stretch recovers. The client therefore identifies the
+ * frame by (dataset id, frame index) and the original is resolved server-side.
+ *
+ * Non-TIFF originals (e.g. 8-bit EO JPEGs) have no extra range to recover, so they
+ * are streamed through as-is rather than failing — toggling stretch is a visual
+ * no-op for them instead of producing a black image.
+ */
 apirouter.get('/media/display', async (req, res, next) => {
-  const { path: reqPath, low: reqLow, high: reqHigh } = req.query;
-  if (!reqPath || Array.isArray(reqPath) || !reqLow || !reqHigh
-      || Array.isArray(reqLow) || Array.isArray(reqHigh)) {
-    return next({ status: 400, statusMessage: 'path, low, and high query params are required' });
+  const {
+    id: reqId, frame: reqFrame, low: reqLow, high: reqHigh,
+  } = req.query;
+  if (!reqId || Array.isArray(reqId) || reqFrame === undefined || Array.isArray(reqFrame)
+      || !reqLow || !reqHigh || Array.isArray(reqLow) || Array.isArray(reqHigh)) {
+    return next({ status: 400, statusMessage: 'id, frame, low, and high query params are required' });
   }
-  const filePath = reqPath.toString();
+  const datasetId = reqId.toString();
+  const frame = parseInt(reqFrame.toString(), 10);
   const low = parseFloat(reqLow.toString());
   const high = parseFloat(reqHigh.toString());
+  if (Number.isNaN(frame)) {
+    return next({ status: 400, statusMessage: 'frame must be an integer' });
+  }
   if (Number.isNaN(low) || Number.isNaN(high)) {
     return next({ status: 400, statusMessage: 'low and high must be numbers' });
   }
@@ -199,16 +219,27 @@ apirouter.get('/media/display', async (req, res, next) => {
     return next({ status: 400, statusMessage: 'low must be less than high' });
   }
   try {
+    const filePath = await common.getDisplayImagePath(settings.get(), datasetId, frame);
+    if (!filePath) {
+      return next({ status: 404, statusMessage: `No source image for dataset ${datasetId} frame ${frame}` });
+    }
     const stat = await fs.stat(filePath);
     if (!stat.isFile()) {
       return next({ status: 404, statusMessage: `Not a file: ${filePath}` });
+    }
+    // Only TIFFs carry recoverable dynamic range; pass everything else through unchanged.
+    if (!tiffExtensions.includes(npath.extname(filePath).toLowerCase())) {
+      const mimetype = mime.lookup(filePath);
+      if (mimetype) res.setHeader('Content-Type', mimetype);
+      pump(fs.createReadStream(filePath), res);
+      return null;
     }
     const pngBuf = await displayProcessing.getDisplayPng(filePath, low, high, stat.mtimeMs);
     res.setHeader('Content-Type', 'image/png');
     res.send(pngBuf);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return next({ status: 404, statusMessage: `File not found: ${filePath}` });
+      return next({ status: 404, statusMessage: 'Source image file not found' });
     }
     (err as { status?: number }).status = 500;
     next(err);

--- a/client/platform/desktop/backend/server.ts
+++ b/client/platform/desktop/backend/server.ts
@@ -185,7 +185,8 @@ apirouter.get('/dataset/:id/:camera?/tiles', async (req, res, next) => {
 /* Serve a TIFF with per-frame percentile stretch applied, returned as a grayscale PNG */
 apirouter.get('/media/display', async (req, res, next) => {
   const { path: reqPath, low: reqLow, high: reqHigh } = req.query;
-  if (!reqPath || Array.isArray(reqPath) || !reqLow || !reqHigh) {
+  if (!reqPath || Array.isArray(reqPath) || !reqLow || !reqHigh
+      || Array.isArray(reqLow) || Array.isArray(reqHigh)) {
     return next({ status: 400, statusMessage: 'path, low, and high query params are required' });
   }
   const filePath = reqPath.toString();
@@ -194,19 +195,21 @@ apirouter.get('/media/display', async (req, res, next) => {
   if (Number.isNaN(low) || Number.isNaN(high)) {
     return next({ status: 400, statusMessage: 'low and high must be numbers' });
   }
+  if (low >= high) {
+    return next({ status: 400, statusMessage: 'low must be less than high' });
+  }
   try {
-    const stat = fs.statSync(filePath);
+    const stat = await fs.stat(filePath);
     if (!stat.isFile()) {
       return next({ status: 404, statusMessage: `Not a file: ${filePath}` });
     }
-  } catch {
-    return next({ status: 404, statusMessage: `File not found: ${filePath}` });
-  }
-  try {
-    const pngBuf = await displayProcessing.getDisplayPng(filePath, low, high);
+    const pngBuf = await displayProcessing.getDisplayPng(filePath, low, high, stat.mtimeMs);
     res.setHeader('Content-Type', 'image/png');
     res.send(pngBuf);
   } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return next({ status: 404, statusMessage: `File not found: ${filePath}` });
+    }
     (err as { status?: number }).status = 500;
     next(err);
   }

--- a/client/platform/desktop/backend/tiles/geotiffTiles.ts
+++ b/client/platform/desktop/backend/tiles/geotiffTiles.ts
@@ -15,6 +15,7 @@ import { fromArrayBuffer, fromFile } from 'geotiff';
 import PNG from 'pngjs';
 import type { Settings } from 'platform/desktop/constants';
 import { getLargeImagePath } from '../native/common';
+import { normalizeToU8 } from '../media/displayProcessing';
 
 const TILE_SIZE = 256;
 
@@ -673,20 +674,6 @@ export async function getTilePng(
   }
 }
 
-/** Map raster samples to display bytes by clamping to [0, 255] (no dynamic range stretch). */
-function normalizeToU8(
-  raw: Uint8Array | Uint16Array | Float32Array | Float64Array,
-  out: Uint8Array,
-  offset = 0,
-  stride = 1,
-): void {
-  const n = Math.min(raw.length, Math.floor((out.length - offset) / stride));
-  if (n === 0) return;
-  const outView = out;
-  for (let i = 0; i < n; i += 1) {
-    outView[offset + i * stride] = clampToByte(Number(raw[i]));
-  }
-}
 
 function normalizeInterleavedRgbToRgba(
   raw: Uint8Array | Uint16Array | Float32Array | Float64Array,

--- a/client/platform/desktop/backend/tiles/geotiffTiles.ts
+++ b/client/platform/desktop/backend/tiles/geotiffTiles.ts
@@ -12,10 +12,9 @@
 
 import fs from 'fs-extra';
 import { fromArrayBuffer, fromFile } from 'geotiff';
-import PNG from 'pngjs';
 import type { Settings } from 'platform/desktop/constants';
 import { getLargeImagePath } from '../native/common';
-import { normalizeToU8 } from '../media/displayProcessing';
+import { normalizeToU8, encodePngRgba } from '../media/displayProcessing';
 
 const TILE_SIZE = 256;
 
@@ -769,15 +768,3 @@ function blitRgba(
   }
 }
 
-function encodePngRgba(width: number, height: number, rgba: Uint8Array): Buffer {
-  type PngInstance = { data: Uint8Array };
-  type PngConstructor = {
-    new(options: { width: number; height: number }): PngInstance;
-    sync: { write(png: PngInstance): Buffer };
-  };
-  const pngModule = PNG as unknown as { PNG?: PngConstructor };
-  const PngCtor = (pngModule.PNG ?? (PNG as unknown as PngConstructor));
-  const png = new PngCtor({ width, height });
-  png.data.set(rgba);
-  return PngCtor.sync.write(png);
-}

--- a/client/platform/desktop/backend/tiles/geotiffTiles.ts
+++ b/client/platform/desktop/backend/tiles/geotiffTiles.ts
@@ -673,7 +673,6 @@ export async function getTilePng(
   }
 }
 
-
 function normalizeInterleavedRgbToRgba(
   raw: Uint8Array | Uint16Array | Float32Array | Float64Array,
   outRgba: Uint8Array,
@@ -767,4 +766,3 @@ function blitRgba(
     targetRgba.set(sourceRgba.subarray(srcOffset, srcOffset + rowLength), dstOffset);
   }
 }
-

--- a/client/platform/web-girder/App.vue
+++ b/client/platform/web-girder/App.vue
@@ -28,6 +28,7 @@ import {
   unwrap,
   getTiles,
   getTileURL,
+  getTileHistogram,
   hasCalibrationFile,
   downloadCalibration,
   deleteCalibration,
@@ -81,6 +82,7 @@ export default defineComponent({
       importAnnotationFile,
       getTiles,
       getTileURL,
+      getTileHistogram,
     });
   },
 });

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -175,7 +175,7 @@ async function saveMetadata(datasetId: string, metadata: DatasetMetaMutable) {
 
 interface ValidationResponse {
   ok: boolean;
-  type: 'video' | 'image-sequence';
+  type: 'video' | 'image-sequence' | 'large-image';
   media: string[];
   annotations: string[];
   message: string;
@@ -189,10 +189,10 @@ export interface CreateMulticamDatasetArgs {
   parentFolderId: string;
   name: string;
   fps: number;
-  type: 'video' | 'image-sequence';
+  type: 'video' | 'image-sequence' | 'large-image';
   subType: 'stereo' | 'multicam';
   defaultDisplay: string;
-  cameras: Record<string, { folderId: string }>;
+  cameras: Record<string, { folderId: string; type?: 'video' | 'image-sequence' | 'large-image' }>;
   cameraOrder?: string[];
   calibrationFileId?: string;
 }

--- a/client/platform/web-girder/api/girder.service.ts
+++ b/client/platform/web-girder/api/girder.service.ts
@@ -21,9 +21,9 @@ function deleteItem(itemId: string) {
   return girderRest.delete(`item/${itemId}`);
 }
 
-function getItemsInFolder(folderId: string, limit: number) {
+function getItemsInFolder(folderId: string, limit: number, offset = 0) {
   return girderRest.get<GirderModel[]>('item', {
-    params: { folderId, limit },
+    params: { folderId, limit, offset },
   });
 }
 

--- a/client/platform/web-girder/api/largeImage.service.ts
+++ b/client/platform/web-girder/api/largeImage.service.ts
@@ -28,9 +28,30 @@ async function getTileFrames(itemId: string, options: any) {
   return data;
 }
 
+interface TileHistogramOptions {
+  bins?: number;
+  frame?: number;
+  width?: number;
+  height?: number;
+}
+
+async function getTileHistogram(itemId: string, options: TileHistogramOptions = {}) {
+  const { data } = await girderRest.get(`item/${itemId}/tiles/histogram`, {
+    params: {
+      bins: options.bins ?? 256,
+      ...(options.frame != null ? { frame: options.frame } : {}),
+      ...(options.width != null ? { width: options.width } : {}),
+      ...(options.height != null ? { height: options.height } : {}),
+    },
+  });
+  return data;
+}
+
 export {
   getTilesMetadata,
   getTiles,
   getTileURL,
   getTileFrames,
+  getTileHistogram,
 };
+export type { TileHistogramOptions };

--- a/client/platform/web-girder/api/waitForFolderDatasetReady.ts
+++ b/client/platform/web-girder/api/waitForFolderDatasetReady.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export -- single-purpose polling helper */
 import { all } from '@girder/components/src/components/Job/status';
 import girderRest from 'platform/web-girder/plugins/girder';
-import { getFolder } from './girder.service';
+import { getFolder, getItemsInFolder } from './girder.service';
 
 const JobStatus = all();
 const TERMINAL_JOB_STATUSES = [
@@ -9,6 +9,47 @@ const TERMINAL_JOB_STATUSES = [
   JobStatus.ERROR.value,
   JobStatus.CANCELED.value,
 ];
+
+const LARGE_IMAGE_ITEM_PATTERN = /\.(tif|tiff|nitf|ntf|vrt)$/i;
+const VIEWABLE_IMAGE_PATTERN = /\.(png|jpe?g)$/i;
+
+async function countLargeImageItems(folderId: string): Promise<number> {
+  let offset = 0;
+  const limit = 100;
+  let count = 0;
+  /* eslint-disable no-await-in-loop -- paginate folder items until all are checked */
+  while (true) {
+    const { data: items } = await getItemsInFolder(folderId, limit, offset);
+    if (!items.length) {
+      break;
+    }
+    count += items.filter((item) => LARGE_IMAGE_ITEM_PATTERN.test(item.name)).length;
+    if (items.length < limit) {
+      break;
+    }
+    offset += items.length;
+  }
+  return count;
+}
+
+async function countViewableImages(folderId: string): Promise<number> {
+  let offset = 0;
+  const limit = 100;
+  let count = 0;
+  /* eslint-disable no-await-in-loop -- paginate folder items until all are checked */
+  while (true) {
+    const { data: items } = await getItemsInFolder(folderId, limit, offset);
+    if (!items.length) {
+      break;
+    }
+    count += items.filter((item) => VIEWABLE_IMAGE_PATTERN.test(item.name)).length;
+    if (items.length < limit) {
+      break;
+    }
+    offset += items.length;
+  }
+  return count;
+}
 
 /**
  * Wait until a folder has been marked as a DIVE dataset (post-process / transcode finished).
@@ -21,6 +62,10 @@ export async function waitForFolderDatasetReady(
     timeoutMs?: number;
     /** Called with average job completion fraction in [0, 1] when jobs report progress. */
     onProgress?: (fraction: number) => void;
+    /** When true, keep polling until at least one web-safe image exists in the folder. */
+    requireViewableImages?: boolean;
+    /** When true, keep polling until at least one tiled/large-image file exists in the folder. */
+    requireLargeImageItems?: boolean;
   },
   jobIds: string[] = [],
 ): Promise<void> {
@@ -28,10 +73,25 @@ export async function waitForFolderDatasetReady(
   const timeoutMs = options?.timeoutMs ?? 10 * 60 * 1000;
   const deadline = Date.now() + timeoutMs;
 
+  async function folderReady(): Promise<boolean> {
+    const { data: folder } = await getFolder(folderId);
+    if (!folder.meta?.annotate) {
+      return false;
+    }
+    if (options?.requireViewableImages) {
+      const viewableCount = await countViewableImages(folderId);
+      return viewableCount > 0;
+    }
+    if (options?.requireLargeImageItems) {
+      const largeImageCount = await countLargeImageItems(folderId);
+      return largeImageCount > 0;
+    }
+    return true;
+  }
+
   /* eslint-disable no-await-in-loop -- poll folder and jobs until ready or timeout */
   while (Date.now() < deadline) {
-    const { data: folder } = await getFolder(folderId);
-    if (folder.meta?.annotate) {
+    if (await folderReady()) {
       return;
     }
 
@@ -63,11 +123,10 @@ export async function waitForFolderDatasetReady(
           const detail = failed.map((job) => job.title || 'processing job failed').join('; ');
           throw new Error(detail);
         }
-        const { data: folderAfterJobs } = await getFolder(folderId);
-        if (folderAfterJobs.meta?.annotate) {
+        if (await folderReady()) {
           return;
         }
-        throw new Error('Video processing finished but the camera folder is not ready for import');
+        throw new Error('Image processing finished but the camera folder has no viewable frames');
       }
     }
 
@@ -76,5 +135,5 @@ export async function waitForFolderDatasetReady(
     });
   }
 
-  throw new Error('Timed out waiting for camera video processing');
+  throw new Error('Timed out waiting for camera folder processing');
 }

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -190,6 +190,7 @@ export default defineComponent({
       annotationFile: File | null,
       mediaList: File[],
       suggestedFps?: number, // suggested FPS for large/images
+      expectedType?: DatasetType,
     ) => {
       const resp = (await validateUploadGroup(allFiles.map((f) => f.name))).data;
       if (!resp.ok) {
@@ -198,6 +199,7 @@ export default defineComponent({
         }
         throw new Error(resp.message);
       }
+      const uploadType = expectedType === LargeImageType ? LargeImageType : resp.type;
       const fps = suggestedFps || clientSettings.annotationFPS || DefaultVideoFPS;
       const defaultFilename = resp.media[0];
       const validFiles = resp.media.concat(resp.annotations);
@@ -220,7 +222,7 @@ export default defineComponent({
         meta,
         annotationFile,
         mediaList,
-        type: resp.type,
+        type: uploadType,
         fps,
         uploading: false,
         skipTranscoding: true,
@@ -305,6 +307,7 @@ export default defineComponent({
                 processed.annotationFile,
                 processed.mediaList,
                 suggestedFps,
+                dstype,
               );
             } else {
               addPendingZipUpload(name, processed.fullList);
@@ -396,7 +399,7 @@ export default defineComponent({
           description: 'Multicamera dataset',
         });
         datasetFolderId = datasetFolder._id;
-        const cameras: Record<string, { folderId: string }> = {};
+        const cameras: Record<string, { folderId: string; type?: string }> = {};
         const cameraOrder = args.cameraOrder?.length
           ? args.cameraOrder
           : Object.keys(args.sourceList);
@@ -416,8 +419,11 @@ export default defineComponent({
           if (!validation.ok) {
             throw new Error(validation.message || `Invalid files for camera "${cameraName}"`);
           }
-          if (validation.type !== args.type) {
-            throw new Error(`Camera "${cameraName}" must use ${args.type} media`);
+          const cameraType = source.type ?? args.type;
+          const uploadType = validation.type;
+          const compatibleTypes = new Set([cameraType, args.type, 'large-image', 'image-sequence']);
+          if (!compatibleTypes.has(uploadType)) {
+            throw new Error(`Camera "${cameraName}" must use ${cameraType} media`);
           }
           const mediaList = files.filter((file) => validation.media.includes(file.name));
           const annotationFile = source.trackFile
@@ -428,7 +434,7 @@ export default defineComponent({
           const { folder, jobIds } = await uploadComponent.uploadCameraDataset({
             name: cameraName,
             fps,
-            type: args.type,
+            type: uploadType,
             mediaList,
             annotationFile: annotationFile ?? null,
             skipTranscoding: true,
@@ -452,6 +458,8 @@ export default defineComponent({
                 `Processing ${cameraName} (${i + 1} of ${totalCameras})`,
               );
             },
+            requireViewableImages: uploadType === ImageSequenceType,
+            requireLargeImageItems: uploadType === LargeImageType,
           }, jobIds);
           setMulticamImportProgress(
             multicamCameraSlotPercent(i + 1, totalCameras, 0),
@@ -459,7 +467,7 @@ export default defineComponent({
               ? `Finished ${cameraName}, starting next camera…`
               : `Finished ${cameraName}`,
           );
-          cameras[cameraName] = { folderId: folder._id };
+          cameras[cameraName] = { folderId: folder._id, type: uploadType };
         }
 
         setMulticamImportProgress(92, 'Finalizing multicam dataset…');

--- a/client/src/components/ImageEnhancements.vue
+++ b/client/src/components/ImageEnhancements.vue
@@ -13,7 +13,7 @@ import { computePercentileBoundsFromBins } from '../use/useImageEnhancements';
 
 export default defineComponent({
   name: 'ImageEnhancements',
-  description: 'Image controls',
+  description: 'Brightness, contrast, and high bit-depth percentile stretch',
   setup() {
     const { setSVGFilters } = useHandler();
     const imageEnhancements = useImageEnhancements();
@@ -135,7 +135,9 @@ export default defineComponent({
 <template>
   <div class="mx-4">
     <span class="text-body-2">
-      Controls for adjusting images.
+      Adjust brightness, contrast, saturation, and sharpness. For high bit-depth TIFF
+      (Web large-image or Desktop TIFF sequences), percentile stretch remaps intensity
+      using the histogram below.
     </span>
     <v-divider class="my-3" />
     <v-row>

--- a/client/src/components/ImageEnhancements.vue
+++ b/client/src/components/ImageEnhancements.vue
@@ -172,7 +172,7 @@ export default defineComponent({
           <v-slider
             v-model="lowPercentile"
             :min="0"
-            :max="100"
+            :max="highPercentile - 1"
             :step="1"
             hide-details
             class="pa-0 ma-0"
@@ -190,7 +190,7 @@ export default defineComponent({
         <v-col>
           <v-slider
             v-model="highPercentile"
-            :min="0"
+            :min="lowPercentile + 1"
             :max="100"
             :step="1"
             hide-details

--- a/client/src/components/ImageEnhancements.vue
+++ b/client/src/components/ImageEnhancements.vue
@@ -12,12 +12,18 @@ export default defineComponent({
     const contrast = ref(imageEnhancements.value.contrast);
     const saturation = ref(imageEnhancements.value.saturation);
     const sharpen = ref(imageEnhancements.value.sharpen);
+    const stretchEnabled = ref(imageEnhancements.value.percentileStretch != null);
+    const lowPercentile = ref(imageEnhancements.value.percentileStretch?.lowPercentile ?? 1);
+    const highPercentile = ref(imageEnhancements.value.percentileStretch?.highPercentile ?? 99);
 
     watch(imageEnhancements, (val) => {
       brightness.value = val.brightness;
       contrast.value = val.contrast;
       saturation.value = val.saturation;
       sharpen.value = val.sharpen;
+      stretchEnabled.value = val.percentileStretch != null;
+      lowPercentile.value = val.percentileStretch?.lowPercentile ?? 1;
+      highPercentile.value = val.percentileStretch?.highPercentile ?? 99;
     }, { deep: true });
 
     const modifyValue = () => {
@@ -26,6 +32,9 @@ export default defineComponent({
         contrast: contrast.value,
         saturation: saturation.value,
         sharpen: sharpen.value,
+        percentileStretch: stretchEnabled.value
+          ? { lowPercentile: lowPercentile.value, highPercentile: highPercentile.value }
+          : null,
       });
     };
 
@@ -34,6 +43,9 @@ export default defineComponent({
       contrast.value = 1;
       saturation.value = 1;
       sharpen.value = 0;
+      stretchEnabled.value = false;
+      lowPercentile.value = 1;
+      highPercentile.value = 99;
       modifyValue();
     };
 
@@ -44,6 +56,9 @@ export default defineComponent({
       contrast,
       saturation,
       sharpen,
+      stretchEnabled,
+      lowPercentile,
+      highPercentile,
     };
   },
 });
@@ -131,6 +146,63 @@ export default defineComponent({
         <span>{{ sharpen.toFixed(1) }}</span>
       </v-col>
     </v-row>
+    <v-divider class="my-3" />
+    <v-row
+      align="center"
+      class="ma-0"
+    >
+      <v-col cols="8">
+        <span class="text-caption">Percentile Stretch</span>
+      </v-col>
+      <v-col class="pa-0">
+        <v-switch
+          v-model="stretchEnabled"
+          hide-details
+          class="ma-0 pa-0 mt-1"
+          @change="modifyValue()"
+        />
+      </v-col>
+    </v-row>
+    <template v-if="stretchEnabled">
+      <v-row>
+        <v-col cols="4">
+          <span class="text-caption">Low %</span>
+        </v-col>
+        <v-col>
+          <v-slider
+            v-model="lowPercentile"
+            :min="0"
+            :max="100"
+            :step="1"
+            hide-details
+            class="pa-0 ma-0"
+            @input="modifyValue()"
+          />
+        </v-col>
+        <v-col cols="2">
+          <span>{{ lowPercentile }}</span>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <span class="text-caption">High %</span>
+        </v-col>
+        <v-col>
+          <v-slider
+            v-model="highPercentile"
+            :min="0"
+            :max="100"
+            :step="1"
+            hide-details
+            class="pa-0 ma-0"
+            @input="modifyValue()"
+          />
+        </v-col>
+        <v-col cols="2">
+          <span>{{ highPercentile }}</span>
+        </v-col>
+      </v-row>
+    </template>
     <v-btn
       block
       depressed

--- a/client/src/components/ImageEnhancements.vue
+++ b/client/src/components/ImageEnhancements.vue
@@ -1,6 +1,15 @@
 <script lang="ts">
-import { defineComponent, ref, watch } from 'vue';
-import { useHandler, useImageEnhancements, usePercentileStretchSupported } from '../provides';
+import {
+  computed, defineComponent, ref, watch,
+} from 'vue';
+import {
+  useHandler,
+  useImageEnhancements,
+  usePercentileHistogram,
+  usePercentileHistogramLoading,
+  usePercentileStretchSupported,
+} from '../provides';
+import { computePercentileBoundsFromBins } from '../use/useImageEnhancements';
 
 export default defineComponent({
   name: 'ImageEnhancements',
@@ -9,6 +18,8 @@ export default defineComponent({
     const { setSVGFilters } = useHandler();
     const imageEnhancements = useImageEnhancements();
     const percentileStretchSupported = usePercentileStretchSupported();
+    const percentileHistogram = usePercentileHistogram();
+    const percentileHistogramLoading = usePercentileHistogramLoading();
     const brightness = ref(imageEnhancements.value.brightness);
     const contrast = ref(imageEnhancements.value.contrast);
     const saturation = ref(imageEnhancements.value.saturation);
@@ -50,6 +61,54 @@ export default defineComponent({
       modifyValue();
     };
 
+    function markerX(value: number): number {
+      const histogram = percentileHistogram.value;
+      if (!histogram) return 0;
+      const range = histogram.sourceMax - histogram.sourceMin;
+      if (range <= 0) return 0;
+      const normalized = (value - histogram.sourceMin) / range;
+      return Math.max(0, Math.min(100, normalized * 100));
+    }
+
+    function formatBound(value: number): string {
+      if (!Number.isFinite(value)) return '-';
+      const abs = Math.abs(value);
+      if (abs >= 1000) return Math.round(value).toString();
+      if (abs >= 100) return value.toFixed(1);
+      return value.toFixed(2);
+    }
+
+    const hasHistogram = computed(() => (percentileHistogram.value?.bins?.length ?? 0) > 0);
+    const histogramPolyline = computed(() => {
+      const bins = percentileHistogram.value?.bins ?? [];
+      if (!bins.length) return '';
+      const maxCount = Math.max(...bins);
+      if (maxCount <= 0) return '';
+      const maxRoot = Math.sqrt(maxCount);
+      return bins.map((count, idx) => {
+        const x = bins.length === 1 ? 0 : (idx / (bins.length - 1)) * 100;
+        const y = 40 - (Math.sqrt(count) / maxRoot) * 40;
+        return `${x.toFixed(2)},${y.toFixed(2)}`;
+      }).join(' ');
+    });
+    const percentileMarkerValues = computed(() => {
+      const histogram = percentileHistogram.value;
+      if (!histogram?.bins?.length) {
+        return { lowValue: 0, highValue: 0 };
+      }
+      return computePercentileBoundsFromBins(
+        histogram.bins,
+        lowPercentile.value,
+        highPercentile.value,
+        histogram.sourceMin,
+        histogram.sourceMax,
+      );
+    });
+    const lowMarkerX = computed(() => markerX(percentileMarkerValues.value.lowValue));
+    const highMarkerX = computed(() => markerX(percentileMarkerValues.value.highValue));
+    const histogramMinLabel = computed(() => formatBound(percentileHistogram.value?.sourceMin ?? 0));
+    const histogramMaxLabel = computed(() => formatBound(percentileHistogram.value?.sourceMax ?? 0));
+
     return {
       modifyValue,
       reset,
@@ -61,6 +120,13 @@ export default defineComponent({
       lowPercentile,
       highPercentile,
       percentileStretchSupported,
+      percentileHistogramLoading,
+      hasHistogram,
+      histogramPolyline,
+      lowMarkerX,
+      highMarkerX,
+      histogramMinLabel,
+      histogramMaxLabel,
     };
   },
 });
@@ -169,12 +235,41 @@ export default defineComponent({
           />
         </v-col>
       </v-row>
+      <v-row class="ma-0 mt-1 mb-2">
+        <v-col cols="12" class="pa-0">
+          <div class="histogram-shell">
+            <div v-if="percentileHistogramLoading" class="histogram-status text-caption">
+              Loading histogram...
+            </div>
+            <template v-else-if="hasHistogram">
+              <svg viewBox="0 0 100 40" preserveAspectRatio="none" class="histogram-svg">
+                <polyline
+                  :points="histogramPolyline"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.4"
+                  class="histogram-line"
+                />
+                <line :x1="lowMarkerX" y1="0" :x2="lowMarkerX" y2="40" class="histogram-marker-low" />
+                <line :x1="highMarkerX" y1="0" :x2="highMarkerX" y2="40" class="histogram-marker-high" />
+              </svg>
+              <div class="histogram-bounds text-caption">
+                <span>{{ histogramMinLabel }}</span>
+                <span>{{ histogramMaxLabel }}</span>
+              </div>
+            </template>
+            <div v-else class="histogram-status text-caption">
+              Histogram unavailable for this frame.
+            </div>
+          </div>
+        </v-col>
+      </v-row>
       <template v-if="stretchEnabled">
-        <v-row>
+        <v-row class="percentile-slider-row">
           <v-col cols="4">
             <span class="text-caption">Low %</span>
           </v-col>
-          <v-col>
+          <v-col cols="5">
             <v-slider
               v-model="lowPercentile"
               :min="0"
@@ -185,15 +280,15 @@ export default defineComponent({
               @input="modifyValue()"
             />
           </v-col>
-          <v-col cols="2">
-            <span>{{ lowPercentile.toFixed(2) }}</span>
+          <v-col cols="3" class="percentile-value-col">
+            <span class="percentile-value">{{ lowPercentile.toFixed(2) }}</span>
           </v-col>
         </v-row>
-        <v-row>
+        <v-row class="percentile-slider-row">
           <v-col cols="4">
             <span class="text-caption">High %</span>
           </v-col>
-          <v-col>
+          <v-col cols="5">
             <v-slider
               v-model="highPercentile"
               :min="99"
@@ -204,8 +299,8 @@ export default defineComponent({
               @input="modifyValue()"
             />
           </v-col>
-          <v-col cols="2">
-            <span>{{ highPercentile.toFixed(2) }}</span>
+          <v-col cols="3" class="percentile-value-col">
+            <span class="percentile-value">{{ highPercentile.toFixed(2) }}</span>
           </v-col>
         </v-row>
       </template>
@@ -223,4 +318,56 @@ export default defineComponent({
 </template>
 
 <style scoped>
+.histogram-shell {
+  border: 1px solid rgba(127, 127, 127, 0.45);
+  border-radius: 4px;
+  padding: 6px 8px 4px;
+}
+
+.histogram-svg {
+  display: block;
+  width: 100%;
+  height: 56px;
+}
+
+.histogram-line {
+  opacity: 0.9;
+}
+
+.histogram-marker-low {
+  stroke: #ff9800;
+  stroke-width: 1;
+  stroke-dasharray: 2 2;
+}
+
+.histogram-marker-high {
+  stroke: #4caf50;
+  stroke-width: 1;
+  stroke-dasharray: 2 2;
+}
+
+.histogram-bounds {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+}
+
+.histogram-status {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+}
+
+.percentile-value-col {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-left: 0;
+}
+
+.percentile-value {
+  min-width: 3.5rem;
+  text-align: right;
+  white-space: nowrap;
+}
 </style>

--- a/client/src/components/ImageEnhancements.vue
+++ b/client/src/components/ImageEnhancements.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, ref, watch } from 'vue';
-import { useHandler, useImageEnhancements } from '../provides';
+import { useHandler, useImageEnhancements, usePercentileStretchSupported } from '../provides';
 
 export default defineComponent({
   name: 'ImageEnhancements',
@@ -8,6 +8,7 @@ export default defineComponent({
   setup() {
     const { setSVGFilters } = useHandler();
     const imageEnhancements = useImageEnhancements();
+    const percentileStretchSupported = usePercentileStretchSupported();
     const brightness = ref(imageEnhancements.value.brightness);
     const contrast = ref(imageEnhancements.value.contrast);
     const saturation = ref(imageEnhancements.value.saturation);
@@ -32,7 +33,7 @@ export default defineComponent({
         contrast: contrast.value,
         saturation: saturation.value,
         sharpen: sharpen.value,
-        percentileStretch: stretchEnabled.value
+        percentileStretch: percentileStretchSupported.value && stretchEnabled.value
           ? { lowPercentile: lowPercentile.value, highPercentile: highPercentile.value }
           : null,
       });
@@ -59,6 +60,7 @@ export default defineComponent({
       stretchEnabled,
       lowPercentile,
       highPercentile,
+      percentileStretchSupported,
     };
   },
 });
@@ -146,62 +148,67 @@ export default defineComponent({
         <span>{{ sharpen.toFixed(1) }}</span>
       </v-col>
     </v-row>
-    <v-divider class="my-3" />
-    <v-row
-      align="center"
-      class="ma-0"
-    >
-      <v-col cols="8">
-        <span class="text-caption">Percentile Stretch</span>
-      </v-col>
-      <v-col class="pa-0">
-        <v-switch
-          v-model="stretchEnabled"
-          hide-details
-          class="ma-0 pa-0 mt-1"
-          @change="modifyValue()"
-        />
-      </v-col>
-    </v-row>
-    <template v-if="stretchEnabled">
-      <v-row>
-        <v-col cols="4">
-          <span class="text-caption">Low %</span>
+    <v-divider
+      v-if="percentileStretchSupported"
+      class="my-3"
+    />
+    <template v-if="percentileStretchSupported">
+      <v-row
+        align="center"
+        class="ma-0"
+      >
+        <v-col cols="8">
+          <span class="text-caption">Percentile Stretch</span>
         </v-col>
-        <v-col>
-          <v-slider
-            v-model="lowPercentile"
-            :min="0"
-            :max="1"
-            :step="0.01"
+        <v-col class="pa-0">
+          <v-switch
+            v-model="stretchEnabled"
             hide-details
-            class="pa-0 ma-0"
-            @input="modifyValue()"
+            class="ma-0 pa-0 mt-1"
+            @change="modifyValue()"
           />
         </v-col>
-        <v-col cols="2">
-          <span>{{ lowPercentile.toFixed(2) }}</span>
-        </v-col>
       </v-row>
-      <v-row>
-        <v-col cols="4">
-          <span class="text-caption">High %</span>
-        </v-col>
-        <v-col>
-          <v-slider
-            v-model="highPercentile"
-            :min="99"
-            :max="100"
-            :step="0.01"
-            hide-details
-            class="pa-0 ma-0"
-            @input="modifyValue()"
-          />
-        </v-col>
-        <v-col cols="2">
-          <span>{{ highPercentile.toFixed(2) }}</span>
-        </v-col>
-      </v-row>
+      <template v-if="stretchEnabled">
+        <v-row>
+          <v-col cols="4">
+            <span class="text-caption">Low %</span>
+          </v-col>
+          <v-col>
+            <v-slider
+              v-model="lowPercentile"
+              :min="0"
+              :max="1"
+              :step="0.01"
+              hide-details
+              class="pa-0 ma-0"
+              @input="modifyValue()"
+            />
+          </v-col>
+          <v-col cols="2">
+            <span>{{ lowPercentile.toFixed(2) }}</span>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="4">
+            <span class="text-caption">High %</span>
+          </v-col>
+          <v-col>
+            <v-slider
+              v-model="highPercentile"
+              :min="99"
+              :max="100"
+              :step="0.01"
+              hide-details
+              class="pa-0 ma-0"
+              @input="modifyValue()"
+            />
+          </v-col>
+          <v-col cols="2">
+            <span>{{ highPercentile.toFixed(2) }}</span>
+          </v-col>
+        </v-row>
+      </template>
     </template>
     <v-btn
       block

--- a/client/src/components/ImageEnhancements.vue
+++ b/client/src/components/ImageEnhancements.vue
@@ -172,15 +172,15 @@ export default defineComponent({
           <v-slider
             v-model="lowPercentile"
             :min="0"
-            :max="highPercentile - 1"
-            :step="1"
+            :max="1"
+            :step="0.01"
             hide-details
             class="pa-0 ma-0"
             @input="modifyValue()"
           />
         </v-col>
         <v-col cols="2">
-          <span>{{ lowPercentile }}</span>
+          <span>{{ lowPercentile.toFixed(2) }}</span>
         </v-col>
       </v-row>
       <v-row>
@@ -190,16 +190,16 @@ export default defineComponent({
         <v-col>
           <v-slider
             v-model="highPercentile"
-            :min="lowPercentile + 1"
+            :min="99"
             :max="100"
-            :step="1"
+            :step="0.01"
             hide-details
             class="pa-0 ma-0"
             @input="modifyValue()"
           />
         </v-col>
         <v-col cols="2">
-          <span>{{ highPercentile }}</span>
+          <span>{{ highPercentile.toFixed(2) }}</span>
         </v-col>
       </v-row>
     </template>

--- a/client/src/components/ImageEnhancements.vue
+++ b/client/src/components/ImageEnhancements.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
+import { defineComponent, ref, watch } from 'vue';
 import { useHandler, useImageEnhancements } from '../provides';
 
 export default defineComponent({
@@ -8,10 +8,17 @@ export default defineComponent({
   setup() {
     const { setSVGFilters } = useHandler();
     const imageEnhancements = useImageEnhancements();
-    const brightness = ref(imageEnhancements.value.brightness || 1);
-    const contrast = ref(imageEnhancements.value.contrast || 1);
-    const saturation = ref(imageEnhancements.value.saturation || 1);
-    const sharpen = ref(imageEnhancements.value.sharpen || 0);
+    const brightness = ref(imageEnhancements.value.brightness);
+    const contrast = ref(imageEnhancements.value.contrast);
+    const saturation = ref(imageEnhancements.value.saturation);
+    const sharpen = ref(imageEnhancements.value.sharpen);
+
+    watch(imageEnhancements, (val) => {
+      brightness.value = val.brightness;
+      contrast.value = val.contrast;
+      saturation.value = val.saturation;
+      sharpen.value = val.sharpen;
+    }, { deep: true });
 
     const modifyValue = () => {
       setSVGFilters({

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -535,16 +535,21 @@ export default defineComponent({
     watch(
       () => aggregateController.value.resizeTrigger.value,
       () => {
-        updateLayers(
-          frameNumberRef.value,
-          editingModeRef.value,
-          selectedTrackIdRef.value,
-          multiSeletListRef.value,
-          enabledTracksRef.value,
-          visibleModesRef.value,
-          selectedKeyRef.value,
-          props.colorBy,
-        );
+        window.requestAnimationFrame(() => {
+          if (!annotator.geoViewerRef?.value) {
+            return;
+          }
+          updateLayers(
+            frameNumberRef.value,
+            editingModeRef.value,
+            selectedTrackIdRef.value,
+            multiSeletListRef.value,
+            enabledTracksRef.value,
+            visibleModesRef.value,
+            selectedKeyRef.value,
+            props.colorBy,
+          );
+        });
       },
     );
 

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -59,6 +59,10 @@ export default defineComponent({
       type: Boolean as PropType<boolean>,
       required: true,
     },
+    filterId: {
+      type: String as PropType<string>,
+      default: 'imageEnhancements',
+    },
   },
   setup(props, { emit }) {
     const loadingVideo = ref(false);
@@ -329,7 +333,7 @@ export default defineComponent({
           if (props.isDefaultImage) {
             local.quadFeature.layer().node().css('filter', '');
           } else {
-            local.quadFeature.layer().node().css('filter', 'url(#imageEhancements)');
+            local.quadFeature.layer().node().css('filter', `url(#${props.filterId})`);
           }
         }
       },
@@ -353,7 +357,7 @@ export default defineComponent({
         });
         // Set quadFeature and conditionally apply brightness filter
         local.quadFeature = quadFeatureLayer.createFeature('quad');
-        local.quadFeature.layer().node().css('filter', 'url(#imageEhancements)');
+        local.quadFeature.layer().node().css('filter', `url(#${props.filterId})`);
         data.ready = true;
         seek(0);
       });
@@ -387,7 +391,7 @@ export default defineComponent({
           data.ready = true;
           seek(0);
           if (!props.isDefaultImage) {
-            local.quadFeature.layer().node().css('filter', 'url(#imageEhancements)');
+            local.quadFeature.layer().node().css('filter', `url(#${props.filterId})`);
           }
         });
       }
@@ -417,7 +421,7 @@ export default defineComponent({
       style="position: absolute; top: -1px; left: -1px"
     >
       <defs>
-        <filter id="imageEhancements">
+        <filter :id="filterId">
           <feComponentTransfer id="feBrightness">
             <feFuncR
               type="linear"

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -364,7 +364,15 @@ export default defineComponent({
     }
     function init() {
       data.maxFrame = props.imageData.length - 1;
-      // Below are configuration settings we can set until we decide on good numbers to utilize.
+      // When the viewer already exists, an imageData change is a URL swap for
+      // the same camera (e.g. the percentile-stretch display remap). Rebuild
+      // only the image cache and redraw the current frame in place: calling
+      // initializeViewer again would replace the geojs map, orphaning every
+      // feature layer and event handler that other components (LayerManager
+      // and its annotation/calibration layers) attached to the old map. Any
+      // dimension change is already handled by drawImage/resetMapDimensions.
+      const reusableQuad = data.ready && geoViewer.value !== undefined
+        ? local.quadFeature : undefined;
       local = {
         playCache: 1, // seconds required to be fully cached before playback
         cacheSeconds: 6, // seconds to cache from the current frame
@@ -372,29 +380,54 @@ export default defineComponent({
         imgs: new Array<ImageDataItemInternal | undefined>(props.imageData.length),
         pendingImgs: new Set<ImageDataItemInternal>(),
         lastFrame: -1,
-        width: 0,
-        height: 0,
+        width: reusableQuad !== undefined ? local.width : 0,
+        height: reusableQuad !== undefined ? local.height : 0,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        quadFeature: undefined as any,
+        quadFeature: reusableQuad as any,
       };
-      if (local.imgs.length) {
-        const imgInternal = cacheFrame(0);
-        imgInternal.onloadPromise.then(() => {
-          initializeViewer(imgInternal.image.naturalWidth, imgInternal.image.naturalHeight);
-          const quadFeatureLayer = geoViewer.value.createLayer('feature', {
-            features: ['quad'],
-            autoshareRenderer: false,
-            renderer: 'canvas',
-          });
-          // Set quadFeature and conditionally apply brightness filter
-          local.quadFeature = quadFeatureLayer.createFeature('quad');
-          data.ready = true;
-          seek(0);
-          if (!props.isDefaultImage) {
-            local.quadFeature.layer().node().css('filter', `url(#${props.filterId})`);
-          }
-        });
+      if (!local.imgs.length) {
+        return;
       }
+      if (reusableQuad !== undefined) {
+        if (data.frame > data.maxFrame) {
+          data.frame = data.maxFrame;
+          data.syncedFrame = data.maxFrame;
+        }
+        data.filename = props.imageData[data.frame].filename;
+        // seek() short-circuits on a same-frame re-seek, so drive the redraw
+        // directly through the fresh cache.
+        cacheImages();
+        const imgInternal = expectFrame(data.frame);
+        drawImage(imgInternal.image);
+        if (!imgInternal.cached) {
+          loadingImage.value = true;
+          imgInternal.onloadPromise.then(() => {
+            if (imgInternal.frame === data.frame) {
+              loadingImage.value = false;
+              drawImage(imgInternal.image);
+            }
+          });
+        } else {
+          loadingImage.value = false;
+        }
+        return;
+      }
+      const imgInternal = cacheFrame(0);
+      imgInternal.onloadPromise.then(() => {
+        initializeViewer(imgInternal.image.naturalWidth, imgInternal.image.naturalHeight);
+        const quadFeatureLayer = geoViewer.value.createLayer('feature', {
+          features: ['quad'],
+          autoshareRenderer: false,
+          renderer: 'canvas',
+        });
+        // Set quadFeature and conditionally apply brightness filter
+        local.quadFeature = quadFeatureLayer.createFeature('quad');
+        data.ready = true;
+        seek(0);
+        if (!props.isDefaultImage) {
+          local.quadFeature.layer().node().css('filter', `url(#${props.filterId})`);
+        }
+      });
     }
     // Watch imageData for change
     watch(toRef(props, 'imageData'), () => {

--- a/client/src/components/annotators/LargeImageAnnotator.vue
+++ b/client/src/components/annotators/LargeImageAnnotator.vue
@@ -2,8 +2,13 @@
 import {
   defineComponent, ref, onUnmounted, PropType, toRef, watch, computed,
 } from 'vue';
+import { debounce } from 'lodash';
 import geo from 'geojs';
-import { ImageEnhancementOutputs } from 'vue-media-annotator/use/useImageEnhancements';
+import {
+  ImageEnhancementOutputs,
+  PercentileStretch,
+  percentileStretchToTileStyle,
+} from 'vue-media-annotator/use/useImageEnhancements';
 import { SetTimeFunc } from '../../use/useTimeObserver';
 import AnnotatorImageCursor from './AnnotatorImageCursor.vue';
 import useAnnotatorImageCursor from './useAnnotatorImageCursor';
@@ -107,6 +112,10 @@ export default defineComponent({
     filterId: {
       type: String as PropType<string>,
       default: 'imageEnhancements',
+    },
+    percentileStretch: {
+      type: Object as PropType<PercentileStretch | null>,
+      default: null,
     },
   },
   setup(props) {
@@ -214,6 +223,72 @@ export default defineComponent({
       nextLayer: '' as any,
       nextLayerFrame: 0,
     };
+    const activePercentileStretch = ref<PercentileStretch | null>(props.percentileStretch);
+
+    function stretchCacheKey(stretch: PercentileStretch | null): string {
+      if (!stretch) return 'none';
+      return `${stretch.lowPercentile}:${stretch.highPercentile}`;
+    }
+
+    function applyTileQueryParams(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      params: Record<string, any>,
+      proj?: string,
+    ) {
+      const updatedParams = { ...params, encoding: 'PNG' };
+      if (proj) {
+        updatedParams.projection = proj;
+      }
+      const style = percentileStretchToTileStyle(activePercentileStretch.value);
+      if (style) {
+        updatedParams.style = style;
+      }
+      return updatedParams;
+    }
+
+    function refreshVisibleTileLayers() {
+      if (
+        !data.ready
+        || !local.currentLayer
+        || typeof local.currentLayer.url !== 'function'
+        || !props.imageData[data.frame]?.id
+      ) {
+        return;
+      }
+      local.currentLayer.url(_getTileURL(props.imageData[data.frame].id, projection));
+      if (
+        local.nextLayer
+        && typeof local.nextLayer.url === 'function'
+        && props.imageData[local.nextLayerFrame]?.id
+      ) {
+        local.nextLayer.url(_getTileURL(props.imageData[local.nextLayerFrame].id, projection));
+      }
+    }
+
+    const debouncedRefreshTileLayers = debounce(refreshVisibleTileLayers, 500, { trailing: true });
+    let previousStretchKey = stretchCacheKey(props.percentileStretch);
+
+    watch(
+      () => props.percentileStretch,
+      (stretch) => {
+        activePercentileStretch.value = stretch;
+        if (!data.ready) {
+          previousStretchKey = stretchCacheKey(stretch);
+          return;
+        }
+        const currentKey = stretchCacheKey(stretch);
+        const isToggle = (currentKey === 'none') !== (previousStretchKey === 'none');
+        previousStretchKey = currentKey;
+        if (isToggle) {
+          debouncedRefreshTileLayers.cancel();
+          refreshVisibleTileLayers();
+        } else {
+          debouncedRefreshTileLayers();
+        }
+      },
+      { deep: true },
+    );
+
     function forceUnload(imgInternal: ImageDataItemInternal) {
       // Removal from list indicates we are no longer attempting to load this image
       local.imgs[imgInternal.frame] = undefined;
@@ -225,10 +300,7 @@ export default defineComponent({
     function _getTileURL(itemId: string, proj?: string) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const returnFunc = (x: number, y: number, level: number, params: any) => {
-        const updatedParams = { ...params, encoding: 'PNG' };
-        if (proj) {
-          updatedParams.projection = proj;
-        }
+        const updatedParams = applyTileQueryParams(params, proj);
         return props.getTileURL(itemId, x, y, level, updatedParams);
       };
       return returnFunc;
@@ -256,6 +328,7 @@ export default defineComponent({
      * requests for image load.
      */
     onUnmounted(() => {
+      debouncedRefreshTileLayers.cancel();
       Array.from(local.pendingImgs).forEach(forceUnload);
       if (tileLoadErrorResizeObserver && container.value) {
         tileLoadErrorResizeObserver.unobserve(container.value);

--- a/client/src/components/annotators/LargeImageAnnotator.vue
+++ b/client/src/components/annotators/LargeImageAnnotator.vue
@@ -104,6 +104,10 @@ export default defineComponent({
       type: Boolean as PropType<boolean>,
       required: true,
     },
+    filterId: {
+      type: String as PropType<string>,
+      default: 'imageEnhancements',
+    },
   },
   setup(props) {
     const loadingVideo = ref(false);
@@ -354,7 +358,7 @@ export default defineComponent({
           if (props.isDefaultImage) {
             local.currentLayer.node().css('filter', '');
           } else {
-            local.currentLayer.node().css('filter', 'url(#imageEhancements)');
+            local.currentLayer.node().css('filter', `url(#${props.filterId})`);
           }
         }
       },
@@ -499,7 +503,7 @@ export default defineComponent({
         );
         // Set quadFeature and conditionally apply brightness filter
         if (!props.isDefaultImage) {
-          local.currentLayer.node().css('filter', 'url(#imageEhancements)');
+          local.currentLayer.node().css('filter', `url(#${props.filterId})`);
         }
         data.ready = true;
         loadingVideo.value = false;
@@ -543,7 +547,7 @@ export default defineComponent({
       style="position: absolute; top: -1px; left: -1px"
     >
       <defs>
-        <filter id="imageEhancements">
+        <filter :id="filterId">
           <feComponentTransfer id="feBrightness">
             <feFuncR
               type="linear"

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -106,6 +106,10 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
+    filterId: {
+      type: String as PropType<string>,
+      default: 'imageEnhancements',
+    },
   },
   setup(props) {
     const cameraInitializer = injectCameraInitializer();
@@ -212,7 +216,7 @@ export default defineComponent({
           if (newVal) {
             quadFeatureLayer.node().css('filter', '');
           } else {
-            quadFeatureLayer.node().css('filter', 'url(#imageEhancements)');
+            quadFeatureLayer.node().css('filter', `url(#${props.filterId})`);
           }
         }
       },
@@ -259,7 +263,7 @@ export default defineComponent({
       // See https://github.com/Kitware/dive/issues/447 for more details.
       seek(0);
       if (!props.isDefaultImage) {
-        quadFeatureLayer.node().css('filter', 'url(#imageEhancements)');
+        quadFeatureLayer.node().css('filter', `url(#${props.filterId})`);
       }
       data.ready = true;
       data.volume = video.volume;
@@ -291,7 +295,7 @@ export default defineComponent({
   <div class="video-annotator" :style="{ cursor: data.cursor }">
     <svg width="0" height="0" style="position: absolute; top: -1px; left: -1px">
       <defs>
-        <filter id="imageEhancements">
+        <filter :id="filterId">
           <feComponentTransfer id="feBrightness">
             <feFuncR
               type="linear"

--- a/client/src/components/annotators/useMediaController.ts
+++ b/client/src/components/annotators/useMediaController.ts
@@ -142,6 +142,7 @@ export function useMediaController() {
    */
   function onResize() {
     let resized = false;
+    const pendingResizes: (() => void)[] = [];
     subControllers.forEach((mc) => {
       const camera = cameraControllerSymbols[mc.cameraName.value].toString();
       const geoViewerRef = geoViewers[camera];
@@ -153,16 +154,22 @@ export function useMediaController() {
       const mapSize = geoViewerRef.value.size();
       if (size.width !== mapSize.width || size.height !== mapSize.height) {
         resized = true;
-        window.requestAnimationFrame(() => {
+        pendingResizes.push(() => {
+          if (geoViewerRef.value === undefined) {
+            return;
+          }
           geoViewerRef.value.size(size);
           mc.resetZoom();
         });
       }
     });
-    // Trigger layer redraw after resize
+    // Resize maps first, then redraw annotation layers once GeoJS has settled.
     if (resized) {
       window.requestAnimationFrame(() => {
-        resizeTrigger.value += 1;
+        pendingResizes.forEach((applyResize) => applyResize());
+        window.requestAnimationFrame(() => {
+          resizeTrigger.value += 1;
+        });
       });
     }
   }

--- a/client/src/layers/BaseLayer.ts
+++ b/client/src/layers/BaseLayer.ts
@@ -104,6 +104,9 @@ export default abstract class BaseLayer<D> {
 
     changeData(frameData: FrameDataTrack[], comparisons: string[] = []) {
       this.formattedData = this.formatData(frameData, comparisons);
+      if (!this.annotator.geoViewerRef?.value || !this.featureLayer) {
+        return;
+      }
       this.redraw();
     }
 

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -16,7 +16,11 @@ import type {
   TimelineAttribute,
 } from './use/AttributeTypes';
 import type { Time } from './use/useTimeObserver';
-import type { ImageEnhancements, PercentileStretch } from './use/useImageEnhancements';
+import type {
+  ImageEnhancements,
+  PercentileHistogram,
+  PercentileStretch,
+} from './use/useImageEnhancements';
 import TrackFilterControls from './TrackFilterControls';
 import GroupFilterControls from './GroupFilterControls';
 import CameraStore from './CameraStore';
@@ -113,6 +117,10 @@ type ImageEnhancementsType = Readonly<Ref<ImageEnhancements>>;
 
 const PercentileStretchSupportedSymbol = Symbol('percentileStretchSupported');
 type PercentileStretchSupportedType = Readonly<Ref<boolean>>;
+const PercentileHistogramSymbol = Symbol('percentileHistogram');
+type PercentileHistogramType = Readonly<Ref<PercentileHistogram | null>>;
+const PercentileHistogramLoadingSymbol = Symbol('percentileHistogramLoading');
+type PercentileHistogramLoadingType = Readonly<Ref<boolean>>;
 
 /** Class-based symbols */
 const CameraStoreSymbol = Symbol('cameraStore');
@@ -318,6 +326,8 @@ export interface State {
   readOnlyMode: ReadOnylModeType;
   imageEnhancements: ImageEnhancementsType;
   percentileStretchSupported: Readonly<Ref<boolean>>;
+  percentileHistogram: PercentileHistogramType;
+  percentileHistogramLoading: PercentileHistogramLoadingType;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -398,6 +408,8 @@ function dummyState(): State {
       sharpen: 0,
     }),
     percentileStretchSupported: ref(false),
+    percentileHistogram: ref(null),
+    percentileHistogramLoading: ref(false),
   };
 }
 
@@ -439,6 +451,8 @@ function provideAnnotator(state: State, handler: Handler, attributesFilters: Att
   provide(ReadOnlyModeSymbol, state.readOnlyMode);
   provide(ImageEnhancementsSymbol, state.imageEnhancements);
   provide(PercentileStretchSupportedSymbol, state.percentileStretchSupported);
+  provide(PercentileHistogramSymbol, state.percentileHistogram);
+  provide(PercentileHistogramLoadingSymbol, state.percentileHistogramLoading);
   provide(HandlerSymbol, handler);
   provide(AttributesFilterSymbol, attributesFilters);
 }
@@ -568,6 +582,14 @@ function usePercentileStretchSupported() {
   return use<PercentileStretchSupportedType>(PercentileStretchSupportedSymbol);
 }
 
+function usePercentileHistogram() {
+  return use<PercentileHistogramType>(PercentileHistogramSymbol);
+}
+
+function usePercentileHistogramLoading() {
+  return use<PercentileHistogramLoadingType>(PercentileHistogramLoadingSymbol);
+}
+
 function useSegmentationPoints() {
   return use<SegmentationPointsType>(SegmentationPointsSymbol);
 }
@@ -610,6 +632,8 @@ export {
   useReadOnlyMode,
   useImageEnhancements,
   usePercentileStretchSupported,
+  usePercentileHistogram,
+  usePercentileHistogramLoading,
   useAttributesFilters,
   useSegmentationPoints,
   useSegmentationCursorLoading,

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -16,7 +16,7 @@ import type {
   TimelineAttribute,
 } from './use/AttributeTypes';
 import type { Time } from './use/useTimeObserver';
-import type { ImageEnhancements } from './use/useImageEnhancements';
+import type { ImageEnhancements, PercentileStretch } from './use/useImageEnhancements';
 import TrackFilterControls from './TrackFilterControls';
 import GroupFilterControls from './GroupFilterControls';
 import CameraStore from './CameraStore';
@@ -111,6 +111,9 @@ type ReadOnylModeType = Readonly<Ref<boolean>>;
 const ImageEnhancementsSymbol = Symbol('imageEnhancements');
 type ImageEnhancementsType = Readonly<Ref<ImageEnhancements>>;
 
+const PercentileStretchSupportedSymbol = Symbol('percentileStretchSupported');
+type PercentileStretchSupportedType = Readonly<Ref<boolean>>;
+
 /** Class-based symbols */
 const CameraStoreSymbol = Symbol('cameraStore');
 
@@ -203,8 +206,14 @@ export interface Handler {
   /* Reload Annotation File */
   reloadAnnotations(): Promise<void>;
   setSVGFilters({
-    brightness, contrast, saturation, sharpen,
-  }: {brightness?: number; contrast?: number; saturation?: number; sharpen?: number}): void;
+    brightness, contrast, saturation, sharpen, percentileStretch,
+  }: {
+    brightness?: number;
+    contrast?: number;
+    saturation?: number;
+    sharpen?: number;
+    percentileStretch?: PercentileStretch | null;
+  }): void;
   /* unlink Camera Track */
   unlinkCameraTrack(trackId: AnnotationId, camera: string): void;
   /* link Camera Track */
@@ -308,6 +317,7 @@ export interface State {
   visibleModes: VisibleModesType;
   readOnlyMode: ReadOnylModeType;
   imageEnhancements: ImageEnhancementsType;
+  percentileStretchSupported: Readonly<Ref<boolean>>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -387,6 +397,7 @@ function dummyState(): State {
       saturation: 1,
       sharpen: 0,
     }),
+    percentileStretchSupported: ref(false),
   };
 }
 
@@ -427,6 +438,7 @@ function provideAnnotator(state: State, handler: Handler, attributesFilters: Att
   provide(VisibleModesSymbol, state.visibleModes);
   provide(ReadOnlyModeSymbol, state.readOnlyMode);
   provide(ImageEnhancementsSymbol, state.imageEnhancements);
+  provide(PercentileStretchSupportedSymbol, state.percentileStretchSupported);
   provide(HandlerSymbol, handler);
   provide(AttributesFilterSymbol, attributesFilters);
 }
@@ -552,6 +564,10 @@ function useImageEnhancements() {
   return use<ImageEnhancementsType>(ImageEnhancementsSymbol);
 }
 
+function usePercentileStretchSupported() {
+  return use<PercentileStretchSupportedType>(PercentileStretchSupportedSymbol);
+}
+
 function useSegmentationPoints() {
   return use<SegmentationPointsType>(SegmentationPointsSymbol);
 }
@@ -593,6 +609,7 @@ export {
   useVisibleModes,
   useReadOnlyMode,
   useImageEnhancements,
+  usePercentileStretchSupported,
   useAttributesFilters,
   useSegmentationPoints,
   useSegmentationCursorLoading,

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -27,13 +27,39 @@ export interface ImageEnhancementOutputs {
     sharpen: { kernelMatrix: string; divisor: number };
   }
 
+export const defaultImageEnhancements: ImageEnhancements = {
+  brightness: 1,
+  contrast: 1,
+  saturation: 1,
+  sharpen: 0,
+};
+
+export function computeOutputs(enh: ImageEnhancements): ImageEnhancementOutputs {
+  const s = enh.sharpen;
+  const center = 1 + 4 * s;
+  const kernel = [0, -s, 0, -s, center, -s, 0, -s, 0].map((n) => Number(n).toFixed(4)).join(' ');
+  return {
+    brightness: { slope: enh.brightness, intercept: 0 },
+    contrast: { slope: enh.contrast, intercept: 0.5 - 0.5 * enh.contrast },
+    saturation: { values: enh.saturation },
+    sharpen: { kernelMatrix: kernel, divisor: 1 },
+  };
+}
+
+export function computeIsDefault(enh: ImageEnhancements): boolean {
+  return (
+    enh.brightness === 1
+    && enh.contrast === 1
+    && enh.saturation === 1
+    && enh.sharpen === 0
+    && enh.percentileStretch?.min == null
+    && enh.percentileStretch?.max == null
+  );
+}
+
 export default function useImageEnhancements() {
-  const imageEnhancements: Ref<ImageEnhancements> = ref({
-    brightness: 1,
-    contrast: 1,
-    saturation: 1,
-    sharpen: 0,
-  });
+  const imageEnhancements: Ref<ImageEnhancements> = ref({ ...defaultImageEnhancements });
+  const imageEnhancementsByCamera: Ref<Record<string, ImageEnhancements>> = ref({});
 
   const setSVGFilters = ({
     brightness, contrast, saturation, sharpen,
@@ -45,37 +71,9 @@ export default function useImageEnhancements() {
     VueSet(imageEnhancements.value, 'sharpen', sharpen);
   };
 
-  const brightness = computed(() => ({ slope: imageEnhancements.value.brightness, intercept: 0 }));
+  const imageEnhancementOutputs = computed(() => computeOutputs(imageEnhancements.value));
 
-  const contrast = computed(() => {
-    const value = imageEnhancements.value.contrast;
-    return { slope: value, intercept: 0.5 - 0.5 * (value) };
-  });
-
-  const saturation = computed(() => ({ values: imageEnhancements.value.saturation }));
-
-  const sharpen = computed(() => {
-    const s = imageEnhancements.value.sharpen;
-    const center = (1 + 4 * s);
-    const kernel = [0, -s, 0, -s, center, -s, 0, -s, 0].map((n) => Number(n).toFixed(4)).join(' ');
-    return { kernelMatrix: kernel, divisor: 1 };
-  });
-
-  const imageEnhancementOutputs = computed(() => ({
-    brightness: brightness.value,
-    contrast: contrast.value,
-    saturation: saturation.value,
-    sharpen: sharpen.value,
-  }));
-
-  const isDefaultImage = computed(() => (
-    imageEnhancements.value.brightness === 1
-    && imageEnhancements.value.contrast === 1
-    && imageEnhancements.value.saturation === 1
-    && imageEnhancements.value.sharpen === 0
-    && imageEnhancements.value.percentileStretch?.min == null
-    && imageEnhancements.value.percentileStretch?.max == null
-  ));
+  const isDefaultImage = computed(() => computeIsDefault(imageEnhancements.value));
 
   const setImageEnhancements = (enhancements: ImageEnhancements) => {
     imageEnhancements.value = {
@@ -89,6 +87,7 @@ export default function useImageEnhancements() {
 
   return {
     imageEnhancements,
+    imageEnhancementsByCamera,
     imageEnhancementOutputs,
     isDefaultImage,
     setSVGFilters,

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -6,8 +6,6 @@ import {
 export interface PercentileStretch {
   lowPercentile: number;
   highPercentile: number;
-  min?: number;
-  max?: number;
 }
 
 // Expecting this may be a placeholder for more complicated client side enhancements
@@ -52,8 +50,7 @@ export function computeIsDefault(enh: ImageEnhancements): boolean {
     && enh.contrast === 1
     && enh.saturation === 1
     && enh.sharpen === 0
-    && enh.percentileStretch?.min == null
-    && enh.percentileStretch?.max == null
+    && enh.percentileStretch == null
   );
 }
 

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -59,13 +59,25 @@ export default function useImageEnhancements() {
   const imageEnhancementsByCamera: Ref<Record<string, ImageEnhancements>> = ref({});
 
   const setSVGFilters = ({
-    brightness, contrast, saturation, sharpen,
-  }:
-    { brightness: number; contrast: number; saturation: number; sharpen: number }) => {
+    brightness, contrast, saturation, sharpen, percentileStretch,
+  }: {
+    brightness: number;
+    contrast: number;
+    saturation: number;
+    sharpen: number;
+    percentileStretch?: PercentileStretch | null;
+  }) => {
     VueSet(imageEnhancements.value, 'brightness', brightness);
     VueSet(imageEnhancements.value, 'contrast', contrast);
     VueSet(imageEnhancements.value, 'saturation', saturation);
     VueSet(imageEnhancements.value, 'sharpen', sharpen);
+    if (percentileStretch !== undefined) {
+      VueSet(
+        imageEnhancements.value,
+        'percentileStretch',
+        percentileStretch ? { ...percentileStretch } : undefined,
+      );
+    }
   };
 
   const imageEnhancementOutputs = computed(() => computeOutputs(imageEnhancements.value));

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -20,6 +20,16 @@ export interface PercentileStretchMetadata {
   type?: string;
   originalImageFiles?: string[];
   originalLargeImageFile?: string;
+  imageData?: readonly { readonly filename?: string }[];
+}
+
+/** Girder large_image histogram entry (first channel). */
+export interface GirderHistogramEntry {
+  hist?: number[];
+  bin_edges?: number[];
+  range?: [number, number];
+  min?: number;
+  max?: number;
 }
 
 const tiffExtensions = ['.tif', '.tiff'];
@@ -29,16 +39,93 @@ export function isTiffImagePath(path: string): boolean {
   return tiffExtensions.some((ext) => lower.endsWith(ext));
 }
 
-/** True when originals are TIFF and the /media/display stretch path can recover range. */
+/** True when originals are TIFF and stretch can recover dynamic range. */
 export function metadataSupportsPercentileStretch(meta: PercentileStretchMetadata): boolean {
-  if (meta.type === 'large-image' && meta.originalLargeImageFile) {
-    return isTiffImagePath(meta.originalLargeImageFile);
+  if (meta.type === 'large-image') {
+    if (meta.originalLargeImageFile && isTiffImagePath(meta.originalLargeImageFile)) {
+      return true;
+    }
+    const { imageData } = meta;
+    if (imageData?.length) {
+      return imageData.some((item) => item.filename && isTiffImagePath(item.filename));
+    }
+    return false;
   }
-  const files = meta.originalImageFiles;
+  const { originalImageFiles: files } = meta;
   if (files?.length) {
     return files.some(isTiffImagePath);
   }
   return false;
+}
+
+/**
+ * Whether percentile stretch UI should be enabled for this dataset on the current platform.
+ * Web large-image uses Girder tile style params; desktop image-sequence uses /media/display.
+ */
+export function resolvePercentileStretchSupported(
+  meta: PercentileStretchMetadata,
+  isDesktopApp: boolean,
+  supportsLargeImageTileStretch: boolean,
+): boolean {
+  if (!metadataSupportsPercentileStretch(meta)) {
+    return false;
+  }
+  if (meta.type === 'large-image') {
+    return supportsLargeImageTileStretch;
+  }
+  return isDesktopApp;
+}
+
+/** Build Girder large_image tile `style` JSON for percentile stretch. */
+export function percentileStretchToTileStyle(
+  stretch: PercentileStretch | null | undefined,
+): string | undefined {
+  if (!stretch) return undefined;
+  const lowFraction = stretch.lowPercentile / 100;
+  const highFraction = (100 - stretch.highPercentile) / 100;
+  const style = {
+    bands: [{
+      min: `min:${lowFraction}`,
+      max: `max:${highFraction}`,
+    }],
+  };
+  return JSON.stringify(style);
+}
+
+/** Map Girder item/{id}/tiles/histogram response to the client histogram shape. */
+export function parseGirderHistogramResponse(
+  response: unknown,
+): GirderHistogramEntry | undefined {
+  if (Array.isArray(response)) {
+    return response[0] as GirderHistogramEntry | undefined;
+  }
+  if (response && typeof response === 'object' && 'histogram' in response) {
+    const { histogram } = response as { histogram?: GirderHistogramEntry[] };
+    return histogram?.[0];
+  }
+  return undefined;
+}
+
+/** Map a single Girder histogram channel to the client histogram shape. */
+export function girderHistogramToPercentileHistogram(
+  entry: GirderHistogramEntry | undefined,
+): PercentileHistogram | null {
+  if (!entry?.hist?.length) return null;
+  const bins = entry.hist.map((count) => Math.round(count));
+  let sourceMin = entry.min ?? entry.range?.[0] ?? 0;
+  let sourceMax = entry.max ?? entry.range?.[1] ?? 255;
+  if (entry.bin_edges && entry.bin_edges.length >= 2) {
+    const [firstEdge, ...remainingEdges] = entry.bin_edges;
+    sourceMin = firstEdge;
+    sourceMax = remainingEdges[remainingEdges.length - 1];
+  }
+  return {
+    bins,
+    lowValue: sourceMin,
+    highValue: sourceMax,
+    sourceMin,
+    sourceMax,
+  };
 }
 
 export function effectiveImageEnhancements(

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -3,13 +3,21 @@ import {
   ref, Ref, set as VueSet,
 } from 'vue';
 
+export interface PercentileStretch {
+  lowPercentile: number;
+  highPercentile: number;
+  min?: number;
+  max?: number;
+}
+
 // Expecting this may be a placeholder for more complicated client side enhancements
 // or more image filters
 export interface ImageEnhancements {
     brightness: number;
     contrast: number;
     saturation: number;
-    sharpen: number
+    sharpen: number;
+    percentileStretch?: PercentileStretch;
   }
 
 export interface ImageEnhancementOutputs {
@@ -65,6 +73,8 @@ export default function useImageEnhancements() {
     && imageEnhancements.value.contrast === 1
     && imageEnhancements.value.saturation === 1
     && imageEnhancements.value.sharpen === 0
+    && imageEnhancements.value.percentileStretch?.min == null
+    && imageEnhancements.value.percentileStretch?.max == null
   ));
 
   const setImageEnhancements = (enhancements: ImageEnhancements) => {
@@ -73,6 +83,7 @@ export default function useImageEnhancements() {
       contrast: enhancements.contrast,
       saturation: enhancements.saturation,
       sharpen: enhancements.sharpen,
+      percentileStretch: enhancements.percentileStretch,
     };
   };
 

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -81,7 +81,9 @@ export default function useImageEnhancements() {
       contrast: enhancements.contrast,
       saturation: enhancements.saturation,
       sharpen: enhancements.sharpen,
-      percentileStretch: enhancements.percentileStretch,
+      percentileStretch: enhancements.percentileStretch
+        ? { ...enhancements.percentileStretch }
+        : undefined,
     };
   };
 

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -8,6 +8,14 @@ export interface PercentileStretch {
   highPercentile: number;
 }
 
+export interface PercentileHistogram {
+  bins: number[];
+  lowValue: number;
+  highValue: number;
+  sourceMin: number;
+  sourceMax: number;
+}
+
 export interface PercentileStretchMetadata {
   type?: string;
   originalImageFiles?: string[];
@@ -40,7 +48,8 @@ export function effectiveImageEnhancements(
   if (percentileStretchSupported || enh.percentileStretch == null) {
     return enh;
   }
-  const { percentileStretch, ...rest } = enh;
+  const rest = { ...enh };
+  delete rest.percentileStretch;
   return rest;
 }
 
@@ -80,6 +89,48 @@ export function computeOutputs(enh: ImageEnhancements): ImageEnhancementOutputs 
   };
 }
 
+/** Derive percentile cutoff values from a binned histogram (no server round-trip). */
+export function computePercentileBoundsFromBins(
+  bins: number[],
+  lowPercentile: number,
+  highPercentile: number,
+  sourceMin: number,
+  sourceMax: number,
+): { lowValue: number; highValue: number } {
+  const total = bins.reduce((sum, count) => sum + count, 0);
+  if (total === 0) return { lowValue: sourceMin, highValue: sourceMax };
+
+  const lowTarget = Math.floor(total * (lowPercentile / 100));
+  const highTarget = Math.floor(total * (highPercentile / 100));
+  const binCount = bins.length;
+
+  function binToValue(binIndex: number): number {
+    if (sourceMax > 255) return Math.min(sourceMax, binIndex * 256);
+    if (sourceMin === 0 && sourceMax <= 255) return binIndex;
+    const range = sourceMax - sourceMin;
+    return sourceMin + (binCount <= 1 ? 0 : (binIndex / (binCount - 1)) * range);
+  }
+
+  let cumulative = 0;
+  let lowValue = sourceMin;
+  let highValue = sourceMax;
+  let foundLow = false;
+
+  for (let i = 0; i < binCount; i += 1) {
+    cumulative += bins[i];
+    if (!foundLow && cumulative > 0 && cumulative >= lowTarget) {
+      lowValue = binToValue(i);
+      foundLow = true;
+    }
+    if (cumulative >= highTarget) {
+      highValue = binToValue(i);
+      break;
+    }
+  }
+
+  return { lowValue, highValue };
+}
+
 export function computeIsDefault(enh: ImageEnhancements): boolean {
   return (
     enh.brightness === 1
@@ -94,6 +145,8 @@ export default function useImageEnhancements() {
   const imageEnhancements: Ref<ImageEnhancements> = ref({ ...defaultImageEnhancements });
   const imageEnhancementsByCamera: Ref<Record<string, ImageEnhancements>> = ref({});
   const percentileStretchSupported: Ref<boolean> = ref(false);
+  const percentileHistogram: Ref<PercentileHistogram | null> = ref(null);
+  const percentileHistogramLoading: Ref<boolean> = ref(false);
 
   const setSVGFilters = ({
     brightness, contrast, saturation, sharpen, percentileStretch,
@@ -137,14 +190,26 @@ export default function useImageEnhancements() {
     percentileStretchSupported.value = supported;
   };
 
+  const setPercentileHistogram = (hist: PercentileHistogram | null) => {
+    percentileHistogram.value = hist;
+  };
+
+  const setPercentileHistogramLoading = (loading: boolean) => {
+    percentileHistogramLoading.value = loading;
+  };
+
   return {
     imageEnhancements,
     imageEnhancementsByCamera,
     imageEnhancementOutputs,
     isDefaultImage,
     percentileStretchSupported,
+    percentileHistogram,
+    percentileHistogramLoading,
     setSVGFilters,
     setImageEnhancements,
     setPercentileStretchSupported,
+    setPercentileHistogram,
+    setPercentileHistogramLoading,
   };
 }

--- a/client/src/use/useImageEnhancements.ts
+++ b/client/src/use/useImageEnhancements.ts
@@ -8,6 +8,42 @@ export interface PercentileStretch {
   highPercentile: number;
 }
 
+export interface PercentileStretchMetadata {
+  type?: string;
+  originalImageFiles?: string[];
+  originalLargeImageFile?: string;
+}
+
+const tiffExtensions = ['.tif', '.tiff'];
+
+export function isTiffImagePath(path: string): boolean {
+  const lower = path.toLowerCase();
+  return tiffExtensions.some((ext) => lower.endsWith(ext));
+}
+
+/** True when originals are TIFF and the /media/display stretch path can recover range. */
+export function metadataSupportsPercentileStretch(meta: PercentileStretchMetadata): boolean {
+  if (meta.type === 'large-image' && meta.originalLargeImageFile) {
+    return isTiffImagePath(meta.originalLargeImageFile);
+  }
+  const files = meta.originalImageFiles;
+  if (files?.length) {
+    return files.some(isTiffImagePath);
+  }
+  return false;
+}
+
+export function effectiveImageEnhancements(
+  enh: ImageEnhancements,
+  percentileStretchSupported: boolean,
+): ImageEnhancements {
+  if (percentileStretchSupported || enh.percentileStretch == null) {
+    return enh;
+  }
+  const { percentileStretch, ...rest } = enh;
+  return rest;
+}
+
 // Expecting this may be a placeholder for more complicated client side enhancements
 // or more image filters
 export interface ImageEnhancements {
@@ -57,6 +93,7 @@ export function computeIsDefault(enh: ImageEnhancements): boolean {
 export default function useImageEnhancements() {
   const imageEnhancements: Ref<ImageEnhancements> = ref({ ...defaultImageEnhancements });
   const imageEnhancementsByCamera: Ref<Record<string, ImageEnhancements>> = ref({});
+  const percentileStretchSupported: Ref<boolean> = ref(false);
 
   const setSVGFilters = ({
     brightness, contrast, saturation, sharpen, percentileStretch,
@@ -96,12 +133,18 @@ export default function useImageEnhancements() {
     };
   };
 
+  const setPercentileStretchSupported = (supported: boolean) => {
+    percentileStretchSupported.value = supported;
+  };
+
   return {
     imageEnhancements,
     imageEnhancementsByCamera,
     imageEnhancementOutputs,
     isDefaultImage,
+    percentileStretchSupported,
     setSVGFilters,
     setImageEnhancements,
+    setPercentileStretchSupported,
   };
 }

--- a/docs/Annotation-User-Interface-Overview.md
+++ b/docs/Annotation-User-Interface-Overview.md
@@ -15,7 +15,9 @@ This documentation section provides a reference guide to the annotation interfac
     * **[Dataset Info](UI-DatasetInfo.md)** - View dataset properties and attach custom dataset-level metadata that is shown while annotating and included in CSV export.
     * **[Revision History](Web-Version.md#revision-history)** (Web) - Inspect and check out past saved annotation states.
     * **Threshold Controls** - Advance thresholding of annotation confidence values per-type.
-    * **Image Enhancement** - Adjust the image threshold range.
+    * **Image Enhancement** — Brightness, contrast, saturation, sharpness, and
+      [percentile stretch for high bit-depth TIFF](UI-Image-Enhancements.md) (Web
+      large-image and Desktop image-sequence).
     * **[Group Manager](UI-Group-Manager.md)** - Controls for creating, managing, and filtering multi-annotation groups.
     * **[Annotation Sets](Annotation-Sets.md)** - Parallel annotation versions on the same dataset (web only): switch sets, create named copies, and compare overlays.
     * **[Attributes Details Panel](UI-AttributeDetails.md)** - Attributes panel used to filter or generate graphs of attributes.

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -180,11 +180,15 @@ interface DatasetMetaMutable {
   customTypeStyling?: Record<string, CustomStyle>;
   customGroupStyling?: Record<string, CustomStyle>;
   confidenceFilters?: Record<string, number>;
-  imageEnhancments?: ImageEnhancements;
+  imageEnhancements?: ImageEnhancements;
   attributes?: Readonly<Record<string, Attribute>>;
   datasetInfo?: Record<string, unknown>;
 }
 ```
+
+`imageEnhancements` stores viewer display settings (brightness, contrast, saturation,
+sharpen, and optional percentile stretch bounds). See
+[Image Enhancements](UI-Image-Enhancements.md) for platform support of high bit-depth stretch.
 
 ## VIAME CSV
 

--- a/docs/Large-Image-Support.md
+++ b/docs/Large-Image-Support.md
@@ -1,6 +1,19 @@
 # Large Image Support
 
-DIVE supports large image datasets (GeoTIFF/TIFF) through tiled pyramid access.
+DIVE supports large image datasets (GeoTIFF/TIFF) through tiled pyramid access on **Web**
+(Girder [large_image](https://girder.github.io/large_image/)) and **Desktop** (local
+GeoTIFF tile server).
+
+## Dynamic range in the viewer
+
+For **Web** tiled TIFF datasets (`large-image` type), use the
+[Image Enhancements](UI-Image-Enhancements.md) panel to apply **percentile stretch** while
+annotating. DIVE passes stretch parameters to Girder tile requests so 16-bit (and other
+high bit-depth) data can be viewed interactively without baking a fixed min/max into the
+file first.
+
+Pre-scaling to 8-bit COG (below) is still useful when you want a fixed display range at
+import time or when preparing files for tools that do not support dynamic tile styling.
 
 ## Requirement: Internal Overviews
 

--- a/docs/UI-Image-Enhancements.md
+++ b/docs/UI-Image-Enhancements.md
@@ -1,0 +1,70 @@
+# Image Enhancements
+
+The **Image Enhancements** panel adjusts how imagery looks in the annotation view. Open it
+from the [context sidebar](UI-Navigation-Editing-Bar.md#context-sidebar-web) (Web) or the
+viewer controls (Desktop).
+
+Settings are saved per dataset in the `imageEnhancements` metadata field and restored the
+next time you open the dataset.
+
+## Standard controls
+
+These apply to **8-bit and tiled imagery** on both Web and Desktop:
+
+* **Brightness** — linear intensity offset
+* **Contrast** — linear intensity scale around mid-gray
+* **Saturation** — color saturation (meaningful for RGB imagery)
+* **Sharpness** — convolution sharpening filter
+
+They are applied as SVG filters on top of the displayed image or tile layer.
+
+Use **Reset** to return all sliders (including percentile stretch) to defaults.
+
+## Percentile stretch (greater than 8-bit)
+
+High bit-depth sources such as **16-bit TIFF** are often imported or transcoded into a
+narrow 8-bit range for display. **Percentile stretch** remaps pixel values using histogram
+percentiles so detail is visible without permanently rewriting the source file.
+
+When supported, the panel shows:
+
+* A **Percentile Stretch** toggle
+* A **histogram** of the current frame (when available)
+* **Low %** and **High %** sliders (defaults 1 and 99) that clip the dimmest and brightest
+  portions of the histogram before stretching to display range
+
+Low and high cutoff markers on the histogram update as you move the sliders.
+
+### Where percentile stretch is available
+
+| Dataset type | Platform | How stretch is applied |
+|--------------|----------|------------------------|
+| `large-image` (TIFF / GeoTIFF) | **Web** | Girder [large_image](Large-Image-Support.md) tile `style` parameters; histogram from `item/{id}/tiles/histogram` |
+| `image-sequence` (TIFF originals) | **Desktop** | On-demand PNG from the original TIFF via the local `/api/media/display` endpoint |
+| `image-sequence` (TIFF) | Web | Not available — import-time transcoding produces 8-bit PNGs |
+| 8-bit PNG / JPEG / video | Web or Desktop | Percentile stretch hidden; use brightness/contrast only |
+
+For **Web** high bit-depth TIFFs, import the file as a **tiled large-image** dataset (see
+[Large Image Support](Large-Image-Support.md)) rather than as a folder of PNGs. The viewer
+uses `LargeImageAnnotator` and Girder tile endpoints for display and stretch.
+
+For **Desktop** folder-based TIFF sequences, DIVE keeps the original TIFF on disk and
+serves stretched frames from that source while annotations continue to reference the
+transcoded PNG timeline.
+
+### Pre-scaling vs dynamic stretch
+
+[Large Image Support](Large-Image-Support.md) documents optional GDAL pre-scaling to 8-bit
+COG (`gdal_translate … -scale <min> <max> 0 255`). That produces a fixed display range at
+import time.
+
+Percentile stretch is an **interactive alternative** (Web large-image and Desktop
+image-sequence TIFF): you can tune low/high percentiles while annotating without
+re-exporting the file. Pre-scaled COGs and percentile stretch can both be valid depending
+on workflow.
+
+## Related documentation
+
+* [Large Image Support](Large-Image-Support.md) — tiled TIFF requirements and COG conversion
+* [Data formats](DataFormats.md) — `imageEnhancements` in dataset metadata
+* [Annotation UI overview](Annotation-User-Interface-Overview.md) — where the panel lives in the layout

--- a/docs/UI-Navigation-Editing-Bar.md
+++ b/docs/UI-Navigation-Editing-Bar.md
@@ -26,7 +26,7 @@ The editing bar is the second row below navigation.
 
 On the right side of the editing bar, ==:material-chevron-left-box:== (or ==:material-chevron-right-box:== when open) toggles the **context sidebar** — advanced tools and settings panels on the right side of the viewer.
 
-Use the dropdown at the top of that panel to switch tools, including [Dataset Info](UI-DatasetInfo.md), [Revision History](Web-Version.md#revision-history), Group Manager, threshold controls, and (when applicable) [Annotation Sets](Annotation-Sets.md).
+Use the dropdown at the top of that panel to switch tools, including [Dataset Info](UI-DatasetInfo.md), [Revision History](Web-Version.md#revision-history), [Image Enhancements](UI-Image-Enhancements.md), Group Manager, threshold controls, and (when applicable) [Annotation Sets](Annotation-Sets.md).
 
 ### Editing Status Indicator
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,8 @@ Freeform or multi-select attributes | ✔️ | ✔️
 | &nbsp;&nbsp;&nbsp; Interactive point-click segmentation | ❌ | ✔️
 | &nbsp;&nbsp;&nbsp; Interactive stereo (warp / length recompute) | ❌ | ✔️
 | **Data Review** |
-Image enhancement (thresholding) | ✔️ | ✔️
+Image enhancement (brightness, contrast, saturation, sharpness) | ✔️ | ✔️
+| &nbsp;&nbsp;&nbsp; Percentile stretch for high bit-depth TIFF | ✔️ (large-image) | ✔️ (image-sequence)
 Advanced per-type annotation confidence threshoding | ✔️ | ✔️
 Review save history and load previous states | ✔️ | ❌
 Multiple parallel annotation sets on one dataset | ✔️ | ❌

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,12 +69,13 @@ nav:
         - Attribute Track Filtering: UI-AttributeTrackFiltering.md
       - Group Manager: UI-Group-Manager.md
       - Dataset Info: UI-DatasetInfo.md
+      - Image Enhancements: UI-Image-Enhancements.md
       - Annotation Sets: Annotation-Sets.md
     - Keyboard Shortcut Reference: Mouse-Keyboard-Shortcuts.md
     - Advanced features:
       - Pipeline Import and Export: Pipeline-Import-Export.md
       - Command Line Tools: Command-Line-Tools.md
-      - Large Image Desktop Support: Large-Image-Support.md
+      - Large Image Support: Large-Image-Support.md
       - Multicamera and Stereo Data: Multicamera-data.md
       - Interactive Annotation (Desktop): Interactive-Annotation.md
     - Screenshots: Screenshots.md

--- a/server/README.md
+++ b/server/README.md
@@ -151,7 +151,8 @@ Image chips that compose a video are stored as girder items in a folder.  Videos
 * `fps` (number) annotation framerate, not to be confused with video raw framerate
 * `ffprobe_info` (JSON) output of ffprobe for raw input video
 * `confidenceFilters` (JSON) map of filter name to float in [0, 1]
-* `imageEnhancements` (JSON) values for image enhancements (brightness, contrast, saturation, sharpen)
+* `imageEnhancements` (JSON) values for image enhancements (brightness, contrast,
+  saturation, sharpen, optional `percentileStretch` with `lowPercentile` / `highPercentile`)
 * `customTypeStyline` (JSON) map of class name to GeoJS display attributes.
 * `foreign_media_id` (string) For "cloned" datasets, this is an objectId pointer to the source media
 

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -897,6 +897,8 @@ def _child_media_frame_count(
 ) -> int:
     if media_type == constants.ImageSequenceType:
         return len(crud.valid_images(child, user))
+    if media_type == constants.LargeImageType:
+        return len(crud.valid_large_images(child, user))
     if media_type == constants.VideoType:
         video_item = Item().findOne(
             {
@@ -1206,9 +1208,13 @@ def create_multicam(
             code=400,
         )
 
-    if validated.type not in (constants.ImageSequenceType, constants.VideoType):
+    if validated.type not in (
+        constants.ImageSequenceType,
+        constants.VideoType,
+        constants.LargeImageType,
+    ):
         raise RestException(
-            f'Multicam type must be image-sequence or video, not {validated.type}',
+            f'Multicam type must be image-sequence, large-image, or video, not {validated.type}',
             code=400,
         )
 
@@ -1223,6 +1229,7 @@ def create_multicam(
         camera_order = list(cameras.keys())
 
     loaded_children: Dict[str, types.GirderModel] = {}
+    camera_types_by_name: Dict[str, str] = {}
     frame_counts: List[int] = []
     child_fps_by_name: Dict[str, float] = {}
     for name in camera_order:
@@ -1230,6 +1237,16 @@ def create_multicam(
         folder_id = cam.get('folderId')
         if not folder_id:
             raise RestException(f'Camera "{name}" missing folderId', code=400)
+        cam_type = cam.get('type') or validated.type
+        if cam_type not in (
+            constants.ImageSequenceType,
+            constants.VideoType,
+            constants.LargeImageType,
+        ):
+            raise RestException(
+                f'Camera "{name}" has unsupported type {cam_type}',
+                code=400,
+            )
         child = Folder().load(folder_id, level=AccessType.WRITE, user=user)
         if child is None:
             raise RestException(f'Camera folder {folder_id} was not found', code=404)
@@ -1240,15 +1257,16 @@ def create_multicam(
             )
         crud.verify_dataset(child)
         child_type = fromMeta(child, constants.TypeMarker)
-        if child_type != validated.type:
+        if child_type != cam_type:
             raise RestException(
-                f'Camera "{name}" has type {child_type}, expected {validated.type}',
+                f'Camera "{name}" has type {child_type}, expected {cam_type}',
                 code=400,
             )
         child_fps = fromMeta(child, constants.FPSMarker)
         child_fps_by_name[name] = child_fps
-        frame_counts.append(_child_media_frame_count(child, user, validated.type))
+        frame_counts.append(_child_media_frame_count(child, user, cam_type))
         loaded_children[name] = child
+        camera_types_by_name[name] = cam_type
 
     use_video_fps = validated.type == constants.VideoType and validated.fps == -1
     if use_video_fps:
@@ -1267,9 +1285,12 @@ def create_multicam(
                 )
 
     if len(set(frame_counts)) > 1:
+        details = ', '.join(
+            f'{name}={count}' for name, count in zip(camera_order, frame_counts)
+        )
         expected = frame_counts[0]
         raise RestException(
-            f'All cameras must have the same number of frames (expected {expected})',
+            f'All cameras must have the same number of frames (expected {expected}; {details})',
             code=400,
         )
 
@@ -1283,7 +1304,7 @@ def create_multicam(
             Folder().save(child)
         multi_cam_cameras[name] = {
             'folderId': str(child['_id']),
-            'type': validated.type,
+            'type': camera_types_by_name[name],
         }
 
     calibration_source_item_id = None

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -47,6 +47,7 @@ allValidLargeImageFormats = {*validImageFormats, *validLargeImageFormats}
 videoRegex = re.compile(r"(\." + r"|\.".join(validVideoFormats) + ')$', re.IGNORECASE)
 imageRegex = re.compile(r"(\." + r"|\.".join(validImageFormats) + ')$', re.IGNORECASE)
 largeImageRegEx = re.compile(r"(\." + r"|\.".join(validLargeImageFormats) + ')$', re.IGNORECASE)
+tiffSequenceRegex = re.compile(r'\.tiff?$', re.IGNORECASE)
 allLargeImageRegEx = re.compile(
     r"(\." + r"|\.".join(allValidLargeImageFormats) + ')$', re.IGNORECASE
 )

--- a/server/tests/test_validate_files.py
+++ b/server/tests/test_validate_files.py
@@ -1,0 +1,29 @@
+from dive_server import crud_dataset
+from dive_utils import constants
+
+
+def test_validate_files_tiff_as_large_image():
+    files = [
+        'kamera_2021_test_fl01_C_20210814_003347.198347_ir.tif',
+        'kamera_2021_test_fl01_C_20210814_003353.208198_ir.tif',
+    ]
+    result = crud_dataset.validate_files(files)
+    assert result['ok'] is True
+    assert result['type'] == constants.LargeImageType
+    assert result['media'] == files
+
+
+def test_validate_files_jpg_as_image_sequence():
+    files = ['frame.jpg', 'frame2.jpg']
+    result = crud_dataset.validate_files(files)
+    assert result['ok'] is True
+    assert result['type'] == constants.ImageSequenceType
+    assert result['media'] == files
+
+
+def test_validate_files_nitf_remains_large_image():
+    files = ['scene.nitf']
+    result = crud_dataset.validate_files(files)
+    assert result['ok'] is True
+    assert result['type'] == constants.LargeImageType
+    assert result['media'] == files


### PR DESCRIPTION
# Feature: Percentile Stretch for 16-bit IR Imagery

## What it does

Adds a **Percentile Stretch** contrast option to the Image Enhancements panel. It lets
an annotator recover usable contrast from imagery whose real signal occupies only a
narrow slice of its value range — most importantly **16-bit thermal/IR TIFFs**, where
the interesting temperature differences are just a few hundred counts inside a
0–65,535 range and look nearly flat when naively squashed to 8-bit.

When enabled, the picture shown in the annotator is re-rendered so that the chosen
low/high percentile of pixel values maps to black/white, spreading the meaningful
range across the full 0–255 grayscale.

## Why it exists

DIVE transcodes imported images to 8-bit PNGs for display. For a 16-bit IR TIFF that
transcode throws away the dynamic range before the annotator ever sees it, so the
target (e.g. a warm seal against cold ice) is hard or impossible to see. This feature
reads the **original** TIFF on demand and stretches *it*, restoring the detail the
8-bit copy lost. The stretch is computed **per frame** so each image is optimally
scaled to its own content.

## Web vs. Desktop

| Capability | Web | Desktop |
|---|---|---|
| Brightness / contrast / saturation / sharpen (existing SVG filters) | ✅ | ✅ |
| **Percentile stretch (this feature)** | ❌ | ✅ |

The stretch is rendered by the **desktop (Electron) backend only** — it depends on a
new Express endpoint and Node-side TIFF decoding. No equivalent Girder/Python endpoint
was added, so on web the toggle has no backing service. **This feature is
desktop-only.**

## GUI elements added

In the existing **Image Enhancements** side panel (`ImageEnhancements.vue`):

- A **"Percentile Stretch"** on/off toggle switch.
- When on, two sliders appear:
  - **Low %** (0 → 1, 0.01 steps, default 1) — value mapped to black.
  - **High %** (99 → 100, 0.01 steps, default 99) — value mapped to white.
- Live numeric readouts (2 decimals) next to each slider.
- "Reset" clears the stretch along with the other enhancements.

Settings are **per camera** in multi-camera datasets and are **persisted** to dataset
metadata (debounced), so they restore on reload and follow the selected camera.

## How it works (high level)

**Frontend**
- `useImageEnhancements.ts` — extends the enhancement model with an optional
  `percentileStretch { lowPercentile, highPercentile }`, adds per-camera state, and
  factors the filter/isDefault math into shared helpers.
- `Viewer.vue` — keeps the original frame list (`rawImageData`) and, when stretch is
  active for a camera, rewrites each frame's `url` to point at the new
  `/media/display` endpoint (`toDisplayUrl`). Handles per-camera apply/save debouncing,
  camera switching, and reload cleanup.
- `ImageAnnotator.vue` — when the image URL is swapped for the *same* camera (a stretch
  remap), it rebuilds the image cache and redraws **in place** instead of recreating the
  geojs map, so annotation/calibration layers attached by other components aren't
  orphaned.

**Desktop backend**
- `media/displayProcessing.ts` *(new)* — the core. Decodes a TIFF band with `geotiff`,
  computes the per-frame pixel values at the low/high percentiles (histogram for
  integer data, sort for signed-16/float), linearly stretches to 0–255, and encodes a
  grayscale PNG. Results are cached by `(path, low, high, mtime)` with an LRU cap, and
  concurrent requests for the same key share one decode.
- `backend/server.ts` — new `GET /api/media/display?id&frame&low&high` route. Resolves
  the original source file, stretches TIFFs, and **passes non-TIFF originals through
  unchanged** (stretch is a visual no-op rather than an error for 8-bit EO images).
- `native/common.ts` — `getDisplayImagePath()` maps `(dataset id, frame index)` back to
  the **original** pre-transcode file (via `originalImageFiles`), which is what makes
  stretching the real 16-bit data possible.
- `tiles/geotiffTiles.ts` — refactor only: shared `normalizeToU8` / `encodePngRgba`
  helpers moved into `displayProcessing.ts` (no behavior change).

## Files touched (feature only)

| File | Role |
|---|---|
| `client/src/components/ImageEnhancements.vue` | Toggle + sliders UI |
| `client/src/use/useImageEnhancements.ts` | Enhancement model, per-camera state, helpers |
| `client/dive-common/components/Viewer.vue` | Display-URL remap, per-camera persistence |
| `client/src/components/annotators/ImageAnnotator.vue` | In-place redraw on URL swap |
| `client/dive-common/apispec.ts` | Type additions |
| `client/platform/desktop/backend/media/displayProcessing.ts` | **New** — TIFF decode + stretch + PNG |
| `client/platform/desktop/backend/server.ts` | New `/media/display` endpoint |
| `client/platform/desktop/backend/native/common.ts` | Resolve original source image path |
| `client/platform/desktop/backend/tiles/geotiffTiles.ts` | Refactor: share helpers |
