### PR TITLE
Round-trip datasetInfo through COCO/KWCOCO and VIAME CSV

### DIFF
--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -178,6 +178,12 @@ beforeEach(() => {
       annotationImport: {
         'viame.csv': emptyCsvString,
         'foreign.meta.json': '{ "confidenceFilters": {"default": 0.8}, "type": "invalidtype" }',
+        'dataset-info.config.json': JSON.stringify({
+          datasetInfo: {
+            year: '2025',
+            gfishsite_id: '2024TXN012',
+          },
+        }),
         // This file will be migrated
         'dive.json': '{ "0": { "trackId": 0 } }', // fake track file
       },
@@ -584,6 +590,38 @@ describe('native.common', () => {
     const meta2 = await common.loadMetadata(settings, final.id, urlMapper);
     expect(meta2.confidenceFilters).toStrictEqual({ default: 0.8 });
     expect(meta2.type).toBe('image-sequence'); // Ensure meta import cannot change immutable fields.
+  });
+
+  it('dataFileImport resolves datasetInfo from DIVE configuration imports', async () => {
+    const payload = await common.beginMediaImport(
+      '/home/user/data/imageLists/success/image_list.txt',
+    );
+    const res = await common.finalizeMediaImport(settings, payload);
+    const final = res.meta;
+    const existingDatasetInfo = { cruise: '2403', sta_lat: '26.8195', year: '2024' };
+    const importedDatasetInfo = { year: '2025', gfishsite_id: '2024TXN012' };
+
+    await common.saveMetadata(settings, final.id, { datasetInfo: existingDatasetInfo });
+    await common.dataFileImport(
+      settings,
+      final.id,
+      '/home/user/data/annotationImport/dataset-info.config.json',
+    );
+    const overwriteMeta = await common.loadMetadata(settings, final.id, urlMapper);
+    expect(overwriteMeta.datasetInfo).toStrictEqual(importedDatasetInfo);
+
+    await common.saveMetadata(settings, final.id, { datasetInfo: existingDatasetInfo });
+    await common.dataFileImport(
+      settings,
+      final.id,
+      '/home/user/data/annotationImport/dataset-info.config.json',
+      true,
+    );
+    const additiveMeta = await common.loadMetadata(settings, final.id, urlMapper);
+    expect(additiveMeta.datasetInfo).toStrictEqual({
+      ...existingDatasetInfo,
+      ...importedDatasetInfo,
+    });
   });
 
   it('import with CSV annotations without specifying track file', async () => {

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -830,15 +830,6 @@ async function _ingestFilePath(
     annotations.tracks = existing.tracks;
   }
 
-  // On an additive import, merge the imported datasetInfo per-key over the existing block
-  // (imported values win) so a re-import never clobbers keys the file didn't carry. The
-  // Overwrite (non-additive) replacement is handled by the caller, which assigns the block
-  // wholesale rather than deep-merging it. A file without datasetInfo never reaches here.
-  if (meta.datasetInfo && additive) {
-    const existingMeta = await loadJsonMetadata(projectInfo.metaFileAbsPath);
-    meta.datasetInfo = { ...(existingMeta.datasetInfo || {}), ...meta.datasetInfo };
-  }
-
   if (Object.values(annotations.tracks).length || Object.values(annotations.groups).length) {
     const processed = processTrackAttributes(Object.values(annotations.tracks));
     meta.attributes = processed.attributes;
@@ -1314,6 +1305,7 @@ function validImageNamesMap(jsonMeta: JsonMeta) {
 async function dataFileImport(settings: Settings, id: string, path: string, additive = false, additivePrepend = '') {
   const projectDirData = await getValidatedProjectDir(settings, id);
   const jsonMeta = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+  const existingDatasetInfo = jsonMeta.datasetInfo;
   const result = await ingestDataFiles(
     settings,
     id,
@@ -1324,11 +1316,13 @@ async function dataFileImport(settings: Settings, id: string, path: string, addi
     additivePrepend,
   );
   merge(jsonMeta, result.meta);
-  // lodash merge deep-merges datasetInfo, which keeps stale keys. On an Overwrite import we
-  // want the block replaced wholesale (mirroring the server); _ingestFilePath has already
-  // folded existing keys into result.meta.datasetInfo for the additive case.
-  if (!additive && result.meta.datasetInfo) {
-    jsonMeta.datasetInfo = result.meta.datasetInfo;
+  // Assign datasetInfo explicitly; the deep-merge above would keep keys an Overwrite
+  // import meant to drop. Like the server, Overwrite replaces the block wholesale while
+  // an additive import merges per-key (imported values win).
+  if (result.meta.datasetInfo) {
+    jsonMeta.datasetInfo = additive
+      ? { ...(existingDatasetInfo ?? {}), ...result.meta.datasetInfo }
+      : result.meta.datasetInfo;
   }
   await _saveAsJson(npath.join(projectDirData.basePath, JsonMetaFileName), jsonMeta);
   return result;

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -797,6 +797,9 @@ async function _ingestFilePath(
     annotations.groups = data[0].groups;
     meta.fps = data[0].fps;
     meta.execTime = data[0].execTime;
+    if (data[0].datasetInfo) {
+      meta.datasetInfo = data[0].datasetInfo;
+    }
     [, warnings] = data;
   } else if (YAMLFileName.test(path)) {
     annotations = await kpf.parse([path]);
@@ -825,6 +828,14 @@ async function _ingestFilePath(
       existing.tracks[newTrack.id] = newTrack;
     }
     annotations.tracks = existing.tracks;
+  }
+
+  // datasetInfo follows the import "Overwrite" checkbox, mirroring the server: Overwrite
+  // (default) replaces the block when saveMetadata persists meta; additive merges per-key
+  // with imported values winning. A file without datasetInfo never reaches here untouched.
+  if (meta.datasetInfo && additive) {
+    const existingMeta = await loadJsonMetadata(projectInfo.metaFileAbsPath);
+    meta.datasetInfo = { ...(existingMeta.datasetInfo || {}), ...meta.datasetInfo };
   }
 
   if (Object.values(annotations.tracks).length || Object.values(annotations.groups).length) {

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -830,9 +830,10 @@ async function _ingestFilePath(
     annotations.tracks = existing.tracks;
   }
 
-  // datasetInfo follows the import "Overwrite" checkbox, mirroring the server: Overwrite
-  // (default) replaces the block when saveMetadata persists meta; additive merges per-key
-  // with imported values winning. A file without datasetInfo never reaches here untouched.
+  // On an additive import, merge the imported datasetInfo per-key over the existing block
+  // (imported values win) so a re-import never clobbers keys the file didn't carry. The
+  // Overwrite (non-additive) replacement is handled by the caller, which assigns the block
+  // wholesale rather than deep-merging it. A file without datasetInfo never reaches here.
   if (meta.datasetInfo && additive) {
     const existingMeta = await loadJsonMetadata(projectInfo.metaFileAbsPath);
     meta.datasetInfo = { ...(existingMeta.datasetInfo || {}), ...meta.datasetInfo };
@@ -1323,6 +1324,12 @@ async function dataFileImport(settings: Settings, id: string, path: string, addi
     additivePrepend,
   );
   merge(jsonMeta, result.meta);
+  // lodash merge deep-merges datasetInfo, which keeps stale keys. On an Overwrite import we
+  // want the block replaced wholesale (mirroring the server); _ingestFilePath has already
+  // folded existing keys into result.meta.datasetInfo for the additive case.
+  if (!additive && result.meta.datasetInfo) {
+    jsonMeta.datasetInfo = result.meta.datasetInfo;
+  }
   await _saveAsJson(npath.join(projectDirData.basePath, JsonMetaFileName), jsonMeta);
   return result;
 }

--- a/client/platform/desktop/backend/serializers/coco.spec.ts
+++ b/client/platform/desktop/backend/serializers/coco.spec.ts
@@ -213,7 +213,7 @@ describe('COCO serializer', () => {
     expect(out.annotations[0].dive_notes).toEqual(['exported note']);
   });
 
-  // --- datasetInfo passthrough (NOAA standardized metadata, Kitware/dive#1585) ---
+  // --- datasetInfo passthrough ---
 
   const datasetInfo = {
     gfishsite_id: '2024TXN012',

--- a/client/platform/desktop/backend/serializers/coco.spec.ts
+++ b/client/platform/desktop/backend/serializers/coco.spec.ts
@@ -222,11 +222,11 @@ describe('COCO serializer', () => {
     year: '2024',
   };
 
-  it('writes datasetInfo under info and advertises it in dive_extensions', async () => {
+  it('writes dive_dataset_info under info and advertises it in dive_extensions', async () => {
     await serializeFile('/output/info.coco.json', annotationSchema, { ...imageMeta, datasetInfo });
     const out = await fs.readJSON('/output/info.coco.json');
-    expect(out.info.datasetInfo).toEqual(datasetInfo);
-    expect(out.info.dive_extensions).toContain('datasetInfo');
+    expect(out.info.dive_dataset_info).toEqual(datasetInfo);
+    expect(out.info.dive_extensions).toContain('dive_dataset_info');
   });
 
   it('omits datasetInfo entirely when empty so exports stay byte-unchanged', async () => {
@@ -234,8 +234,8 @@ describe('COCO serializer', () => {
     const withEmpty = await fs.readJSON('/output/empty.coco.json');
     await serializeFile('/output/base.coco.json', annotationSchema, imageMeta);
     const baseline = await fs.readJSON('/output/base.coco.json');
-    expect(withEmpty.info).not.toHaveProperty('datasetInfo');
-    expect(withEmpty.info.dive_extensions).not.toContain('datasetInfo');
+    expect(withEmpty.info).not.toHaveProperty('dive_dataset_info');
+    expect(withEmpty.info.dive_extensions).not.toContain('dive_dataset_info');
     expect(withEmpty.info).toEqual(baseline.info);
   });
 
@@ -246,8 +246,8 @@ describe('COCO serializer', () => {
           ...cocoInput,
           info: {
             description: 'DIVE export for x',
-            dive_extensions: ['dive_detection_attributes', 'datasetInfo'],
-            datasetInfo,
+            dive_extensions: ['dive_detection_attributes', 'dive_dataset_info'],
+            dive_dataset_info: datasetInfo,
           },
         }),
       },

--- a/client/platform/desktop/backend/serializers/coco.spec.ts
+++ b/client/platform/desktop/backend/serializers/coco.spec.ts
@@ -212,6 +212,54 @@ describe('COCO serializer', () => {
     expect(out.annotations[0].dive_track_attributes).toEqual({ reviewer: 'alice' });
     expect(out.annotations[0].dive_notes).toEqual(['exported note']);
   });
+
+  // --- datasetInfo passthrough (NOAA standardized metadata, Kitware/dive#1585) ---
+
+  const datasetInfo = {
+    gfishsite_id: '2024TXN012',
+    cruise: '2403',
+    sta_lat: '26.8195',
+    year: '2024',
+  };
+
+  it('writes datasetInfo under info and advertises it in dive_extensions', async () => {
+    await serializeFile('/output/info.coco.json', annotationSchema, { ...imageMeta, datasetInfo });
+    const out = await fs.readJSON('/output/info.coco.json');
+    expect(out.info.datasetInfo).toEqual(datasetInfo);
+    expect(out.info.dive_extensions).toContain('datasetInfo');
+  });
+
+  it('omits datasetInfo entirely when empty so exports stay byte-unchanged', async () => {
+    await serializeFile('/output/empty.coco.json', annotationSchema, { ...imageMeta, datasetInfo: {} });
+    const withEmpty = await fs.readJSON('/output/empty.coco.json');
+    await serializeFile('/output/base.coco.json', annotationSchema, imageMeta);
+    const baseline = await fs.readJSON('/output/base.coco.json');
+    expect(withEmpty.info).not.toHaveProperty('datasetInfo');
+    expect(withEmpty.info.dive_extensions).not.toContain('datasetInfo');
+    expect(withEmpty.info).toEqual(baseline.info);
+  });
+
+  it('restores datasetInfo from info on import', async () => {
+    mockfs({
+      '/input': {
+        'coco_info.json': JSON.stringify({
+          ...cocoInput,
+          info: {
+            description: 'DIVE export for x',
+            dive_extensions: ['dive_detection_attributes', 'datasetInfo'],
+            datasetInfo,
+          },
+        }),
+      },
+    });
+    const [, parsedMeta] = await parseFile('/input/coco_info.json');
+    expect(parsedMeta.datasetInfo).toEqual(datasetInfo);
+  });
+
+  it('returns no datasetInfo when the COCO file has none', async () => {
+    const [, parsedMeta] = await parseFile('/input/coco.json');
+    expect(parsedMeta).not.toHaveProperty('datasetInfo');
+  });
 });
 
 afterEach(() => {

--- a/client/platform/desktop/backend/serializers/coco.ts
+++ b/client/platform/desktop/backend/serializers/coco.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { isEmpty } from 'lodash';
 import { AnnotationSchema } from 'dive-common/apispec';
 import { JsonMeta } from 'platform/desktop/constants';
 import processTrackAttributes from 'platform/desktop/backend/native/attributeProcessor';
@@ -298,7 +299,14 @@ async function parseFile(path: string): Promise<[AnnotationSchema, Record<string
   const annotations: AnnotationSchema = { version: 2, tracks, groups: {} };
   const processed = processTrackAttributes(Object.values(annotations.tracks));
   const warnings = skippedRleMasks ? [RLE_SEGMENTATION_WARNING] : [];
-  return [annotations, { attributes: processed.attributes }, warnings];
+  const meta: Record<string, unknown> = { attributes: processed.attributes };
+  // Restore the per-dataset station metadata namespaced under `info.datasetInfo`; the
+  // caller merges it into the dataset's metadata. Omitted when absent/empty.
+  const { datasetInfo } = parsed.info ?? {};
+  if (datasetInfo && typeof datasetInfo === 'object' && !isEmpty(datasetInfo)) {
+    meta.datasetInfo = datasetInfo;
+  }
+  return [annotations, meta, warnings];
 }
 
 function frameNameForExport(frame: number, meta: JsonMeta): string {
@@ -366,11 +374,20 @@ async function serializeFile(
     name,
     keypoints: ['head', 'tail'],
   }));
+  // datasetInfo rides in the `info` block + dive_extensions; omitted entirely when empty.
+  const datasetInfo = meta.datasetInfo && !isEmpty(meta.datasetInfo) ? meta.datasetInfo : undefined;
+  const info: CocoDocument['info'] = {
+    description: `DIVE export for ${meta.name}`,
+    dive_extensions: [
+      'dive_detection_attributes',
+      'dive_track_attributes',
+      'dive_notes',
+      ...(datasetInfo ? ['datasetInfo'] : []),
+    ],
+    ...(datasetInfo ? { datasetInfo } : {}),
+  };
   const output: CocoDocument = {
-    info: {
-      description: `DIVE export for ${meta.name}`,
-      dive_extensions: ['dive_detection_attributes', 'dive_track_attributes', 'dive_notes'],
-    },
+    info,
     images: Array.from(images.values()),
     annotations,
     categories: categoryDocs,

--- a/client/platform/desktop/backend/serializers/coco.ts
+++ b/client/platform/desktop/backend/serializers/coco.ts
@@ -300,9 +300,9 @@ async function parseFile(path: string): Promise<[AnnotationSchema, Record<string
   const processed = processTrackAttributes(Object.values(annotations.tracks));
   const warnings = skippedRleMasks ? [RLE_SEGMENTATION_WARNING] : [];
   const meta: Record<string, unknown> = { attributes: processed.attributes };
-  // Restore the per-dataset station metadata namespaced under `info.datasetInfo`; the
+  // Restore the per-dataset station metadata namespaced under `info.dive_dataset_info`; the
   // caller merges it into the dataset's metadata. Omitted when absent/empty.
-  const { datasetInfo } = parsed.info ?? {};
+  const { dive_dataset_info: datasetInfo } = parsed.info ?? {};
   if (datasetInfo && typeof datasetInfo === 'object' && !isEmpty(datasetInfo)) {
     meta.datasetInfo = datasetInfo;
   }
@@ -382,9 +382,9 @@ async function serializeFile(
       'dive_detection_attributes',
       'dive_track_attributes',
       'dive_notes',
-      ...(datasetInfo ? ['datasetInfo'] : []),
+      ...(datasetInfo ? ['dive_dataset_info'] : []),
     ],
-    ...(datasetInfo ? { datasetInfo } : {}),
+    ...(datasetInfo ? { dive_dataset_info: datasetInfo } : {}),
   };
   const output: CocoDocument = {
     info,

--- a/client/platform/desktop/backend/serializers/coco.ts
+++ b/client/platform/desktop/backend/serializers/coco.ts
@@ -303,7 +303,7 @@ async function parseFile(path: string): Promise<[AnnotationSchema, Record<string
   // Restore the per-dataset station metadata namespaced under `info.dive_dataset_info`; the
   // caller merges it into the dataset's metadata. Omitted when absent/empty.
   const { dive_dataset_info: datasetInfo } = parsed.info ?? {};
-  if (datasetInfo && typeof datasetInfo === 'object' && !isEmpty(datasetInfo)) {
+  if (typeof datasetInfo === 'object' && !isEmpty(datasetInfo)) {
     meta.datasetInfo = datasetInfo;
   }
   return [annotations, meta, warnings];

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -308,8 +308,8 @@ function getDatasetInfoEntry(output: string[]): Record<string, unknown> | null {
   if (fields === null) {
     return null;
   }
-  const entry = fields.find((field) => field.startsWith('datasetInfo: '));
-  return entry ? JSON.parse(entry.slice('datasetInfo: '.length)) : null;
+  const entry = fields.find((field) => field.startsWith('dataset_info: '));
+  return entry ? JSON.parse(entry.slice('dataset_info: '.length)) : null;
 }
 
 describe('VIAME datasetInfo passthrough', () => {
@@ -346,7 +346,18 @@ describe('VIAME datasetInfo passthrough', () => {
     const output = fs.readFileSync(path).toString().split('\n');
     const fields = getMetadataFields(output);
     expect(fields).not.toBeNull();
-    expect(fields?.some((field) => field.startsWith('datasetInfo'))).toBe(false);
+    expect(fields?.some((field) => field.startsWith('dataset_info'))).toBe(false);
+  });
+
+  it('restores datasetInfo from the # metadata line on parse', async () => {
+    const path = '/home/test.json';
+    const stream = fs.createWriteStream(path);
+    await serialize(stream, data, { ...meta, datasetInfo } as JsonMeta, new Set<string>(), {
+      excludeBelowThreshold: false,
+      header: true,
+    });
+    const [parsedData] = await parseFile(path);
+    expect(parsedData.datasetInfo).toEqual(datasetInfo);
   });
 });
 

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -3,6 +3,7 @@ import { AnnotationSchema, MultiTrackRecord } from 'dive-common/apispec';
 import parseSync from 'csv-parse/lib/sync';
 import fs from 'fs-extra';
 import mockfs from 'mock-fs';
+import { Readable } from 'stream';
 import { AnnotationsCurrentVersion, JsonMeta } from 'platform/desktop/constants';
 import { serialize, parse, parseFile } from 'platform/desktop/backend/serializers/viame';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
@@ -358,6 +359,19 @@ describe('VIAME datasetInfo passthrough', () => {
     });
     const [parsedData] = await parseFile(path);
     expect(parsedData.datasetInfo).toEqual(datasetInfo);
+  });
+
+  // Drive an unusable dataset_info field straight into parse via a # metadata row.
+  // Each case should be skipped with a warning rather than aborting the import.
+  it.each([
+    ['malformed JSON', 'dataset_info: {bad json}', /malformed dataset_info/],
+    ['a JSON number', 'dataset_info: 42', /expected a JSON object but got number/],
+    ['a JSON array', 'dataset_info: [1]', /expected a JSON object but got array/],
+    ['JSON null', 'dataset_info: null', /expected a JSON object but got null/],
+  ])('skips %s with a warning and no datasetInfo', async (_label, field, pattern) => {
+    const [parsedData, warnings] = await parse(Readable.from(`# metadata,fps: 30,${field}`));
+    expect(parsedData.datasetInfo).toBeUndefined();
+    expect(warnings.some((w) => pattern.test(w))).toBe(true);
   });
 });
 

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -41,6 +41,7 @@ export interface AnnotationFileData {
   groups: MultiGroupRecord;
   fps?: number;
   execTime?: number;
+  datasetInfo?: Record<string, unknown>;
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll
@@ -105,7 +106,22 @@ function parseCommentRow(row: string[]) {
     execTime = Number.parseFloat(execMatches[1]);
   }
 
-  return { fps, execTime };
+  // Per-dataset station metadata, written as one `dataset_info: <json>` field. The JSON can
+  // contain spaces, so read it from the field directly rather than the space-joined row.
+  let datasetInfo: Record<string, unknown> | undefined;
+  const dsField = row.find((field) => field.trim().startsWith('dataset_info:'));
+  if (dsField) {
+    try {
+      const parsed = JSON.parse(dsField.slice(dsField.indexOf(':') + 1).trim());
+      if (parsed && typeof parsed === 'object') {
+        datasetInfo = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // ignore a malformed dataset_info entry rather than failing the whole import
+    }
+  }
+
+  return { fps, execTime, datasetInfo };
 }
 
 function _deduceType(value: string): boolean | number | string {
@@ -284,6 +300,7 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<[
   });
   let fps: number | undefined;
   let execTime: number | undefined;
+  let datasetInfo: Record<string, unknown> | undefined;
   const dataMap = new Map<number, TrackData>();
   const missingImages: string[] = [];
   const foundImages: {image: string; frame: number; csvFrame: number}[] = [];
@@ -399,7 +416,7 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<[
         reject(error);
       }
       resolve([{
-        tracks, groups: {}, fps, execTime,
+        tracks, groups: {}, fps, execTime, datasetInfo,
       }, warnings]);
     });
     parser.on('readable', () => {
@@ -489,6 +506,9 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<[
             if (parsedComment.execTime) {
               execTime = parsedComment.execTime;
             }
+            if (parsedComment.datasetInfo) {
+              datasetInfo = parsedComment.datasetInfo;
+            }
           } else if (!err.toString().includes('malformed row')) {
             // Allow malformed row errors
             error = err;
@@ -522,7 +542,7 @@ async function writeHeader(writer: Writable, meta: JsonMeta) {
     'Confidence Pairs or Attributes',
   ]);
   /* Per-dataset station metadata travels out as one nested JSON entry; omit entirely when empty
-   * (no `datasetInfo: {}` noise) so existing exports stay byte-unchanged. */
+   * (no `dataset_info: {}` noise) so existing exports stay byte-unchanged. */
   const datasetInfo = meta.datasetInfo && !isEmpty(meta.datasetInfo)
     ? meta.datasetInfo
     : undefined;
@@ -537,7 +557,7 @@ async function writeHeader(writer: Writable, meta: JsonMeta) {
       metadataRow.push(`exec_time: ${meta.execTime}`);
     }
     if (datasetInfo) {
-      metadataRow.push(`datasetInfo: ${JSON.stringify(datasetInfo)}`);
+      metadataRow.push(`dataset_info: ${JSON.stringify(datasetInfo)}`);
     }
     writer.write(metadataRow);
   }

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -94,10 +94,8 @@ function _rowInfo(row: string[]) {
 }
 
 /**
- * Pull per-dataset station metadata out of a comment row. It is written as one
- * `dataset_info: <json>` field whose JSON may contain spaces, so it is read straight from the
- * field rather than the space-joined row. Returns the parsed object, or a `warning` describing why
- * a present-but-unusable field was skipped (so the import can continue rather than failing).
+ * Read dataset metadata from a `dataset_info: <json>` comment field. Returns the parsed
+ * object, or a `warning` if the field is present but unusable so the import can continue.
  */
 function parseDatasetInfo(row: string[]): {
   datasetInfo?: Record<string, unknown>;
@@ -110,10 +108,12 @@ function parseDatasetInfo(row: string[]): {
   const json = field.slice(field.indexOf(':') + 1).trim();
   try {
     const parsed = JSON.parse(json);
-    if (parsed && typeof parsed === 'object') {
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return { datasetInfo: parsed as Record<string, unknown> };
     }
-    return { warning: `Ignored dataset_info entry: expected a JSON object but got ${typeof parsed}` };
+    // eslint-disable-next-line no-nested-ternary
+    const kind = parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed;
+    return { warning: `Ignored dataset_info entry: expected a JSON object but got ${kind}` };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { warning: `Ignored malformed dataset_info entry (${message})` };

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -93,6 +93,33 @@ function _rowInfo(row: string[]) {
   };
 }
 
+/**
+ * Pull per-dataset station metadata out of a comment row. It is written as one
+ * `dataset_info: <json>` field whose JSON may contain spaces, so it is read straight from the
+ * field rather than the space-joined row. Returns the parsed object, or a `warning` describing why
+ * a present-but-unusable field was skipped (so the import can continue rather than failing).
+ */
+function parseDatasetInfo(row: string[]): {
+  datasetInfo?: Record<string, unknown>;
+  warning?: string;
+} {
+  const field = row.find((f) => f.trim().startsWith('dataset_info:'));
+  if (!field) {
+    return {};
+  }
+  const json = field.slice(field.indexOf(':') + 1).trim();
+  try {
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === 'object') {
+      return { datasetInfo: parsed as Record<string, unknown> };
+    }
+    return { warning: `Ignored dataset_info entry: expected a JSON object but got ${typeof parsed}` };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { warning: `Ignored malformed dataset_info entry (${message})` };
+  }
+}
+
 function parseCommentRow(row: string[]) {
   const fullrow = row.join(' ');
   const matches = getCaptureGroups(FpsRegex, fullrow);
@@ -106,22 +133,11 @@ function parseCommentRow(row: string[]) {
     execTime = Number.parseFloat(execMatches[1]);
   }
 
-  // Per-dataset station metadata, written as one `dataset_info: <json>` field. The JSON can
-  // contain spaces, so read it from the field directly rather than the space-joined row.
-  let datasetInfo: Record<string, unknown> | undefined;
-  const dsField = row.find((field) => field.trim().startsWith('dataset_info:'));
-  if (dsField) {
-    try {
-      const parsed = JSON.parse(dsField.slice(dsField.indexOf(':') + 1).trim());
-      if (parsed && typeof parsed === 'object') {
-        datasetInfo = parsed as Record<string, unknown>;
-      }
-    } catch {
-      // ignore a malformed dataset_info entry rather than failing the whole import
-    }
-  }
+  const { datasetInfo, warning } = parseDatasetInfo(row);
 
-  return { fps, execTime, datasetInfo };
+  return {
+    fps, execTime, datasetInfo, warning,
+  };
 }
 
 function _deduceType(value: string): boolean | number | string {
@@ -509,6 +525,9 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<[
             if (parsedComment.datasetInfo) {
               datasetInfo = parsedComment.datasetInfo;
             }
+            if (parsedComment.warning) {
+              warnings.push(parsedComment.warning);
+            }
           } else if (!err.toString().includes('malformed row')) {
             // Allow malformed row errors
             error = err;
@@ -541,8 +560,7 @@ async function writeHeader(writer: Writable, meta: JsonMeta) {
     '10-11+: Repeated Species',
     'Confidence Pairs or Attributes',
   ]);
-  /* Per-dataset station metadata travels out as one nested JSON entry; omit entirely when empty
-   * (no `dataset_info: {}` noise) so existing exports stay byte-unchanged. */
+  // Omit datasetInfo when empty so existing exports stay unchanged.
   const datasetInfo = meta.datasetInfo && !isEmpty(meta.datasetInfo)
     ? meta.datasetInfo
     : undefined;

--- a/client/platform/desktop/frontend/components/Export.vue
+++ b/client/platform/desktop/frontend/components/Export.vue
@@ -243,7 +243,7 @@ export default defineComponent({
         </v-card-actions>
         <v-card-text class="pb-0">
           Export the dataset configuration, including
-          attribute definitions, types, styles, and thresholds.
+          attribute definitions, types, styles, thresholds, and dataset info.
         </v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/client/platform/web-girder/views/Export.vue
+++ b/client/platform/web-girder/views/Export.vue
@@ -449,7 +449,7 @@ export default defineComponent({
 
           <v-card-text class="pb-0">
             Export the dataset configuration, including
-            attribute definitions, types, styles, and thresholds.
+            attribute definitions, types, styles, thresholds, and dataset info.
           </v-card-text>
           <v-card-actions>
             <v-spacer />

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -164,7 +164,13 @@ This information provides the specification for an individual dataset.  It consi
 * Track and Detection attribute specifications are defined in `attributes`
 * Free-form, dataset-level metadata (cruise id, station id, location, …) is stored in `datasetInfo` as a key/value object.
   * Edited from the [Dataset Info panel](UI-DatasetInfo.md).
+  * Included in DIVE Configuration JSON as `datasetInfo`.
   * Included in [VIAME CSV](#viame-csv) and [COCO / KWCOCO](#coco-and-kwcoco) export, and restored on import.
+
+When importing a DIVE Configuration JSON with `datasetInfo`, **Overwrite** import (the
+default) replaces the existing `datasetInfo` block; an additive import merges it per-key
+(imported values win). A configuration file with no `datasetInfo` entry leaves existing
+dataset metadata untouched.
 
 The full [DatasetMetaMutable definition can be found here](https://github.com/Kitware/dive/blob/main/client/dive-common/apispec.ts).
 

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -162,7 +162,7 @@ This information provides the specification for an individual dataset.  It consi
 * Allowed types (or labels) and their appearances are defined by `customTypeStyling` and `customGroupStyling`.
 * Preset confidence filters for those types are defined in `confidenceFilters`
 * Track and Detection attribute specifications are defined in `attributes`
-* Free-form, dataset-level metadata (cruise id, station id, location, …) is stored in `datasetInfo` as a key/value object. It is edited from the [Dataset Info panel](UI-DatasetInfo.md) and included in [VIAME CSV](#viame-csv) export.
+* Free-form, dataset-level metadata (cruise id, station id, location, …) is stored in `datasetInfo` as a key/value object. It is edited from the [Dataset Info panel](UI-DatasetInfo.md) and travels with both [VIAME CSV](#viame-csv) and [COCO / KWCOCO](#coco-and-kwcoco) export, and is restored on import.
 
 The full [DatasetMetaMutable definition can be found here](https://github.com/Kitware/dive/blob/main/client/dive-common/apispec.ts).
 
@@ -243,6 +243,21 @@ on each COCO `annotation` object:
 These extension keys are declared in the COCO `info` object as:
 
 * `info.dive_extensions = ["dive_detection_attributes", "dive_track_attributes"]`
+
+### Dataset-level metadata (`datasetInfo`)
+
+The dataset's free-form [Dataset Info](UI-DatasetInfo.md) metadata (e.g. `gfishsite_id`,
+cruise, station) is written to the COCO `info` block under a single `datasetInfo` key and
+advertised in `info.dive_extensions`:
+
+* `info.datasetInfo = { "gfishsite_id": "2024TXN012", "year": "2024", ... }`
+
+It is omitted entirely when the dataset has no `datasetInfo`, so exports for datasets
+without it stay byte-unchanged. On import, `info.datasetInfo` is merged per-key back onto
+the dataset's metadata (imported values win; existing keys the file did not carry are
+preserved). This is how dataset context — for example a `gfishsite_id` used to re-link
+annotations to an external database — travels with the KWCOCO export without renaming
+files.
 
 ### Extension Field Details
 

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -190,13 +190,17 @@ Read the [VIAME CSV Specification](https://viame.readthedocs.io/en/latest/sectio
 DIVE writes a `# metadata` comment line near the top of the CSV carrying dataset-level
 values such as `fps`. When a dataset has [Dataset Info](UI-DatasetInfo.md) custom
 metadata, the whole `datasetInfo` object is added to that line as a single nested JSON
-entry:
+entry keyed `dataset_info`:
 
 ```
-# metadata,fps: 23.976,"datasetInfo: {""gfishsite_id"": ""2024TXN012"", ""year"": ""2024""}", ...
+# metadata,fps: 23.976,"dataset_info: {""gfishsite_id"": ""2024TXN012"", ""year"": ""2024""}", ...
 ```
 
-* On import the `# metadata` line is parsed as dataset metadata, not as an annotation row.
+* On import the `# metadata` line is parsed back into dataset metadata: `fps` and the
+  `dataset_info` block are both restored (other fields such as `exported_by` are ignored).
+  With the import **Overwrite** option (the default) the `dataset_info` block replaces the
+  dataset's existing one; an additive import merges it per-key (imported values win). A CSV
+  with no `dataset_info` entry leaves existing metadata untouched.
 * This is how dataset context, for example a `gfishsite_id` used to re-link
   annotations to an external database, travels with the exported annotations without
   renaming files. See the [Dataset Info panel](UI-DatasetInfo.md) for how to populate it.
@@ -247,17 +251,17 @@ These extension keys are declared in the COCO `info` object as:
 ### Dataset-level metadata (`datasetInfo`)
 
 The dataset's free-form [Dataset Info](UI-DatasetInfo.md) metadata (e.g. `gfishsite_id`,
-cruise, station) is written to the COCO `info` block under a single `datasetInfo` key and
+cruise, station) is written to the COCO `info` block under a single `dive_dataset_info` key and
 advertised in `info.dive_extensions`:
 
-* `info.datasetInfo = { "gfishsite_id": "2024TXN012", "year": "2024", ... }`
+* `info.dive_dataset_info = { "gfishsite_id": "2024TXN012", "year": "2024", ... }`
 
 It is omitted entirely when the dataset has no `datasetInfo`, so exports for datasets
-without it stay byte-unchanged. On import, `info.datasetInfo` is merged per-key back onto
-the dataset's metadata (imported values win; existing keys the file did not carry are
-preserved). This is how dataset context — for example a `gfishsite_id` used to re-link
-annotations to an external database — travels with the KWCOCO export without renaming
-files.
+without it stay byte-unchanged. On import, `info.dive_dataset_info` is restored onto the
+dataset's metadata: the **Overwrite** import option (the default) replaces the block, while
+an additive import merges it per-key (imported values win; existing-only keys preserved).
+This is how dataset context — for example a `gfishsite_id` used to re-link annotations to an
+external database — travels with the KWCOCO export without renaming files.
 
 ### Extension Field Details
 

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -162,7 +162,9 @@ This information provides the specification for an individual dataset.  It consi
 * Allowed types (or labels) and their appearances are defined by `customTypeStyling` and `customGroupStyling`.
 * Preset confidence filters for those types are defined in `confidenceFilters`
 * Track and Detection attribute specifications are defined in `attributes`
-* Free-form, dataset-level metadata (cruise id, station id, location, …) is stored in `datasetInfo` as a key/value object. It is edited from the [Dataset Info panel](UI-DatasetInfo.md) and travels with both [VIAME CSV](#viame-csv) and [COCO / KWCOCO](#coco-and-kwcoco) export, and is restored on import.
+* Free-form, dataset-level metadata (cruise id, station id, location, …) is stored in `datasetInfo` as a key/value object.
+  * Edited from the [Dataset Info panel](UI-DatasetInfo.md).
+  * Included in [VIAME CSV](#viame-csv) and [COCO / KWCOCO](#coco-and-kwcoco) export, and restored on import.
 
 The full [DatasetMetaMutable definition can be found here](https://github.com/Kitware/dive/blob/main/client/dive-common/apispec.ts).
 
@@ -196,11 +198,10 @@ entry keyed `dataset_info`:
 # metadata,fps: 23.976,"dataset_info: {""gfishsite_id"": ""2024TXN012"", ""year"": ""2024""}", ...
 ```
 
-* On import the `# metadata` line is parsed back into dataset metadata: `fps` and the
-  `dataset_info` block are both restored (other fields such as `exported_by` are ignored).
-  With the import **Overwrite** option (the default) the `dataset_info` block replaces the
-  dataset's existing one; an additive import merges it per-key (imported values win). A CSV
-  with no `dataset_info` entry leaves existing metadata untouched.
+* On import the `# metadata` line is parsed back into dataset metadata.
+  * `fps` and the `dataset_info` block are restored; other fields (such as `exported_by`) are ignored.
+  * **Overwrite** import (the default) replaces the existing `dataset_info` block; an additive import merges it per-key (imported values win).
+  * A CSV with no `dataset_info` entry leaves existing metadata untouched.
 * This is how dataset context, for example a `gfishsite_id` used to re-link
   annotations to an external database, travels with the exported annotations without
   renaming files. See the [Dataset Info panel](UI-DatasetInfo.md) for how to populate it.
@@ -255,13 +256,6 @@ cruise, station) is written to the COCO `info` block under a single `dive_datase
 advertised in `info.dive_extensions`:
 
 * `info.dive_dataset_info = { "gfishsite_id": "2024TXN012", "year": "2024", ... }`
-
-It is omitted entirely when the dataset has no `datasetInfo`, so exports for datasets
-without it stay byte-unchanged. On import, `info.dive_dataset_info` is restored onto the
-dataset's metadata: the **Overwrite** import option (the default) replaces the block, while
-an additive import merges it per-key (imported values win; existing-only keys preserved).
-This is how dataset context — for example a `gfishsite_id` used to re-link annotations to an
-external database — travels with the KWCOCO export without renaming files.
 
 ### Extension Field Details
 

--- a/docs/UI-DatasetInfo.md
+++ b/docs/UI-DatasetInfo.md
@@ -41,13 +41,16 @@ three ways:
 ## How it is exported
 
 On **VIAME CSV** export, a non-empty `datasetInfo` is written into the `# metadata`
-header line as one nested JSON entry:
+header line as one nested JSON entry keyed `dataset_info`:
 
 ```
-# metadata,fps: 23.976,"datasetInfo: {""gfishsite_id"": ""2024TXN012"", ""year"": ""2024""}", ...
+# metadata,fps: 23.976,"dataset_info: {""gfishsite_id"": ""2024TXN012"", ""year"": ""2024""}", ...
 ```
 
-On import, its read back to dataset metadata. See [Data Formats → VIAME CSV](DataFormats.md#viame-csv).
+On import, the `dataset_info` block is read back into the dataset's metadata — replaced with
+the **Overwrite** import option (the default), or merged per-key on an additive import. A CSV
+with no `dataset_info` entry leaves existing metadata untouched. See
+[Data Formats → VIAME CSV](DataFormats.md#viame-csv).
 
 ### Value types
 

--- a/docs/UI-DatasetInfo.md
+++ b/docs/UI-DatasetInfo.md
@@ -5,8 +5,9 @@ custom metadata to it. It is one pane of the
 [context sidebar](UI-Navigation-Editing-Bar.md#context-sidebar-web).
 
 Metadata you add travels with the dataset: it is shown while annotating and written into
-the [VIAME CSV export](DataFormats.md#viame-csv), so downstream tooling can re-link
-annotations to their source records.
+DIVE Configuration, [VIAME CSV](DataFormats.md#viame-csv), and
+[COCO / KWCOCO](DataFormats.md#coco-and-kwcoco) exports, so downstream tooling can
+re-link annotations to their source records.
 
 ## What it shows
 
@@ -40,17 +41,14 @@ three ways:
 
 ## How it is exported
 
-On **VIAME CSV** export, a non-empty `datasetInfo` is written into the `# metadata`
-header line as one nested JSON entry keyed `dataset_info`:
+Non-empty `datasetInfo` is included in dataset-level exports with format-specific keys:
 
-```
-# metadata,fps: 23.976,"dataset_info: {""gfishsite_id"": ""2024TXN012"", ""year"": ""2024""}", ...
-```
+* [DIVE Configuration JSON](DataFormats.md#dive-configuration-json): top-level `datasetInfo`.
+* [VIAME CSV](DataFormats.md#viame-csv): `dataset_info` in the `# metadata` header.
+* [COCO / KWCOCO](DataFormats.md#coco-and-kwcoco): `info.dive_dataset_info`.
 
-On import, the `dataset_info` block is read back into the dataset's metadata — replaced with
-the **Overwrite** import option (the default), or merged per-key on an additive import. A CSV
-with no `dataset_info` entry leaves existing metadata untouched. See
-[Data Formats → VIAME CSV](DataFormats.md#viame-csv).
+Imports restore `datasetInfo` using the selected import mode. See
+[Data Formats](DataFormats.md) for the exact wire format and merge behavior.
 
 ### Value types
 

--- a/samples/scripts/assetStoreImport/generateSampleData.py
+++ b/samples/scripts/assetStoreImport/generateSampleData.py
@@ -21,6 +21,36 @@ FRAME_WIDTH = 1280
 FRAME_HEIGHT = 720
 VIDEO_FPS = 30
 
+ANNOTATION_FORMATS = ("dive-json", "viame-csv", "coco-json")
+
+
+def generate_random_dataset_info() -> dict:
+    """Random per-dataset metadata for CSV/COCO import testing."""
+    return {
+        "gfishsite_id": f"{random.randint(2020, 2025)}TXN{random.randint(100, 999):03d}",
+        "cruise": random.randint(2300, 2500),
+        "year": str(random.randint(2020, 2025)),
+        "station": fake.word(),
+        "sta_lat": round(random.uniform(24.0, 30.0), 4),
+        "sta_lon": round(random.uniform(-98.0, -80.0), 4),
+    }
+
+
+def _random_detection_attributes() -> dict:
+    return {
+        "visibility": random.choice(["clear", "poor", "partial"]),
+        "occluded": random.choice([True, False]),
+        "lighting": random.choice(["good", "dim", "backlit"]),
+    }
+
+
+def _random_track_attributes() -> dict:
+    return {
+        "reviewed": random.choice([True, False]),
+        "source": random.choice(["analyst", "model", "import"]),
+        "qa_status": random.choice(["pending", "approved", "flagged"]),
+    }
+
 def create_random_video(file_path: Path, duration: int):
     """Create a random test video using ffmpeg (MP4 container, H.264 codec)."""
     cmd = [
@@ -128,6 +158,7 @@ def build_tracks(num_frames: int):
         base_size = random.randint(40, 80)
         growth_rate = random.uniform(0.05, 0.15)
 
+        track_attributes = _random_track_attributes()
         features = []
         for frame in range(num_frames):
             x += dx
@@ -147,17 +178,20 @@ def build_tracks(num_frames: int):
             coords = output_data['coords']
             bounds = geometry_bounds(coords)
 
-            features.append({
+            feature = {
                 "frame": frame,
                 "bounds": bounds,
                 "keyframe": True,
                 "geometry": geom,
-            })
+            }
+            if random.random() < 0.7:
+                feature["attributes"] = _random_detection_attributes()
+            features.append(feature)
 
         tracks[str(track_id)] = {
             "id": track_id,
             "meta": {"shape": shape_type},
-            "attributes": {},
+            "attributes": track_attributes,
             "confidencePairs": [[fake.word(), float(random.randrange(0, 100) / 100)]],
             "begin": begin,
             "end": end,
@@ -171,6 +205,14 @@ def _viame_timestamp(frame: int, fps: int) -> str:
     return datetime.datetime.fromtimestamp(
         frame / fps, datetime.timezone.utc
     ).strftime(r'%H:%M:%S.%f')
+
+
+def _format_viame_metadata_row(metadata: dict) -> list:
+    """Format metadata entries as ``key: <json>`` fields for a VIAME ``# metadata`` row."""
+    row = ["# metadata"]
+    for key, value in metadata.items():
+        row.append(f"{key}: {json.dumps(value)}")
+    return row
 
 
 def _append_viame_geometry_columns(columns: list, geometry: dict):
@@ -196,8 +238,17 @@ def generate_annotation_viame_csv(
     *,
     fps: int = VIDEO_FPS,
     frame_filenames: list = None,
+    dataset_info: dict = None,
 ):
     """Write tracks as a VIAME CSV annotation file."""
+    metadata = {
+        "fps": fps,
+        "exported_by": "dive:generateSampleData",
+        "exported_time": datetime.datetime.now().ctime(),
+    }
+    if dataset_info:
+        metadata["dataset_info"] = dataset_info
+
     with open(output_file, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow([
@@ -213,7 +264,7 @@ def generate_annotation_viame_csv(
             "10-11+: Repeated Species",
             "Confidence Pairs or Attributes",
         ])
-        writer.writerow(["# metadata", f"fps: {json.dumps(fps)}"])
+        writer.writerow(_format_viame_metadata_row(metadata))
 
         for track in tracks.values():
             confidence_pairs = sorted(
@@ -251,24 +302,155 @@ def generate_annotation_json(tracks: dict, output_file: Path):
         json.dump(annotation, f, indent=2)
 
 
+def _feature_to_coco_segmentation(feature: dict) -> list:
+    geometry = feature.get("geometry")
+    if not geometry or geometry.get("type") != "FeatureCollection":
+        return []
+    segmentation = []
+    for geo_feature in geometry.get("features", []):
+        geom = geo_feature.get("geometry", {})
+        if geom.get("type") != "Polygon":
+            continue
+        for ring in geom.get("coordinates", []):
+            flat_coords = []
+            for x, y in ring:
+                flat_coords.extend([x, y])
+            if flat_coords:
+                segmentation.append(flat_coords)
+    return segmentation
+
+
+def generate_annotation_coco_json(
+    tracks: dict,
+    output_file: Path,
+    *,
+    dataset_name: str,
+    frame_filenames: list = None,
+    dataset_info: dict = None,
+):
+    """Write tracks as a COCO JSON annotation file (DIVE-compatible extensions)."""
+    categories = {}
+    coco_annotations = []
+    images = {}
+    annotation_id = 1
+
+    for track in tracks.values():
+        confidence_pairs = sorted(
+            track["confidencePairs"], key=lambda item: item[1], reverse=True
+        )
+        class_name, score = confidence_pairs[0]
+        category_id = categories.setdefault(class_name, len(categories) + 1)
+
+        for feature in track["features"]:
+            frame = feature["frame"]
+            if frame_filenames is not None:
+                if frame >= len(frame_filenames):
+                    continue
+                file_name = frame_filenames[frame]
+            else:
+                file_name = f"frame_{frame:06d}.jpg"
+
+            x1, y1, x2, y2 = feature["bounds"]
+            width = max(0, x2 - x1)
+            height = max(0, y2 - y1)
+            image_id = frame + 1
+            images.setdefault(
+                image_id,
+                {
+                    "id": image_id,
+                    "file_name": file_name,
+                    "frame_index": frame,
+                    "width": FRAME_WIDTH,
+                    "height": FRAME_HEIGHT,
+                },
+            )
+
+            annotation = {
+                "id": annotation_id,
+                "image_id": image_id,
+                "category_id": category_id,
+                "bbox": [x1, y1, width, height],
+                "area": width * height,
+                "iscrowd": 0,
+                "score": score,
+                "track_id": track["id"],
+            }
+            if feature.get("attributes"):
+                annotation["dive_detection_attributes"] = feature["attributes"]
+            if track.get("attributes"):
+                annotation["dive_track_attributes"] = track["attributes"]
+            segmentation = _feature_to_coco_segmentation(feature)
+            if segmentation:
+                annotation["segmentation"] = segmentation
+            coco_annotations.append(annotation)
+            annotation_id += 1
+
+    categories_doc = [
+        {"id": category_id, "name": class_name}
+        for class_name, category_id in categories.items()
+    ]
+    info = {
+        "description": f"Sample COCO export for {dataset_name}",
+        "dive_extensions": [
+            "dive_detection_attributes",
+            "dive_track_attributes",
+        ],
+    }
+    if dataset_info:
+        info["dive_dataset_info"] = dataset_info
+        info["dive_extensions"].append("dive_dataset_info")
+
+    coco = {
+        "info": info,
+        "images": list(images.values()),
+        "annotations": coco_annotations,
+        "categories": categories_doc,
+    }
+    with open(output_file, "w") as f:
+        json.dump(coco, f, indent=2)
+
+
 def write_annotations(
     num_frames: int,
     output_file: Path,
     *,
-    use_viame_csv: bool,
+    annotation_format: str,
     frame_filenames: list = None,
+    dataset_name: str = "sample-dataset",
 ):
-    """Write annotations as either DIVE JSON or VIAME CSV."""
+    """Write annotations as DIVE JSON, VIAME CSV, or COCO JSON."""
     tracks = build_tracks(num_frames)
-    if use_viame_csv:
+    dataset_info = generate_random_dataset_info()
+    if annotation_format == "viame-csv":
         generate_annotation_viame_csv(
-            tracks, output_file, frame_filenames=frame_filenames
+            tracks,
+            output_file,
+            frame_filenames=frame_filenames,
+            dataset_info=dataset_info,
+        )
+    elif annotation_format == "coco-json":
+        generate_annotation_coco_json(
+            tracks,
+            output_file,
+            dataset_name=dataset_name,
+            frame_filenames=frame_filenames,
+            dataset_info=dataset_info,
         )
     else:
         generate_annotation_json(tracks, output_file)
 
-def create_video_content(base_dir: Path, max_videos: int, counter: dict, total: int):
-    """Create videos and associated JSON or VIAME CSV annotations."""
+def _annotation_extension(annotation_format: str) -> str:
+    return ".csv" if annotation_format == "viame-csv" else ".json"
+
+
+def create_video_content(
+    base_dir: Path,
+    max_videos: int,
+    counter: dict,
+    total: int,
+    annotation_formats: tuple,
+):
+    """Create videos and associated annotation files."""
     if counter['count'] >= total:
         return
     num_videos = random.randint(1, max_videos)
@@ -281,16 +463,22 @@ def create_video_content(base_dir: Path, max_videos: int, counter: dict, total: 
         create_random_video(video_path, duration)
         counter['count'] += 1
 
-        use_viame_csv = random.choice([True, False])
-        ext = ".csv" if use_viame_csv else ".json"
+        annotation_format = random.choice(annotation_formats)
+        ext = _annotation_extension(annotation_format)
         write_annotations(
             duration * VIDEO_FPS,
             video_path.with_suffix(ext),
-            use_viame_csv=use_viame_csv,
+            annotation_format=annotation_format,
+            dataset_name=video_path.stem,
         )
 
-def create_image_sequence_content(base_dir: Path, counter: dict, total: int):
-    """Create image sequence from a temporary video and generate JSON or VIAME CSV annotations."""
+def create_image_sequence_content(
+    base_dir: Path,
+    counter: dict,
+    total: int,
+    annotation_formats: tuple,
+):
+    """Create image sequence from a temporary video and generate annotations."""
     if counter['count'] >= total:
         return
     duration = random.randint(5, 30)
@@ -303,27 +491,35 @@ def create_image_sequence_content(base_dir: Path, counter: dict, total: int):
 
     num_frames = duration * VIDEO_FPS
     frame_filenames = [p.name for p in sorted(seq_folder.glob("frame_*.jpg"))]
-    use_viame_csv = random.choice([True, False])
-    ext = ".csv" if use_viame_csv else ".json"
+    annotation_format = random.choice(annotation_formats)
+    ext = _annotation_extension(annotation_format)
     annotation_file = seq_folder / (seq_folder.stem + ext)
     write_annotations(
         num_frames,
         annotation_file,
-        use_viame_csv=use_viame_csv,
-        frame_filenames=frame_filenames if use_viame_csv else None,
+        annotation_format=annotation_format,
+        frame_filenames=frame_filenames,
+        dataset_name=seq_folder.stem,
     )
 
-def create_folder_structure(base_dir: Path, depth: int, max_depth: int,
-                            max_videos: int, counter: dict, total: int):
+def create_folder_structure(
+    base_dir: Path,
+    depth: int,
+    max_depth: int,
+    max_videos: int,
+    counter: dict,
+    total: int,
+    annotation_formats: tuple,
+):
     """Recursively create folders with either videos or image sequences."""
     if counter['count'] >= total:
         return
 
     content_type = random.choice(["video", "images"])
     if content_type == "video":
-        create_video_content(base_dir, max_videos, counter, total)
+        create_video_content(base_dir, max_videos, counter, total, annotation_formats)
     else:
-        create_image_sequence_content(base_dir, counter, total)
+        create_image_sequence_content(base_dir, counter, total, annotation_formats)
 
     if counter['count'] >= total:
         return
@@ -335,13 +531,15 @@ def create_folder_structure(base_dir: Path, depth: int, max_depth: int,
         subfolder = base_dir / fake.word()
         subfolder.mkdir(parents=True, exist_ok=True)
         if depth < max_depth:
-            create_folder_structure(subfolder, depth+1, max_depth, max_videos, counter, total)
+            create_folder_structure(
+                subfolder, depth + 1, max_depth, max_videos, counter, total, annotation_formats
+            )
         else:
             leaf_type = random.choice(["video", "images"])
             if leaf_type == "video":
-                create_video_content(subfolder, max_videos, counter, total)
+                create_video_content(subfolder, max_videos, counter, total, annotation_formats)
             else:
-                create_image_sequence_content(subfolder, counter, total)
+                create_image_sequence_content(subfolder, counter, total, annotation_formats)
 
 @click.command()
 @click.option('--output', '-o', default='./sample', show_default=True,
@@ -354,18 +552,46 @@ def create_folder_structure(base_dir: Path, depth: int, max_depth: int,
               help="Maximum videos per folder")
 @click.option('--total', '-t', default=10, show_default=True,
               help="Total number of datasets (videos or image sequences)")
-def main(output, folders, max_depth, videos, total):
+@click.option(
+    '--annotation-formats',
+    default='coco-json,viame-csv',
+    show_default=True,
+    help=(
+        "Comma-separated annotation formats to randomly choose per dataset: "
+        "dive-json, viame-csv, coco-json"
+    ),
+)
+def main(output, folders, max_depth, videos, total, annotation_formats):
     base_path = Path(output)
     base_path.mkdir(parents=True, exist_ok=True)
 
+    format_choices = tuple(
+        fmt.strip()
+        for fmt in annotation_formats.split(',')
+        if fmt.strip()
+    )
+    invalid = [fmt for fmt in format_choices if fmt not in ANNOTATION_FORMATS]
+    if invalid:
+        raise click.BadParameter(
+            f"Unknown annotation format(s): {', '.join(invalid)}. "
+            f"Choose from: {', '.join(ANNOTATION_FORMATS)}"
+        )
+    if not format_choices:
+        raise click.BadParameter("At least one annotation format is required.")
+
     counter = {'count': 0}
-    click.echo(f"Generating up to {total} datasets in {base_path}...")
+    click.echo(
+        f"Generating up to {total} datasets in {base_path} "
+        f"(formats: {', '.join(format_choices)})..."
+    )
     for _ in range(folders):
         if counter['count'] >= total:
             break
         folder_path = base_path / fake.word()
         folder_path.mkdir(parents=True, exist_ok=True)
-        create_folder_structure(folder_path, 1, max_depth, videos, counter, total)
+        create_folder_structure(
+            folder_path, 1, max_depth, videos, counter, total, format_choices
+        )
 
     click.echo(f"Done! Created {counter['count']} datasets.")
 

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -473,6 +473,7 @@ def _coco_json_export_text(
         filtered_tracks,
         image_filenames=image_filenames,
         dataset_name=dsFolder['name'],
+        datasetInfo=fromMeta(dsFolder, "datasetInfo", {}),
     )
     return json.dumps(coco)
 

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -610,6 +610,16 @@ def _get_data_by_type(
     return None, None
 
 
+def merge_imported_dataset_info(existing: dict, imported: dict) -> dict:
+    """Per-key merge of an imported ``datasetInfo`` block over the existing one.
+
+    Imported values win on collision; keys the imported file did not carry are kept
+    from ``existing`` so a re-import never clobbers prior station metadata. Inputs are
+    not mutated.
+    """
+    return {**existing, **imported}
+
+
 def process_items(
     folder: types.GirderModel,
     user: types.GirderUserModel,
@@ -687,7 +697,9 @@ def process_items(
             if meta.get('datasetInfo'):
                 meta = {
                     **meta,
-                    'datasetInfo': {**fromMeta(folder, 'datasetInfo', {}), **meta['datasetInfo']},
+                    'datasetInfo': merge_imported_dataset_info(
+                        fromMeta(folder, 'datasetInfo', {}), meta['datasetInfo']
+                    ),
                 }
             crud_dataset.update_metadata(folder, meta, False)
     return aggregate_warnings

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -554,15 +554,21 @@ def _get_data_by_type(
 
     # Parse the file as the now known type
     if as_type == crud.FileType.VIAME_CSV:
-        converted, attributes, warnings, fps = viame.load_csv_as_tracks_and_attributes(
-            file_string.splitlines(), image_map
-        )
-        meta = None
+        (
+            converted,
+            attributes,
+            warnings,
+            fps,
+            datasetInfo,
+        ) = viame.load_csv_as_tracks_and_attributes(file_string.splitlines(), image_map)
+        meta = {}
         if fps is not None:
-            meta = {"fps": fps}
+            meta['fps'] = fps
+        if datasetInfo:
+            meta['datasetInfo'] = datasetInfo
         return {
             'annotations': converted,
-            'meta': meta,
+            'meta': meta or None,
             'attributes': attributes,
             'type': as_type,
         }, warnings
@@ -613,9 +619,10 @@ def _get_data_by_type(
 def merge_imported_dataset_info(existing: dict, imported: dict) -> dict:
     """Per-key merge of an imported ``datasetInfo`` block over the existing one.
 
-    Imported values win on collision; keys the imported file did not carry are kept
-    from ``existing`` so a re-import never clobbers prior station metadata. Inputs are
-    not mutated.
+    Used for *additive* imports (Overwrite unchecked): imported values win on collision,
+    while keys the imported file did not carry are kept from ``existing`` so an additive
+    re-import never clobbers prior station metadata. Inputs are not mutated. Overwrite
+    imports replace the block instead of calling this.
     """
     return {**existing, **imported}
 
@@ -691,16 +698,17 @@ def process_items(
             crud.saveImportAttributes(folder, results['attributes'], user)
         if results['meta']:
             meta = results['meta']
-            # Merge imported datasetInfo per-key into any existing dataset metadata
-            # (imported values win) rather than replacing the whole datasetInfo block, so
-            # a re-import never clobbers keys the file didn't carry.
+            # datasetInfo follows the import "Overwrite" checkbox, mirroring annotations:
+            # Overwrite (additive=False) replaces the whole block; additive merges per-key
+            # with imported values winning. A file that carries no datasetInfo never touches
+            # the existing block, in either mode.
             if meta.get('datasetInfo'):
-                meta = {
-                    **meta,
-                    'datasetInfo': merge_imported_dataset_info(
-                        fromMeta(folder, 'datasetInfo', {}), meta['datasetInfo']
-                    ),
-                }
+                imported_info = meta['datasetInfo']
+                if additive:
+                    imported_info = merge_imported_dataset_info(
+                        fromMeta(folder, 'datasetInfo', {}), imported_info
+                    )
+                meta = {**meta, 'datasetInfo': imported_info}
             crud_dataset.update_metadata(folder, meta, False)
     return aggregate_warnings
 

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -579,10 +579,15 @@ def _get_data_by_type(
     if data_dict is None:
         data_dict = json.loads(file_string)
     if as_type == crud.FileType.COCO_JSON:
-        converted, attributes, coco_warnings = kwcoco.load_coco_as_tracks_and_attributes(data_dict)
+        (
+            converted,
+            attributes,
+            coco_warnings,
+            datasetInfo,
+        ) = kwcoco.load_coco_as_tracks_and_attributes(data_dict)
         return {
             'annotations': converted,
-            'meta': None,
+            'meta': {"datasetInfo": datasetInfo} if datasetInfo else None,
             'attributes': attributes,
             'type': as_type,
         }, coco_warnings or warnings
@@ -675,7 +680,16 @@ def process_items(
         if results['attributes']:
             crud.saveImportAttributes(folder, results['attributes'], user)
         if results['meta']:
-            crud_dataset.update_metadata(folder, results['meta'], False)
+            meta = results['meta']
+            # Merge imported datasetInfo per-key into any existing dataset metadata
+            # (imported values win) rather than replacing the whole datasetInfo block, so
+            # a re-import never clobbers keys the file didn't carry.
+            if meta.get('datasetInfo'):
+                meta = {
+                    **meta,
+                    'datasetInfo': {**fromMeta(folder, 'datasetInfo', {}), **meta['datasetInfo']},
+                }
+            crud_dataset.update_metadata(folder, meta, False)
     return aggregate_warnings
 
 

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -561,14 +561,13 @@ def _get_data_by_type(
             fps,
             datasetInfo,
         ) = viame.load_csv_as_tracks_and_attributes(file_string.splitlines(), image_map)
-        meta = {}
-        if fps is not None:
-            meta['fps'] = fps
-        if datasetInfo:
-            meta['datasetInfo'] = datasetInfo
+        meta = {
+            **({'fps': fps} if fps is not None else {}),
+            **({'datasetInfo': datasetInfo} if datasetInfo else {}),
+        }
         return {
             'annotations': converted,
-            'meta': meta or None,
+            'meta': meta,
             'attributes': attributes,
             'type': as_type,
         }, warnings

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -615,15 +615,19 @@ def _get_data_by_type(
     return None, None
 
 
-def merge_imported_dataset_info(existing: dict, imported: dict) -> dict:
-    """Per-key merge of an imported ``datasetInfo`` block over the existing one.
+def resolve_imported_dataset_info(existing: types.DatasetInfo, meta: dict, additive: bool) -> dict:
+    """Return ``meta`` with its ``datasetInfo`` reconciled against the dataset's ``existing`` block.
 
-    Used for *additive* imports (Overwrite unchecked): imported values win on collision,
-    while keys the imported file did not carry are kept from ``existing`` so an additive
-    re-import never clobbers prior station metadata. Inputs are not mutated. Overwrite
-    imports replace the block instead of calling this.
+    datasetInfo follows the import "Overwrite" checkbox, mirroring annotations: Overwrite
+    (``additive=False``) replaces the block; additive merges per-key with imported values
+    winning, so a re-import never clobbers station metadata the file omits. A file carrying
+    no datasetInfo leaves ``existing`` untouched in either mode. Inputs are not mutated.
     """
-    return {**existing, **imported}
+    imported = meta.get('datasetInfo')
+    if not imported:
+        return meta
+    resolved = {**existing, **imported} if additive else imported
+    return {**meta, 'datasetInfo': resolved}
 
 
 def process_items(
@@ -696,18 +700,9 @@ def process_items(
         if results['attributes']:
             crud.saveImportAttributes(folder, results['attributes'], user)
         if results['meta']:
-            meta = results['meta']
-            # datasetInfo follows the import "Overwrite" checkbox, mirroring annotations:
-            # Overwrite (additive=False) replaces the whole block; additive merges per-key
-            # with imported values winning. A file that carries no datasetInfo never touches
-            # the existing block, in either mode.
-            if meta.get('datasetInfo'):
-                imported_info = meta['datasetInfo']
-                if additive:
-                    imported_info = merge_imported_dataset_info(
-                        fromMeta(folder, 'datasetInfo', {}), imported_info
-                    )
-                meta = {**meta, 'datasetInfo': imported_info}
+            meta = resolve_imported_dataset_info(
+                fromMeta(folder, 'datasetInfo', {}), results['meta'], additive
+            )
             crud_dataset.update_metadata(folder, meta, False)
     return aggregate_warnings
 

--- a/server/dive_server/views_annotation.py
+++ b/server/dive_server/views_annotation.py
@@ -204,6 +204,7 @@ class AnnotationResource(Resource):
                 filtered_tracks,
                 image_filenames=image_filenames,
                 dataset_name=folder['name'],
+                datasetInfo=fromMeta(folder, "datasetInfo", {}),
             )
             return json.dumps(coco).encode('utf-8')
         else:

--- a/server/dive_server/views_annotation.py
+++ b/server/dive_server/views_annotation.py
@@ -10,7 +10,6 @@ from girder.exceptions import RestException
 from girder.models.folder import Folder
 
 from dive_utils import constants, fromMeta, models, setContentDisposition
-from dive_utils.serializers import kwcoco
 
 from . import crud, crud_annotation, crud_dataset
 
@@ -173,40 +172,13 @@ class AnnotationResource(Resource):
         elif format == 'coco_json':
             setContentDisposition(f'{folder["name"]}.coco.json', mime='application/json')
             setRawResponse()
-            annotations = crud_annotation.get_annotations(folder, revision=revisionId)
-            tracks = annotations['tracks']
-            thresholds = fromMeta(folder, "confidenceFilters", {}) if excludeBelowThreshold else {}
-            selected_types = set(typeFilter) if typeFilter else None
-            filtered_tracks = []
-            for track_data in tracks.values():
-                track = models.Track(**track_data)
-                if excludeBelowThreshold and not track.exceeds_thresholds(thresholds):
-                    continue
-                if selected_types:
-                    pairs = [pair for pair in track.confidencePairs if pair[0] in selected_types]
-                    if not pairs:
-                        continue
-                filtered_tracks.append(track_data)
-            image_filenames = {}
-            dataset_type = fromMeta(folder, constants.TypeMarker)
-            if dataset_type == constants.ImageSequenceType:
-                images = crud.valid_images(folder, self.getCurrentUser())
-                image_filenames = {i: image['name'] for i, image in enumerate(images)}
-            else:
-                # COCO has no canonical video container field. For video datasets we
-                # export per-frame placeholders using a deterministic naming scheme.
-                max_frame = -1
-                for track_data in filtered_tracks:
-                    for feature in track_data.get('features', []):
-                        max_frame = max(max_frame, feature.get('frame', -1))
-                image_filenames = {i: f'frame_{i:06d}.jpg' for i in range(max_frame + 1)}
-            coco = kwcoco.export_dive_as_coco(
-                filtered_tracks,
-                image_filenames=image_filenames,
-                dataset_name=folder['name'],
-                datasetInfo=fromMeta(folder, "datasetInfo", {}),
-            )
-            return json.dumps(coco).encode('utf-8')
+            return crud_dataset._coco_json_export_text(
+                folder,
+                self.getCurrentUser(),
+                revisionId,
+                excludeBelowThreshold,
+                typeFilter,
+            ).encode('utf-8')
         else:
             raise RestException(f'Format {format} is not a valid option.')
 

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -325,6 +325,8 @@ class CocoMetadata(BaseModel):
     keypoint_categories: Dict[int, dict]
     images: Dict[int, dict]
     videos: Dict[int, dict]
+    # Per-dataset station metadata carried in the COCO ``info.datasetInfo`` block.
+    datasetInfo: Dict[str, Any] = {}
 
 
 class BrandData(BaseModel):

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -5,7 +5,7 @@ from bson.objectid import ObjectId
 from pydantic import BaseModel, Field, validator
 from typing_extensions import Literal
 
-from dive_utils import constants
+from dive_utils import constants, types
 
 
 class PydanticObjectId(str):
@@ -237,7 +237,7 @@ class MetadataMutable(BaseModel):
     imageEnhancements: Optional[Dict[str, Any]]
     attributes: Optional[Dict[str, Attribute]]
     attributeTrackFilters: Optional[Dict[str, AttributeTrackFilter]]
-    datasetInfo: Optional[Dict[str, Any]]
+    datasetInfo: Optional[types.DatasetInfo]
     fps: Optional[float]
 
     @staticmethod
@@ -325,8 +325,7 @@ class CocoMetadata(BaseModel):
     keypoint_categories: Dict[int, dict]
     images: Dict[int, dict]
     videos: Dict[int, dict]
-    # Per-dataset station metadata carried in the COCO ``info.dive_dataset_info`` block.
-    datasetInfo: Dict[str, Any] = {}
+    datasetInfo: types.DatasetInfo = {}
 
 
 class BrandData(BaseModel):

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -325,7 +325,7 @@ class CocoMetadata(BaseModel):
     keypoint_categories: Dict[int, dict]
     images: Dict[int, dict]
     videos: Dict[int, dict]
-    # Per-dataset station metadata carried in the COCO ``info.datasetInfo`` block.
+    # Per-dataset station metadata carried in the COCO ``info.dive_dataset_info`` block.
     datasetInfo: Dict[str, Any] = {}
 
 

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -247,7 +247,7 @@ def load_coco_metadata(coco: Dict[str, Any]) -> CocoMetadata:
     images = coco.get('images', [])
     videos = coco.get('videos', [])
     annotations = coco.get('annotations', [])
-    datasetInfo = (coco.get('info') or {}).get('datasetInfo') or {}
+    datasetInfo = (coco.get('info') or {}).get('dive_dataset_info') or {}
 
     # check if annotations have track IDs
     has_track_id = annotations and 'track_id' in annotations[0]
@@ -293,7 +293,7 @@ def load_coco_as_tracks_and_attributes(
     Convert KWCOCO json to DIVE json tracks.
 
     Returns the converted annotations, discovered attribute metadata, any warnings, and the
-    per-dataset ``info.datasetInfo`` block (empty dict when absent) so the caller can restore
+    per-dataset ``info.dive_dataset_info`` block (empty dict when absent) so the caller can restore
     it onto the dataset's metadata.
     """
     tracks: Dict[int, Track] = {}
@@ -406,7 +406,7 @@ def export_dive_as_coco(
         tracks: Track documents matching ``dive_utils.models.Track`` schema.
         image_filenames: Frame-indexed filename mapping for the dataset.
         dataset_name: Human-readable dataset name used in the COCO info block.
-        datasetInfo: per-dataset station metadata; written under a single ``datasetInfo``
+        datasetInfo: per-dataset station metadata; written under a single ``dive_dataset_info``
             key in the COCO ``info`` block (and advertised in ``info.dive_extensions``)
             when non-empty, omitted entirely when empty/absent so exports stay
             byte-unchanged for datasets without it.
@@ -482,11 +482,11 @@ def export_dive_as_coco(
             'dive_notes',
         ],
     }
-    # Namespace the per-dataset station metadata under one `datasetInfo` key (mirrors the
+    # Namespace the per-dataset station metadata under one `dive_dataset_info` key (mirrors the
     # VIAME CSV passthrough); advertise it in dive_extensions. Omitted entirely when empty.
     if datasetInfo:
-        info['datasetInfo'] = datasetInfo
-        info['dive_extensions'].append('datasetInfo')
+        info['dive_dataset_info'] = datasetInfo
+        info['dive_extensions'].append('dive_dataset_info')
 
     return {
         'info': info,

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -288,18 +288,16 @@ def load_coco_metadata(coco: Dict[str, Any]) -> CocoMetadata:
 
 def load_coco_as_tracks_and_attributes(
     coco: Dict[str, Any],
-) -> Tuple[types.DIVEAnnotationSchema, dict, List[str], Dict[str, Any]]:
-    """
-    Convert KWCOCO json to DIVE json tracks.
+) -> Tuple[types.DIVEAnnotationSchema, types.Attributes, types.Warnings, types.DatasetInfo]:
+    """Convert KWCOCO json to DIVE json tracks.
 
-    Returns the converted annotations, discovered attribute metadata, any warnings, and the
-    per-dataset ``info.dive_dataset_info`` block (empty dict when absent) so the caller can restore
-    it onto the dataset's metadata.
+    Returns (annotations, attributes, warnings, dataset_info); dataset_info is empty when the
+    file carries no ``info.dive_dataset_info`` block.
     """
     tracks: Dict[int, Track] = {}
-    metadata_attributes: Dict[str, Dict[str, Any]] = {}
+    metadata_attributes: types.Attributes = {}
     test_vals: Dict[str, Dict[str, int]] = {}
-    warnings: List[str] = []
+    warnings: types.Warnings = []
     skipped_rle_masks = False
     meta = load_coco_metadata(coco)
     annotations = coco.get('annotations', [])
@@ -397,7 +395,7 @@ def export_dive_as_coco(
     tracks: Iterable[dict],
     image_filenames: Dict[int, str],
     dataset_name: str,
-    datasetInfo: Optional[Dict[str, Any]] = None,
+    datasetInfo: Optional[types.DatasetInfo] = None,
 ) -> Dict[str, Any]:
     """
     Export DIVE tracks to a single-dataset COCO JSON document.

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -6,7 +6,7 @@ KWCOCO-compatible extensions when they are present.
 """
 
 import functools
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from dive_utils import constants, strNumericCompare, types
 from dive_utils.models import CocoMetadata, Feature, Track
@@ -397,7 +397,7 @@ def export_dive_as_coco(
     tracks: Iterable[dict],
     image_filenames: Dict[int, str],
     dataset_name: str,
-    datasetInfo=None,
+    datasetInfo: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Export DIVE tracks to a single-dataset COCO JSON document.

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -404,10 +404,9 @@ def export_dive_as_coco(
         tracks: Track documents matching ``dive_utils.models.Track`` schema.
         image_filenames: Frame-indexed filename mapping for the dataset.
         dataset_name: Human-readable dataset name used in the COCO info block.
-        datasetInfo: per-dataset station metadata; written under a single ``dive_dataset_info``
-            key in the COCO ``info`` block (and advertised in ``info.dive_extensions``)
-            when non-empty, omitted entirely when empty/absent so exports stay
-            byte-unchanged for datasets without it.
+        datasetInfo: per-dataset station metadata; when present, written under
+            ``info.dive_dataset_info`` and advertised in ``info.dive_extensions``.
+            Omitted entirely when empty.
     """
     categories: Dict[str, int] = {}
     coco_annotations: List[dict] = []
@@ -480,8 +479,6 @@ def export_dive_as_coco(
             'dive_notes',
         ],
     }
-    # Namespace the per-dataset station metadata under one `dive_dataset_info` key (mirrors the
-    # VIAME CSV passthrough); advertise it in dive_extensions. Omitted entirely when empty.
     if datasetInfo:
         info['dive_dataset_info'] = datasetInfo
         info['dive_extensions'].append('dive_dataset_info')

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -241,12 +241,13 @@ def _parse_annotation_for_tracks(
     return feature, attributes, track_attributes, confidence_pairs, rle_skipped
 
 
-def load_coco_metadata(coco: Dict[str, List[dict]]) -> CocoMetadata:
+def load_coco_metadata(coco: Dict[str, Any]) -> CocoMetadata:
     categories = coco.get('categories', [])
     keypoint_categories = coco.get('keypoint_categories', [])
     images = coco.get('images', [])
     videos = coco.get('videos', [])
     annotations = coco.get('annotations', [])
+    datasetInfo = (coco.get('info') or {}).get('datasetInfo') or {}
 
     # check if annotations have track IDs
     has_track_id = annotations and 'track_id' in annotations[0]
@@ -281,14 +282,19 @@ def load_coco_metadata(coco: Dict[str, List[dict]]) -> CocoMetadata:
         keypoint_categories=keypoint_categories_map,
         images=images_map,
         videos=videos_map,
+        datasetInfo=datasetInfo,
     )
 
 
 def load_coco_as_tracks_and_attributes(
-    coco: Dict[str, List[dict]],
-) -> Tuple[types.DIVEAnnotationSchema, dict, List[str]]:
+    coco: Dict[str, Any],
+) -> Tuple[types.DIVEAnnotationSchema, dict, List[str], Dict[str, Any]]:
     """
     Convert KWCOCO json to DIVE json tracks.
+
+    Returns the converted annotations, discovered attribute metadata, any warnings, and the
+    per-dataset ``info.datasetInfo`` block (empty dict when absent) so the caller can restore
+    it onto the dataset's metadata.
     """
     tracks: Dict[int, Track] = {}
     metadata_attributes: Dict[str, Dict[str, Any]] = {}
@@ -338,7 +344,7 @@ def load_coco_as_tracks_and_attributes(
     }
     if skipped_rle_masks:
         warnings.append(RLE_SEGMENTATION_WARNING)
-    return converted, metadata_attributes, warnings
+    return converted, metadata_attributes, warnings, meta.datasetInfo
 
 
 def _feature_to_segmentation(feature: Feature) -> List[List[float]]:
@@ -391,6 +397,7 @@ def export_dive_as_coco(
     tracks: Iterable[dict],
     image_filenames: Dict[int, str],
     dataset_name: str,
+    datasetInfo=None,
 ) -> Dict[str, Any]:
     """
     Export DIVE tracks to a single-dataset COCO JSON document.
@@ -399,6 +406,10 @@ def export_dive_as_coco(
         tracks: Track documents matching ``dive_utils.models.Track`` schema.
         image_filenames: Frame-indexed filename mapping for the dataset.
         dataset_name: Human-readable dataset name used in the COCO info block.
+        datasetInfo: per-dataset station metadata; written under a single ``datasetInfo``
+            key in the COCO ``info`` block (and advertised in ``info.dive_extensions``)
+            when non-empty, omitted entirely when empty/absent so exports stay
+            byte-unchanged for datasets without it.
     """
     categories: Dict[str, int] = {}
     coco_annotations: List[dict] = []
@@ -463,15 +474,22 @@ def export_dive_as_coco(
         category['keypoints'] = ['head', 'tail']
         categories_doc.append(category)
 
+    info: Dict[str, Any] = {
+        'description': f'DIVE export for {dataset_name}',
+        'dive_extensions': [
+            'dive_detection_attributes',
+            'dive_track_attributes',
+            'dive_notes',
+        ],
+    }
+    # Namespace the per-dataset station metadata under one `datasetInfo` key (mirrors the
+    # VIAME CSV passthrough); advertise it in dive_extensions. Omitted entirely when empty.
+    if datasetInfo:
+        info['datasetInfo'] = datasetInfo
+        info['dive_extensions'].append('datasetInfo')
+
     return {
-        'info': {
-            'description': f'DIVE export for {dataset_name}',
-            'dive_extensions': [
-                'dive_detection_attributes',
-                'dive_track_attributes',
-                'dive_notes',
-            ],
-        },
+        'info': info,
         'images': list(images.values()),
         'annotations': coco_annotations,
         'categories': categories_doc,

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -285,10 +285,30 @@ def custom_sort(row):
         return (1, int(row[2]))
 
 
+def parse_metadata_row(row: List[str]) -> Dict[str, Any]:
+    """Parse a ``# metadata`` comment row back into a dict.
+
+    Mirror of :func:`writeHeader`, which writes each field as
+    ``f"{key}: {json.dumps(value)}"``. Keys are lower-cased so lookups tolerate
+    producer casing (e.g. native VIAME's ``fps:`` vs a capitalized ``Fps:``).
+    Values that are not valid JSON are kept as the raw, trimmed string.
+    """
+    metadata: Dict[str, Any] = {}
+    for field in row[1:]:  # skip the leading '# metadata' marker
+        key, sep, raw = field.partition(':')
+        if not sep:
+            continue
+        try:
+            metadata[key.strip().lower()] = json.loads(raw.strip())
+        except (json.JSONDecodeError, ValueError):
+            metadata[key.strip().lower()] = raw.strip()
+    return metadata
+
+
 def load_csv_as_tracks_and_attributes(
     rows: List[str],
     imageMap: Optional[Dict[str, int]] = None,
-) -> Tuple[types.DIVEAnnotationSchema, dict, List[str], Optional[str]]:
+) -> Tuple[types.DIVEAnnotationSchema, dict, List[str], Optional[str], Dict[str, Any]]:
     """
     Convert VIAME CSV to json tracks
 
@@ -305,14 +325,19 @@ def load_csv_as_tracks_and_attributes(
     sortedlist = sorted(reader, key=custom_sort)
     warnings: List[str] = []
     fps = None
+    datasetInfo: Dict[str, Any] = {}
     for row in sortedlist:
         if len(row) == 0 or row[0].startswith('#'):
             # This is not a data row
             if len(row) > 0 and row[0] == '# metadata':
-                if row[1].startswith('Fps: '):
-                    fps_splits = row[1].split(':')
-                    if len(fps_splits) > 1:
-                        fps = fps_splits[1]
+                # Symmetric with writeHeader: read the `key: <json>` fields back. fps is
+                # matched case-insensitively (native VIAME writes lowercase `fps:`), and a
+                # `dataset_info` block is restored so VIAME CSV round-trips it like COCO.
+                metadata_fields = parse_metadata_row(row)
+                if fps is None and metadata_fields.get('fps') is not None:
+                    fps = metadata_fields['fps']
+                if isinstance(metadata_fields.get('dataset_info'), dict):
+                    datasetInfo = metadata_fields['dataset_info']
             continue
         (
             feature,
@@ -470,7 +495,7 @@ def load_csv_as_tracks_and_attributes(
         'groups': {},
         'version': constants.AnnotationsCurrentVersion,
     }
-    return annotations, metadata_attributes, warnings, fps
+    return annotations, metadata_attributes, warnings, fps, datasetInfo
 
 
 def export_tracks_as_csv(
@@ -493,8 +518,8 @@ def export_tracks_as_csv(
     :param fps: if FPS is set, column 2 will be video timestamp derived from (frame / fps)
     :param header: include or omit header
     :param typeFilter: set of track types to only export if not empty
-    :param datasetInfo: per-dataset station metadata; emitted as a nested JSON entry on the
-        ``# metadata`` line when non-empty (omitted entirely when empty/absent)
+    :param datasetInfo: per-dataset station metadata; emitted as a nested ``dataset_info`` JSON
+        entry on the ``# metadata`` line when non-empty (omitted entirely when empty/absent)
     """
     if thresholds is None:
         thresholds = {}
@@ -510,7 +535,7 @@ def export_tracks_as_csv(
         if revision is not None:
             metadata["revision"] = revision
         if datasetInfo:
-            metadata["datasetInfo"] = datasetInfo
+            metadata["dataset_info"] = datasetInfo
         writeHeader(writer, metadata)
 
     for t in track_iterator:

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -196,7 +196,7 @@ def _parse_row_for_tracks(row: List[str]) -> Tuple[Feature, Dict, Dict, List]:
 
 
 def create_attributes(
-    metadata_attributes: Dict[str, Dict[str, Any]],
+    metadata_attributes: types.Attributes,
     test_vals: Dict[str, Dict[str, int]],
     atr_type: str,
     key: str,
@@ -223,7 +223,7 @@ def create_attributes(
 
 
 def calculate_attribute_types(
-    metadata_attributes: Dict[str, Dict[str, Any]], test_vals: Dict[str, Dict[str, int]]
+    metadata_attributes: types.Attributes, test_vals: Dict[str, Dict[str, int]]
 ):
     # count all keys must have a value to convert to predefined
     predefined_min_count = 3
@@ -252,12 +252,12 @@ def calculate_attribute_types(
 
 def load_json_as_track_and_attributes(
     json_data: types.DIVEAnnotationSchema,
-) -> Tuple[types.DIVEAnnotationSchema, dict]:
+) -> Tuple[types.DIVEAnnotationSchema, types.Attributes]:
     """
     Load VIAME Track JSON and Computes Attributes
     """
     # Go through tracks and gather all attributes
-    metadata_attributes: Dict[str, Dict[str, Any]] = {}
+    metadata_attributes: types.Attributes = {}
     test_vals: Dict[str, Dict[str, int]] = {}
     tracks = json_data['tracks']
     # Get Attribute Maps to values
@@ -308,7 +308,7 @@ def parse_metadata_row(row: List[str]) -> Dict[str, Any]:
 def load_csv_as_tracks_and_attributes(
     rows: List[str],
     imageMap: Optional[Dict[str, int]] = None,
-) -> Tuple[types.DIVEAnnotationSchema, dict, List[str], Optional[str], Dict[str, Any]]:
+) -> Tuple[types.DIVEAnnotationSchema, types.Attributes, types.Warnings, Optional[str], types.DatasetInfo]:
     """
     Convert VIAME CSV to json tracks
 
@@ -317,15 +317,15 @@ def load_csv_as_tracks_and_attributes(
     """
     reader = csv.reader(row for row in rows)
     tracks: Dict[int, Track] = {}
-    metadata_attributes: Dict[str, Dict[str, Any]] = {}
+    metadata_attributes: types.Attributes = {}
     test_vals: Dict[str, Dict[str, int]] = {}
     multiFrameTracks = False
     missingImages: List[str] = []
     foundImages: List[Dict[str, Any]] = []  # {image:str, frame: int, csvFrame: int}
     sortedlist = sorted(reader, key=custom_sort)
-    warnings: List[str] = []
+    warnings: types.Warnings = []
     fps = None
-    datasetInfo: Dict[str, Any] = {}
+    datasetInfo: types.DatasetInfo = {}
     for row in sortedlist:
         if len(row) == 0 or row[0].startswith('#'):
             # This is not a data row
@@ -507,7 +507,7 @@ def export_tracks_as_csv(
     header=True,
     typeFilter=None,
     revision=None,
-    datasetInfo=None,
+    datasetInfo: Optional[types.DatasetInfo] = None,
 ) -> Generator[str, None, None]:
     """
     Export track json to a CSV format.

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -330,9 +330,8 @@ def load_csv_as_tracks_and_attributes(
         if len(row) == 0 or row[0].startswith('#'):
             # This is not a data row
             if len(row) > 0 and row[0] == '# metadata':
-                # Symmetric with writeHeader: read the `key: <json>` fields back. fps is
-                # matched case-insensitively (native VIAME writes lowercase `fps:`), and a
-                # `dataset_info` block is restored so VIAME CSV round-trips it like COCO.
+                # Read back the `key: <json>` fields written by writeHeader.
+                # fps is matched case-insensitively (native VIAME writes lowercase `fps:`).
                 metadata_fields = parse_metadata_row(row)
                 if fps is None and metadata_fields.get('fps') is not None:
                     fps = metadata_fields['fps']

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel
 from typing_extensions import NotRequired, TypedDict
 
 __all__ = [
+    "Attributes",
+    "DatasetInfo",
     "DiveParam",
     "GirderModel",
     "PipelineDescription",
@@ -12,6 +14,7 @@ __all__ = [
     "PipelineJob",
     "PipelineCategory",
     "PipeMetadata",
+    "Warnings",
 ]
 
 
@@ -176,3 +179,13 @@ class DIVEAnnotationSchema(TypedDict):
     tracks: Dict[str, dict]
     groups: Dict[str, dict]
     version: int
+
+
+# Attribute metadata discovered while deserializing annotations, keyed by attribute name.
+Attributes = Dict[str, Dict[str, Any]]
+
+# Human-readable warnings surfaced during an import.
+Warnings = List[str]
+
+# Per-dataset station metadata (the COCO ``info.dive_dataset_info`` block).
+DatasetInfo = Dict[str, Any]

--- a/server/scripts/commands_main.py
+++ b/server/scripts/commands_main.py
@@ -48,7 +48,9 @@ def convert_kpf(inputs: List[BinaryIO], output: TextIO, output_attrs: TextIO):
 @click.option('--output-attrs', type=click.File('wt'), default='attributes.json')
 def convert_coco(input: TextIO, output: TextIO, output_attrs: TextIO):
     coco_json = json.load(input)
-    tracks, attributes, warnings = kwcoco.load_coco_as_tracks_and_attributes(coco_json)
+    tracks, attributes, warnings, _datasetInfo = kwcoco.load_coco_as_tracks_and_attributes(
+        coco_json
+    )
     json.dump(tracks, output)
     json.dump(attributes, output_attrs, indent=4)
     click.secho(f'wrote output {output.name}', fg='green')

--- a/server/scripts/commands_main.py
+++ b/server/scripts/commands_main.py
@@ -65,7 +65,9 @@ def convert_coco(input: TextIO, output: TextIO, output_attrs: TextIO):
 @click.option('--output-attrs', type=click.File('wt'), default='attributes.json')
 def convert_viame_csv(input: TextIO, output: TextIO, output_attrs: TextIO):
     rows = input.readlines()
-    converted, attributes = viame.load_csv_as_tracks_and_attributes(rows)
+    converted, attributes, _warnings, _fps, _datasetInfo = viame.load_csv_as_tracks_and_attributes(
+        rows
+    )
     json.dump(converted, output)
     json.dump(attributes, output_attrs, indent=4)
     click.secho(f'wrote output {output.name}', fg='green')

--- a/server/tests/test_attributes_processor.py
+++ b/server/tests/test_attributes_processor.py
@@ -26,7 +26,9 @@ def test_read_viame_attributes(
         rows.append(line)
         text = text + line
         print()
-    converted, attributes, warnings, fps = load_csv_as_tracks_and_attributes(text.split('\n'))
+    converted, attributes, warnings, fps, _datasetInfo = load_csv_as_tracks_and_attributes(
+        text.split('\n')
+    )
     assert json.dumps(converted['tracks'], sort_keys=True) == json.dumps(
         expected_tracks, sort_keys=True
     )

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -727,7 +727,7 @@ def test_export_dive_as_coco_single_dataset():
     assert "dive_notes" in coco["info"]["dive_extensions"]
 
 
-# --- datasetInfo passthrough (NOAA standardized metadata, Kitware/dive#1585) ---
+# --- datasetInfo passthrough ---
 
 DATASET_INFO = {
     "gfishsite_id": "2024TXN012",

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -680,7 +680,7 @@ def test_read_kwcoco_json(
     expected_tracks: Dict[str, dict],
     expected_attributes: Dict[str, dict],
 ):
-    converted, attributes, _ = kwcoco.load_coco_as_tracks_and_attributes(input)
+    converted, attributes, _, _ = kwcoco.load_coco_as_tracks_and_attributes(input)
     assert json.dumps(converted['tracks'], sort_keys=True) == json.dumps(
         expected_tracks, sort_keys=True
     )
@@ -727,6 +727,87 @@ def test_export_dive_as_coco_single_dataset():
     assert "dive_notes" in coco["info"]["dive_extensions"]
 
 
+# --- datasetInfo passthrough (NOAA standardized metadata, Kitware/dive#1585) ---
+
+DATASET_INFO = {
+    "gfishsite_id": "2024TXN012",
+    "cruise": "2403",
+    "sta_lat": "26.8195",
+    "year": "2024",
+}
+
+_EXPORT_TRACKS = [
+    {
+        "id": 1,
+        "begin": 0,
+        "end": 0,
+        "confidencePairs": [["fish", 0.9]],
+        "features": [{"frame": 0, "bounds": [10, 20, 30, 60]}],
+    }
+]
+
+
+def test_export_dive_as_coco_writes_dataset_info():
+    """A populated datasetInfo lands under info.datasetInfo and is advertised in dive_extensions."""
+    coco = kwcoco.export_dive_as_coco(
+        _EXPORT_TRACKS, {0: "frame_000000.jpg"}, dataset_name="demo", datasetInfo=DATASET_INFO
+    )
+    assert coco["info"]["datasetInfo"] == DATASET_INFO
+    assert "datasetInfo" in coco["info"]["dive_extensions"]
+
+
+@pytest.mark.parametrize("datasetInfo", [None, {}])
+def test_export_dive_as_coco_omits_empty_dataset_info(datasetInfo):
+    """No datasetInfo key (and dive_extensions unchanged) when empty/absent -> byte-unchanged."""
+    coco = kwcoco.export_dive_as_coco(
+        _EXPORT_TRACKS, {0: "frame_000000.jpg"}, dataset_name="demo", datasetInfo=datasetInfo
+    )
+    baseline = kwcoco.export_dive_as_coco(
+        _EXPORT_TRACKS, {0: "frame_000000.jpg"}, dataset_name="demo"
+    )
+    assert "datasetInfo" not in coco["info"]
+    assert "datasetInfo" not in coco["info"]["dive_extensions"]
+    assert coco["info"] == baseline["info"]
+
+
+def test_load_coco_restores_dataset_info():
+    """info.datasetInfo is surfaced as the 4th return value for the caller to persist."""
+    coco = {
+        "info": {"datasetInfo": DATASET_INFO},
+        "images": [{"id": 1, "file_name": "img_1.jpg"}],
+        "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 2, 3, 4]}],
+        "categories": [{"id": 1, "name": "fish"}],
+    }
+    _converted, _attributes, _warnings, datasetInfo = kwcoco.load_coco_as_tracks_and_attributes(
+        coco
+    )
+    assert datasetInfo == DATASET_INFO
+
+
+def test_load_coco_without_dataset_info_returns_empty():
+    """A COCO file with no info.datasetInfo yields an empty datasetInfo (nothing to persist)."""
+    coco = {
+        "images": [{"id": 1, "file_name": "img_1.jpg"}],
+        "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 2, 3, 4]}],
+        "categories": [{"id": 1, "name": "fish"}],
+    }
+    _converted, _attributes, _warnings, datasetInfo = kwcoco.load_coco_as_tracks_and_attributes(
+        coco
+    )
+    assert datasetInfo == {}
+
+
+def test_dataset_info_export_import_roundtrip():
+    """Export then re-import carries datasetInfo through unchanged (values are opaque strings)."""
+    exported = kwcoco.export_dive_as_coco(
+        _EXPORT_TRACKS, {0: "frame_000000.jpg"}, dataset_name="demo", datasetInfo=DATASET_INFO
+    )
+    _converted, _attributes, _warnings, datasetInfo = kwcoco.load_coco_as_tracks_and_attributes(
+        exported
+    )
+    assert datasetInfo == DATASET_INFO
+
+
 def test_import_dive_attribute_extensions():
     coco = {
         "images": [{"id": 1, "file_name": "img_1.jpg"}],
@@ -744,7 +825,7 @@ def test_import_dive_attribute_extensions():
         ],
         "categories": [{"id": 1, "name": "fish"}],
     }
-    converted, _, _ = kwcoco.load_coco_as_tracks_and_attributes(coco)
+    converted, _, _, _ = kwcoco.load_coco_as_tracks_and_attributes(coco)
     track = converted["tracks"]["5"]
     assert track["attributes"]["reviewed"] is True
     assert track["features"][0]["attributes"]["visibility"] == "poor"
@@ -770,7 +851,7 @@ def test_import_rle_segmentation_skips_masks_with_warning():
         ],
         "categories": [{"id": 1, "name": "fish"}],
     }
-    converted, _, warnings = kwcoco.load_coco_as_tracks_and_attributes(coco)
+    converted, _, warnings, _ = kwcoco.load_coco_as_tracks_and_attributes(coco)
     track = converted["tracks"]["5"]
     assert track["features"][0]["bounds"] == [10, 20, 40, 60]
     assert "geometry" not in track["features"][0]
@@ -814,7 +895,7 @@ def test_import_polygon_without_bbox_derives_bounds():
         ],
         "categories": [{"id": 1, "name": "fish"}],
     }
-    converted, _, warnings = kwcoco.load_coco_as_tracks_and_attributes(coco)
+    converted, _, warnings, _ = kwcoco.load_coco_as_tracks_and_attributes(coco)
     track = converted["tracks"]["401"]
     assert track["features"][0]["bounds"] == [120, 80, 200, 120]
     assert track["features"][0]["geometry"] is not None
@@ -848,7 +929,7 @@ def test_import_polygon_and_rle_segmentation():
             {"id": 2, "name": "crowd"},
         ],
     }
-    converted, _, warnings = kwcoco.load_coco_as_tracks_and_attributes(coco)
+    converted, _, warnings, _ = kwcoco.load_coco_as_tracks_and_attributes(coco)
     polygon_track = converted["tracks"]["301"]
     assert polygon_track["features"][0]["geometry"] is not None
     rle_track = converted["tracks"]["302"]

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -748,32 +748,32 @@ _EXPORT_TRACKS = [
 
 
 def test_export_dive_as_coco_writes_dataset_info():
-    """A populated datasetInfo lands under info.datasetInfo and is advertised in dive_extensions."""
+    """A populated datasetInfo lands under info.dive_dataset_info and is advertised in dive_extensions."""
     coco = kwcoco.export_dive_as_coco(
         _EXPORT_TRACKS, {0: "frame_000000.jpg"}, dataset_name="demo", datasetInfo=DATASET_INFO
     )
-    assert coco["info"]["datasetInfo"] == DATASET_INFO
-    assert "datasetInfo" in coco["info"]["dive_extensions"]
+    assert coco["info"]["dive_dataset_info"] == DATASET_INFO
+    assert "dive_dataset_info" in coco["info"]["dive_extensions"]
 
 
 @pytest.mark.parametrize("datasetInfo", [None, {}])
 def test_export_dive_as_coco_omits_empty_dataset_info(datasetInfo):
-    """No datasetInfo key (and dive_extensions unchanged) when empty/absent -> byte-unchanged."""
+    """No dive_dataset_info key (and dive_extensions unchanged) when empty/absent -> byte-unchanged."""
     coco = kwcoco.export_dive_as_coco(
         _EXPORT_TRACKS, {0: "frame_000000.jpg"}, dataset_name="demo", datasetInfo=datasetInfo
     )
     baseline = kwcoco.export_dive_as_coco(
         _EXPORT_TRACKS, {0: "frame_000000.jpg"}, dataset_name="demo"
     )
-    assert "datasetInfo" not in coco["info"]
-    assert "datasetInfo" not in coco["info"]["dive_extensions"]
+    assert "dive_dataset_info" not in coco["info"]
+    assert "dive_dataset_info" not in coco["info"]["dive_extensions"]
     assert coco["info"] == baseline["info"]
 
 
 def test_load_coco_restores_dataset_info():
-    """info.datasetInfo is surfaced as the 4th return value for the caller to persist."""
+    """info.dive_dataset_info is surfaced as the 4th return value for the caller to persist."""
     coco = {
-        "info": {"datasetInfo": DATASET_INFO},
+        "info": {"dive_dataset_info": DATASET_INFO},
         "images": [{"id": 1, "file_name": "img_1.jpg"}],
         "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 2, 3, 4]}],
         "categories": [{"id": 1, "name": "fish"}],
@@ -785,7 +785,7 @@ def test_load_coco_restores_dataset_info():
 
 
 def test_load_coco_without_dataset_info_returns_empty():
-    """A COCO file with no info.datasetInfo yields an empty datasetInfo (nothing to persist)."""
+    """A COCO file with no info.dive_dataset_info yields an empty datasetInfo (nothing to persist)."""
     coco = {
         "images": [{"id": 1, "file_name": "img_1.jpg"}],
         "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 2, 3, 4]}],

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -15,7 +15,9 @@ def test_read_viame_csv(
     expected_tracks: Dict[str, dict],
     expected_attributes: Dict[str, dict],
 ):
-    converted, attributes, warnings, fps = viame.load_csv_as_tracks_and_attributes(input)
+    converted, attributes, warnings, fps, _datasetInfo = viame.load_csv_as_tracks_and_attributes(
+        input
+    )
     assert json.dumps(converted['tracks'], sort_keys=True) == json.dumps(
         expected_tracks, sort_keys=True
     )

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -356,12 +356,12 @@ def test_image_filenames():
     image_map = {'1': 0, '2': 1, '3': 2}
     for test in image_filename_tests:
         if not test['warning']:
-            converted, _, warnings, fps = viame.load_csv_as_tracks_and_attributes(
+            converted, _, warnings, fps, _datasetInfo = viame.load_csv_as_tracks_and_attributes(
                 test['csv'], image_map
             )
             assert len(converted['tracks'].values()) > 0
         else:
-            converted, _, warnings, fps = viame.load_csv_as_tracks_and_attributes(
+            converted, _, warnings, fps, _datasetInfo = viame.load_csv_as_tracks_and_attributes(
                 test['csv'], image_map
             )
             assert len(warnings) > 0
@@ -376,11 +376,11 @@ def _metadata_fields(csv_text: str) -> Optional[List[str]]:
 
 
 def _dataset_info_entry(fields: List[str]) -> Optional[dict]:
-    entries = [f for f in fields if f.startswith('datasetInfo: ')]
+    entries = [f for f in fields if f.startswith('dataset_info: ')]
     if not entries:
         return None
     assert len(entries) == 1
-    return json.loads(entries[0][len('datasetInfo: ') :])
+    return json.loads(entries[0][len('dataset_info: ') :])
 
 
 def test_dataset_info_on_metadata_line():
@@ -404,15 +404,15 @@ def test_dataset_info_on_metadata_line():
 
 @pytest.mark.parametrize("datasetInfo", [None, {}])
 def test_dataset_info_absent_when_empty(datasetInfo):
-    """No datasetInfo entry (no `datasetInfo: {}` noise) when empty/absent."""
+    """No dataset_info entry (no `dataset_info: {}` noise) when empty/absent."""
     csv_text = ''.join(viame.export_tracks_as_csv([], header=True, datasetInfo=datasetInfo))
     fields = _metadata_fields(csv_text)
     assert fields is not None
-    assert not any(f.startswith('datasetInfo') for f in fields)
+    assert not any(f.startswith('dataset_info') for f in fields)
 
 
-def test_dataset_info_ignored_on_parse_roundtrip():
-    """The datasetInfo metadata entry is ignored cleanly when re-parsed into tracks."""
+def test_dataset_info_restored_on_parse_roundtrip():
+    """datasetInfo exported on the # metadata line round-trips back as the 5th return value."""
     datasetInfo = {"gfishsite_id": "2024TXN012", "cruise": 2403}
     tracks = test_tuple[0][0]
     csv_text = ''.join(
@@ -421,6 +421,24 @@ def test_dataset_info_ignored_on_parse_roundtrip():
         )
     )
     rows = csv_text.splitlines()
-    annotations, _attributes, warnings, _fps = viame.load_csv_as_tracks_and_attributes(rows)
+    annotations, _attributes, _warnings, _fps, parsed_info = (
+        viame.load_csv_as_tracks_and_attributes(rows)
+    )
     assert len(annotations['tracks']) == len(tracks)
+    assert parsed_info == datasetInfo
+
+
+def test_fps_parsed_case_insensitively_from_metadata():
+    """Lowercase ``fps:`` (what DIVE and native VIAME write) is read back on import.
+
+    Regression for an importer that only matched a capitalized ``Fps:`` and so silently
+    dropped the frame rate from real VIAME CSVs.
+    """
+    csv_text = ''.join(viame.export_tracks_as_csv([], header=True, fps=23.976))
+    assert '# metadata' in csv_text and 'fps: 23.976' in csv_text  # exported lowercase
+    rows = csv_text.splitlines()
+    _annotations, _attributes, _warnings, fps, _info = viame.load_csv_as_tracks_and_attributes(
+        rows
+    )
+    assert float(fps) == 23.976
     assert warnings == []

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -441,4 +441,3 @@ def test_fps_parsed_case_insensitively_from_metadata():
         rows
     )
     assert float(fps) == 23.976
-    assert warnings == []

--- a/server/tests/test_update_metadata.py
+++ b/server/tests/test_update_metadata.py
@@ -1,7 +1,10 @@
+import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from dive_server import crud_dataset
-from dive_server.crud_rpc import resolve_imported_dataset_info
+from dive_server.crud_rpc import process_items, resolve_imported_dataset_info
 
 
 @patch('dive_server.crud_dataset.Folder')
@@ -87,3 +90,66 @@ def test_resolve_imported_dataset_info_does_not_mutate_inputs():
 
     assert existing == {'cruise': '2403'}
     assert meta == {'datasetInfo': {'year': '2025'}}
+
+
+@pytest.mark.parametrize(
+    ('additive', 'expected'),
+    [
+        (False, {'year': '2025', 'gfishsite_id': '2024TXN012'}),
+        (
+            True,
+            {
+                'cruise': '2403',
+                'sta_lat': '26.8195',
+                'year': '2025',
+                'gfishsite_id': '2024TXN012',
+            },
+        ),
+    ],
+)
+@patch('dive_server.crud_rpc.crud_dataset.update_metadata')
+@patch('dive_server.crud_rpc.crud.get_or_create_auxiliary_folder')
+@patch('dive_server.crud_rpc.File')
+@patch('dive_server.crud_rpc.Item')
+@patch('dive_server.crud_rpc.Folder')
+def test_process_items_resolves_dataset_info_from_dive_configuration_import(
+    folder_cls,
+    item_cls,
+    file_cls,
+    get_auxiliary_folder,
+    update_metadata,
+    additive,
+    expected,
+):
+    folder = {
+        '_id': 'dataset-id',
+        'meta': {
+            'annotate': True,
+            'type': 'video',
+            'datasetInfo': {'cruise': '2403', 'sta_lat': '26.8195', 'year': '2024'},
+        },
+    }
+    item = {'_id': 'item-id', 'name': 'metadata.config.json', 'meta': {}}
+    file = {'_id': 'file-id', 'name': 'metadata.config.json', 'exts': ['json']}
+    payload = {
+        'datasetInfo': {
+            'year': '2025',
+            'gfishsite_id': '2024TXN012',
+        }
+    }
+
+    folder_cls.return_value.childItems.return_value = [item]
+    item_cls.return_value.childFiles.return_value = iter([file])
+    file_cls.return_value.download.return_value = lambda: [json.dumps(payload).encode()]
+    get_auxiliary_folder.return_value = {'_id': 'auxiliary-id'}
+
+    warnings = process_items(folder, {'_id': 'user-id'}, additive=additive)
+
+    assert warnings == []
+    item_cls.return_value.move.assert_called_once_with(item, {'_id': 'auxiliary-id'})
+    update_metadata.assert_called_once()
+    update_folder, update_payload, verify = update_metadata.call_args.args
+    assert update_folder == folder
+    assert update_payload['datasetInfo'] == expected
+    assert update_payload['version'] == 1
+    assert verify is False

--- a/server/tests/test_update_metadata.py
+++ b/server/tests/test_update_metadata.py
@@ -41,8 +41,9 @@ def test_update_metadata_sets_time_filters(_verify, folder_cls):
 
 
 # --- datasetInfo re-import merge (NOAA standardized metadata, Kitware/dive#1585) ---
-# process_items merges an imported info.datasetInfo over the dataset's existing block via
-# this helper. The subtle, regression-prone bit is the merge direction.
+# On an *additive* import, process_items merges an imported datasetInfo over the dataset's
+# existing block via this helper (an Overwrite import replaces the block instead). The subtle,
+# regression-prone bit is the merge direction.
 
 
 def test_merge_imported_dataset_info_imported_wins_and_preserves_existing():

--- a/server/tests/test_update_metadata.py
+++ b/server/tests/test_update_metadata.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from dive_server import crud_dataset
-from dive_server.crud_rpc import merge_imported_dataset_info
+from dive_server.crud_rpc import resolve_imported_dataset_info
 
 
 @patch('dive_server.crud_dataset.Folder')
@@ -40,20 +40,19 @@ def test_update_metadata_sets_time_filters(_verify, folder_cls):
     assert folder['meta']['timeFilters'] == [10, 50]
 
 
-# --- datasetInfo re-import merge ---
-# On an *additive* import, process_items merges an imported datasetInfo over the dataset's
-# existing block via this helper (an Overwrite import replaces the block instead). The subtle,
-# regression-prone bit is the merge direction.
+# --- datasetInfo re-import resolution ---
+# process_items reconciles an imported datasetInfo with the dataset's existing block via this
+# helper. The subtle, regression-prone bit is the merge direction on an additive import.
 
 
-def test_merge_imported_dataset_info_imported_wins_and_preserves_existing():
-    """Imported values win on collision; keys absent from the file survive the re-import."""
+def test_resolve_imported_dataset_info_additive_imported_wins_and_preserves_existing():
+    """Additive: imported values win on collision; keys absent from the file survive."""
     existing = {'cruise': '2403', 'year': '2024', 'sta_lat': '26.8195'}
-    imported = {'year': '2025', 'gfishsite_id': '2024TXN012'}
+    meta = {'datasetInfo': {'year': '2025', 'gfishsite_id': '2024TXN012'}}
 
-    merged = merge_imported_dataset_info(existing, imported)
+    resolved = resolve_imported_dataset_info(existing, meta, additive=True)
 
-    assert merged == {
+    assert resolved['datasetInfo'] == {
         'cruise': '2403',  # preserved: the imported file did not carry it
         'sta_lat': '26.8195',  # preserved
         'year': '2025',  # imported wins on collision
@@ -61,11 +60,30 @@ def test_merge_imported_dataset_info_imported_wins_and_preserves_existing():
     }
 
 
-def test_merge_imported_dataset_info_does_not_mutate_inputs():
-    existing = {'cruise': '2403'}
-    imported = {'year': '2025'}
+def test_resolve_imported_dataset_info_overwrite_replaces_block():
+    """Overwrite (additive=False) drops the existing block entirely."""
+    existing = {'cruise': '2403', 'year': '2024'}
+    meta = {'datasetInfo': {'year': '2025'}}
 
-    merge_imported_dataset_info(existing, imported)
+    resolved = resolve_imported_dataset_info(existing, meta, additive=False)
+
+    assert resolved['datasetInfo'] == {'year': '2025'}
+
+
+def test_resolve_imported_dataset_info_absent_leaves_meta_untouched():
+    """A file carrying no datasetInfo never touches the existing block, in either mode."""
+    existing = {'cruise': '2403'}
+    meta = {'type': 'image-sequence'}
+
+    assert resolve_imported_dataset_info(existing, meta, additive=True) == meta
+    assert resolve_imported_dataset_info(existing, meta, additive=False) == meta
+
+
+def test_resolve_imported_dataset_info_does_not_mutate_inputs():
+    existing = {'cruise': '2403'}
+    meta = {'datasetInfo': {'year': '2025'}}
+
+    resolve_imported_dataset_info(existing, meta, additive=True)
 
     assert existing == {'cruise': '2403'}
-    assert imported == {'year': '2025'}
+    assert meta == {'datasetInfo': {'year': '2025'}}

--- a/server/tests/test_update_metadata.py
+++ b/server/tests/test_update_metadata.py
@@ -40,7 +40,7 @@ def test_update_metadata_sets_time_filters(_verify, folder_cls):
     assert folder['meta']['timeFilters'] == [10, 50]
 
 
-# --- datasetInfo re-import merge (NOAA standardized metadata, Kitware/dive#1585) ---
+# --- datasetInfo re-import merge ---
 # On an *additive* import, process_items merges an imported datasetInfo over the dataset's
 # existing block via this helper (an Overwrite import replaces the block instead). The subtle,
 # regression-prone bit is the merge direction.

--- a/server/tests/test_update_metadata.py
+++ b/server/tests/test_update_metadata.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from dive_server import crud_dataset
+from dive_server.crud_rpc import merge_imported_dataset_info
 
 
 @patch('dive_server.crud_dataset.Folder')
@@ -37,3 +38,33 @@ def test_update_metadata_sets_time_filters(_verify, folder_cls):
     crud_dataset.update_metadata(folder, {'timeFilters': [10, 50]})
 
     assert folder['meta']['timeFilters'] == [10, 50]
+
+
+# --- datasetInfo re-import merge (NOAA standardized metadata, Kitware/dive#1585) ---
+# process_items merges an imported info.datasetInfo over the dataset's existing block via
+# this helper. The subtle, regression-prone bit is the merge direction.
+
+
+def test_merge_imported_dataset_info_imported_wins_and_preserves_existing():
+    """Imported values win on collision; keys absent from the file survive the re-import."""
+    existing = {'cruise': '2403', 'year': '2024', 'sta_lat': '26.8195'}
+    imported = {'year': '2025', 'gfishsite_id': '2024TXN012'}
+
+    merged = merge_imported_dataset_info(existing, imported)
+
+    assert merged == {
+        'cruise': '2403',  # preserved: the imported file did not carry it
+        'sta_lat': '26.8195',  # preserved
+        'year': '2025',  # imported wins on collision
+        'gfishsite_id': '2024TXN012',  # added by the import
+    }
+
+
+def test_merge_imported_dataset_info_does_not_mutate_inputs():
+    existing = {'cruise': '2403'}
+    imported = {'year': '2025'}
+
+    merge_imported_dataset_info(existing, imported)
+
+    assert existing == {'cruise': '2403'}
+    assert imported == {'year': '2025'}


### PR DESCRIPTION
## Round-trip `datasetInfo` through COCO/KWCOCO and VIAME CSV (#1585)

Builds on the Dataset Info panel (#1688). The dataset-level `datasetInfo` block (cruise id, station id, lat/lon, a `gfishsite_id` for re-linking to an external DB, …) now travels with the annotations on **export** and is restored on **import** — for both VIAME CSV and COCO/KWCOCO, on both the server and the desktop client.

### Interface changes

**Wire format (serialized keys)**
- **COCO** — written to `info.dive_dataset_info`, advertised in `info.dive_extensions`. Restored on import. Omitted when empty.
- **VIAME CSV** — added to the `# metadata` line as one nested JSON entry keyed `dataset_info` (renamed from `datasetInfo:` in #1688). Omitted when empty.

```
# metadata,fps: 23.976,"dataset_info: {""gfishsite_id"": ""2024TXN012"", ""year"": ""2024""}", ...
info.dive_dataset_info = { "gfishsite_id": "2024TXN012", "year": "2024", ... }
```

The in-memory field stays `datasetInfo` (camelCase); the snake_case wire keys exist only at each serializer boundary.

### Behavior
- **Import merge** (mirrored server + desktop): **Overwrite** (the default) replaces the block wholesale; **additive** merges per-key, imported values winning. A file carrying no `datasetInfo` never touches the existing block.
- **Fix:** the importer only matched a capitalized `Fps:` and silently dropped the frame rate from real VIAME CSVs — metadata keys are now parsed case-insensitively.
- Unified the single-dataset and multicam COCO export paths: `views_annotation.export` now delegates to `crud_dataset._coco_json_export_text` instead of duplicating the track-filtering / image-naming logic.

### Tests & docs
Round-trip, empty-omission, and merge-direction tests on both platforms, plus the case-insensitive `fps` regression test. Updated `docs/DataFormats.md` and `docs/UI-DatasetInfo.md`.
