### PR TITLE
improve calibration file importing

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -241,6 +241,10 @@ interface Api {
     subfolderPath: string,
     mediaType: 'image-sequence' | 'video',
   ): Promise<string>;
+  /** Desktop: stereoscopic calibration file in a parent folder root. */
+  findParentFolderCalibrationFile?(parentPath: string): Promise<string | null>;
+  /** Web: stash a calibration File for multicam upload lookup. */
+  stashCalibrationFile?(key: string, file: File): void;
   getTiles?(itemId: string, projection?: string): Promise<StringKeyObject>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getTileURL?(itemId: string, x: number, y: number, level: number, query: Record<string, any>):

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamCalibration.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamCalibration.vue
@@ -1,0 +1,48 @@
+<!--
+  Stereoscopic calibration file picker. Requires `ctx`; uses calibrationFile and open from ctx.
+-->
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { importMultiCamContextProp } from './importMultiCamContext';
+
+export default defineComponent({
+  name: 'ImportMultiCamCalibration',
+  props: {
+    ...importMultiCamContextProp,
+  },
+  setup(props) {
+    const { calibrationFile, open } = props.ctx;
+    return {
+      calibrationFile,
+      open,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-row
+    no-gutters
+    class="align-center my-3"
+  >
+    <v-text-field
+      label="Calibration File"
+      placeholder="Not selected"
+      disabled
+      outlined
+      dense
+      hide-details
+      :value="calibrationFile"
+      class="mr-3"
+    />
+    <v-btn
+      color="primary"
+      @click="open('calibration', 'calibration')"
+    >
+      Choose calibration
+      <v-icon class="ml-2">
+        mdi-matrix
+      </v-icon>
+    </v-btn>
+  </v-row>
+</template>

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamDialog.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamDialog.vue
@@ -13,6 +13,7 @@ import ImportMultiCamSubfolders from './ImportMultiCamSubfolders.vue';
 import ImportMultiCamMultiFolder from './ImportMultiCamMultiFolder.vue';
 import ImportMultiCamKeyword from './ImportMultiCamKeyword.vue';
 import ImportMultiCamFinalizeStep from './ImportMultiCamFinalizeStep.vue';
+import ImportMultiCamCalibration from './ImportMultiCamCalibration.vue';
 
 export default defineComponent({
   name: 'ImportMultiCamDialog',
@@ -22,6 +23,7 @@ export default defineComponent({
     ImportMultiCamMultiFolder,
     ImportMultiCamKeyword,
     ImportMultiCamFinalizeStep,
+    ImportMultiCamCalibration,
   },
   props: {
     stereo: {
@@ -105,6 +107,11 @@ export default defineComponent({
         :stereo="stereo"
       />
 
+      <ImportMultiCamCalibration
+        v-if="stereo && importType"
+        :ctx="ctx"
+      />
+
       <div>
         <v-alert
           v-if="errorMessage"
@@ -127,7 +134,6 @@ export default defineComponent({
         </v-alert>
         <ImportMultiCamFinalizeStep
           :ctx="ctx"
-          :stereo="stereo"
           :show-default-display="camerasReady"
         />
       </div>

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamFinalizeStep.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamFinalizeStep.vue
@@ -1,6 +1,5 @@
 <!--
-  Dataset name, default display, and calibration UI. Requires `ctx`; reads finalize
-  fields from props.ctx (datasetName, defaultDisplay, open, …).
+  Dataset name, default display. Requires `ctx`; reads finalize fields from props.ctx.
 -->
 <script lang="ts">
 import { defineComponent } from 'vue';
@@ -10,10 +9,6 @@ export default defineComponent({
   name: 'ImportMultiCamFinalizeStep',
   props: {
     ...importMultiCamContextProp,
-    stereo: {
-      type: Boolean,
-      default: false,
-    },
     showDatasetName: {
       type: Boolean,
       default: true,
@@ -34,8 +29,6 @@ export default defineComponent({
       defaultDisplay,
       displayKeys,
       displayKeysKey,
-      calibrationFile,
-      open,
     } = props.ctx;
     return {
       datasetName,
@@ -43,8 +36,6 @@ export default defineComponent({
       defaultDisplay,
       displayKeys,
       displayKeysKey,
-      calibrationFile,
-      open,
     };
   },
 });
@@ -87,31 +78,5 @@ export default defineComponent({
         :label="cameraKey"
       />
     </v-radio-group>
-    <v-row
-      v-if="stereo"
-      no-gutters
-      class="align-center"
-      :class="{ 'mt-2': showDefaultDisplayInfo }"
-    >
-      <v-text-field
-        label="Calibration File:"
-        placeholder="Choose File"
-        disabled
-        outlined
-        dense
-        hide-details
-        :value="calibrationFile"
-        class="mr-3"
-      />
-      <v-btn
-        color="primary"
-        @click="open('calibration', 'calibration')"
-      >
-        Open Calibration File
-        <v-icon class="ml-2">
-          mdi-matrix
-        </v-icon>
-      </v-btn>
-    </v-row>
   </div>
 </template>

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamSubfolders.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamSubfolders.vue
@@ -5,6 +5,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
 import { DatasetType } from 'dive-common/apispec';
+import { ImageSequenceType } from 'dive-common/constants';
 import ImportMultiCamCameraGroup from './ImportMultiCamCameraGroup.vue';
 import ImportMultiCamChooseSource from './ImportMultiCamChooseSource.vue';
 import ImportMultiCamCameraOrderControls from './ImportMultiCamCameraOrderControls.vue';
@@ -42,6 +43,8 @@ export default defineComponent({
       deleteSet: props.ctx.deleteSet,
       onRenameCamera: props.ctx.onRenameCamera,
       openParentFolder: props.ctx.openParentFolder,
+      open: props.ctx.open,
+      ImageSequenceType,
     };
   },
 });
@@ -120,10 +123,11 @@ export default defineComponent({
         :camera-name="key"
         :data-type="dataType"
         :value="subfolderOriginalNames[key] || key"
-        :hide-actions="true"
+        @open="open(dataType, key)"
+        @open-text="open('text', key)"
       />
       <v-chip
-        v-if="pendingImportPayloads[key]"
+        v-if="dataType === ImageSequenceType && pendingImportPayloads[key]"
         :color="pendingImportPayloads[key].jsonMeta.originalImageFiles.length ? 'success' : 'error'"
         outlined
         class="mt-2"
@@ -134,7 +138,6 @@ export default defineComponent({
     <ImportMultiCamFinalizeStep
       v-if="camerasReady"
       :ctx="ctx"
-      :stereo="stereo"
       show-default-display-info
     />
   </div>

--- a/client/dive-common/components/ImportMultiCamDialog/README.md
+++ b/client/dive-common/components/ImportMultiCamDialog/README.md
@@ -37,6 +37,7 @@ ImportMultiCamDialog.vue          Shell: platform props, ctx wiring, errors, act
 ├── ImportMultiCamSubfolders.vue
 ├── ImportMultiCamKeyword.vue
 ├── ImportMultiCamFinalizeStep.vue
+├── ImportMultiCamCalibration.vue
 ├── ImportMultiCamCameraOrderControls.vue
 │
 └── Primitives (presentational)

--- a/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
@@ -22,6 +22,7 @@ import {
   organizeSubfolderCameras,
   pickDefaultMulticamCamera,
 } from 'dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout';
+import { findStereoCalibrationInFileList } from 'dive-common/stereoParentFolder';
 import { ImageSequenceType, VideoType } from 'dive-common/constants';
 import { useRequest } from 'dive-common/use';
 import {
@@ -51,8 +52,10 @@ export function useImportMultiCamDialog(
     openFromDisk,
     getLastCalibration,
     saveCalibration,
+    stashCalibrationFile,
     listParentFolderCameras,
     resolveMulticamCameraSourcePath,
+    findParentFolderCalibrationFile,
   } = useApi();
   const importType: Ref<MulticamImportType> = ref('');
   const folderList: Ref<Record<string, { sourcePath: string; trackFile: string }>> = ref({});
@@ -102,6 +105,7 @@ export function useImportMultiCamDialog(
     parentFolderName.value = '';
     subfolderLayoutLabel.value = '';
     datasetName.value = '';
+    calibrationFile.value = '';
     subfolderOriginalNames.value = {};
     cameraOrder.value = [];
     defaultDisplay.value = props.stereo ? 'left' : 'center';
@@ -110,12 +114,15 @@ export function useImportMultiCamDialog(
         left: { sourcePath: '', trackFile: '' },
         right: { sourcePath: '', trackFile: '' },
       };
+    } else {
+      folderList.value = {};
+    }
+    if (props.stereo && importType.value === 'keyword') {
       globList.value = {
         left: { glob: '', trackFile: '' },
         right: { glob: '', trackFile: '' },
       };
     } else {
-      folderList.value = {};
       globList.value = {};
     }
 
@@ -131,11 +138,15 @@ export function useImportMultiCamDialog(
       }
     } else if (importType.value === 'keyword') {
       pendingImportPayloads.value = { keyword: null };
+      if (props.stereo) {
+        cameraOrder.value = ['left', 'right'];
+        defaultDisplay.value = 'left';
+      }
     }
   };
   clearCameraSet();
 
-  if (props.dataType === VideoType) {
+  if (props.dataType === VideoType && !props.enableSubfolderImport) {
     importType.value = 'multi';
   }
 
@@ -289,6 +300,12 @@ export function useImportMultiCamDialog(
         datasetName.value = parentFolderName.value;
       }
 
+      await discoverParentFolderCalibration(
+        parentPath,
+        ret.fileList,
+        ret.root || parentPath,
+      );
+
       let { assignments } = organized;
       if (useDesktopDiscovery) {
         if (desktopCameras?.length) {
@@ -330,7 +347,11 @@ export function useImportMultiCamDialog(
         if (grouped && !files.length) {
           throw new Error(`Camera "${organized.assignments[i].folderName}" has no media files`);
         }
-        Vue.set(subfolderOriginalNames.value, cameraName, organized.assignments[i].folderName);
+        Vue.set(
+          subfolderOriginalNames.value,
+          cameraName,
+          subfolderSourceDisplayLabel(sourcePath, organized.assignments[i].folderName),
+        );
         Vue.set(folderList.value, cameraName, { sourcePath, trackFile: '' });
         // eslint-disable-next-line no-await-in-loop -- import each camera media sequentially
         const mediaPayload = await props.importMedia(sourcePath);
@@ -385,6 +406,41 @@ export function useImportMultiCamDialog(
     syncDefaultDisplay();
   }
 
+  async function updateSubfolderCameraSource(
+    cameraKey: string,
+    sourcePath: string,
+    displayRoot?: string,
+    files: File[] = [],
+  ) {
+    const mediaType = props.dataType === VideoType ? 'video' : 'image-sequence';
+    let resolvedPath = sourcePath;
+    if (resolveMulticamCameraSourcePath) {
+      resolvedPath = await resolveMulticamCameraSourcePath(sourcePath, mediaType);
+    }
+    const oldSourcePath = folderList.value[cameraKey]?.sourcePath;
+    if (oldSourcePath && props.unregisterSubfolderCamera) {
+      props.unregisterSubfolderCamera(oldSourcePath);
+    }
+    const displayName = props.dataType === VideoType
+      ? (resolvedPath.split(/[/\\]/).pop() || cameraKey)
+      : ((displayRoot || sourcePath).split(/[/\\]/).pop() || cameraKey);
+    Vue.set(subfolderOriginalNames.value, cameraKey, displayName);
+    folderList.value[cameraKey].sourcePath = resolvedPath;
+    folderList.value[cameraKey].trackFile = '';
+    if (props.registerSubfolderCameras && files.length) {
+      props.registerSubfolderCameras([{
+        cameraName: cameraKey,
+        sourcePath: resolvedPath,
+        files,
+      }]);
+    }
+    Vue.set(
+      pendingImportPayloads.value,
+      cameraKey,
+      await props.importMedia(resolvedPath),
+    );
+  }
+
   async function openAnnotationFile(folder: string) {
     const ret = await openFromDisk('annotation');
     if (!ret.canceled) {
@@ -395,8 +451,12 @@ export function useImportMultiCamDialog(
     }
   }
 
-  async function open(dstype: DatasetType | 'calibration' | 'text', folder: string | 'calibration') {
-    const ret = await openFromDisk(dstype, dstype === 'image-sequence');
+  async function open(
+    dstype: DatasetType | 'calibration' | 'text',
+    folder: string | 'calibration',
+    directory = false,
+  ) {
+    const ret = await openFromDisk(dstype, directory || dstype === 'image-sequence');
     if (!ret.canceled) {
       const path = ret.filePaths[0];
       if (folder === 'calibration') {
@@ -417,6 +477,14 @@ export function useImportMultiCamDialog(
           folder,
           await importRequest(() => props.importMedia(sourcePath)),
         );
+      } else if (importType.value === 'subfolders') {
+        const sourcePath = ret.root || path;
+        await importRequest(() => updateSubfolderCameraSource(
+          folder,
+          sourcePath,
+          ret.root,
+          ret.fileList ?? [],
+        ));
       } else if (importType.value === 'keyword') {
         [keywordFolder.value] = ret.filePaths;
         if (ret.root) {
@@ -498,6 +566,44 @@ export function useImportMultiCamDialog(
   const datasetNameRules = [
     (val: string) => (val || '').trim().length > 0 || 'Dataset name is required',
   ];
+
+  function subfolderSourceDisplayLabel(
+    sourcePath: string,
+    folderName: string,
+  ): string {
+    if (props.dataType === VideoType) {
+      return sourcePath.split(/[/\\]/).pop() || folderName;
+    }
+    return folderName;
+  }
+
+  async function discoverParentFolderCalibration(
+    parentPath: string,
+    fileList?: File[],
+    root?: string,
+  ) {
+    if (!props.stereo) {
+      return;
+    }
+    let discoveredPath: string | null = null;
+    let discoveredFile: File | undefined;
+    if (fileList?.length) {
+      const found = findStereoCalibrationInFileList(fileList, root || parentPath, commonPathPrefix);
+      if (found) {
+        discoveredPath = found.path;
+        discoveredFile = found.file;
+      }
+    } else if (findParentFolderCalibrationFile) {
+      discoveredPath = await findParentFolderCalibrationFile(parentPath);
+    }
+    if (!discoveredPath) {
+      return;
+    }
+    calibrationFile.value = discoveredPath;
+    if (discoveredFile && stashCalibrationFile) {
+      stashCalibrationFile(discoveredPath, discoveredFile);
+    }
+  }
 
   return {
     importType,

--- a/client/dive-common/stereoParentFolder.spec.ts
+++ b/client/dive-common/stereoParentFolder.spec.ts
@@ -1,0 +1,41 @@
+// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
+import { describe, expect, it } from 'vitest';
+
+import { commonPathPrefix } from 'dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout';
+import {
+  findStereoCalibrationInFileList,
+  isStereoCalibrationFileName,
+  pickStereoCalibrationFileName,
+} from './stereoParentFolder';
+
+describe('isStereoCalibrationFileName', () => {
+  it('accepts json/npz with calibration or cal in the name', () => {
+    expect(isStereoCalibrationFileName('stereoCalibration.npz')).toBe(true);
+    expect(isStereoCalibrationFileName('stereo_cal.json')).toBe(true);
+    expect(isStereoCalibrationFileName('notes.txt')).toBe(false);
+    expect(isStereoCalibrationFileName('data.json')).toBe(false);
+    expect(isStereoCalibrationFileName('calibration.yml')).toBe(false);
+  });
+});
+
+describe('pickStereoCalibrationFileName', () => {
+  it('prefers calibration-like names', () => {
+    expect(pickStereoCalibrationFileName([
+      'stereo_cal.json',
+      'stereoCalibration.npz',
+    ])).toBe('stereoCalibration.npz');
+  });
+});
+
+describe('findStereoCalibrationInFileList', () => {
+  const mk = (path: string) => ({ webkitRelativePath: path, name: path.split('/').pop() } as File);
+
+  it('finds calibration files in the parent folder root', () => {
+    const match = findStereoCalibrationInFileList([
+      mk('stereo/left/video.mp4'),
+      mk('stereo/right/video.mp4'),
+      mk('stereo/stereoCalibration.npz'),
+    ], 'stereo', commonPathPrefix);
+    expect(match?.path).toBe('stereoCalibration.npz');
+  });
+});

--- a/client/dive-common/stereoParentFolder.ts
+++ b/client/dive-common/stereoParentFolder.ts
@@ -1,0 +1,87 @@
+/** Shared helpers for stereoscopic parent-folder import (desktop and web). */
+
+const STEREO_CALIBRATION_EXTENSIONS = new Set(['json', 'npz']);
+
+/** True for .json / .npz files whose name contains "calibration" or "cal". */
+export function isStereoCalibrationFileName(fileName: string): boolean {
+  const lower = fileName.toLowerCase();
+  const parts = fileName.split('.');
+  if (parts.length < 2) {
+    return false;
+  }
+  const ext = parts.pop()?.toLowerCase() ?? '';
+  if (!STEREO_CALIBRATION_EXTENSIONS.has(ext)) {
+    return false;
+  }
+  return lower.includes('calibration') || lower.includes('cal');
+}
+
+function stereoCalibrationRank(fileName: string): number {
+  const lower = fileName.toLowerCase();
+  let score = 0;
+  if (lower.includes('calibration')) {
+    score += 2;
+  } else if (lower.includes('cal')) {
+    score += 1;
+  }
+  return score;
+}
+
+/** Pick the best calibration filename from a list of parent-folder root files. */
+export function pickStereoCalibrationFileName(fileNames: string[]): string | null {
+  const candidates = fileNames.filter(isStereoCalibrationFileName);
+  if (!candidates.length) {
+    return null;
+  }
+  return [...candidates].sort((a, b) => {
+    const scoreDiff = stereoCalibrationRank(b) - stereoCalibrationRank(a);
+    return scoreDiff !== 0 ? scoreDiff : a.localeCompare(b);
+  })[0];
+}
+
+function stripPathPrefix(path: string, prefix: string): string {
+  if (!prefix) {
+    return path;
+  }
+  const normalized = prefix.replace(/\/$/, '');
+  const withSlash = `${normalized}/`;
+  if (path.startsWith(withSlash)) {
+    return path.slice(withSlash.length);
+  }
+  if (path.toLowerCase().startsWith(withSlash.toLowerCase())) {
+    return path.slice(withSlash.length);
+  }
+  return path;
+}
+
+export interface StereoCalibrationFileMatch {
+  path: string;
+  file: File;
+}
+
+/** Find a stereo calibration file sitting directly in the selected parent folder (web). */
+export function findStereoCalibrationInFileList(
+  fileList: File[],
+  root: string,
+  commonPathPrefix: (paths: string[]) => string,
+): StereoCalibrationFileMatch | null {
+  const paths = fileList.map((file) => file.webkitRelativePath || file.name);
+  const effectiveRoot = root || commonPathPrefix(paths);
+  const matches: StereoCalibrationFileMatch[] = [];
+
+  fileList.forEach((file, index) => {
+    const rel = paths[index];
+    const path = stripPathPrefix(rel, effectiveRoot);
+    const parts = path.split('/').filter(Boolean);
+    if (parts.length !== 1 || !isStereoCalibrationFileName(parts[0])) {
+      return;
+    }
+    matches.push({ path: parts[0], file });
+  });
+
+  const bestName = pickStereoCalibrationFileName(matches.map((match) => match.path));
+  if (!bestName) {
+    return null;
+  }
+  return matches.find((match) => match.path === bestName) ?? null;
+}

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -157,6 +157,11 @@ export default function register() {
     { path, mediaType }: { path: string; mediaType: 'image-sequence' | 'video' },
   ) => common.resolveMulticamCameraSourcePath(path, mediaType));
 
+  ipcMain.handle('find-parent-folder-calibration-file', async (
+    event,
+    { path }: { path: string },
+  ) => common.findParentFolderCalibrationFile(path));
+
   ipcMain.handle('delete-dataset', async (event, { datasetId }: { datasetId: string }) => {
     const ret = await common.deleteDataset(settings.get(), datasetId);
     return ret;

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -38,6 +38,7 @@ import {
   websafeImageTypes, websafeVideoTypes, otherImageTypes, otherVideoTypes, fileVideoTypes,
   MultiType, JsonMetaRegEx, largeImageDesktopTypes,
 } from 'dive-common/constants';
+import { pickStereoCalibrationFileName } from 'dive-common/stereoParentFolder';
 import {
   JsonMeta, Settings, JsonMetaCurrentVersion, DesktopMetadata,
   RunTraining, ExportDatasetArgs, DesktopMediaImportResponse,
@@ -1074,6 +1075,27 @@ async function listParentFolderCameras(
 }
 
 /**
+ * Find a stereoscopic calibration file (.json or .npz with cal/calibration in the name)
+ * in the parent folder root.
+ */
+async function findParentFolderCalibrationFile(parentPath: string): Promise<string | null> {
+  if (!await fs.pathExists(parentPath)) {
+    return null;
+  }
+  const stat = await fs.stat(parentPath);
+  if (!stat.isDirectory()) {
+    return null;
+  }
+  const children = await fs.readdir(parentPath, { withFileTypes: true });
+  const fileNames = children.filter((entry) => entry.isFile()).map((entry) => entry.name);
+  const bestName = pickStereoCalibrationFileName(fileNames);
+  if (!bestName) {
+    return null;
+  }
+  return npath.join(parentPath, bestName);
+}
+
+/**
  * Resolve the import path for one camera subfolder (directory or first video file).
  */
 async function resolveMulticamCameraSourcePath(
@@ -1628,6 +1650,7 @@ export {
   findImagesInFolder,
   listImmediateSubfolders,
   listParentFolderCameras,
+  findParentFolderCalibrationFile,
   resolveMulticamCameraSourcePath,
   findTrackandMetaFileinFolder,
   getLastCalibrationPath,

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -73,10 +73,10 @@ async function openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 
       allFiles,
     ];
   }
-  const props = (['image-sequence', 'bulk'].includes(datasetType) || directory) ? 'openDirectory' : 'openFile';
+  const openDirectory = ['image-sequence', 'bulk'].includes(datasetType) || directory;
   const results = await window.diveDesktop.showOpenDialog({
-    properties: [props],
-    filters,
+    properties: [openDirectory ? 'openDirectory' : 'openFile'],
+    filters: openDirectory ? [] : filters,
   });
   if (datasetType === 'annotation') {
     const allowed = new Set(inputAnnotationFileTypes.map((ext) => ext.toLowerCase()));
@@ -188,6 +188,10 @@ function resolveMulticamCameraSourcePath(
     path: subfolderPath,
     mediaType,
   });
+}
+
+function findParentFolderCalibrationFile(parentPath: string): Promise<string | null> {
+  return window.diveDesktop.invoke('find-parent-folder-calibration-file', { path: parentPath });
 }
 
 function bulkImportMedia(path: string): Promise<DesktopMediaImportResponse[]> {
@@ -376,6 +380,7 @@ export {
   listImmediateSubfolders,
   listParentFolderCameras,
   resolveMulticamCameraSourcePath,
+  findParentFolderCalibrationFile,
   bulkImportMedia,
   deleteDataset,
   checkDataset,

--- a/client/platform/web-girder/App.vue
+++ b/client/platform/web-girder/App.vue
@@ -32,6 +32,7 @@ import {
   getLastCalibration,
   openFromDiskWithRegistry,
   saveCalibration,
+  stashCalibrationFile,
 } from './multicamFileRegistry';
 import { reportHandledPromiseRejection } from './reportHandledPromiseRejection';
 
@@ -66,6 +67,7 @@ export default defineComponent({
       openFromDisk: openFromDiskWithRegistry,
       getLastCalibration,
       saveCalibration,
+      stashCalibrationFile,
       importAnnotationFile,
       getTiles,
       getTileURL,

--- a/client/src/components/Tracks/TrackList.vue
+++ b/client/src/components/Tracks/TrackList.vue
@@ -578,4 +578,9 @@ export default defineComponent({
     background: #666;
   }
 }
+
+/* Above timeline current-frame bar (z-index: 10) */
+.track-settings-menu-content {
+  z-index: 999;
+}
 </style>

--- a/client/src/components/Tracks/bottombar/BottomBarTrackListView.vue
+++ b/client/src/components/Tracks/bottombar/BottomBarTrackListView.vue
@@ -63,6 +63,7 @@ export default defineComponent({
           v-model="data.columnSettingsActive"
           :close-on-content-click="false"
           :nudge-bottom="28"
+          class="track-settings-menu-content"
         >
           <template #activator="{ on: menuOn, attrs }">
             <v-tooltip
@@ -97,6 +98,7 @@ export default defineComponent({
           v-model="data.settingsActive"
           :close-on-content-click="false"
           :nudge-bottom="28"
+          content-class="track-settings-menu-content"
         >
           <template #activator="{ on, attrs }">
             <v-btn

--- a/client/src/components/Tracks/sidebar/SideBarTrackListView.vue
+++ b/client/src/components/Tracks/sidebar/SideBarTrackListView.vue
@@ -57,6 +57,7 @@ export default defineComponent({
             v-model="data.settingsActive"
             :close-on-content-click="false"
             :nudge-bottom="28"
+            class="track-settings-menu-content"
           >
             <template #activator="{ on, attrs }">
               <v-btn


### PR DESCRIPTION
Stereo import improvements (stereo-import-improvements)

- Auto-discovers calibration in the parent folder root when using subfolder layout (.json/.npz with cal or calibration in the name), on both desktop and web
- Extracts calibration UI into ImportMultiCamCalibration.vue, shown for all stereo import modes (multi-folder, subfolders, and keyword)
- Prefills last calibration on dialog open via getLastCalibration (desktop settings / web session)
- Improves subfolder import UX — per-camera re-pick, clearer video source labels, file-count chip only for image sequences
- Adds shared helpers in stereoParentFolder.ts with unit tests; desktop IPC for findParentFolderCalibrationFile; web stashCalibrationFile for discovered files
- Fixes desktop folder picker by omitting file-type filters when opening directories
- Fixes track settings menu z-index so it renders above the timeline bar (unrelated UI fix bundled in)