### PR TITLE
Parent native file dialogs to the requesting window

### DIFF
--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -3,7 +3,7 @@ import http from 'http';
 import fs from 'fs';
 import path from 'path';
 import {
-  app, ipcMain, shell, dialog,
+  app, ipcMain, shell, dialog, BrowserWindow,
 } from 'electron';
 import { MultiCamImportArgs } from 'dive-common/apispec';
 import type { Pipe } from 'dive-common/apispec';
@@ -77,12 +77,16 @@ export default function register() {
   ipcMain.handle('open-link-in-browser', (_, url: string) => {
     common.openLink(url);
   });
-  ipcMain.handle('desktop:show-open-dialog', (_, options: Electron.OpenDialogOptions) => (
-    dialog.showOpenDialog(options)
-  ));
-  ipcMain.handle('desktop:show-save-dialog', (_, options: Electron.SaveDialogOptions) => (
-    dialog.showSaveDialog(options)
-  ));
+  ipcMain.handle('desktop:show-open-dialog', (event, options: Electron.OpenDialogOptions) => {
+    // Parent the dialog to the requesting window so it opens in front of (and
+    // modal to) DIVE instead of behind it (notably on Linux).
+    const win = BrowserWindow.fromWebContents(event.sender);
+    return win ? dialog.showOpenDialog(win, options) : dialog.showOpenDialog(options);
+  });
+  ipcMain.handle('desktop:show-save-dialog', (event, options: Electron.SaveDialogOptions) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    return win ? dialog.showSaveDialog(win, options) : dialog.showSaveDialog(options);
+  });
   ipcMain.handle('desktop:get-app-version', () => getDiveVersion());
   ipcMain.on('desktop:get-app-version-sync', (event) => {
     // Sync IPC reply: Electron sets the return value on the event object.


### PR DESCRIPTION
Native open/save dialogs were invoked without a parent `BrowserWindow`, so on Linux the file/folder picker could open *behind* the DIVE window instead of in front of it.

- Derive the window from the IPC sender (`BrowserWindow.fromWebContents(event.sender)`) and pass it to `dialog.showOpenDialog`/`showSaveDialog`.
- Falls back to the unparented call if no window is found.

Result: the picker is parented and modal to DIVE.