### PR TITLE
Fix single-dataset dive_json export emitting tracks as a list

### DIFF
--- a/server/dive_server/views_annotation.py
+++ b/server/dive_server/views_annotation.py
@@ -164,34 +164,12 @@ class AnnotationResource(Resource):
         elif format == 'dive_json':
             setContentDisposition(f'{folder["name"]}.dive.json', mime='application/json')
             setRawResponse()
-            annotations = crud_annotation.get_annotations(folder, revision=revisionId)
-            tracks = annotations['tracks']
-            thresholds = None
-            if excludeBelowThreshold:
-                thresholds = fromMeta(folder, "confidenceFilters", {})
-            if thresholds is None:
-                thresholds = {}
-
-            updated_tracks = []
-            if typeFilter is None:
-                typeFilter = set()
-            print(tracks)
-            for t in tracks:
-                print(t)
-                print(tracks[t])
-                track = models.Track(**tracks[t])
-                if (not excludeBelowThreshold) or track.exceeds_thresholds(thresholds):
-                    # filter by types if applicable
-                    if typeFilter:
-                        confidence_pairs = [
-                            item for item in track.confidencePairs if item[0] in typeFilter
-                        ]
-                        # skip line if no confidence pairs
-                        if not confidence_pairs:
-                            continue
-                    updated_tracks.append(tracks[t])
-            annotations['tracks'] = updated_tracks
-            return json.dumps(annotations).encode('utf-8')
+            return crud_dataset._dive_json_export_text(
+                folder,
+                revisionId,
+                excludeBelowThreshold,
+                typeFilter,
+            ).encode('utf-8')
         elif format == 'coco_json':
             setContentDisposition(f'{folder["name"]}.coco.json', mime='application/json')
             setRawResponse()


### PR DESCRIPTION
The single-dataset `dive_json` export built `tracks` as a **list**, while every other producer/consumer treats it as a **dict keyed by id** (`get_annotations`, the multicam path, the `DIVEAnnotationSchema` type, and the client's `MultiTrackRecord`).

The result: a single-cam `.dive.json` export can't be re-imported — `serializers/dive.py` calls `tracks.items()` and raises `AttributeError: 'list' object has no attribute 'items'`. 