### PR TITLE
fix: remove play icon in run pipeline menu

### DIFF
--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -414,8 +414,10 @@ export default defineComponent({
                         >
                           <v-list-item-title class="font-weight-regular" style="display: flex; justify-content: space-between; align-items: center;">
                             {{ pipeline.name }}
-                            <v-icon style="margin-left: 20px">
-                              {{ pipeline.metadata?.diveParams?.length ?? 0 > 0 ? 'mdi-application-cog-outline' : 'mdi-play-outline' }}
+                            <v-icon style="margin-left: 20px; font-size: 1.5em;">
+                              <template v-if="pipeline.metadata?.diveParams?.length ?? 0 > 0">
+                                mdi-cog-outline
+                              </template>
                             </v-icon>
                           </v-list-item-title>
                         </v-list-item>


### PR DESCRIPTION
This small MR remove the play icon from pipeline run menu (when there was no dive params to setup).
It was misleading and users could believe it would expand a submenu on the right when hovering.

I also replaced the icon when there is dive params by a simple and smaller cog.

<img width="465" height="908" alt="image" src="https://github.com/user-attachments/assets/494017b2-8461-470a-8ff6-89eb4fba8a94" />
