### PR TITLE
Write (note) columns on CSV export so notes survive a round trip

### DIFF
--- a/client/src/components/Tracks/sidebar/SideBarTrackItemView.vue
+++ b/client/src/components/Tracks/sidebar/SideBarTrackItemView.vue
@@ -179,7 +179,8 @@ export default defineComponent({
       <v-tooltip
         open-delay="200"
         bottom
-        max-width="320"
+        max-width="360"
+        content-class="sidebar-notes-tooltip"
       >
         <template #activator="{ on, attrs }">
           <v-btn
@@ -187,7 +188,7 @@ export default defineComponent({
             small
             icon
             class="ma-0"
-            :color="hasNotes ? 'warning' : 'grey darken-1'"
+            :color="hasNotes ? 'white' : 'grey darken-1'"
             v-on="on"
             @click="openNotesDialog"
           >
@@ -196,7 +197,7 @@ export default defineComponent({
             </v-icon>
           </v-btn>
         </template>
-        <span style="white-space: pre-wrap; word-break: break-word;">{{ notesTooltip }}</span>
+        <span>{{ notesTooltip }}</span>
       </v-tooltip>
       <TypePicker
         :value="trackType"
@@ -367,5 +368,24 @@ export default defineComponent({
     min-height: 15px;
     max-height: 15px;
   }
+}
+</style>
+
+<!-- Unscoped: tooltip content is teleported outside this component -->
+<style lang="scss">
+.v-tooltip__content.sidebar-notes-tooltip {
+  opacity: 1 !important;
+  background-color: #1e1e1e !important;
+  color: #f5f5f5 !important;
+  font-size: 14px !important;
+  font-weight: 500;
+  line-height: 1.45;
+  letter-spacing: 0.01em;
+  padding: 10px 14px !important;
+  border: 1px solid #555;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45);
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 </style>

--- a/client/src/components/Tracks/sidebar/SideBarTrackItemView.vue
+++ b/client/src/components/Tracks/sidebar/SideBarTrackItemView.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { computed, defineComponent } from 'vue';
+import { computed, defineComponent, ref } from 'vue';
 import context from 'dive-common/store/context';
 import TooltipBtn from '../../TooltipButton.vue';
 import TypePicker from '../../TypePicker.vue';
@@ -45,6 +45,27 @@ export default defineComponent({
     const { typeStyling } = useTrackStyleManager();
     const multiCam = computed(() => cameraStore.camMap.value.size > 1);
 
+    const notesDialog = ref(false);
+    const editNotesValue = ref('');
+
+    const currentNotes = computed(() => {
+      // Depend on revision so UI updates when notes change
+      if (props.track.revision.value === undefined) {
+        return '';
+      }
+      const feature = props.track.features[props.track.begin];
+      if (feature && feature.notes && feature.notes.length > 0) {
+        return feature.notes.join(', ');
+      }
+      return '';
+    });
+
+    const hasNotes = computed(() => currentNotes.value.length > 0);
+
+    const notesTooltip = computed(() => (
+      hasNotes.value ? currentNotes.value : 'Add note'
+    ));
+
     function setTrackType(type: string) {
       cameraStore.setTrackType(props.track.id, type);
     }
@@ -60,6 +81,26 @@ export default defineComponent({
       handler.trackSeek(props.track.trackId, modifiers);
     }
 
+    function openNotesDialog(event: MouseEvent) {
+      event.stopPropagation();
+      editNotesValue.value = currentNotes.value;
+      notesDialog.value = true;
+    }
+
+    function saveNotes() {
+      if (readOnlyMode.value) return;
+      props.track.setFeatureNotes(props.track.begin, editNotesValue.value.trim());
+      notesDialog.value = false;
+    }
+
+    function cancelNotes() {
+      notesDialog.value = false;
+    }
+
+    function clearNotes() {
+      editNotesValue.value = '';
+    }
+
     return {
       allTypes: trackFilters.allTypes,
       handler,
@@ -70,6 +111,15 @@ export default defineComponent({
       setTrackType,
       trackFilters,
       typeStyling,
+      currentNotes,
+      hasNotes,
+      notesTooltip,
+      notesDialog,
+      editNotesValue,
+      openNotesDialog,
+      saveNotes,
+      cancelNotes,
+      clearNotes,
     };
   },
 });
@@ -126,6 +176,28 @@ export default defineComponent({
         {{ track.set }}
       </v-chip>
       <v-spacer />
+      <v-tooltip
+        open-delay="200"
+        bottom
+        max-width="320"
+      >
+        <template #activator="{ on, attrs }">
+          <v-btn
+            v-bind="attrs"
+            small
+            icon
+            class="ma-0"
+            :color="hasNotes ? 'warning' : 'grey darken-1'"
+            v-on="on"
+            @click="openNotesDialog"
+          >
+            <v-icon>
+              {{ hasNotes ? 'mdi-note-text' : 'mdi-note-text-outline' }}
+            </v-icon>
+          </v-btn>
+        </template>
+        <span style="white-space: pre-wrap; word-break: break-word;">{{ notesTooltip }}</span>
+      </v-tooltip>
       <TypePicker
         :value="trackType"
         v-bind="{
@@ -224,6 +296,56 @@ export default defineComponent({
         @click="handler.trackEdit(track.trackId)"
       />
     </v-row>
+
+    <v-dialog
+      v-model="notesDialog"
+      width="480"
+      @click:outside="cancelNotes"
+    >
+      <v-card>
+        <v-card-title>
+          {{ readOnlyMode ? 'View note' : 'Edit note' }} — track {{ track.trackId }}
+        </v-card-title>
+        <v-card-text>
+          <v-textarea
+            v-model="editNotesValue"
+            autofocus
+            auto-grow
+            rows="3"
+            outlined
+            dense
+            hide-details
+            :readonly="readOnlyMode"
+            :placeholder="readOnlyMode ? 'No note' : 'Add a note...'"
+            @keydown.ctrl.enter="saveNotes"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-btn
+            v-if="!readOnlyMode"
+            text
+            :disabled="!editNotesValue"
+            @click="clearNotes"
+          >
+            Clear
+          </v-btn>
+          <v-spacer />
+          <v-btn
+            text
+            @click="cancelNotes"
+          >
+            {{ readOnlyMode ? 'Close' : 'Cancel' }}
+          </v-btn>
+          <v-btn
+            v-if="!readOnlyMode"
+            color="primary"
+            @click="saveNotes"
+          >
+            Save
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -81,6 +81,12 @@ interface Feature {
   attributes?: Record<string, unknown>;
   head?: [number, number];
   tail?: [number, number];
+  /**
+   * Free-form note text for this detection (frame). Stored as a string
+   * array for format compatibility; DIVE typically uses a single entry.
+   * Omitted when the detection has no note.
+   */
+  notes?: string[];
 }
 ```
 
@@ -238,6 +244,21 @@ Multiple holes are supported with additional `(hole)` columns.
 
 **Length measurements** — the standard VIAME length column (8th numeric field) stores stereo fish-length values. DIVE also reads and writes a `length` entry in detection attributes; on export, the resolved value is written to both the column and attributes when present. Interactive stereo in [DIVE Desktop](Interactive-Annotation.md) populates these values during annotation.
 
+### VIAME CSV notes
+
+DIVE stores a free-form note on each detection (`Feature.notes`). In VIAME CSV
+it is written as a `(note)` column on the detection row:
+
+```
+0,1.png,0,100,100,500,500,1.0,-1,fish,1.0,(note) primary observation
+```
+
+* The `(note)` column is followed by the note text (whitespace after `(note)` is trimmed on import).
+* Notes are per-detection (CSV row), not track-level. There is no track-scoped note token.
+* On import, `(note)` text is stored in `Feature.notes` (typically a single-element `string[]`).
+* On export, the note is emitted last among the token columns so DIVE Desktop and Web produce identical row order.
+* If a row contains more than one `(note)` column, all values are imported into `Feature.notes` and preserved on re-export, but the DIVE UI edits a single combined note string.
+
 ## KWIVER Packet Format (KPF)
 
 DIVE supports [MEVA KPF](https://mevadata.org/)
@@ -270,16 +291,17 @@ are also accepted on import.
 
 ### DIVE COCO Attribute Extensions
 
-COCO does not define standard fields for arbitrary track or detection attributes.
-To preserve DIVE attributes during COCO export/import, DIVE uses extension fields
-on each COCO `annotation` object:
+COCO does not define standard fields for arbitrary track or detection attributes
+or free-form notes. To preserve DIVE attributes and notes during COCO
+export/import, DIVE uses extension fields on each COCO `annotation` object:
 
 * `dive_detection_attributes`: Detection/frame-level attributes (maps to `Feature.attributes`)
 * `dive_track_attributes`: Track-level attributes (maps to `Track.attributes`)
+* `dive_notes`: Per-detection note (maps to `Feature.notes`)
 
 These extension keys are declared in the COCO `info` object as:
 
-* `info.dive_extensions = ["dive_detection_attributes", "dive_track_attributes"]`
+* `info.dive_extensions = ["dive_detection_attributes", "dive_track_attributes", "dive_notes"]`
 
 ### Dataset-level metadata (`datasetInfo`)
 
@@ -300,11 +322,17 @@ Values are typically strings, numbers, or booleans.
 * `annotation.dive_track_attributes`
   * Scope: logical track identity across frames (`track_id`)
   * DIVE mapping: `Track.attributes`
+* `annotation.dive_notes`
+  * Scope: one COCO annotation (one frame-level detection)
+  * Type: `string[]` (typically one entry; a single non-empty string is also accepted on import)
+  * DIVE mapping: `Track.features[i].notes`
+  * Legacy alias: on import, if `dive_notes` is absent, DIVE also reads `notes`
 
-When importing, DIVE merges any keys in these objects into the target
+When importing, DIVE merges any keys in the attribute objects into the target
 detection/track attribute dictionaries. If the same key appears in multiple
 annotations belonging to the same track, later imported entries may overwrite
-earlier values for that track-level key.
+earlier values for that track-level key. The note is attached to the feature for
+that annotation only.
 
 ### Round-Trip Behavior
 
@@ -313,7 +341,8 @@ For COCO files produced by DIVE:
 * DIVE writes `info.dive_extensions` to advertise the extension keys used.
 * DIVE writes `dive_detection_attributes` and `dive_track_attributes` on each
   annotation when attributes are present.
-* Re-importing that file into DIVE preserves those attributes.
+* DIVE writes `dive_notes` on each annotation when that feature has a note.
+* Re-importing that file into DIVE preserves those attributes and notes.
 
 For COCO files not produced by DIVE:
 
@@ -339,7 +368,7 @@ For COCO files not produced by DIVE:
 {
   "info": {
     "description": "DIVE export for my-dataset",
-    "dive_extensions": ["dive_detection_attributes", "dive_track_attributes"]
+    "dive_extensions": ["dive_detection_attributes", "dive_track_attributes", "dive_notes"]
   },
   "images": [
     { "id": 1, "file_name": "frame_000000.jpg", "frame_index": 0 }
@@ -363,7 +392,8 @@ For COCO files not produced by DIVE:
       "dive_track_attributes": {
         "reviewed": true,
         "source": "analyst"
-      }
+      },
+      "dive_notes": ["primary observation"]
     },
     {
       "id": 2,

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -724,6 +724,11 @@ def export_tracks_as_csv(
                                     f"{round(coordinates[0])} {round(coordinates[1])}"
                                 )
 
+                    # Emitted last, matching the desktop TypeScript serializer's
+                    # column order so both exporters produce identical rows.
+                    for note in feature.notes or []:
+                        columns.append(f"(note) {note}")
+
                     writer.writerow(columns)
                     yield csvFile.getvalue()
                     csvFile.seek(0)

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -564,3 +564,41 @@ def test_fps_parsed_case_insensitively_from_metadata():
         rows
     )
     assert float(fps) == 23.976
+
+
+def test_notes_round_trip_through_csv_export():
+    """Detection notes survive an export -> import cycle.
+
+    Regression for an exporter that parsed ``(note)`` columns on import but never
+    wrote them on export, so notes were silently dropped by every server-side CSV
+    round trip while the desktop TypeScript serializer preserved them.
+    """
+    tracks = {
+        "0": {
+            "id": 0,
+            "attributes": {},
+            "confidencePairs": [["fish", 0.9]],
+            "features": [
+                {
+                    "frame": 0,
+                    "bounds": [884, 510, 1219, 737],
+                    "notes": ["needs review", "occluded by kelp"],
+                }
+            ],
+            "begin": 0,
+            "end": 0,
+        }
+    }
+
+    csv_text = ''.join(viame.export_tracks_as_csv(tracks.values(), filenames=filenames))
+    assert '(note) needs review' in csv_text
+    assert '(note) occluded by kelp' in csv_text
+
+    rows = csv_text.splitlines()
+    annotations, _attributes, _warnings, _fps, _info = viame.load_csv_as_tracks_and_attributes(
+        rows
+    )
+    assert annotations['tracks']['0']['features'][0]['notes'] == [
+        "needs review",
+        "occluded by kelp",
+    ]


### PR DESCRIPTION
## Problem

The server CSV exporter (`export_tracks_as_csv`) emits `(atr)`, `(trk-atr)`, `(poly)`, `(hole)` and `(kp)` columns — but never `(note)`.

This is a one-sided format gap:

- its **own importer** parses `(note)` (`_parse_row`, `viame.py:234-237`)
- the `Feature` model carries the field (`models.py:54`)
- the **desktop TypeScript serializer already writes it** (`viame.ts:790-792`)

So detection notes are dropped by every server-side export, and an export → import cycle — which is how DIVE moves annotations through pipelines and downloads — silently loses them. The two exporters disagree on the same format.

Before this change, a feature carrying notes exported as:

```
0,1.png,0,884,510,1219,737,0.9,-1,fish,0.9
```

— the notes are simply gone.

## Fix

Append `(note)` columns after the geometry columns, matching the column ordering the TypeScript serializer uses so both exporters produce identical rows.

## Tests

Adds an export → import round-trip test asserting notes survive. It fails on `main` and passes with this change; the existing 23 serializer tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)