### PR TITLE
Fix interactive stereo not auto-enabling on load

### DIFF
--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -416,9 +416,8 @@ export default defineComponent({
       }
     }
 
-    // Watch stereo toggle (immediate so a remembered setting enables on load)
     // The backend stereo service is needed whenever either stereo feature is on
-    // (length-on-modify or cross-camera auto-compute). Watch the combined state
+    // (length-on-modify or cross-camera auto-compute). Track the combined state
     // so toggling one feature while the other is already on does not restart it.
     const stereoServiceWanted = () => clientSettings.stereoSettings.updateLengthsOnModify
       || clientSettings.stereoSettings.autoComputeOtherCamera;
@@ -428,13 +427,16 @@ export default defineComponent({
       clientSettings.stereoSettings.autoComputeOtherCamera = false;
     }
 
-    watch(stereoServiceWanted, async (enabled, wasEnabled) => {
-      // wasEnabled === undefined on the initial immediate run. A failure then
-      // (e.g. a stereo dataset without calibration, with length-update on by
-      // default) degrades quietly rather than popping an error dialog or
-      // persisting the feature toggles off.
-      const userInitiated = wasEnabled !== undefined;
+    // Enable or disable the backend stereo service to match the desired state.
+    // userInitiated distinguishes an explicit toggle -- surface failures and
+    // revert the toggles -- from the load-time auto-enable of a remembered
+    // setting, which degrades quietly on benign failures (e.g. an uncalibrated
+    // dataset) so a later calibrated dataset still works.
+    async function applyStereoServiceState(enabled: boolean, userInitiated: boolean) {
       if (enabled) {
+        // Already running (e.g. a user toggle raced the load-time auto-enable):
+        // nothing to do.
+        if (stereoEnabled.value) return;
         stereoLoadingDialog.value = userInitiated;
         stereoLoadingMessage.value = 'Loading stereo model...';
         stereoLoadingError.value = '';
@@ -493,7 +495,33 @@ export default defineComponent({
         }
         stereoEnabled.value = false;
       }
-    }, { immediate: true });
+    }
+
+    // Runtime toggle changes are always user-initiated. This watcher is NOT
+    // immediate: a remembered setting must NOT auto-enable here, because this
+    // runs during setup() -- before the dataset/viewer has loaded. Enabling then
+    // races the not-yet-ready multicam metadata; on failure the load-time path
+    // degrades silently with nothing to retry, so the service would stay off
+    // until the toggle was flipped off and on again. The load-time auto-enable
+    // is deferred to the viewer-ready watcher below instead.
+    watch(stereoServiceWanted, (enabled) => applyStereoServiceState(enabled, true));
+
+    // Load-time auto-enable of a remembered setting: run once the viewer has
+    // actually finished loading the dataset (progress.loaded), so the metadata
+    // and calibration the enable needs are available. One-shot -- stop after the
+    // first load so later dataset reloads (which reset progress.loaded) do not
+    // re-trigger it.
+    const stopStereoAutoEnable = watch(
+      () => viewerRef.value?.progress?.loaded === true,
+      (loaded) => {
+        if (!loaded) return;
+        stopStereoAutoEnable();
+        if (stereoServiceWanted() && !stereoEnabled.value) {
+          applyStereoServiceState(true, false);
+        }
+      },
+      { immediate: true },
+    );
 
     // Watch frame changes to proactively compute disparity
     watch(() => getViewerFrame(), (frameNum) => {


### PR DESCRIPTION
## Problem

In the desktop interactive stereo feature, if the "update lengths on modify" option (or "auto-compute location on other camera") is on at program boot, the backend stereo service was **not initialized** and lengths were not auto-recomputed — until the user flipped a stereo toggle off and on again (or turned on the other stereo option).

## Root cause

The stereo service was enabled by a single `watch(stereoServiceWanted, …, { immediate: true })` in `ViewerLoader.vue`. The `immediate` run fires during `setup()` — **before** the dataset/viewer has finished loading. On that boot run (treated as non-user-initiated), if `loadStereoMetadata()` / `stereoEnable()` doesn't succeed at that instant (multicam metadata / calibration or backend not ready yet), the catch block degrades silently and **nothing retries**. The frame watcher only pushes frames and bails on `!stereoEnabled`, so the only re-entry points were a user toggle or a calibration import.

## Fix

Split the single watcher into two responsibilities:

- **Runtime toggle changes** → a non-immediate watcher, always treated as user-initiated (surfaces failures / reverts toggles, unchanged behavior).
- **Load-time auto-enable of a remembered setting** → a one-shot watcher on the viewer's `progress.loaded`, so the enable runs once the dataset is actually loaded and the metadata/calibration it needs are available.

The enable/disable logic is extracted into a shared `applyStereoServiceState(enabled, userInitiated)` helper (with an idempotency guard so a user toggle racing the load-time enable can't start the service twice). Benign-failure silent-degrade and launch-failure dialog behavior are preserved.

## Verification

`eslint` passes on the changed file.