### PR TITLE
Add interactive text-query annotation button

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -418,6 +418,78 @@ export interface SegmentationStatusResponse {
   ready?: boolean;
 }
 
+/**
+ * Text Query Types for open-vocabulary detection/segmentation
+ */
+
+/** A single detection returned from a text query */
+export interface TextQueryDetection {
+  /** Bounding box [x1, y1, x2, y2] */
+  box: [number, number, number, number];
+  /** Polygon coordinates as [x, y] pairs */
+  polygon?: [number, number][];
+  /** Confidence score */
+  score: number;
+  /** Label/class name (often the query text) */
+  label: string;
+  /** Low-res mask for refinement (optional) */
+  lowResMask?: number[][];
+}
+
+export interface TextQueryRequest {
+  /** Path to the image file */
+  imagePath: string;
+  /** Text query describing what to find (e.g., "fish", "person swimming") */
+  text: string;
+  /** Confidence threshold for detections (default: 0.3) */
+  boxThreshold?: number;
+  /** Maximum number of detections to return (default: 10) */
+  maxDetections?: number;
+  /** Optional boxes to refine [x1, y1, x2, y2][] */
+  boxes?: [number, number, number, number][];
+  /** Optional keypoints for refinement [x, y][] */
+  points?: [number, number][];
+  /** Labels for points: 1 for foreground, 0 for background */
+  pointLabels?: number[];
+  /** Optional masks to refine */
+  masks?: number[][][];
+}
+
+export interface TextQueryResponse {
+  /** Whether the query succeeded */
+  success: boolean;
+  /** Error message if failed */
+  error?: string;
+  /** List of detections found */
+  detections?: TextQueryDetection[];
+  /** The original query text */
+  query?: string;
+  /** Whether fallback method was used (no native text support) */
+  fallback?: boolean;
+}
+
+export interface RefineDetectionsRequest {
+  /** Path to the image file */
+  imagePath: string;
+  /** Detections to refine */
+  detections: TextQueryDetection[];
+  /** Optional additional keypoints for refinement [x, y][] */
+  points?: [number, number][];
+  /** Labels for additional points: 1 for foreground, 0 for background */
+  pointLabels?: number[];
+  /** Whether to include refined masks in response */
+  refineMasks?: boolean;
+}
+
+export interface RefineDetectionsResponse {
+  /** Whether the refinement succeeded */
+  success: boolean;
+  /** Error message if failed */
+  error?: string;
+  /** Refined detections */
+  detections?: TextQueryDetection[];
+}
+
 export {
   provideApi,
   useApi,

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -437,8 +437,11 @@ export interface TextQueryDetection {
 }
 
 export interface TextQueryRequest {
-  /** Path to the image file */
+  /** Path to the image file (or video file for video datasets) */
   imagePath: string;
+  /** Frame time in seconds, required when imagePath is a video so the service
+   * extracts the correct frame. Omitted for image-sequence datasets. */
+  frameTime?: number;
   /** Text query describing what to find (e.g., "fish", "person swimming") */
   text: string;
   /** Confidence threshold for detections (default: 0.3) */

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -23,10 +23,14 @@ interface ButtonData {
   type?: VisibleAnnotationTypes;
   active: boolean;
   loading?: boolean;
+  unavailable?: boolean;
+  unavailableTooltip?: string;
   mousetrap?: Mousetrap[];
   description: string;
   click: () => void;
 }
+
+const SAM3_ADDON_WIKI_URL = 'https://github.com/VIAME/VIAME/wiki/Model-Zoo-and-Add-Ons';
 
 export default defineComponent({
   name: 'EditorMenu',
@@ -84,6 +88,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    textQueryAvailable: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: [
     'set-annotation-state',
@@ -92,6 +100,7 @@ export default defineComponent({
     'text-query-init',
     'text-query',
     'text-query-all-frames',
+    'open-external-link',
   ],
   setup(props, { emit }) {
     const toolTimeTimeout = ref<number | null>(null);
@@ -121,6 +130,27 @@ export default defineComponent({
     // When on, existing annotations are removed before the query results are
     // applied. Off by default so results are added alongside existing ones.
     const textQueryReplaceExisting = ref(false);
+    const sam3InfoDialogOpen = ref(false);
+
+    const openSam3InfoDialog = () => {
+      sam3InfoDialogOpen.value = true;
+    };
+
+    const closeSam3InfoDialog = () => {
+      sam3InfoDialogOpen.value = false;
+    };
+
+    const openSam3AddonWiki = () => {
+      emit('open-external-link', SAM3_ADDON_WIKI_URL);
+    };
+
+    const handleTextQueryClick = () => {
+      if (!props.textQueryAvailable) {
+        openSam3InfoDialog();
+        return;
+      }
+      openTextQueryDialog();
+    };
 
     const openTextQueryDialog = () => {
       textQueryDialogOpen.value = true;
@@ -223,12 +253,14 @@ export default defineComponent({
           id: 'Text Query',
           icon: 'mdi-text-search',
           active: false,
+          unavailable: !props.textQueryAvailable,
+          unavailableTooltip: 'SAM3 add-on not installed. Click for more information.',
           description: 'Text Query',
           mousetrap: [{
             bind: 't',
-            handler: () => openTextQueryDialog(),
+            handler: () => handleTextQueryClick(),
           }],
-          click: () => openTextQueryDialog(),
+          click: () => handleTextQueryClick(),
         }] : []),
       ];
     });
@@ -345,6 +377,9 @@ export default defineComponent({
       closeTextQueryDialog,
       onTextQueryServiceReady,
       submitTextQuery,
+      sam3InfoDialogOpen,
+      closeSam3InfoDialog,
+      openSam3AddonWiki,
     };
   },
 });
@@ -434,19 +469,33 @@ export default defineComponent({
               :key="`${button.id}-menu`"
             >
               <v-list-item-icon>
-                <v-btn
-                  :disabled="!editingMode || button.loading"
-                  :outlined="!button.active"
-                  :color="button.active ? editingHeader.color : ''"
-                  class="mx-1"
-                  small
-                  @click="button.click"
+                <v-tooltip
+                  bottom
+                  :disabled="!button.unavailable"
                 >
-                  <pre v-if="button.mousetrap">{{ button.mousetrap[0].bind }}:</pre>
-                  <v-icon :class="{ 'mdi-spin': button.loading }">
-                    {{ button.icon }}
-                  </v-icon>
-                </v-btn>
+                  <template #activator="{ on: tooltipOn, attrs: tooltipAttrs }">
+                    <span
+                      v-bind="button.unavailable ? tooltipAttrs : {}"
+                      v-on="button.unavailable ? tooltipOn : {}"
+                    >
+                      <v-btn
+                        :disabled="button.unavailable ? !!button.loading : (!editingMode || !!button.loading)"
+                        :outlined="!button.active"
+                        :color="button.active ? editingHeader.color : ''"
+                        :class="{ 'edit-btn-unavailable': button.unavailable && !button.loading }"
+                        class="mx-1"
+                        small
+                        @click="button.click"
+                      >
+                        <pre v-if="button.mousetrap">{{ button.mousetrap[0].bind }}:</pre>
+                        <v-icon :class="{ 'mdi-spin': button.loading }">
+                          {{ button.icon }}
+                        </v-icon>
+                      </v-btn>
+                    </span>
+                  </template>
+                  <span>{{ button.unavailableTooltip }}</span>
+                </v-tooltip>
               </v-list-item-icon>
               <v-list-item-content>
                 <v-list-item-title>{{ button.id }}</v-list-item-title>
@@ -472,21 +521,36 @@ export default defineComponent({
               />
             </span>
           </template>
-          <v-btn
+          <v-tooltip
             v-for="button in editButtons"
             :key="button.id + 'view'"
-            :disabled="!editingMode || button.loading"
-            :outlined="!button.active"
-            :color="button.active ? editingHeader.color : ''"
-            class="mx-1"
-            small
-            @click="button.click"
+            bottom
+            :disabled="!button.unavailable"
           >
-            <pre v-if="button.mousetrap">{{ button.mousetrap[0].bind }}:</pre>
-            <v-icon :class="{ 'mdi-spin': button.loading }">
-              {{ button.icon }}
-            </v-icon>
-          </v-btn>
+            <template #activator="{ on: tooltipOn, attrs: tooltipAttrs }">
+              <span
+                v-bind="button.unavailable ? tooltipAttrs : {}"
+                v-on="button.unavailable ? tooltipOn : {}"
+                class="d-inline-block"
+              >
+                <v-btn
+                  :disabled="button.unavailable ? !!button.loading : (!editingMode || !!button.loading)"
+                  :outlined="!button.active"
+                  :color="button.active ? editingHeader.color : ''"
+                  :class="{ 'edit-btn-unavailable': button.unavailable && !button.loading }"
+                  class="mx-1"
+                  small
+                  @click="button.click"
+                >
+                  <pre v-if="button.mousetrap">{{ button.mousetrap[0].bind }}:</pre>
+                  <v-icon :class="{ 'mdi-spin': button.loading }">
+                    {{ button.icon }}
+                  </v-icon>
+                </v-btn>
+              </span>
+            </template>
+            <span>{{ button.unavailableTooltip }}</span>
+          </v-tooltip>
         </outlined-labeled-group>
       </span>
       <!-- Segmentation Reset button -->
@@ -635,6 +699,54 @@ export default defineComponent({
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <!-- SAM3 Add-On Info Dialog -->
+    <v-dialog
+      v-if="textQueryEnabled"
+      v-model="sam3InfoDialogOpen"
+      max-width="500"
+    >
+      <v-card>
+        <v-card-title class="text-h6">
+          <v-icon left>
+            mdi-package-down
+          </v-icon>
+          SAM3 Add-On Required
+        </v-card-title>
+        <v-card-text>
+          <p class="text-body-2 mb-3">
+            Text query requires the SAM3 Text Query Segmentation and Tracking Models
+            add-on to be installed in your VIAME directory.
+          </p>
+          <p class="text-body-2 mb-0">
+            You can download the add-on from the
+            <span
+              class="sam3-wiki-link"
+              @click="openSam3AddonWiki"
+            >
+              VIAME Model Zoo and Add-Ons
+            </span>
+            page. Extract the package and merge its folders into your existing VIAME
+            installation.
+          </p>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            text
+            @click="closeSam3InfoDialog"
+          >
+            Close
+          </v-btn>
+          <v-btn
+            color="primary"
+            @click="openSam3AddonWiki"
+          >
+            Open Model Zoo
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-row>
 </template>
 
@@ -645,8 +757,18 @@ export default defineComponent({
   border-radius: 16px;
   white-space: nowrap;
   border: 1px solid;
-  cursor: default;
 }
+
+.edit-btn-unavailable {
+  opacity: 0.45 !important;
+}
+
+.sam3-wiki-link {
+  color: var(--v-primary-base);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 .mode-button{
   border: 1px solid grey;
   min-width: 36px;

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -80,11 +80,18 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
+    textQueryEnabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: [
     'set-annotation-state',
     'update:tail-settings',
     'update:show-user-created-icon',
+    'text-query-init',
+    'text-query',
+    'text-query-all-frames',
   ],
   setup(props, { emit }) {
     const toolTimeTimeout = ref<number | null>(null);
@@ -102,6 +109,59 @@ export default defineComponent({
     watch(isEditButtonsExpanded, (value) => {
       localStorage.setItem(STORAGE_KEY, String(value));
     });
+
+    // Text query state
+    const textQueryDialogOpen = ref(false);
+    const textQueryInput = ref('');
+    const textQueryLoading = ref(false);
+    const textQueryThreshold = ref(0.3);
+    const textQueryInitializing = ref(false);
+    const textQueryServiceError = ref('');
+    const textQueryAllFrames = ref(false);
+
+    const openTextQueryDialog = () => {
+      textQueryDialogOpen.value = true;
+      textQueryInput.value = '';
+      textQueryServiceError.value = '';
+      textQueryAllFrames.value = false;
+      textQueryInitializing.value = true;
+      emit('text-query-init');
+    };
+
+    const closeTextQueryDialog = () => {
+      textQueryDialogOpen.value = false;
+      textQueryInput.value = '';
+      textQueryServiceError.value = '';
+      textQueryInitializing.value = false;
+      textQueryAllFrames.value = false;
+    };
+
+    const onTextQueryServiceReady = (success: boolean, error?: string) => {
+      textQueryInitializing.value = false;
+      if (!success) {
+        textQueryServiceError.value = error || 'Text query service is not available';
+      }
+    };
+
+    const submitTextQuery = () => {
+      if (!textQueryInput.value.trim()) {
+        return;
+      }
+      textQueryLoading.value = true;
+      if (textQueryAllFrames.value) {
+        emit('text-query-all-frames', {
+          text: textQueryInput.value.trim(),
+          boxThreshold: textQueryThreshold.value,
+        });
+      } else {
+        emit('text-query', {
+          text: textQueryInput.value.trim(),
+          boxThreshold: textQueryThreshold.value,
+        });
+      }
+      closeTextQueryDialog();
+      textQueryLoading.value = false;
+    };
 
     const modeToolTips = {
       Creating: {
@@ -151,6 +211,18 @@ export default defineComponent({
             ...r.mousetrap(),
           ],
         })),
+        /* Text Query button included alongside other annotation types (desktop only) */
+        ...(props.textQueryEnabled ? [{
+          id: 'Text Query',
+          icon: 'mdi-text-search',
+          active: false,
+          description: 'Text Query',
+          mousetrap: [{
+            bind: 't',
+            handler: () => openTextQueryDialog(),
+          }],
+          click: () => openTextQueryDialog(),
+        }] : []),
       ];
     });
 
@@ -253,6 +325,18 @@ export default defineComponent({
       segmentationPredicting,
       segmentationLoading,
       segmentationTooltip,
+      // Text query
+      textQueryDialogOpen,
+      textQueryInput,
+      textQueryLoading,
+      textQueryThreshold,
+      textQueryInitializing,
+      textQueryServiceError,
+      textQueryAllFrames,
+      openTextQueryDialog,
+      closeTextQueryDialog,
+      onTextQueryServiceReady,
+      submitTextQuery,
     };
   },
 });
@@ -434,6 +518,108 @@ export default defineComponent({
         @update:show-user-created-icon="$emit('update:show-user-created-icon', $event)"
       />
     </div>
+
+    <!-- Text Query Dialog -->
+    <v-dialog
+      v-if="textQueryEnabled"
+      v-model="textQueryDialogOpen"
+      max-width="500"
+      :persistent="textQueryInitializing || textQueryLoading"
+    >
+      <v-card>
+        <v-card-title class="text-h6">
+          <v-icon left>
+            mdi-text-search
+          </v-icon>
+          Text Query
+        </v-card-title>
+        <v-card-text>
+          <!-- Loading state while initializing service -->
+          <div
+            v-if="textQueryInitializing"
+            class="text-center py-4"
+          >
+            <v-progress-circular
+              indeterminate
+              color="primary"
+              size="48"
+            />
+            <p class="text-body-2 mt-3">
+              Loading text query model...
+            </p>
+          </div>
+          <!-- Error state if service failed to initialize -->
+          <div
+            v-else-if="textQueryServiceError"
+            class="text-center py-4"
+          >
+            <v-icon
+              color="error"
+              size="48"
+            >
+              mdi-alert-circle
+            </v-icon>
+            <p class="text-body-2 mt-3 error--text">
+              {{ textQueryServiceError }}
+            </p>
+          </div>
+          <!-- Normal input form when service is ready -->
+          <template v-else>
+            <p class="text-body-2 mb-3">
+              Enter a description of objects to find in the current frame.
+            </p>
+            <v-text-field
+              v-model="textQueryInput"
+              label="Object description"
+              placeholder="e.g., fish swimming near coral"
+              outlined
+              dense
+              autofocus
+              :disabled="textQueryLoading"
+              @keyup.enter="submitTextQuery"
+            />
+            <v-slider
+              v-model="textQueryThreshold"
+              label="Confidence threshold"
+              min="0.1"
+              max="0.9"
+              step="0.05"
+              thumb-label
+              :disabled="textQueryLoading"
+            />
+            <v-checkbox
+              v-model="textQueryAllFrames"
+              label="Apply to all frames"
+              hint="Run across all frames instead of only the current (this will run as a job)"
+              persistent-hint
+              :disabled="textQueryLoading"
+            />
+          </template>
+          <p class="text-caption mt-3 mb-0 text--secondary">
+            Textual query support uses architectures derived from Meta's SAM3 project
+          </p>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            text
+            :disabled="textQueryLoading"
+            @click="closeTextQueryDialog"
+          >
+            {{ textQueryServiceError ? 'Close' : 'Cancel' }}
+          </v-btn>
+          <v-btn
+            v-if="!textQueryInitializing && !textQueryServiceError"
+            color="primary"
+            :loading="textQueryLoading"
+            :disabled="!textQueryInput.trim() || textQueryLoading"
+            @click="submitTextQuery"
+          >
+            Search
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-row>
 </template>
 

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -530,8 +530,8 @@ export default defineComponent({
             <template #activator="{ on: tooltipOn, attrs: tooltipAttrs }">
               <span
                 v-bind="button.unavailable ? tooltipAttrs : {}"
-                v-on="button.unavailable ? tooltipOn : {}"
                 class="d-inline-block"
+                v-on="button.unavailable ? tooltipOn : {}"
               >
                 <v-btn
                   :disabled="button.unavailable ? !!button.loading : (!editingMode || !!button.loading)"

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -118,12 +118,16 @@ export default defineComponent({
     const textQueryInitializing = ref(false);
     const textQueryServiceError = ref('');
     const textQueryAllFrames = ref(false);
+    // When on, existing annotations are removed before the query results are
+    // applied. Off by default so results are added alongside existing ones.
+    const textQueryReplaceExisting = ref(false);
 
     const openTextQueryDialog = () => {
       textQueryDialogOpen.value = true;
       textQueryInput.value = '';
       textQueryServiceError.value = '';
       textQueryAllFrames.value = false;
+      textQueryReplaceExisting.value = false;
       textQueryInitializing.value = true;
       emit('text-query-init');
     };
@@ -134,6 +138,7 @@ export default defineComponent({
       textQueryServiceError.value = '';
       textQueryInitializing.value = false;
       textQueryAllFrames.value = false;
+      textQueryReplaceExisting.value = false;
     };
 
     const onTextQueryServiceReady = (success: boolean, error?: string) => {
@@ -152,11 +157,13 @@ export default defineComponent({
         emit('text-query-all-frames', {
           text: textQueryInput.value.trim(),
           boxThreshold: textQueryThreshold.value,
+          replaceExisting: textQueryReplaceExisting.value,
         });
       } else {
         emit('text-query', {
           text: textQueryInput.value.trim(),
           boxThreshold: textQueryThreshold.value,
+          replaceExisting: textQueryReplaceExisting.value,
         });
       }
       closeTextQueryDialog();
@@ -333,6 +340,7 @@ export default defineComponent({
       textQueryInitializing,
       textQueryServiceError,
       textQueryAllFrames,
+      textQueryReplaceExisting,
       openTextQueryDialog,
       closeTextQueryDialog,
       onTextQueryServiceReady,
@@ -591,6 +599,13 @@ export default defineComponent({
               v-model="textQueryAllFrames"
               label="Apply to all frames"
               hint="Run across all frames instead of only the current (this will run as a job)"
+              persistent-hint
+              :disabled="textQueryLoading"
+            />
+            <v-checkbox
+              v-model="textQueryReplaceExisting"
+              label="Replace existing annotations"
+              hint="Remove annotations already present before adding query results (off = keep them)"
               persistent-hint
               :disabled="textQueryLoading"
             />

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -652,7 +652,7 @@ export default defineComponent({
             />
             <v-slider
               v-model="textQueryThreshold"
-              label="Confidence threshold"
+              :label="`Confidence threshold: ${Number(textQueryThreshold).toFixed(2)}`"
               min="0.1"
               max="0.9"
               step="0.05"

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -257,7 +257,7 @@ export default defineComponent({
           unavailableTooltip: 'SAM3 add-on not installed. Click for more information.',
           description: 'Text Query',
           mousetrap: [{
-            bind: 't',
+            bind: 'q',
             handler: () => handleTextQueryClick(),
           }],
           click: () => handleTextQueryClick(),

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -128,8 +128,8 @@ export default defineComponent({
     const textQueryServiceError = ref('');
     const textQueryAllFrames = ref(false);
     // When on, existing annotations are removed before the query results are
-    // applied. Off by default so results are added alongside existing ones.
-    const textQueryReplaceExisting = ref(false);
+    // applied. On by default so a query replaces rather than accumulates.
+    const textQueryReplaceExisting = ref(true);
     const sam3InfoDialogOpen = ref(false);
 
     const openSam3InfoDialog = () => {
@@ -157,7 +157,7 @@ export default defineComponent({
       textQueryInput.value = '';
       textQueryServiceError.value = '';
       textQueryAllFrames.value = false;
-      textQueryReplaceExisting.value = false;
+      textQueryReplaceExisting.value = true;
       textQueryInitializing.value = true;
       emit('text-query-init');
     };
@@ -168,7 +168,7 @@ export default defineComponent({
       textQueryServiceError.value = '';
       textQueryInitializing.value = false;
       textQueryAllFrames.value = false;
-      textQueryReplaceExisting.value = false;
+      textQueryReplaceExisting.value = true;
     };
 
     const onTextQueryServiceReady = (success: boolean, error?: string) => {

--- a/client/dive-common/components/UserGuideDialog.vue
+++ b/client/dive-common/components/UserGuideDialog.vue
@@ -1,8 +1,16 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
+import isDesktopRuntime from 'dive-common/isDesktopRuntime';
 
 export default defineComponent({
   setup() {
+    const desktopShortcuts = isDesktopRuntime() ? [{
+      name: 'Text Query',
+      icon: 'mdi-keyboard',
+      actions: ['Q Key'],
+      description: 'Open the SAM3 text query dialog to find objects by description in the current frame',
+    }] : [];
+
     return {
       categories: [
         {
@@ -104,6 +112,7 @@ export default defineComponent({
             {
               name: 'Add Head/Tail', icon: 'mdi-keyboard', actions: ['H Key - Head', 'T Key - Tail'], description: 'While a track is selected add head/tail annotations',
             },
+            ...desktopShortcuts,
           ],
         },
       ],

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -186,6 +186,17 @@ export default defineComponent({
       }
     }
 
+    /**
+     * Forward a single-frame text query submission to the platform handler,
+     * injecting the current frame number the query should run against.
+     */
+    function onTextQuerySubmit(payload: { text: string; boxThreshold: number }) {
+      emit('text-query-submit', {
+        ...payload,
+        frameNum: aggregateController.value.frame.value,
+      });
+    }
+
     const sideBarCollapsed = ref(false);
     // Sidebar mode: 'left', 'bottom', or 'collapsed'
     const getInitialSidebarMode = (): 'left' | 'bottom' | 'collapsed' => {
@@ -1250,6 +1261,7 @@ export default defineComponent({
       sideBarCollapsed,
       editorMenuRef,
       onTextQueryServiceReady,
+      onTextQuerySubmit,
       sidebarMode,
       cycleSidebarMode,
       sidebarModeIcon,
@@ -1452,7 +1464,7 @@ export default defineComponent({
           @set-annotation-state="handler.setAnnotationState"
           @exit-edit="handler.trackAbort"
           @text-query-init="$emit('text-query-init')"
-          @text-query="$emit('text-query', $event)"
+          @text-query="onTextQuerySubmit"
           @text-query-all-frames="$emit('text-query-all-frames', $event)"
         >
           <template slot="delete-controls">

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -131,6 +131,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    textQueryAvailable: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props, { emit }) {
     const { prompt, visible } = usePrompt();
@@ -1460,6 +1464,7 @@ export default defineComponent({
             lassoModeActive: !readonlyState && lassoModeActive,
             lassoDrawing: !readonlyState && lassoDrawing,
             textQueryEnabled,
+            textQueryAvailable,
           }"
           :tail-settings.sync="clientSettings.annotatorPreferences.trackTails"
           :show-user-created-icon.sync="clientSettings.annotatorPreferences.showUserCreatedIcon"
@@ -1468,6 +1473,7 @@ export default defineComponent({
           @text-query-init="$emit('text-query-init')"
           @text-query="onTextQuerySubmit"
           @text-query-all-frames="$emit('text-query-all-frames', $event)"
+          @open-external-link="$emit('open-external-link', $event)"
         >
           <template slot="delete-controls">
             <delete-controls

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -127,6 +127,10 @@ export default defineComponent({
       type: Array as PropType<string[]>,
       default: () => [],
     },
+    textQueryEnabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props, { emit }) {
     const { prompt, visible } = usePrompt();
@@ -170,6 +174,17 @@ export default defineComponent({
     const controlsRef = ref();
     const controlsHeight = ref(0);
     const controlsCollapsed = ref(false);
+    const editorMenuRef = ref();
+
+    /**
+     * Forward text query service ready status to EditorMenu
+     * Called by ViewerLoader when text query service initialization completes
+     */
+    function onTextQueryServiceReady(success: boolean, error?: string) {
+      if (editorMenuRef.value?.onTextQueryServiceReady) {
+        editorMenuRef.value.onTextQueryServiceReady(success, error);
+      }
+    }
 
     const sideBarCollapsed = ref(false);
     // Sidebar mode: 'left', 'bottom', or 'collapsed'
@@ -1233,6 +1248,8 @@ export default defineComponent({
       controlsHeight,
       controlsCollapsed,
       sideBarCollapsed,
+      editorMenuRef,
+      onTextQueryServiceReady,
       sidebarMode,
       cycleSidebarMode,
       sidebarModeIcon,
@@ -1417,6 +1434,7 @@ export default defineComponent({
         </v-tooltip>
 
         <EditorMenu
+          ref="editorMenuRef"
           v-bind="{
             editingMode,
             visibleModes,
@@ -1427,11 +1445,15 @@ export default defineComponent({
             groupEditActive: editingGroupId !== null,
             lassoModeActive: !readonlyState && lassoModeActive,
             lassoDrawing: !readonlyState && lassoDrawing,
+            textQueryEnabled,
           }"
           :tail-settings.sync="clientSettings.annotatorPreferences.trackTails"
           :show-user-created-icon.sync="clientSettings.annotatorPreferences.showUserCreatedIcon"
           @set-annotation-state="handler.setAnnotationState"
           @exit-edit="handler.trackAbort"
+          @text-query-init="$emit('text-query-init')"
+          @text-query="$emit('text-query', $event)"
+          @text-query-all-frames="$emit('text-query-all-frames', $event)"
         >
           <template slot="delete-controls">
             <delete-controls

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -190,7 +190,9 @@ export default defineComponent({
      * Forward a single-frame text query submission to the platform handler,
      * injecting the current frame number the query should run against.
      */
-    function onTextQuerySubmit(payload: { text: string; boxThreshold: number }) {
+    function onTextQuerySubmit(
+      payload: { text: string; boxThreshold: number; replaceExisting?: boolean },
+    ) {
       emit('text-query-submit', {
         ...payload,
         frameNum: aggregateController.value.frame.value,

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -375,6 +375,49 @@ export default function register() {
     return { ready: segService.isSegmentationReady() };
   });
 
+  ipcMain.handle('segmentation-text-query', async (_, args: {
+    imagePath: string;
+    text: string;
+    boxThreshold?: number;
+    maxDetections?: number;
+    boxes?: [number, number, number, number][];
+    points?: [number, number][];
+    pointLabels?: number[];
+  }) => {
+    const segService = getInteractiveServiceManager();
+
+    // Auto-initialize if not ready
+    if (!segService.isSegmentationReady()) {
+      await segService.initialize(settings.get());
+    }
+
+    const response = await segService.textQuery(args);
+    return response;
+  });
+
+  ipcMain.handle('segmentation-refine', async (_, args: {
+    imagePath: string;
+    detections: {
+      box: [number, number, number, number];
+      polygon?: [number, number][];
+      score: number;
+      label: string;
+    }[];
+    points?: [number, number][];
+    pointLabels?: number[];
+    refineMasks?: boolean;
+  }) => {
+    const segService = getInteractiveServiceManager();
+
+    // Auto-initialize if not ready
+    if (!segService.isSegmentationReady()) {
+      await segService.initialize(settings.get());
+    }
+
+    const response = await segService.refineDetections(args);
+    return response;
+  });
+
   /**
    * Interactive Stereo Service
    */

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -44,6 +44,18 @@ import {
 // defaults to linux if win32 doesn't exist
 const currentPlatform = OS.platform() === 'win32' ? win32 : linux;
 let samWarningShown = false;
+
+const SAM3_PIPELINE_CONFIGS = [
+  'interactive_segmenter_sam3.conf',
+  'interactive_sam3_segmenter.conf',
+];
+
+function isSam3Installed(viamePath: string): boolean {
+  const pipelinesDir = path.join(viamePath, 'configs', 'pipelines');
+  return SAM3_PIPELINE_CONFIGS.some((configName) => fs.existsSync(
+    path.join(pipelinesDir, configName),
+  ));
+}
 if (OS.platform() === 'win32') {
   win32.initialize();
 }
@@ -306,7 +318,7 @@ export default function register() {
     const currentSettings = settings.get();
     const pipelinesDir = path.join(currentSettings.viamePath, 'configs', 'pipelines');
     const hasSam2 = fs.existsSync(path.join(pipelinesDir, 'interactive_segmenter_sam2.conf'));
-    const hasSam3 = fs.existsSync(path.join(pipelinesDir, 'interactive_segmenter_sam3.conf'));
+    const hasSam3 = isSam3Installed(currentSettings.viamePath);
     const noSamInstalled = !hasSam2 && !hasSam3;
 
     // Show a one-time warning if neither SAM pack is installed,
@@ -373,6 +385,11 @@ export default function register() {
   ipcMain.handle('segmentation-is-ready', () => {
     const segService = getInteractiveServiceManager();
     return { ready: segService.isSegmentationReady() };
+  });
+
+  ipcMain.handle('segmentation-sam3-installed', () => {
+    const currentSettings = settings.get();
+    return { installed: isSam3Installed(currentSettings.viamePath) };
   });
 
   ipcMain.handle('segmentation-text-query', async (_, args: {

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -377,6 +377,7 @@ export default function register() {
 
   ipcMain.handle('segmentation-text-query', async (_, args: {
     imagePath: string;
+    frameTime?: number;
     text: string;
     boxThreshold?: number;
     maxDetections?: number;

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -333,6 +333,16 @@ export default function register() {
     return { success: true, noSamInstalled: showWarning };
   });
 
+  // Start the interactive service process WITHOUT warming the point-
+  // segmentation model. Used by the text-query dialog: text query loads its
+  // own (often different/heavier) model lazily and must not force a
+  // segmentation-model load.
+  ipcMain.handle('segmentation-ensure-started', async () => {
+    const segService = getInteractiveServiceManager();
+    await segService.ensureStarted(settings.get());
+    return { success: true };
+  });
+
   ipcMain.handle('segmentation-predict', async (_, args: SegmentationPredictRequest) => {
     const segService = getInteractiveServiceManager();
 
@@ -404,10 +414,10 @@ export default function register() {
   }) => {
     const segService = getInteractiveServiceManager();
 
-    // Auto-initialize if not ready
-    if (!segService.isSegmentationReady()) {
-      await segService.initialize(settings.get());
-    }
+    // Text query only needs the service process running -- not the (possibly
+    // different) point-segmentation model warmed. Start it without warming;
+    // the text-query model loads lazily inside the text_query request.
+    await segService.ensureStarted(settings.get());
 
     const response = await segService.textQuery(args);
     return response;

--- a/client/platform/desktop/backend/native/interactive.ts
+++ b/client/platform/desktop/backend/native/interactive.ts
@@ -450,6 +450,53 @@ export class InteractiveServiceManager extends EventEmitter {
     return { success: true };
   }
 
+  async textQuery(request: {
+    imagePath: string;
+    text: string;
+    boxThreshold?: number;
+    maxDetections?: number;
+    boxes?: [number, number, number, number][];
+    points?: [number, number][];
+    pointLabels?: number[];
+    frameTime?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }): Promise<any> {
+    return this.sendRequest({
+      command: 'text_query',
+      image_path: request.imagePath,
+      text: request.text,
+      box_threshold: request.boxThreshold ?? 0.3,
+      max_detections: request.maxDetections ?? 10,
+      boxes: request.boxes,
+      points: request.points,
+      point_labels: request.pointLabels,
+      frame_time: request.frameTime,
+    }, 'Text query');
+  }
+
+  async refineDetections(request: {
+    imagePath: string;
+    detections: {
+      box: [number, number, number, number];
+      polygon?: [number, number][];
+      score: number;
+      label: string;
+    }[];
+    points?: [number, number][];
+    pointLabels?: number[];
+    refineMasks?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }): Promise<any> {
+    return this.sendRequest({
+      command: 'refine',
+      image_path: request.imagePath,
+      detections: request.detections,
+      points: request.points,
+      point_labels: request.pointLabels,
+      refine_masks: request.refineMasks ?? true,
+    }, 'Refine');
+  }
+
   // ----------------------------------------------------------- stereo API
 
   async enable(

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -335,6 +335,10 @@ async function segmentationIsReady(): Promise<SegmentationStatusResponse> {
   return window.diveDesktop.invoke('segmentation-is-ready');
 }
 
+async function segmentationSam3Installed(): Promise<{ installed: boolean }> {
+  return window.diveDesktop.invoke('segmentation-sam3-installed');
+}
+
 /**
  * Text Query API
  * Allows open-vocabulary detection and segmentation using text prompts
@@ -705,6 +709,7 @@ export {
   segmentationClearImage,
   segmentationShutdown,
   segmentationIsReady,
+  segmentationSam3Installed,
   /* Text Query APIs */
   textQuery,
   refineDetections,

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -7,6 +7,7 @@ import type {
   DatasetCalibrationResult,
   SegmentationPredictRequest, SegmentationPredictResponse, SegmentationStatusResponse,
   SegmentationStereoSegmentRequest, SegmentationStereoSegmentResponse,
+  TextQueryRequest, TextQueryResponse, RefineDetectionsRequest, RefineDetectionsResponse,
 } from 'dive-common/apispec';
 
 import {
@@ -335,6 +336,50 @@ async function segmentationIsReady(): Promise<SegmentationStatusResponse> {
 }
 
 /**
+ * Text Query API
+ * Allows open-vocabulary detection and segmentation using text prompts
+ */
+
+async function textQuery(request: TextQueryRequest): Promise<TextQueryResponse> {
+  return window.diveDesktop.invoke('segmentation-text-query', request);
+}
+
+async function refineDetections(request: RefineDetectionsRequest): Promise<RefineDetectionsResponse> {
+  return window.diveDesktop.invoke('segmentation-refine', request);
+}
+
+/**
+ * Run text query pipeline on all frames
+ */
+async function runTextQueryPipeline(
+  datasetId: string,
+  queryText: string,
+  threshold?: number,
+): Promise<void> {
+  const pipeline: Pipe = {
+    name: 'Text Query',
+    pipe: 'utility_text_query.pipe',
+    type: 'utility',
+  };
+
+  const pipelineParams: Record<string, string> = {
+    'track_refiner:refiner:text_query': queryText,
+  };
+
+  if (threshold !== undefined) {
+    pipelineParams['track_refiner:refiner:detection_threshold'] = threshold.toString();
+  }
+
+  const args: RunPipeline = {
+    type: JobType.RunPipeline,
+    pipeline,
+    datasetId,
+    pipelineParams,
+  };
+  gpuJobQueue.enqueue(args);
+}
+
+/**
  * Interactive Stereo API
  */
 
@@ -656,6 +701,10 @@ export {
   segmentationClearImage,
   segmentationShutdown,
   segmentationIsReady,
+  /* Text Query APIs */
+  textQuery,
+  refineDetections,
+  runTextQueryPipeline,
   /* Stereo APIs */
   stereoEnable,
   stereoDisable,

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -355,19 +355,23 @@ async function runTextQueryPipeline(
   datasetId: string,
   queryText: string,
   threshold?: number,
+  replaceExisting = false,
 ): Promise<void> {
   const pipeline: Pipe = {
     name: 'Text Query',
-    pipe: 'utility_text_query.pipe',
+    pipe: 'utility_text_query_default.pipe',
     type: 'utility',
   };
 
+  // Config keys must address the refiner's sam3 sub-block
+  // (process track_refiner -> :refiner:type sam3 -> block refiner:sam3).
   const pipelineParams: Record<string, string> = {
-    'track_refiner:refiner:text_query': queryText,
+    'track_refiner:refiner:sam3:text_query': queryText,
+    'track_refiner:refiner:sam3:replace_existing': replaceExisting ? 'true' : 'false',
   };
 
   if (threshold !== undefined) {
-    pipelineParams['track_refiner:refiner:detection_threshold'] = threshold.toString();
+    pipelineParams['track_refiner:refiner:sam3:detection_threshold'] = threshold.toString();
   }
 
   const args: RunPipeline = {

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -309,6 +309,12 @@ async function segmentationInitialize(): Promise<{ success: boolean; noSamInstal
   return window.diveDesktop.invoke('segmentation-initialize');
 }
 
+// Start the interactive service process without warming the point-segmentation
+// model (used by text query, which loads its own model lazily).
+async function segmentationEnsureStarted(): Promise<{ success: boolean }> {
+  return window.diveDesktop.invoke('segmentation-ensure-started');
+}
+
 async function segmentationPredict(request: SegmentationPredictRequest): Promise<SegmentationPredictResponse> {
   return window.diveDesktop.invoke('segmentation-predict', request);
 }
@@ -703,6 +709,7 @@ export {
   deleteCalibration,
   /* Segmentation APIs */
   segmentationInitialize,
+  segmentationEnsureStarted,
   segmentationPredict,
   segmentationStereoSegment,
   segmentationSetImage,

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -374,21 +374,23 @@ async function runTextQueryPipeline(
   };
 
   // Config keys must address the refiner's sam3 sub-block
-  // (process track_refiner -> :refiner:type sam3 -> block refiner:sam3).
-  const pipelineParams: Record<string, string> = {
+  // (process track_refiner -> :refiner:type sam3 -> block refiner:sam3), and
+  // must go under kwiverParams -- that is the only place runPipeline() threads
+  // into "-s key=value" flags on the viame runner command.
+  const kwiverParams: Record<string, string> = {
     'track_refiner:refiner:sam3:text_query': queryText,
     'track_refiner:refiner:sam3:replace_existing': replaceExisting ? 'true' : 'false',
   };
 
   if (threshold !== undefined) {
-    pipelineParams['track_refiner:refiner:sam3:detection_threshold'] = threshold.toString();
+    kwiverParams['track_refiner:refiner:sam3:detection_threshold'] = threshold.toString();
   }
 
   const args: RunPipeline = {
     type: JobType.RunPipeline,
     pipeline,
     datasetId,
-    pipelineParams,
+    pipelineParams: { kwiverParams },
   };
   gpuJobQueue.enqueue(args);
 }

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -246,6 +246,10 @@ export default defineComponent({
             : undefined;
         }
 
+        // Share the resolvers with text query (handles video + multicam).
+        segmentationGetImagePath = getImagePath;
+        segmentationGetFrameTime = getFrameTime;
+
         // Initialize the recipe
         // Desktop uses imagePath from the request, so we ignore the frameNum parameter
         viewerRef.value.segmentationRecipe.initialize({
@@ -285,6 +289,12 @@ export default defineComponent({
       type: string;
       originalVideoFile?: string;
     } | null = null;
+
+    // Frame -> media-path / frame-time resolvers built by initializeSegmentation.
+    // Shared with text query so it resolves video and multicam media the same way
+    // segmentation does (selected-camera aware, video frame-time aware).
+    let segmentationGetImagePath: ((frameNum: number) => string) | null = null;
+    let segmentationGetFrameTime: ((frameNum: number) => number | undefined) | undefined;
 
     /**
      * Get image path for a given frame number
@@ -337,7 +347,11 @@ export default defineComponent({
         }
       }
 
-      const imagePath = getImagePathForFrame(frameNum);
+      // Prefer the segmentation resolvers (selected-camera + video aware); fall
+      // back to the single-cam image-sequence getter if segmentation never
+      // initialized.
+      const imagePath = segmentationGetImagePath?.(frameNum) || getImagePathForFrame(frameNum);
+      const frameTime = segmentationGetFrameTime?.(frameNum);
       if (!imagePath) {
         await prompt({
           title: 'Text Query Error',
@@ -349,6 +363,7 @@ export default defineComponent({
       try {
         const response = await textQuery({
           imagePath,
+          frameTime,
           text,
           boxThreshold,
           maxDetections: 10,

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -24,6 +24,7 @@ import {
 import type { RectBounds } from 'vue-media-annotator/utils';
 import {
   segmentationPredict, segmentationStereoSegment, segmentationInitialize, segmentationIsReady,
+  segmentationEnsureStarted,
   segmentationSam3Installed,
   loadMetadata, textQuery,
   runTextQueryPipeline,
@@ -545,8 +546,9 @@ export default defineComponent({
           return;
         }
 
-        // Try to initialize the service
-        await segmentationInitialize();
+        // Start the service process only -- do NOT warm the point-segmentation
+        // model. The text-query model loads lazily on the first query.
+        await segmentationEnsureStarted();
         viewerRef.value?.onTextQueryServiceReady(true);
       } catch (error) {
         // Provide text-query specific error message instead of generic segmentation error

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -321,6 +321,11 @@ export default defineComponent({
     /**
      * Handle text query submission from Viewer
      */
+    // Loading state for the single-frame (interactive) text query. The
+    // all-frames path runs as a pipeline job with its own progress UI, so it
+    // does not use this.
+    const textQueryRunning = ref(false);
+
     async function handleTextQuerySubmit(params: {
       text: string;
       boxThreshold: number;
@@ -363,6 +368,7 @@ export default defineComponent({
         return;
       }
 
+      textQueryRunning.value = true;
       try {
         const response = await textQuery({
           imagePath,
@@ -371,6 +377,8 @@ export default defineComponent({
           boxThreshold,
           maxDetections: 10,
         });
+        // Query finished; drop the loading bar before any result/error prompts.
+        textQueryRunning.value = false;
 
         if (!response.success) {
           throw new Error(response.error || 'Text query failed');
@@ -471,11 +479,13 @@ export default defineComponent({
           });
         }
       } catch (error) {
+        textQueryRunning.value = false;
         await prompt({
           title: 'Text Query Error',
           text: [`Failed to execute text query: ${error}`],
         });
       } finally {
+        textQueryRunning.value = false;
         // Exit edit/draw mode after text query completes (success or failure)
         if (viewerRef.value?.handler) {
           viewerRef.value.handler.trackAbort();
@@ -1591,6 +1601,7 @@ export default defineComponent({
       /* Stereo */
       stereoLoadingDialog,
       stereoLoadingMessage,
+      textQueryRunning,
       stereoLoadingError,
       stereoLengthSnackbar,
       stereoLengthMessage,
@@ -1688,6 +1699,26 @@ export default defineComponent({
         </SidebarContext>
       </template>
     </Viewer>
+    <v-dialog
+      :value="textQueryRunning"
+      persistent
+      max-width="420"
+    >
+      <v-card>
+        <v-card-title class="text-h6">
+          Text Query
+        </v-card-title>
+        <v-card-text>
+          <div class="mb-2">
+            Searching the current frame&hellip;
+          </div>
+          <v-progress-linear
+            indeterminate
+            color="primary"
+          />
+        </v-card-text>
+      </v-card>
+    </v-dialog>
     <v-dialog
       :value="stereoLoadingDialog"
       persistent

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -437,6 +437,14 @@ export default defineComponent({
               newTrackId, // Use the new track ID
             );
 
+            // add() seeds the confidence pair at 1.0; apply the detection's
+            // actual confidence from the text-query model so it isn't shown
+            // as 100%. (setType clamps >=1 to 1.0, which is the correct
+            // behavior for a genuinely-1.0 score.)
+            if (typeof det.score === 'number') {
+              newTrack.setType(det.label, det.score);
+            }
+
             // Calculate bounds from box [x1, y1, x2, y2]
             const [x1, y1, x2, y2] = det.box;
             const bounds = [x1, y1, x2, y2] as [number, number, number, number];

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -24,11 +24,13 @@ import {
 import type { RectBounds } from 'vue-media-annotator/utils';
 import {
   segmentationPredict, segmentationStereoSegment, segmentationInitialize, segmentationIsReady,
+  segmentationSam3Installed,
   loadMetadata, textQuery,
   runTextQueryPipeline,
   stereoEnable, stereoDisable, stereoSetFrame, stereoTransferLine, stereoTransferPoints,
   stereoMeasureLine, stereoAggregateLengths,
   onStereoDisparityReady, onStereoDisparityError,
+  openLink,
 } from 'platform/desktop/frontend/api';
 import Export from './Export.vue';
 import JobTab from './JobTab.vue';
@@ -122,6 +124,20 @@ export default defineComponent({
     });
     const readOnlyMode = computed(() => settings.value?.readonlyMode || false);
     const timeFilter: Ref<[number, number] | null> = ref(null);
+    const textQueryAvailable = ref(false);
+
+    async function refreshTextQueryAvailability() {
+      try {
+        const result = await segmentationSam3Installed();
+        textQueryAvailable.value = result.installed;
+      } catch {
+        textQueryAvailable.value = false;
+      }
+    }
+
+    watch(() => settings.value?.viamePath, () => {
+      refreshTextQueryAvailability();
+    });
 
     watch(
       () => viewerRef.value?.trackFilters?.timeFilters?.value,
@@ -504,6 +520,7 @@ export default defineComponent({
     // Initialize segmentation when component is mounted
     onMounted(() => {
       initializeSegmentation();
+      refreshTextQueryAvailability();
     });
 
     /**
@@ -1606,6 +1623,8 @@ export default defineComponent({
       handleTextQuerySubmit,
       handleTextQueryInit,
       handleTextQueryAllFrames,
+      textQueryAvailable,
+      openLink,
       /* Stereo */
       stereoLoadingDialog,
       stereoLoadingMessage,
@@ -1632,11 +1651,13 @@ export default defineComponent({
       ref="viewerRef"
       :read-only-mode="readOnlyMode || runningPipelines.length > 0"
       :text-query-enabled="true"
+      :text-query-available="textQueryAvailable"
       @change-camera="changeCamera"
       @large-image-warning="largeImageWarning()"
       @text-query-submit="handleTextQuerySubmit"
       @text-query-init="handleTextQueryInit"
       @text-query-all-frames="handleTextQueryAllFrames"
+      @open-external-link="openLink"
       @stereo-annotation-complete="handleStereoAnnotationComplete"
       @stereo-annotation-reset="handleStereoAnnotationReset"
       @stereo-segmentation-finalize="handleStereoSegmentationFinalize"

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -325,8 +325,11 @@ export default defineComponent({
       text: string;
       boxThreshold: number;
       frameNum: number;
+      replaceExisting?: boolean;
     }) {
-      const { text, boxThreshold, frameNum } = params;
+      const {
+        text, boxThreshold, frameNum, replaceExisting = false,
+      } = params;
 
       // Ensure metadata is loaded
       if (!cachedMeta) {
@@ -375,6 +378,35 @@ export default defineComponent({
 
         const detections = response.detections || [];
 
+        // Resolve the target camera/track store up front so that "replace"
+        // can clear the current frame even when the query returns nothing.
+        const cameraStore = viewerRef.value?.cameraStore;
+        const selectedCamera = viewerRef.value?.selectedCamera || 'singleCam';
+        const trackStore = cameraStore?.camMap.value.get(selectedCamera)?.trackStore;
+
+        // When replacing, remove annotations already present on this frame
+        // before adding the query results. Tracks that exist only on this
+        // frame are removed entirely; tracks spanning other frames lose just
+        // this frame's feature (and are removed if that empties them). Other
+        // frames' annotations are left untouched.
+        if (replaceExisting && cameraStore && trackStore) {
+          const removeIds: number[] = [];
+          trackStore.annotationMap.forEach((track) => {
+            if (frameNum < track.begin || frameNum > track.end) {
+              return;
+            }
+            if (track.begin === frameNum && track.end === frameNum) {
+              removeIds.push(track.id);
+            } else {
+              track.deleteFeature(frameNum);
+              if (track.featureIndex.length === 0) {
+                removeIds.push(track.id);
+              }
+            }
+          });
+          removeIds.forEach((id) => cameraStore.remove(id, selectedCamera));
+        }
+
         if (detections.length === 0) {
           await prompt({
             title: 'Text Query Results',
@@ -384,19 +416,7 @@ export default defineComponent({
         }
 
         // Create tracks from detections
-        if (viewerRef.value) {
-          const { cameraStore } = viewerRef.value;
-          const selectedCamera = viewerRef.value.selectedCamera || 'singleCam';
-          const trackStore = cameraStore.camMap.value.get(selectedCamera)?.trackStore;
-
-          if (!trackStore) {
-            await prompt({
-              title: 'Text Query Error',
-              text: ['Could not create tracks - trackStore not found.'],
-            });
-            return;
-          }
-
+        if (cameraStore && trackStore) {
           detections.forEach((det) => {
             // Get a new unique track ID
             const newTrackId = cameraStore.getNewTrackId();
@@ -500,11 +520,12 @@ export default defineComponent({
     async function handleTextQueryAllFrames(params: {
       text: string;
       boxThreshold: number;
+      replaceExisting?: boolean;
     }) {
-      const { text, boxThreshold } = params;
+      const { text, boxThreshold, replaceExisting = false } = params;
 
       try {
-        await runTextQueryPipeline(props.id, text, boxThreshold);
+        await runTextQueryPipeline(props.id, text, boxThreshold, replaceExisting);
         await prompt({
           title: 'Text Query Pipeline Started',
           text: [

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -24,7 +24,8 @@ import {
 import type { RectBounds } from 'vue-media-annotator/utils';
 import {
   segmentationPredict, segmentationStereoSegment, segmentationInitialize, segmentationIsReady,
-  loadMetadata,
+  loadMetadata, textQuery,
+  runTextQueryPipeline,
   stereoEnable, stereoDisable, stereoSetFrame, stereoTransferLine, stereoTransferPoints,
   stereoMeasureLine, stereoAggregateLengths,
   onStereoDisparityReady, onStereoDisparityError,
@@ -277,7 +278,7 @@ export default defineComponent({
       }
     }
 
-    // Store metadata for video frame-time / image path resolution
+    // Store metadata for text query image path resolution
     let cachedMeta: {
       originalBasePath: string;
       originalImageFiles: string[];
@@ -285,10 +286,224 @@ export default defineComponent({
       originalVideoFile?: string;
     } | null = null;
 
+    /**
+     * Get image path for a given frame number
+     */
+    function getImagePathForFrame(frameNum: number): string {
+      if (!cachedMeta) {
+        return '';
+      }
+      const { originalBasePath, originalImageFiles, type } = cachedMeta;
+      if (type === 'video') {
+        // Video datasets require frame extraction - not yet supported
+        return npath.join(originalBasePath, cachedMeta.originalVideoFile || '');
+      }
+      if (originalImageFiles && originalImageFiles[frameNum]) {
+        const imagePath = originalImageFiles[frameNum];
+        if (npath.isAbsolute(imagePath)) {
+          return imagePath;
+        }
+        return npath.join(originalBasePath, imagePath);
+      }
+      return '';
+    }
+
+    /**
+     * Handle text query submission from Viewer
+     */
+    async function handleTextQuerySubmit(params: {
+      text: string;
+      boxThreshold: number;
+      frameNum: number;
+    }) {
+      const { text, boxThreshold, frameNum } = params;
+
+      // Ensure metadata is loaded
+      if (!cachedMeta) {
+        try {
+          const meta = await loadMetadata(props.id);
+          cachedMeta = {
+            originalBasePath: meta.originalBasePath,
+            originalImageFiles: meta.originalImageFiles,
+            type: meta.type,
+            originalVideoFile: meta.originalVideoFile,
+          };
+        } catch {
+          await prompt({
+            title: 'Text Query Error',
+            text: ['Failed to load dataset metadata for text query.'],
+          });
+          return;
+        }
+      }
+
+      const imagePath = getImagePathForFrame(frameNum);
+      if (!imagePath) {
+        await prompt({
+          title: 'Text Query Error',
+          text: ['Could not determine image path for current frame.'],
+        });
+        return;
+      }
+
+      try {
+        const response = await textQuery({
+          imagePath,
+          text,
+          boxThreshold,
+          maxDetections: 10,
+        });
+
+        if (!response.success) {
+          throw new Error(response.error || 'Text query failed');
+        }
+
+        const detections = response.detections || [];
+
+        if (detections.length === 0) {
+          await prompt({
+            title: 'Text Query Results',
+            text: [`No objects matching "${text}" were found in the current frame.`],
+          });
+          return;
+        }
+
+        // Create tracks from detections
+        if (viewerRef.value) {
+          const { cameraStore } = viewerRef.value;
+          const selectedCamera = viewerRef.value.selectedCamera || 'singleCam';
+          const trackStore = cameraStore.camMap.value.get(selectedCamera)?.trackStore;
+
+          if (!trackStore) {
+            await prompt({
+              title: 'Text Query Error',
+              text: ['Could not create tracks - trackStore not found.'],
+            });
+            return;
+          }
+
+          detections.forEach((det) => {
+            // Get a new unique track ID
+            const newTrackId = cameraStore.getNewTrackId();
+
+            // Create a new track with the detection label as its type
+            const newTrack = trackStore.add(
+              frameNum,
+              det.label, // Use the detection label as the track type
+              undefined, // No parent track
+              newTrackId, // Use the new track ID
+            );
+
+            // Calculate bounds from box [x1, y1, x2, y2]
+            const [x1, y1, x2, y2] = det.box;
+            const bounds = [x1, y1, x2, y2] as [number, number, number, number];
+
+            // Create GeoJSON features array for polygon if available
+            const geoJsonFeatures: GeoJSON.Feature[] = [];
+            if (det.polygon && det.polygon.length >= 3) {
+              // Ensure polygon is closed (first point = last point for GeoJSON)
+              const closedPolygon = [...det.polygon];
+              const first = closedPolygon[0];
+              const last = closedPolygon[closedPolygon.length - 1];
+              if (first[0] !== last[0] || first[1] !== last[1]) {
+                closedPolygon.push([...first] as [number, number]);
+              }
+
+              const polygonFeature: GeoJSON.Feature = {
+                type: 'Feature',
+                geometry: {
+                  type: 'Polygon',
+                  coordinates: [closedPolygon],
+                },
+                properties: { key: '' },
+              };
+              geoJsonFeatures.push(polygonFeature);
+            }
+
+            // Set the feature with bounds and optional polygon
+            newTrack.setFeature({
+              frame: frameNum,
+              flick: 0,
+              keyframe: true,
+              bounds,
+              interpolate: false, // Single detection, no interpolation
+            }, geoJsonFeatures.length > 0 ? geoJsonFeatures : undefined);
+          });
+
+          await prompt({
+            title: 'Text Query Results',
+            text: [`Created ${detections.length} tracks for objects matching "${text}".`],
+          });
+        }
+      } catch (error) {
+        await prompt({
+          title: 'Text Query Error',
+          text: [`Failed to execute text query: ${error}`],
+        });
+      } finally {
+        // Exit edit/draw mode after text query completes (success or failure)
+        if (viewerRef.value?.handler) {
+          viewerRef.value.handler.trackAbort();
+        }
+      }
+    }
+
     // Initialize segmentation when component is mounted
     onMounted(() => {
       initializeSegmentation();
     });
+
+    /**
+     * Handle text query service initialization request
+     * Called when user opens the text query dialog
+     */
+    async function handleTextQueryInit() {
+      try {
+        // Check if the service is already ready
+        const status = await segmentationIsReady();
+        if (status.ready) {
+          viewerRef.value?.onTextQueryServiceReady(true);
+          return;
+        }
+
+        // Try to initialize the service
+        await segmentationInitialize();
+        viewerRef.value?.onTextQueryServiceReady(true);
+      } catch (error) {
+        // Provide text-query specific error message instead of generic segmentation error
+        const rawMessage = error instanceof Error ? error.message : '';
+        const errorMessage = rawMessage.toLowerCase().includes('segmentation')
+          ? 'Unable to load text query model. Please ensure the service is properly configured.'
+          : (rawMessage || 'Text query model is not available. Please ensure the service is properly configured.');
+        viewerRef.value?.onTextQueryServiceReady(false, errorMessage);
+      }
+    }
+
+    /**
+     * Handle text query on all frames - runs as a pipeline job
+     */
+    async function handleTextQueryAllFrames(params: {
+      text: string;
+      boxThreshold: number;
+    }) {
+      const { text, boxThreshold } = params;
+
+      try {
+        await runTextQueryPipeline(props.id, text, boxThreshold);
+        await prompt({
+          title: 'Text Query Pipeline Started',
+          text: [
+            `A pipeline job has been started to search for "${text}" in all frames.`,
+            'You will be notified when the job completes.',
+          ],
+        });
+      } catch (error) {
+        await prompt({
+          title: 'Text Query Pipeline Error',
+          text: [`Failed to start text query pipeline: ${error}`],
+        });
+      }
+    }
 
     /**
      * Interactive Stereo Service
@@ -1334,6 +1549,9 @@ export default defineComponent({
       runningPipelines,
       largeImageWarning,
       timeFilter,
+      handleTextQuerySubmit,
+      handleTextQueryInit,
+      handleTextQueryAllFrames,
       /* Stereo */
       stereoLoadingDialog,
       stereoLoadingMessage,
@@ -1358,8 +1576,12 @@ export default defineComponent({
       :id.sync="id"
       ref="viewerRef"
       :read-only-mode="readOnlyMode || runningPipelines.length > 0"
+      :text-query-enabled="true"
       @change-camera="changeCamera"
       @large-image-warning="largeImageWarning()"
+      @text-query-submit="handleTextQuerySubmit"
+      @text-query-init="handleTextQueryInit"
+      @text-query-all-frames="handleTextQueryAllFrames"
       @stereo-annotation-complete="handleStereoAnnotationComplete"
       @stereo-annotation-reset="handleStereoAnnotationReset"
       @stereo-segmentation-finalize="handleStereoSegmentationFinalize"

--- a/client/platform/desktop/frontend/store/jobs.ts
+++ b/client/platform/desktop/frontend/store/jobs.ts
@@ -16,6 +16,7 @@ import {
   RunTraining,
   JsonMeta,
 } from 'platform/desktop/constants';
+import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import AsyncGpuJobQueue from './queues/asyncGpuJobQueue';
 import AsyncCpuJobQueue from './queues/asyncCpuJobQueue';
 import { setRecents } from './dataset';
@@ -24,6 +25,9 @@ interface DesktopJobHistory {
   job: DesktopJob;
   truncatedLogs: string[];
   totalLogLength: number;
+  // Set once we've surfaced this job's failure to the user, so the repeated
+  // updates that arrive don't re-open the dialog.
+  errorNotified?: boolean;
 }
 
 const truncateOutputAtLines = 500;
@@ -63,6 +67,36 @@ export function updateHistory(args: DesktopJobUpdate) {
   }
   if (args.endTime !== undefined) {
     existing.job.endTime = args.endTime;
+  }
+
+  // Surface a failed job's error to the user. The process reports the cause on
+  // lines beginning with "ERROR:" (DIVE convention); we only prompt when the
+  // job has actually exited with a non-zero, non-cancellation code and at
+  // least one such line was captured.
+  const finished = existing.job.endTime !== undefined;
+  const failed = existing.job.exitCode !== null
+    && existing.job.exitCode !== 0
+    && existing.job.exitCode !== cancelledJobExitCode
+    && !existing.job.cancelledJob;
+  if (finished && failed && !existing.errorNotified) {
+    existing.errorNotified = true;
+    const errorLines = existing.truncatedLogs
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('ERROR:'))
+      .map((line) => line.replace(/^ERROR:\s*/, ''));
+    if (errorLines.length > 0) {
+      try {
+        const { prompt } = usePrompt();
+        prompt({
+          title: `${existing.job.title || 'Job'} failed`,
+          text: errorLines,
+          positiveButton: 'OK',
+        });
+      } catch {
+        // Prompt service not available (e.g. very early startup); the error
+        // is still visible in the job log.
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #1582. Adds the SAM3 interactive **text-query annotation button** on top of the interactive segmentation + stereo branch.

## Changes
- EditorMenu text-query button + dialog (query text, threshold, all-frames toggle).
- `textQuery` / `refineDetections` / `runTextQueryPipeline` frontend API + IPC handlers.
- Text-query methods on the consolidated interactive service.
- Viewer / ViewerLoader wiring (`text-query-init` / `text-query` / `text-query-all-frames`, service-ready forwarding).

## Notes
- Stacked on `dev/add-interactive-seg-and-stereo`; review/merge #1582 first.
- Builds web + electron; unit suite green (217 tests).
