### PR TITLE
clear calibration file, use parent folder name for desktop import

### DIFF
--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamCalibration.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamCalibration.vue
@@ -11,10 +11,11 @@ export default defineComponent({
     ...importMultiCamContextProp,
   },
   setup(props) {
-    const { calibrationFile, open } = props.ctx;
+    const { calibrationFile, open, clearCalibration } = props.ctx;
     return {
       calibrationFile,
       open,
+      clearCalibration,
     };
   },
 });
@@ -28,13 +29,22 @@ export default defineComponent({
     <v-text-field
       label="Calibration File"
       placeholder="Not selected"
-      disabled
+      readonly
       outlined
       dense
       hide-details
       :value="calibrationFile"
       class="mr-3"
     />
+    <v-btn
+      v-if="calibrationFile"
+      icon
+      class="mr-2"
+      aria-label="Clear calibration file"
+      @click="clearCalibration"
+    >
+      <v-icon>mdi-close</v-icon>
+    </v-btn>
     <v-btn
       color="primary"
       @click="open('calibration', 'calibration')"

--- a/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.spec.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.spec.ts
@@ -10,6 +10,7 @@ import {
   isVideoFileName,
   organizeSubfolderCameras,
   orderSubfolderCameraNames,
+  parentFolderLabelFromAbsolutePaths,
   preferLeftSubfolderFirst,
   pickDefaultMulticamCamera,
   sortSubfolderCameraNames,
@@ -43,6 +44,27 @@ describe('applyParentPathToAssignments', () => {
     const resolved = applyParentPathToAssignments('C:\\datasets\\stereo', organized.assignments);
     expect(resolved[0].sourcePath).toBe('C:\\datasets\\stereo\\left');
     expect(resolved[1].sourcePath).toBe('C:\\datasets\\stereo\\right');
+  });
+});
+
+describe('parentFolderLabelFromAbsolutePaths', () => {
+  it('returns the shared parent folder name for sibling camera paths', () => {
+    expect(parentFolderLabelFromAbsolutePaths([
+      '/data/my_scene/left',
+      '/data/my_scene/right',
+    ])).toBe('my_scene');
+  });
+
+  it('handles Windows-style paths', () => {
+    expect(parentFolderLabelFromAbsolutePaths([
+      'C:\\datasets\\stereo\\left',
+      'C:\\datasets\\stereo\\right',
+    ])).toBe('stereo');
+  });
+
+  it('returns empty when no paths are provided', () => {
+    expect(parentFolderLabelFromAbsolutePaths([])).toBe('');
+    expect(parentFolderLabelFromAbsolutePaths(['', '   '])).toBe('');
   });
 });
 

--- a/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.spec.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.spec.ts
@@ -14,6 +14,7 @@ import {
   preferLeftSubfolderFirst,
   pickDefaultMulticamCamera,
   sortSubfolderCameraNames,
+  subfolderVideoDisplayLabel,
 } from './multicamSubfolderLayout';
 
 describe('isValidCameraName', () => {
@@ -150,6 +151,23 @@ describe('isVideoFileName', () => {
     expect(isVideoFileName('left.mp4')).toBe(true);
     expect(isVideoFileName('right.MOV')).toBe(true);
     expect(isVideoFileName('notes.txt')).toBe(false);
+  });
+});
+
+describe('subfolderVideoDisplayLabel', () => {
+  const mk = (name: string) => ({ name } as File);
+
+  it('uses the video file name when only the stem is known on web', () => {
+    expect(subfolderVideoDisplayLabel('left', 'left', [mk('left.mp4')])).toBe('left.mp4');
+    expect(subfolderVideoDisplayLabel('right', 'right', [mk('right.mov')])).toBe('right.mov');
+  });
+
+  it('uses the path basename when it includes a video extension', () => {
+    expect(subfolderVideoDisplayLabel('/data/stereo/left.mp4', 'left', [])).toBe('left.mp4');
+  });
+
+  it('falls back to folder name when no video file is available', () => {
+    expect(subfolderVideoDisplayLabel('left', 'left', [])).toBe('left');
   });
 });
 

--- a/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.ts
@@ -288,6 +288,23 @@ export function isVideoFileName(fileName: string): boolean {
   return fileVideoTypes.includes(ext);
 }
 
+/** Display label for a video camera in parent-folder import (includes file extension when known). */
+export function subfolderVideoDisplayLabel(
+  sourcePath: string,
+  folderName: string,
+  files: Pick<File, 'name'>[] = [],
+): string {
+  const videoFile = files.find((file) => isVideoFileName(file.name));
+  if (videoFile) {
+    return videoFile.name;
+  }
+  const fromPath = sourcePath.split(/[/\\]/).pop() || '';
+  if (fromPath && isVideoFileName(fromPath)) {
+    return fromPath;
+  }
+  return fromPath || folderName;
+}
+
 /**
  * Group video files that sit directly in the selected parent folder (one camera per file).
  * Camera keys are the file stem (basename without extension).

--- a/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.ts
@@ -220,6 +220,21 @@ export function commonPathPrefix(paths: string[]): string {
   return prefix.join('/');
 }
 
+/** Last path segment of the common parent directory across absolute filesystem paths. */
+export function parentFolderLabelFromAbsolutePaths(paths: string[]): string {
+  const normalized = paths.map((p) => p.trim()).filter(Boolean);
+  if (!normalized.length) {
+    return '';
+  }
+  const withForwardSlashes = normalized.map((p) => p.replace(/\\/g, '/'));
+  const parentPath = commonPathPrefix(withForwardSlashes);
+  if (!parentPath) {
+    return '';
+  }
+  const segments = parentPath.split('/').filter(Boolean);
+  return segments[segments.length - 1] || parentPath;
+}
+
 function stripPathPrefix(path: string, prefix: string): string {
   if (!prefix) {
     return path;

--- a/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
@@ -22,6 +22,7 @@ import {
   organizeSubfolderCameras,
   parentFolderLabelFromAbsolutePaths,
   pickDefaultMulticamCamera,
+  subfolderVideoDisplayLabel,
 } from 'dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout';
 import { findStereoCalibrationInFileList } from 'dive-common/stereoParentFolder';
 import { ImageSequenceType, VideoType } from 'dive-common/constants';
@@ -351,7 +352,11 @@ export function useImportMultiCamDialog(
         Vue.set(
           subfolderOriginalNames.value,
           cameraName,
-          subfolderSourceDisplayLabel(sourcePath, organized.assignments[i].folderName),
+          subfolderSourceDisplayLabel(
+            sourcePath,
+            organized.assignments[i].folderName,
+            files,
+          ),
         );
         Vue.set(folderList.value, cameraName, { sourcePath, trackFile: '' });
         // eslint-disable-next-line no-await-in-loop -- import each camera media sequentially
@@ -423,7 +428,7 @@ export function useImportMultiCamDialog(
       props.unregisterSubfolderCamera(oldSourcePath);
     }
     const displayName = props.dataType === VideoType
-      ? (resolvedPath.split(/[/\\]/).pop() || cameraKey)
+      ? subfolderSourceDisplayLabel(resolvedPath, cameraKey, files)
       : ((displayRoot || sourcePath).split(/[/\\]/).pop() || cameraKey);
     Vue.set(subfolderOriginalNames.value, cameraKey, displayName);
     folderList.value[cameraKey].sourcePath = resolvedPath;
@@ -589,9 +594,10 @@ export function useImportMultiCamDialog(
   function subfolderSourceDisplayLabel(
     sourcePath: string,
     folderName: string,
+    files: File[] = [],
   ): string {
     if (props.dataType === VideoType) {
-      return sourcePath.split(/[/\\]/).pop() || folderName;
+      return subfolderVideoDisplayLabel(sourcePath, folderName, files);
     }
     return folderName;
   }

--- a/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
@@ -20,6 +20,7 @@ import {
   groupParentFolderByCamera,
   isValidCameraName,
   organizeSubfolderCameras,
+  parentFolderLabelFromAbsolutePaths,
   pickDefaultMulticamCamera,
 } from 'dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout';
 import { findStereoCalibrationInFileList } from 'dive-common/stereoParentFolder';
@@ -477,6 +478,7 @@ export function useImportMultiCamDialog(
           folder,
           await importRequest(() => props.importMedia(sourcePath)),
         );
+        syncSuggestedDatasetNameFromCameraPaths();
       } else if (importType.value === 'subfolders') {
         const sourcePath = ret.root || path;
         await importRequest(() => updateSubfolderCameraSource(
@@ -567,6 +569,23 @@ export function useImportMultiCamDialog(
     (val: string) => (val || '').trim().length > 0 || 'Dataset name is required',
   ];
 
+  function syncSuggestedDatasetNameFromCameraPaths() {
+    if (!listParentFolderCameras || importType.value !== 'multi') {
+      return;
+    }
+    const paths = Object.values(folderList.value)
+      .map((entry) => entry.sourcePath)
+      .filter((path) => path);
+    const label = parentFolderLabelFromAbsolutePaths(paths);
+    if (label && !datasetName.value.trim()) {
+      datasetName.value = label;
+    }
+  }
+
+  function clearCalibration() {
+    calibrationFile.value = '';
+  }
+
   function subfolderSourceDisplayLabel(
     sourcePath: string,
     folderName: string,
@@ -636,5 +655,6 @@ export function useImportMultiCamDialog(
     deleteSet,
     onRenameCamera,
     openAnnotationFile,
+    clearCalibration,
   };
 }

--- a/client/platform/desktop/backend/native/multiCam.spec.ts
+++ b/client/platform/desktop/backend/native/multiCam.spec.ts
@@ -87,6 +87,19 @@ type FailingKeyword= Record<string, {
 }>;
 
 describe('native.multiCamImport', () => {
+  it('uses datasetName when provided for folder imports', async () => {
+    const output = await beginMultiCamImport({
+      datasetName: 'my_stereo_scene',
+      defaultDisplay: 'left',
+      sourceList: {
+        left: { sourcePath: '/home/user/data/stereoLeftRightImages/left', trackFile: '' },
+        right: { sourcePath: '/home/user/data/stereoLeftRightImages/right', trackFile: '' },
+      },
+      type: 'image-sequence',
+    });
+    expect(output.jsonMeta.name).toBe('my_stereo_scene');
+  });
+
   if (multiCamSetup.folderTests) {
     const folderTests = (multiCamSetup.folderTests as FolderTest);
     Object.entries(folderTests).forEach(([key, val]) => {

--- a/client/platform/desktop/backend/native/multiCamImport.ts
+++ b/client/platform/desktop/backend/native/multiCamImport.ts
@@ -101,7 +101,9 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
     originalImageFiles: [],
     transcodedVideoFile: '',
     transcodedImageFiles: [],
-    name: 'Multi-camera data',
+    name: (isFolderArgs(args) && args.datasetName?.trim())
+      ? args.datasetName.trim()
+      : 'Multi-camera data',
     multiCam: {
       cameras,
       calibration: args.calibrationFile,


### PR DESCRIPTION
- Allows an automatically selected calibration file to be cleared
- Passes through the parent folder name for desktop importing
    - Specifically after the initial selection of items in the desktop, the final import will have the passthrough name as well.
- Makes it so it displays the file extension for video folder imports automatically.