### PR TITLE
Desktop auto-save cadence + unsaved-changes exit guard

### DIFF
--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -154,7 +154,7 @@ const defaultSettings: AnnotationSettings = {
   },
   autoSaveSettings: {
     enabled: false, // Disabled by default for backward compatibility
-    delaySeconds: 60,
+    delaySeconds: 15,
   },
   stereoSettings: {
     clearLengthOnCameraFileLoad: true,

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -154,7 +154,8 @@ const defaultSettings: AnnotationSettings = {
   },
   autoSaveSettings: {
     enabled: false, // Disabled by default for backward compatibility
-    delaySeconds: 15,
+    // Shorter default delay on desktop; web keeps the longer default to reduce server churn.
+    delaySeconds: isDesktopRuntime() ? 15 : 60,
   },
   stereoSettings: {
     clearLengthOnCameraFileLoad: true,

--- a/client/platform/desktop/background.ts
+++ b/client/platform/desktop/background.ts
@@ -1,5 +1,5 @@
 import {
-  app, protocol, screen, BrowserWindow, session, dialog,
+  app, protocol, screen, BrowserWindow, session, dialog, ipcMain,
 } from 'electron';
 import fs from 'fs';
 import os from 'os';
@@ -32,6 +32,21 @@ app.commandLine.appendSwitch('ignore-gpu-blacklist');
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let win: BrowserWindow | null;
+let allowClose = false;
+let closeGuardActive = false;
+
+ipcMain.on('desktop:close-guard-active', (event, active: boolean) => {
+  if (win && event.sender === win.webContents) {
+    closeGuardActive = active;
+  }
+});
+
+ipcMain.on('desktop:close-response', (event, allow: boolean) => {
+  if (win && event.sender === win.webContents && allow) {
+    allowClose = true;
+    win.close();
+  }
+});
 
 // This application uses localStorage with persistent sessions.
 // In order to use this mechanism, only one application instance
@@ -138,7 +153,17 @@ async function createWindow() {
     }
   }
 
+  allowClose = false;
+  closeGuardActive = false;
+  win.on('close', (e) => {
+    if (allowClose || !closeGuardActive) return;
+    e.preventDefault();
+    win?.webContents.send('desktop:close-requested');
+  });
+
   win.on('closed', () => {
+    allowClose = false;
+    closeGuardActive = false;
     win = null;
   });
 }

--- a/client/platform/desktop/background.ts
+++ b/client/platform/desktop/background.ts
@@ -48,6 +48,25 @@ ipcMain.on('desktop:close-response', (event, allow: boolean) => {
   }
 });
 
+// Native three-way prompt shown by the renderer close guard when the window is
+// closed with unsaved changes. Returns the user's choice.
+ipcMain.handle('desktop:confirm-close-unsaved', async (): Promise<'save' | 'discard' | 'cancel'> => {
+  if (!win) return 'discard';
+  const { response } = await dialog.showMessageBox(win, {
+    type: 'warning',
+    buttons: ['Save and Exit', 'Exit Without Saving', 'Cancel'],
+    defaultId: 0,
+    cancelId: 2,
+    noLink: true,
+    title: 'Unsaved Changes',
+    message: 'You have unsaved changes.',
+    detail: 'Do you want to save your changes before exiting DIVE Desktop?',
+  });
+  if (response === 0) return 'save';
+  if (response === 1) return 'discard';
+  return 'cancel';
+});
+
 // This application uses localStorage with persistent sessions.
 // In order to use this mechanism, only one application instance
 // can exist at a time.  Acquire a lock or quit and focus the running window.

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -1339,8 +1339,27 @@ export default defineComponent({
       stereoCalibrationFile = undefined;
     }
 
+    // Desktop window-close guard: on unsaved changes, offer a native three-way
+    // choice (save / discard / cancel) rather than the two-button navigate-away
+    // prompt. Resolves true to allow the close, false to keep the app open.
+    async function desktopCloseGuard(): Promise<boolean> {
+      const count = viewerRef.value?.pendingSaveCount ?? 0;
+      if (!count) return true;
+      const choice = await window.diveDesktop.invoke('desktop:confirm-close-unsaved');
+      if (choice === 'cancel') return false;
+      if (choice === 'save') {
+        try {
+          await viewerRef.value.save();
+        } catch {
+          // Save failed; the Viewer surfaces its own error, so keep the app open.
+          return false;
+        }
+      }
+      return true;
+    }
+
     onMounted(() => {
-      setCloseGuard(() => viewerRef.value.navigateAwayGuard());
+      setCloseGuard(desktopCloseGuard);
       window.diveDesktop.send('desktop:close-guard-active', true);
     });
 

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -35,6 +35,7 @@ import DatasetSourceInfo from './DatasetSourceInfo.vue';
 import { datasets } from '../store/dataset';
 import { settings } from '../store/settings';
 import { runningJobs } from '../store/jobs';
+import { setCloseGuard } from '../store/closeGuard';
 
 // Renderer-safe path helpers. Node's 'path' module is externalized in the
 // renderer (contextIsolation), so npath.* is unavailable here.
@@ -69,6 +70,14 @@ export default defineComponent({
     CalibrationMenu,
     ...context.getComponents(),
   },
+
+  // TODO: This will require an import from vue-router for Vue3 compatibility
+  async beforeRouteLeave(to, from, next) {
+    if (await this.viewerRef.navigateAwayGuard()) {
+      next();
+    }
+  },
+
   props: {
     id: { // always the base ID
       type: String,
@@ -1329,6 +1338,16 @@ export default defineComponent({
       }
       stereoCalibrationFile = undefined;
     }
+
+    onMounted(() => {
+      setCloseGuard(() => viewerRef.value.navigateAwayGuard());
+      window.diveDesktop.send('desktop:close-guard-active', true);
+    });
+
+    onBeforeUnmount(() => {
+      setCloseGuard(null);
+      window.diveDesktop.send('desktop:close-guard-active', false);
+    });
 
     return {
       datasets,

--- a/client/platform/desktop/frontend/store/closeGuard.ts
+++ b/client/platform/desktop/frontend/store/closeGuard.ts
@@ -1,0 +1,14 @@
+type CloseGuard = () => Promise<boolean>;
+
+let closeGuard: CloseGuard | null = null;
+
+export function setCloseGuard(guard: CloseGuard | null) {
+  closeGuard = guard;
+}
+
+export async function runCloseGuard(): Promise<boolean> {
+  if (closeGuard) {
+    return closeGuard();
+  }
+  return true;
+}

--- a/client/platform/desktop/main.ts
+++ b/client/platform/desktop/main.ts
@@ -6,6 +6,7 @@ import vMousetrap from 'dive-common/vue-utilities/v-mousetrap';
 import vuetify from './plugins/vuetify';
 import router from './router';
 import { migrate } from './frontend/store';
+import { runCloseGuard } from './frontend/store/closeGuard';
 import App from './App.vue';
 
 Vue.config.productionTip = false;
@@ -13,6 +14,11 @@ Vue.use(promptService(vuetify));
 Vue.use(vMousetrap);
 
 migrate().then(() => {
+  window.diveDesktop.on('desktop:close-requested', async () => {
+    const allow = await runCloseGuard();
+    window.diveDesktop.send('desktop:close-response', allow);
+  });
+
   new Vue({
     vuetify,
     router,


### PR DESCRIPTION
## Summary

Two related desktop annotation-safety improvements:

### Auto-save cadence
- Default auto-save interval lowered from **60s to 15s** so annotation work is persisted more frequently when auto-save is enabled.
- Shorter default applies on **desktop only**; web keeps the 60s default to reduce server churn.
- Auto-save remains **disabled by default** (unchanged); this only affects the default delay.

### Unsaved-changes guard on desktop exit
Closing the desktop window with unsaved annotations now prompts instead of silently discarding work.

- The main process intercepts window close while a viewer with unsaved changes is open and defers the decision to the renderer's close guard.
- On unsaved changes the user gets a native **three-button** prompt:
  - **Save and Exit** — saves, then closes
  - **Exit Without Saving** — closes immediately
  - **Cancel** — keeps the app open
- With no pending changes (or no viewer open) the app closes with no prompt.
- If the save fails, the app stays open (the viewer surfaces the save error).

## Testing
- Verified the desktop app builds and runs.
- Open a dataset, make an edit, then close the window: confirm the three-button prompt appears and each option behaves correctly; confirm no prompt when there are no pending changes.
