### PR TITLE
Calibration Requirements

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -49,6 +49,7 @@ interface PipeMetadata {
   inputType?: string;
   outputType?: string;
   diveParams?: DiveParam[];
+  requiresCalibration?: boolean;
 }
 
 interface PipelineRuntimeParams {
@@ -243,6 +244,8 @@ interface Api {
   ): Promise<string>;
   /** Desktop: stereoscopic calibration file in a parent folder root. */
   findParentFolderCalibrationFile?(parentPath: string): Promise<string | null>;
+  /** True when the dataset folder has an attached stereoscopic calibration file. */
+  hasCalibrationFile?(datasetId: string): Promise<boolean>;
   /** Web: stash a calibration File for multicam upload lookup. */
   stashCalibrationFile?(key: string, file: File): void;
   getTiles?(itemId: string, projection?: string): Promise<StringKeyObject>;

--- a/client/dive-common/components/PipelineCalibrationWarningIcon.vue
+++ b/client/dive-common/components/PipelineCalibrationWarningIcon.vue
@@ -1,0 +1,83 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { calibrationRequiredPipelineMessage } from 'dive-common/pipelineCalibration';
+
+export default defineComponent({
+  name: 'PipelineCalibrationWarningIcon',
+
+  props: {
+    small: {
+      type: Boolean,
+      default: false,
+    },
+    disabled: {
+      type: Boolean,
+      default: true,
+    },
+  },
+
+  setup() {
+    return {
+      calibrationRequiredPipelineMessage,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-tooltip
+    top
+    :open-delay="250"
+    max-width="300"
+    content-class="pipeline-calibration-warning-tooltip"
+  >
+    <template #activator="{ on, attrs }">
+      <v-icon
+        v-bind="attrs"
+        :small="small"
+        color="warning"
+        class="pipeline-calibration-warning-icon"
+        v-on="on"
+        @click.stop
+      >
+        mdi-alert
+      </v-icon>
+    </template>
+    <div class="pipeline-calibration-warning-tooltip__body">
+      <v-icon
+        small
+        class="pipeline-calibration-warning-tooltip__icon"
+      >
+        mdi-alert
+      </v-icon>
+      <span>
+        <template v-if="disabled">Cannot run: </template>
+        {{ calibrationRequiredPipelineMessage }}
+      </span>
+    </div>
+  </v-tooltip>
+</template>
+
+<style>
+.pipeline-calibration-warning-tooltip.v-tooltip__content {
+  background: #fb8c00 !important;
+  color: #1a1a1a !important;
+  opacity: 1 !important;
+  border: 1px solid #e65100;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+.pipeline-calibration-warning-tooltip__body {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.pipeline-calibration-warning-tooltip__icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: #1a1a1a !important;
+}
+</style>

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -1,11 +1,12 @@
 <script lang="ts">
 import {
-  defineComponent,
   computed,
+  defineComponent,
   PropType,
   ref,
   Ref,
   onBeforeMount,
+  watch,
 } from 'vue';
 import {
   Pipelines,
@@ -25,6 +26,11 @@ import {
 } from 'dive-common/constants';
 import { parentDatasetId } from 'dive-common/compositeDatasetId';
 import { filterPipelinesForDatasets } from 'dive-common/pipelineMenuFilters';
+import {
+  calibrationRequiredPipelineMessage,
+  pipelineDisabledForMissingCalibration,
+  pipelineRequiresCalibration,
+} from 'dive-common/pipelineCalibration';
 import pipelineTypeDisplay from 'dive-common/pipelineTypeDisplay';
 import { useRequest } from 'dive-common/use';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
@@ -92,7 +98,7 @@ export default defineComponent({
 
   setup(props) {
     const { prompt } = usePrompt();
-    const { runPipeline, getPipelineList } = useApi();
+    const { runPipeline, getPipelineList, hasCalibrationFile } = useApi();
     const unsortedPipelines = ref({} as Pipelines);
     const {
       request: _runPipelineRequest,
@@ -137,6 +143,39 @@ export default defineComponent({
     onBeforeMount(async () => {
       unsortedPipelines.value = await getPipelineList();
     });
+
+    const calibrationAvailableByDatasetId = ref<Record<string, boolean>>({});
+
+    async function refreshCalibrationStatus() {
+      if (!hasCalibrationFile || props.selectedDatasetIds.length === 0) {
+        calibrationAvailableByDatasetId.value = {};
+        return;
+      }
+      const parentIds = [...new Set(props.selectedDatasetIds.map((id) => parentDatasetId(id)))];
+      const entries = await Promise.all(
+        parentIds.map(async (datasetId) => {
+          const available = await hasCalibrationFile(datasetId);
+          return [datasetId, available] as const;
+        }),
+      );
+      calibrationAvailableByDatasetId.value = Object.fromEntries(entries);
+    }
+
+    watch(() => props.selectedDatasetIds, () => {
+      refreshCalibrationStatus();
+    }, { immediate: true });
+
+    function isPipelineDisabledForCalibration(pipeline: Pipe) {
+      return pipelineDisabledForMissingCalibration(
+        pipeline,
+        calibrationAvailableByDatasetId.value,
+        props.selectedDatasetIds.map((id) => parentDatasetId(id)),
+      );
+    }
+
+    function pipelineTooltipDisabled(pipeline: Pipe) {
+      return !isPipelineDisabledForCalibration(pipeline) && !pipeline?.metadata?.description;
+    }
 
     const pipelines = computed(() => filterPipelinesForDatasets(
       unsortedPipelines.value,
@@ -202,6 +241,9 @@ export default defineComponent({
     }
 
     async function runPipelineOnSelectedItem(pipeline: Pipe) {
+      if (isPipelineDisabledForCalibration(pipeline)) {
+        return;
+      }
       if (pipeline.metadata?.diveParams && pipeline.metadata?.diveParams?.length > 0) {
         openDiveParamsDialog(pipeline);
         return;
@@ -258,6 +300,10 @@ export default defineComponent({
       pipelineParams,
       showParamsDialog,
       confirmPipelineExecution,
+      pipelineRequiresCalibration,
+      isPipelineDisabledForCalibration,
+      pipelineTooltipDisabled,
+      calibrationRequiredPipelineMessage,
     };
   },
 });
@@ -402,27 +448,46 @@ export default defineComponent({
                       :key="`${pipeline.name}-${pipeline.pipe}`"
                       left
                       :open-delay="250"
-                      :disabled="!pipeline?.metadata?.description"
+                      :disabled="pipelineTooltipDisabled(pipeline)"
                       max-width="400"
                       content-class="pipeline-description-tooltip"
                     >
                       <template #activator="{ on, attrs }">
                         <v-list-item
                           v-bind="attrs"
+                          :disabled="isPipelineDisabledForCalibration(pipeline)"
                           v-on="on"
                           @click="runPipelineOnSelectedItem(pipeline)"
                         >
                           <v-list-item-title class="font-weight-regular" style="display: flex; justify-content: space-between; align-items: center;">
                             {{ pipeline.name }}
-                            <v-icon style="margin-left: 20px; font-size: 1.5em;">
-                              <template v-if="pipeline.metadata?.diveParams?.length ?? 0 > 0">
-                                mdi-cog-outline
-                              </template>
-                            </v-icon>
+                            <span style="display: flex; align-items: center; gap: 8px; margin-left: 20px;">
+                              <v-icon
+                                v-if="pipelineRequiresCalibration(pipeline)"
+                                style="font-size: 1.25em;"
+                                color="warning"
+                              >
+                                mdi-crosshairs-gps
+                              </v-icon>
+                              <v-icon style="font-size: 1.5em;">
+                                <template v-if="pipeline.metadata?.diveParams?.length ?? 0 > 0">
+                                  mdi-cog-outline
+                                </template>
+                              </v-icon>
+                            </span>
                           </v-list-item-title>
+                          <v-list-item-subtitle
+                            v-if="isPipelineDisabledForCalibration(pipeline)"
+                            class="error--text"
+                          >
+                            {{ calibrationRequiredPipelineMessage }}
+                          </v-list-item-subtitle>
                         </v-list-item>
                       </template>
-                      <RunPipelineToast :pipeline="pipeline" />
+                      <span v-if="isPipelineDisabledForCalibration(pipeline)">
+                        {{ calibrationRequiredPipelineMessage }}
+                      </span>
+                      <RunPipelineToast v-else :pipeline="pipeline" />
                     </v-tooltip>
                   </v-list>
                 </v-menu>

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -27,14 +27,13 @@ import {
 import { parentDatasetId } from 'dive-common/compositeDatasetId';
 import { filterPipelinesForDatasets } from 'dive-common/pipelineMenuFilters';
 import {
-  calibrationRequiredPipelineMessage,
   pipelineDisabledForMissingCalibration,
-  pipelineRequiresCalibration,
 } from 'dive-common/pipelineCalibration';
 import pipelineTypeDisplay from 'dive-common/pipelineTypeDisplay';
 import { useRequest } from 'dive-common/use';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import PipelineParamsDialog from 'dive-common/components/PipelineParamsDialog.vue';
+import PipelineCalibrationWarningIcon from 'dive-common/components/PipelineCalibrationWarningIcon.vue';
 
 type MenuState = 'idle' | 'configuring';
 
@@ -46,6 +45,7 @@ export default defineComponent({
     JobConfigFilterTranscodeDialog,
     PipelineParamsDialog,
     RunPipelineToast,
+    PipelineCalibrationWarningIcon,
   },
 
   props: {
@@ -174,7 +174,7 @@ export default defineComponent({
     }
 
     function pipelineTooltipDisabled(pipeline: Pipe) {
-      return !isPipelineDisabledForCalibration(pipeline) && !pipeline?.metadata?.description;
+      return !pipeline?.metadata?.description;
     }
 
     const pipelines = computed(() => filterPipelinesForDatasets(
@@ -300,10 +300,8 @@ export default defineComponent({
       pipelineParams,
       showParamsDialog,
       confirmPipelineExecution,
-      pipelineRequiresCalibration,
       isPipelineDisabledForCalibration,
       pipelineTooltipDisabled,
-      calibrationRequiredPipelineMessage,
     };
   },
 });
@@ -455,20 +453,16 @@ export default defineComponent({
                       <template #activator="{ on, attrs }">
                         <v-list-item
                           v-bind="attrs"
-                          :disabled="isPipelineDisabledForCalibration(pipeline)"
+                          :class="{ 'pipeline-item--unavailable': isPipelineDisabledForCalibration(pipeline) }"
                           v-on="on"
                           @click="runPipelineOnSelectedItem(pipeline)"
                         >
                           <v-list-item-title class="font-weight-regular" style="display: flex; justify-content: space-between; align-items: center;">
                             {{ pipeline.name }}
                             <span style="display: flex; align-items: center; gap: 8px; margin-left: 20px;">
-                              <v-icon
-                                v-if="pipelineRequiresCalibration(pipeline)"
-                                style="font-size: 1.25em;"
-                                color="warning"
-                              >
-                                mdi-crosshairs-gps
-                              </v-icon>
+                              <PipelineCalibrationWarningIcon
+                                v-if="isPipelineDisabledForCalibration(pipeline)"
+                              />
                               <v-icon style="font-size: 1.5em;">
                                 <template v-if="pipeline.metadata?.diveParams?.length ?? 0 > 0">
                                   mdi-cog-outline
@@ -476,18 +470,9 @@ export default defineComponent({
                               </v-icon>
                             </span>
                           </v-list-item-title>
-                          <v-list-item-subtitle
-                            v-if="isPipelineDisabledForCalibration(pipeline)"
-                            class="error--text"
-                          >
-                            {{ calibrationRequiredPipelineMessage }}
-                          </v-list-item-subtitle>
                         </v-list-item>
                       </template>
-                      <span v-if="isPipelineDisabledForCalibration(pipeline)">
-                        {{ calibrationRequiredPipelineMessage }}
-                      </span>
-                      <RunPipelineToast v-else :pipeline="pipeline" />
+                      <RunPipelineToast :pipeline="pipeline" />
                     </v-tooltip>
                   </v-list>
                 </v-menu>
@@ -542,5 +527,11 @@ export default defineComponent({
 .pipeline-description-tooltip.v-tooltip__content {
   background: #3a3a3a !important;
   opacity: 1 !important;
+}
+
+.pipeline-item--unavailable {
+  opacity: 0.55;
+  cursor: not-allowed;
+  background: rgba(251, 140, 0, 0.08);
 }
 </style>

--- a/client/dive-common/pipelineCalibration.spec.ts
+++ b/client/dive-common/pipelineCalibration.spec.ts
@@ -1,0 +1,57 @@
+import {
+  calibrationRequiredPipelineMessage,
+  pipelineDisabledForMissingCalibration,
+  pipelineRequiresCalibration,
+} from './pipelineCalibration';
+import type { Pipe } from './apispec';
+
+describe('pipelineCalibration', () => {
+  const measurementPipe: Pipe = {
+    name: 'gmm',
+    type: 'measurement',
+    pipe: 'measurement_gmm.pipe',
+  };
+
+  it('requires calibration when metadata flag is true', () => {
+    const pipe: Pipe = {
+      ...measurementPipe,
+      metadata: { requiresCalibration: true },
+    };
+    expect(pipelineRequiresCalibration(pipe)).toBe(true);
+  });
+
+  it('does not require calibration when metadata flag is false', () => {
+    const pipe: Pipe = {
+      name: 'detector',
+      type: 'detector',
+      pipe: 'detector_default.pipe',
+      metadata: { requiresCalibration: false },
+    };
+    expect(pipelineRequiresCalibration(pipe)).toBe(false);
+  });
+
+  it('does not require calibration when metadata flag is absent', () => {
+    expect(pipelineRequiresCalibration(measurementPipe)).toBe(false);
+  });
+
+  it('disables calibration pipelines when any selected dataset lacks calibration', () => {
+    const pipe: Pipe = {
+      ...measurementPipe,
+      metadata: { requiresCalibration: true },
+    };
+    expect(pipelineDisabledForMissingCalibration(
+      pipe,
+      { ds1: true, ds2: false },
+      ['ds1', 'ds2'],
+    )).toBe(true);
+    expect(pipelineDisabledForMissingCalibration(
+      pipe,
+      { ds1: true, ds2: true },
+      ['ds1', 'ds2'],
+    )).toBe(false);
+  });
+
+  it('exports a user-facing calibration message', () => {
+    expect(calibrationRequiredPipelineMessage).toMatch(/requires a calibration file/i);
+  });
+});

--- a/client/dive-common/pipelineCalibration.ts
+++ b/client/dive-common/pipelineCalibration.ts
@@ -1,0 +1,21 @@
+import type { Pipe } from 'dive-common/apispec';
+
+export const calibrationRequiredPipelineMessage = (
+  'This pipeline requires a calibration file. Import or attach a calibration file to the dataset.'
+);
+
+/** True only when the pipe file declares `# Requires Calibration: True`. */
+export function pipelineRequiresCalibration(pipeline: Pipe): boolean {
+  return pipeline.metadata?.requiresCalibration === true;
+}
+
+export function pipelineDisabledForMissingCalibration(
+  pipeline: Pipe,
+  calibrationAvailableByDatasetId: Record<string, boolean | undefined>,
+  selectedDatasetIds: string[],
+): boolean {
+  if (!pipelineRequiresCalibration(pipeline) || !selectedDatasetIds.length) {
+    return false;
+  }
+  return selectedDatasetIds.some((datasetId) => !calibrationAvailableByDatasetId[datasetId]);
+}

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -162,6 +162,11 @@ export default function register() {
     { path }: { path: string },
   ) => common.findParentFolderCalibrationFile(path));
 
+  ipcMain.handle('dataset-has-calibration-file', async (
+    event,
+    { datasetId }: { datasetId: string },
+  ) => common.datasetHasCalibrationFile(settings.get(), datasetId));
+
   ipcMain.handle('delete-dataset', async (event, { datasetId }: { datasetId: string }) => {
     const ret = await common.deleteDataset(settings.get(), datasetId);
     return ret;

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -135,7 +135,7 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
       }
 
       if (inDescription) {
-        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output):/i.test(line) || !line.startsWith('#')) {
+        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output|Requires\s+Calibration):/i.test(line) || !line.startsWith('#')) {
           inDescription = false;
         } else {
           fullDescription += ` ${line.replace(/^#\s*/, '').trim()}`;

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -150,6 +150,12 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
       if (/^#\s*Output:\s*/i.test(line)) {
         metadata.outputType = line.split(':')[1]?.trim();
       }
+
+      const calibrationMatch = line.match(/^#\s*Requires\s+Calibration:\s*(.*)/i);
+      if (calibrationMatch) {
+        const value = calibrationMatch[1].trim().toLowerCase();
+        metadata.requiresCalibration = ['true', 'yes', '1'].includes(value);
+      }
     });
     metadata.description = fullDescription.trim() || undefined;
   } catch (error) {
@@ -1618,6 +1624,24 @@ async function applyCalibrationToUncalibratedStereoDatasets(
   return updatedIds;
 }
 
+/**
+ * True when a dataset has a stereoscopic calibration file on disk.
+ */
+async function datasetHasCalibrationFile(settings: Settings, datasetId: string): Promise<boolean> {
+  const parentId = datasetId.split('/')[0];
+  try {
+    const projectDirData = await getValidatedProjectDir(settings, parentId);
+    const meta = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+    if (meta.multiCam?.calibration && await fs.pathExists(meta.multiCam.calibration)) {
+      return true;
+    }
+    const discovered = await findParentFolderCalibrationFile(projectDirData.basePath);
+    return discovered !== null;
+  } catch {
+    return false;
+  }
+}
+
 export {
   ProjectsFolderName,
   JobsFolderName,
@@ -1656,4 +1680,5 @@ export {
   getLastCalibrationPath,
   saveLastCalibration,
   applyCalibrationToUncalibratedStereoDatasets,
+  datasetHasCalibrationFile,
 };

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -194,6 +194,10 @@ function findParentFolderCalibrationFile(parentPath: string): Promise<string | n
   return window.diveDesktop.invoke('find-parent-folder-calibration-file', { path: parentPath });
 }
 
+function hasCalibrationFile(datasetId: string): Promise<boolean> {
+  return window.diveDesktop.invoke('dataset-has-calibration-file', { datasetId });
+}
+
 function bulkImportMedia(path: string): Promise<DesktopMediaImportResponse[]> {
   return window.diveDesktop.invoke('bulk-import-media', { path });
 }
@@ -381,6 +385,7 @@ export {
   listParentFolderCameras,
   resolveMulticamCameraSourcePath,
   findParentFolderCalibrationFile,
+  hasCalibrationFile,
   bulkImportMedia,
   deleteDataset,
   checkDataset,

--- a/client/platform/desktop/frontend/components/MultiPipeline.vue
+++ b/client/platform/desktop/frontend/components/MultiPipeline.vue
@@ -17,11 +17,16 @@ import {
   MultiType,
 } from 'dive-common/constants';
 import pipelineTypeDisplay from 'dive-common/pipelineTypeDisplay';
+import {
+  pipelineDisabledForMissingCalibration,
+  pipelineRequiresCalibration,
+} from 'dive-common/pipelineCalibration';
+import PipelineCalibrationWarningIcon from 'dive-common/components/PipelineCalibrationWarningIcon.vue';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { clientSettings } from 'dive-common/store/settings';
 import { datasets, JsonMetaCache } from '../store/dataset';
 
-const { getPipelineList, runPipeline } = useApi();
+const { getPipelineList, runPipeline, hasCalibrationFile } = useApi();
 const { prompt } = usePrompt();
 const router = useRouter();
 
@@ -114,6 +119,45 @@ const availableItems: Ref<JsonMetaCache[]> = ref([]);
 const availableDatasetSearch = ref('');
 const stagedDatasetIds: Ref<string[]> = ref([]);
 const stagedDatasets = computed(() => availableItems.value.filter((item: JsonMetaCache) => stagedDatasetIds.value.includes(item.id)));
+const calibrationAvailableByDatasetId = ref<Record<string, boolean>>({});
+
+async function refreshCalibrationForDatasets(datasetIds: string[]) {
+  if (!hasCalibrationFile || !datasetIds.length) {
+    return;
+  }
+  const entries = await Promise.all(
+    datasetIds.map(async (id) => [id, await hasCalibrationFile(id)] as const),
+  );
+  calibrationAvailableByDatasetId.value = {
+    ...calibrationAvailableByDatasetId.value,
+    ...Object.fromEntries(entries),
+  };
+}
+
+watch(availableItems, (items) => {
+  refreshCalibrationForDatasets(items.map((item) => item.id));
+}, { immediate: true });
+
+const runDisabled = computed(() => {
+  if (!selectedPipeline.value || stagedDatasets.value.length === 0) {
+    return true;
+  }
+  if (!pipelineRequiresCalibration(selectedPipeline.value)) {
+    return false;
+  }
+  return stagedDatasets.value.some(
+    (dataset) => !calibrationAvailableByDatasetId.value[dataset.id],
+  );
+});
+
+function isPipelineItemDisabledForCalibration(pipe: Pipe) {
+  return pipelineDisabledForMissingCalibration(
+    pipe,
+    calibrationAvailableByDatasetId.value,
+    availableItems.value.map((dataset) => dataset.id),
+  );
+}
+
 watch(selectedPipeline, () => {
   availableItems.value = getAvailableItems();
 });
@@ -218,7 +262,15 @@ onBeforeMount(async () => {
                       v-on="{ ...on, ...tooltipOn }"
                     >
                       <v-list-item-content>
-                        <v-list-item-title>{{ item.name }}</v-list-item-title>
+                        <v-list-item-title>
+                          {{ item.name }}
+                          <span
+                            v-if="isPipelineItemDisabledForCalibration(item)"
+                            class="ml-2"
+                          >
+                            <PipelineCalibrationWarningIcon small />
+                          </span>
+                        </v-list-item-title>
                       </v-list-item-content>
                     </v-list-item>
                   </template>
@@ -260,7 +312,7 @@ onBeforeMount(async () => {
         <v-spacer />
         <v-col cols="auto">
           <v-btn
-            :disabled="stagedDatasets.length === 0"
+            :disabled="runDisabled"
             color="primary"
             @click="runPipelineForDatasets"
           >

--- a/client/platform/web-girder/App.vue
+++ b/client/platform/web-girder/App.vue
@@ -27,6 +27,7 @@ import {
   unwrap,
   getTiles,
   getTileURL,
+  hasCalibrationFile,
 } from './api';
 import {
   getLastCalibration,
@@ -64,6 +65,7 @@ export default defineComponent({
       saveAttributes: unwrap(saveAttributes),
       saveAttributeTrackFilters: unwrap(saveAttributeTrackFilters),
       loadMetadata,
+      hasCalibrationFile,
       openFromDisk: openFromDiskWithRegistry,
       getLastCalibration,
       saveCalibration,

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -4,6 +4,8 @@ import {
   DatasetMetaMutable, FrameImage, SaveAttributeArgs, SaveAttributeTrackFilterArgs,
 } from 'dive-common/apispec';
 import { calibrationFileMarker } from 'dive-common/constants';
+import { parentDatasetId } from 'dive-common/compositeDatasetId';
+import { isStereoCalibrationFileName } from 'dive-common/stereoParentFolder';
 import { GirderMetadataStatic } from 'platform/web-girder/constants';
 import girderRest from 'platform/web-girder/plugins/girder';
 import { resolveDatasetFolderId } from './multicamResolve';
@@ -242,6 +244,28 @@ async function uploadCalibrationItem(parentFolderId: string, file: File): Promis
   return itemId;
 }
 
+function calibrationMarkerTruthy(meta: Record<string, unknown> | undefined): boolean {
+  const marker = meta?.[calibrationFileMarker];
+  return marker === true || marker === 'true' || marker === '1';
+}
+
+async function hasCalibrationFile(datasetId: string): Promise<boolean> {
+  const parentId = parentDatasetId(datasetId);
+  const folder = await girderRest.get<{
+    meta?: { multiCam?: { calibrationItemId?: string } };
+  }>(`folder/${parentId}`);
+  if (folder.data.meta?.multiCam?.calibrationItemId) {
+    return true;
+  }
+  const items = await girderRest.get<Array<{ name: string; meta?: Record<string, unknown> }>>(
+    'item',
+    { params: { folderId: parentId, limit: 0 } },
+  );
+  return items.data.some(
+    (item) => calibrationMarkerTruthy(item.meta) && isStereoCalibrationFileName(item.name),
+  );
+}
+
 export {
   clone,
   createGirderFolder,
@@ -249,6 +273,7 @@ export {
   getDataset,
   getDatasetList,
   getDatasetMedia,
+  hasCalibrationFile,
   importAnnotationFile,
   makeViameFolder,
   saveAttributes,

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -887,6 +887,14 @@ def find_calibration_item_id(folder_id: str) -> Optional[str]:
     return None
 
 
+def pipeline_requires_calibration(pipeline: types.PipelineDescription) -> bool:
+    """True when pipeline metadata (or legacy measurement type) requires calibration input."""
+    metadata = pipeline.get('metadata') or {}
+    if 'requiresCalibration' in metadata:
+        return bool(metadata['requiresCalibration'])
+    return pipeline.get('type') == constants.StereoPipelineMarker
+
+
 def resolve_stereo_calibration_item_id(
     parent_folder: types.GirderModel,
     pipeline: types.PipelineDescription,
@@ -894,12 +902,10 @@ def resolve_stereo_calibration_item_id(
     """
     Resolve stereoscopic calibration item id for pipeline input.
 
-    Returns an item in the dataset folder root with meta.calibrationFile set. Only
-    measurement pipelines on stereo datasets use calibration input.
+    Returns an item in the dataset folder root with meta.calibrationFile set when the
+    pipeline declares that calibration is required.
     """
-    if fromMeta(parent_folder, constants.SubTypeMarker) != 'stereo':
-        return None
-    if pipeline.get('type') != constants.StereoPipelineMarker:
+    if not pipeline_requires_calibration(pipeline):
         return None
 
     folder_id = str(parent_folder['_id'])

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -313,13 +313,10 @@ def run_pipeline(
             )
         input_type = default_cam['media_type']
         calibration_item_id = crud_dataset.resolve_stereo_calibration_item_id(folder, pipeline)
-        needs_calibration = (
-            fromMeta(folder, constants.SubTypeMarker) == 'stereo'
-            and pipeline.get('type') == constants.StereoPipelineMarker
-        )
+        needs_calibration = crud_dataset.pipeline_requires_calibration(pipeline)
         if needs_calibration and calibration_item_id is None:
             raise RestException(
-                'Stereo calibration file was not found in the dataset folder. '
+                'This pipeline requires a calibration file. '
                 'Import or upload a calibration file with the calibrationFile marker.',
                 code=404,
             )

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -149,6 +149,16 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                 if output_match:
                     metadata["outputType"] = output_match.group(1).strip()
 
+                calibration_match = re.match(
+                    r'^#\s*Requires\s+Calibration:\s*(.*)', line_raw, re.IGNORECASE
+                )
+                if calibration_match:
+                    metadata["requiresCalibration"] = calibration_match.group(1).strip().lower() in (
+                        'true',
+                        'yes',
+                        '1',
+                    )
+
         if full_description_parts:
             metadata["description"] = " ".join(full_description_parts)
         else:

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -129,7 +129,9 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                     is_stop_condition = (
                         re.match(r'^#\s*$', line_raw)
                         or re.match(r'^#\s*=', line_raw)
-                        or re.match(r'^#\s*(Input|Output):', line_raw, re.IGNORECASE)
+                        or re.match(
+                            r'^#\s*(Input|Output|Requires\s+Calibration):', line_raw, re.IGNORECASE
+                        )
                         or not line_raw.startswith('#')
                     )
 

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -77,6 +77,7 @@ class PipeMetadata(TypedDict):
     inputType: Optional[str]
     outputType: Optional[str]
     diveParams: Optional[list[DiveParam]]
+    requiresCalibration: Optional[bool]
 
 
 class PipelineDescription(TypedDict):

--- a/server/tests/test_create_multicam.py
+++ b/server/tests/test_create_multicam.py
@@ -283,12 +283,17 @@ def test_resolve_stereo_calibration_item_id_legacy_multi_cam_id(item_cls):
 
 
 @patch('dive_server.crud_dataset.Item')
-def test_resolve_stereo_calibration_item_id_skips_non_measurement_pipeline(item_cls):
+def test_resolve_stereo_calibration_item_id_skips_non_calibration_pipeline(item_cls):
     parent_folder = {
         '_id': 'multi-id',
         'meta': {constants.SubTypeMarker: 'stereo'},
     }
-    pipeline = {'name': '2cam', 'type': '2-cam', 'pipe': '2-cam_foo.pipe'}
+    pipeline = {
+        'name': '2cam',
+        'type': '2-cam',
+        'pipe': '2-cam_foo.pipe',
+        'metadata': {'requiresCalibration': False},
+    }
 
     assert crud_dataset.resolve_stereo_calibration_item_id(parent_folder, pipeline) is None
     item_cls.return_value.find.assert_not_called()

--- a/server/tests/test_pipeline_discovery.py
+++ b/server/tests/test_pipeline_discovery.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from dive_tasks.pipeline_discovery import load_static_pipelines, parse_pipe_type_and_name
+from dive_tasks.pipeline_discovery import (
+    extract_pipe_metadata,
+    load_static_pipelines,
+    parse_pipe_type_and_name,
+)
 
 
 def test_parse_pipe_type_and_name_measurement():
@@ -69,3 +73,24 @@ def test_load_static_pipelines_excludes_common_stereo(tmp_path: Path):
     pipedict = load_static_pipelines(tmp_path)
     assert 'stereo' not in pipedict
     assert 'common' not in pipedict
+
+
+def test_extract_pipe_metadata_requires_calibration(tmp_path: Path):
+    pipe = tmp_path / 'measurement_foo.pipe'
+    pipe.write_text(
+        '\n'.join(
+            [
+                '# Description: stereo measurement',
+                '# Requires Calibration: True',
+                '# Input: TRACK',
+                '# Output: TRACK',
+            ]
+        )
+    )
+
+    metadata = extract_pipe_metadata(pipe)
+
+    assert metadata['requiresCalibration'] is True
+    assert metadata['description'] == 'stereo measurement'
+    assert metadata['inputType'] == 'TRACK'
+    assert metadata['outputType'] == 'TRACK'


### PR DESCRIPTION
- Calibration Requirements - `.pipe` files can declare `# Requires Calibration: True/False` and this is parsed into `requiresCalibration` metadata on both the desktop and server versions
- Girder pipeline runs require calibration are now gated and will properly disable the pipeline and display a warning icon that when hovered will give details

<img width="1000" height="810" alt="image" src="https://github.com/user-attachments/assets/e7b27c7a-26a8-49b8-b0a8-25a3cb8cef0e" />

