### PR TITLE
upgrade axios using new girder-web-components

### DIFF
--- a/client/dive-common/components/DatasetInfo.vue
+++ b/client/dive-common/components/DatasetInfo.vue
@@ -255,7 +255,7 @@ export default defineComponent({
                 :title="`Delete ${key}`"
                 @click="removeEntry(key)"
               >
-                <v-icon small>
+                <v-icon small color="error">
                   mdi-delete
                 </v-icon>
               </v-btn>

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -5,7 +5,6 @@ import {
 } from 'vue';
 import type { Vue } from 'vue/types/vue';
 import type Vuetify from 'vuetify/lib';
-import type { AxiosError } from 'axios';
 import { cloneDeep, debounce } from 'lodash';
 
 /* VUE MEDIA ANNOTATOR */
@@ -904,7 +903,7 @@ export default defineComponent({
         progress.loaded = false;
         console.error(err);
         const errorEl = document.createElement('div');
-        errorEl.innerHTML = getResponseError(err as AxiosError);
+        errorEl.innerHTML = getResponseError(err);
         loadError.value = errorEl.innerText
           .concat(". If you don't know how to resolve this, please contact the server administrator.");
         throw err;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,11 +10,11 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.11",
-        "@girder/components": "girder/girder_web_components#girder-5-websocket-upgrade",
+        "@girder/components": "github:girder/girder_web_components#girder-5-axios-upgrade",
         "@mdi/font": "^6.2.95",
         "@sentry/browser": "^5.24.2",
         "@sentry/integrations": "^5.24.2",
-        "axios": "^0.21.1",
+        "axios": "^1.17.0",
         "csv-stringify": "^5.6.0",
         "d3": "^5.12.0",
         "geojs": "~1.6.2",
@@ -2695,11 +2695,11 @@
     },
     "node_modules/@girder/components": {
       "version": "3.2.0",
-      "resolved": "git+ssh://git@github.com/girder/girder_web_components.git#f941013aec03606f2c38043c1dcfa4b5fb2c39ee",
+      "resolved": "git+ssh://git@github.com/girder/girder_web_components.git#cdd764ce58a63941269062382074ac44b7dae616",
       "license": "Apache-2.0",
       "dependencies": {
         "@mdi/font": "^5.3.45",
-        "axios": "^0.21.2",
+        "axios": "^1.17.0",
         "js-cookie": "^2.2.0",
         "markdown-it": "^12.3.2",
         "moment": "^2.29.4",
@@ -5153,7 +5153,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -5799,7 +5798,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -5876,12 +5874,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -6554,7 +6555,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -7247,7 +7247,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7364,7 +7363,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -8064,7 +8062,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9262,7 +9259,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -9790,7 +9786,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9957,7 +9952,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -11380,7 +11374,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -11390,7 +11383,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -11495,7 +11487,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mylas": {
@@ -12334,6 +12325,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/psl": {

--- a/client/package.json
+++ b/client/package.json
@@ -31,11 +31,11 @@
   },
   "dependencies": {
     "@flatten-js/interval-tree": "^1.0.11",
-    "@girder/components": "girder/girder_web_components#girder-5-websocket-upgrade",
+    "@girder/components": "github:girder/girder_web_components#girder-5-axios-upgrade",
     "@mdi/font": "^6.2.95",
     "@sentry/browser": "^5.24.2",
     "@sentry/integrations": "^5.24.2",
-    "axios": "^0.21.1",
+    "axios": "^1.17.0",
     "csv-stringify": "^5.6.0",
     "d3": "^5.12.0",
     "geojs": "~1.6.2",

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from 'axios';
+import axios from 'axios';
 import { difference } from 'lodash';
 
 // [x1, y1, x2, y2] as (left, top), (bottom, right)
@@ -171,9 +171,21 @@ function reOrderBounds(bounds: RectBounds) {
   return [x1, y1, x2, y2];
 }
 
-function getResponseError(error: AxiosError): string {
-  const { response } = error;
-  return String(response?.data?.message || response?.data || error);
+function getResponseError(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data;
+    if (data && typeof data === 'object' && data !== null && 'message' in data) {
+      const { message } = data as { message: unknown };
+      if (typeof message === 'string') {
+        return message;
+      }
+    }
+    return String(data ?? error.message);
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
 }
 
 function withinBounds(coord: [number, number], bounds: RectBounds) {


### PR DESCRIPTION
Upgraded Axios in Girder-web-components and specifically a girder-5 capable branch that still uses vue 2 and vuetify 2.
Only think of note was a change to how nested JSON params are passed so I had to write a quick serializer in girder_web_components that would serialize data in the same way that DIVE expects it specifically for dive/rpc endpoints.