### PR TITLE
Fix rollback leaving stale tombstones that re-delete restored annotations

### DIFF
--- a/server/dive_server/crud_annotation.py
+++ b/server/dive_server/crud_annotation.py
@@ -140,12 +140,18 @@ def rollback(dsFolder: types.GirderModel, revision: int):
     # And erase deletions for anything deleted after revision
     dsId = dsFolder['_id']
     RevisionLogItem().removeWithQuery({DATASET: dsId, REVISION: {'$gt': revision}})
-    listQuery = {DATASET: dsId, REVISION_CREATED: {'$gt': revision}}
+    removeQuery = {DATASET: dsId, REVISION_CREATED: {'$gt': revision}}
+    # Deletion is lazy, so restoring a record means clearing its rev_deleted
+    # tombstone.  Those records must be selected by REVISION_DELETED: keying this
+    # off REVISION_CREATED only ever matches records removeWithQuery just dropped,
+    # leaving live records tombstoned with a revision number that save_annotations
+    # will re-issue, silently deleting them again on the next save.
+    restoreQuery = {DATASET: dsId, REVISION_DELETED: {'$gt': revision}}
     updateQuery = {'$unset': {REVISION_DELETED: ""}}
-    TrackItem().removeWithQuery(listQuery)
-    TrackItem().update(listQuery, updateQuery)
-    GroupItem().removeWithQuery(listQuery)
-    GroupItem().update(listQuery, updateQuery)
+    TrackItem().removeWithQuery(removeQuery)
+    TrackItem().update(restoreQuery, updateQuery)
+    GroupItem().removeWithQuery(removeQuery)
+    GroupItem().update(restoreQuery, updateQuery)
 
 
 def get_annotation_csv_generator(

--- a/server/tests/test_annotation_rollback.py
+++ b/server/tests/test_annotation_rollback.py
@@ -1,0 +1,115 @@
+from unittest.mock import patch
+
+from dive_server import crud_annotation
+from dive_server.crud_annotation import (
+    DATASET,
+    IDENTIFIER,
+    REVISION,
+    REVISION_CREATED,
+    REVISION_DELETED,
+)
+
+
+@patch('dive_server.crud_annotation.GroupItem')
+@patch('dive_server.crud_annotation.TrackItem')
+@patch('dive_server.crud_annotation.RevisionLogItem')
+def test_rollback_issues_correct_queries(revision_log, track_item, group_item):
+    """Records are removed by rev_created, but restored by rev_deleted."""
+    crud_annotation.rollback({'_id': 'dataset-id'}, 4)
+
+    revision_log.return_value.removeWithQuery.assert_called_once_with(
+        {DATASET: 'dataset-id', REVISION: {'$gt': 4}}
+    )
+
+    for model in (track_item, group_item):
+        model.return_value.removeWithQuery.assert_called_once_with(
+            {DATASET: 'dataset-id', REVISION_CREATED: {'$gt': 4}}
+        )
+        # Restoring must select tombstoned records by REVISION_DELETED.  Selecting
+        # them by REVISION_CREATED (the original defect) only matches records that
+        # removeWithQuery already dropped, so nothing is ever un-deleted.
+        model.return_value.update.assert_called_once_with(
+            {DATASET: 'dataset-id', REVISION_DELETED: {'$gt': 4}},
+            {'$unset': {REVISION_DELETED: ""}},
+        )
+
+
+class FakeCollection:
+    """Minimal stand-in for the mongo-backed track/group models."""
+
+    def __init__(self, docs):
+        self.docs = [dict(doc) for doc in docs]
+
+    @staticmethod
+    def _matches(doc, query):
+        for key, condition in query.items():
+            if isinstance(condition, dict):
+                for operator, value in condition.items():
+                    if operator == '$gt' and not (key in doc and doc[key] > value):
+                        return False
+                    if operator == '$exists' and (key in doc) != value:
+                        return False
+            elif doc.get(key) != condition:
+                return False
+        return True
+
+    def removeWithQuery(self, query):
+        self.docs = [doc for doc in self.docs if not self._matches(doc, query)]
+
+    def update(self, query, update):
+        for doc in self.docs:
+            if self._matches(doc, query):
+                for field in update.get('$unset', {}):
+                    doc.pop(field, None)
+
+    def save(self, dataset, upsert_ids, new_revision):
+        """Mirrors the expire-then-insert behavior of save_annotations()."""
+        expire = {DATASET: dataset, REVISION_DELETED: {'$exists': False}}
+        for identifier in upsert_ids:
+            for doc in self.docs:
+                if doc[IDENTIFIER] == identifier and self._matches(doc, expire):
+                    doc[REVISION_DELETED] = new_revision
+            self.docs.append(
+                {IDENTIFIER: identifier, DATASET: dataset, REVISION_CREATED: new_revision}
+            )
+
+    def live_at(self, head):
+        """Mirrors the visibility query in BaseItem.list()."""
+        return sorted(
+            doc[IDENTIFIER]
+            for doc in self.docs
+            if doc.get(REVISION_CREATED, 0) <= head
+            and (REVISION_DELETED not in doc or doc[REVISION_DELETED] > head)
+        )
+
+
+@patch('dive_server.crud_annotation.GroupItem')
+@patch('dive_server.crud_annotation.TrackItem')
+@patch('dive_server.crud_annotation.RevisionLogItem')
+def test_rollback_restored_track_survives_next_save(revision_log, track_item, _group_item):
+    """
+    A track deleted after the rollback target must stay restored once further
+    edits are made.
+
+    Revision 1 creates tracks a and b, revision 2 deletes a, revision 3 creates c.
+    Rolling back to revision 1 restores a, but the restore is only real if a's
+    tombstone is cleared: the next save re-issues revision 2, which would otherwise
+    reactivate a stale rev_deleted=2 and drop the track again.
+    """
+    tracks = FakeCollection(
+        [
+            {IDENTIFIER: 'a', DATASET: 'dataset-id', REVISION_CREATED: 1, REVISION_DELETED: 2},
+            {IDENTIFIER: 'b', DATASET: 'dataset-id', REVISION_CREATED: 1},
+            {IDENTIFIER: 'c', DATASET: 'dataset-id', REVISION_CREATED: 3},
+        ]
+    )
+    track_item.return_value = tracks
+
+    crud_annotation.rollback({'_id': 'dataset-id'}, 1)
+
+    # Truncating the revision log puts the head back at revision 1.
+    assert tracks.live_at(1) == ['a', 'b']
+
+    # An edit to an unrelated track allocates revision 2 again.
+    tracks.save('dataset-id', upsert_ids=['b'], new_revision=2)
+    assert tracks.live_at(2) == ['a', 'b']


### PR DESCRIPTION
## Problem

Annotations are lazily deleted: a track removed at revision `R` keeps its document and is tombstoned with `rev_deleted = R`. Restoring it means clearing that tombstone.

`rollback()` built one query keyed on `REVISION_CREATED` and used it for **both** the removal and the un-delete:

```python
listQuery = {DATASET: dsId, REVISION_CREATED: {'$gt': revision}}
updateQuery = {'$unset': {REVISION_DELETED: ""}}
TrackItem().removeWithQuery(listQuery)
TrackItem().update(listQuery, updateQuery)   # <-- wrong selector
```

As an un-delete selector that query is wrong: it only ever matches documents `removeWithQuery` just dropped, so **tombstones are never cleared**. The function's own comment states the intent it doesn't implement — *"erase deletions for anything deleted after revision"*.

## Why this is worse than it looks

The bug is **invisible immediately after the rollback**. A track tombstoned `rev_deleted = R` is still visible while the head sits at `R-1`, because `BaseItem.list()` treats `rev_deleted > head` as live. The rollback appears to work.

But `save_annotations()` computes `new_revision = latest + 1`, so **the next save of any kind re-issues revision `R`**. The stale tombstone reactivates and the restored track disappears — permanently, since every later head is `>= R`.

A user who rolls back a bad delete and then makes one unrelated edit silently loses the restored data.

## Fix

Select records to restore by `REVISION_DELETED`; removal still keys off `REVISION_CREATED`.

## Tests

`server/tests/test_annotation_rollback.py` covers both the query shape and the end-to-end property that a restored track **survives a subsequent save**. Note the latter matters: a test that asserts only immediately after the rollback passes even against the buggy code.

Both tests fail on `main` and pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)