### PR TITLE
Fail signal-killed pipelines instead of ingesting their partial output

### DIFF
--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -118,6 +118,17 @@ def check_canceled(task: Task, context: dict, force=True):
     return False
 
 
+def describe_exit(code: int) -> str:
+    """Describe a Popen return code, naming the signal for a kill."""
+    if code < 0:
+        try:
+            name = signal.Signals(-code).name
+        except ValueError:
+            name = 'unknown signal'
+        return f'was terminated by {name} ({-code})'
+    return f'exited with nonzero status code {code}'
+
+
 def stream_subprocess(
     task: Task,
     context: dict,
@@ -186,12 +197,14 @@ def stream_subprocess(
             manager.updateStatus(JobStatus.CANCELED)
             raise CanceledError('Job was canceled')
 
-        if code > 0:
+        # Popen reports death by signal as a negative return code, so anything other
+        # than 0 is a failure.  Treating only code > 0 as failure let a SIGKILLed
+        # pipeline (-9, typically the OOM killer) report success, and callers then
+        # ingested whatever partial or empty output file it left behind.
+        if code != 0:
             stderr_file.seek(0)
             stderr = stderr_file.read().decode('utf-8', errors='replace')
-            raise RuntimeError(
-                'Pipeline exited with nonzero status code {}: {}'.format(process.returncode, stderr)
-            )
+            raise RuntimeError(f'Pipeline {describe_exit(code)}: {stderr}')
         else:
             end_time = datetime.now()
             manager.write(f"\nProcess completed in {str((end_time - start_time))}\n")

--- a/server/tests/test_stream_subprocess.py
+++ b/server/tests/test_stream_subprocess.py
@@ -1,0 +1,45 @@
+import signal
+from unittest.mock import MagicMock
+
+import pytest
+
+from dive_tasks.utils import describe_exit, stream_subprocess
+
+
+def run_command(args):
+    task = MagicMock()
+    task.canceled = False
+    manager = MagicMock()
+    manager.status = None
+    return stream_subprocess(task, {}, manager, {'args': args})
+
+
+def test_describe_exit_names_the_signal():
+    described = describe_exit(-signal.SIGKILL)
+    assert 'SIGKILL' in described
+    assert '9' in described
+
+
+def test_describe_exit_reports_the_status_code():
+    assert 'status code 3' in describe_exit(3)
+
+
+def test_signal_killed_subprocess_raises():
+    """
+    A pipeline killed by a signal must not be reported as successful.
+
+    Popen surfaces a kill as a negative return code, so an OOM-killed pipeline
+    exits -9.  Callers upload and ingest the pipeline's output file on success,
+    so treating this as success overwrites annotations with a partial result.
+    """
+    with pytest.raises(RuntimeError, match='SIGKILL'):
+        run_command(['bash', '-c', 'kill -9 $$'])
+
+
+def test_nonzero_exit_raises():
+    with pytest.raises(RuntimeError, match='status code 3'):
+        run_command(['bash', '-c', 'exit 3'])
+
+
+def test_successful_exit_returns_normally():
+    assert run_command(['bash', '-c', 'exit 0']) == ""


### PR DESCRIPTION
## Problem

`stream_subprocess` only treated a **positive** return code as failure:

```python
code = process.wait(30)
...
if code > 0:
    raise RuntimeError(...)
else:
    manager.write(f"\nProcess completed in ...")
```

`Popen` reports death by signal as a **negative** return code. A pipeline killed by `SIGKILL` — most commonly the OOM killer, at `-9` — fails the `code > 0` test and falls into the **success** branch.

## Why it corrupts data

Callers act on that "success". `run_pipeline` proceeds straight to `PUSHING_OUTPUT`, uploads the output file the dead pipeline left behind, and posts it to `postprocess`, which imports it over the dataset's existing annotations.

So a pipeline OOM-killed partway through **replaced the user's annotations with a truncated CSV — or an empty one — and the job still reported success.**

Reproduced directly:

```
$ bash -c 'echo partial-output; kill -9 $$'
child stdout     : b'partial-output\n'
Popen returncode : -9
  'code > 0'  -> False   => success branch, partial output ingested
  'code != 0' -> True    => raises, upload/import skipped
```

## Fix

Treat any nonzero code as failure, and name the signal in the error so an OOM-killed run is identifiable from the job log (`was terminated by SIGKILL (9)` rather than a bare number).

Cancellation is unaffected — it is detected and raised *before* this check.

## Tests

`server/tests/test_stream_subprocess.py` runs real subprocesses, including one that SIGKILLs itself, and asserts it raises rather than returning normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)