### PR TITLE
Support launching DIVE Desktop on a dataset from the command line

### DIFF
--- a/client/platform/desktop/README.md
+++ b/client/platform/desktop/README.md
@@ -71,9 +71,32 @@ Relative paths are resolved against the working directory. For example, to revie
 dive-desktop --import input_list.txt --annotations detections.csv --name "Sea Lions"
 ```
 
-The dataset is imported through the same backend calls as the wizard (`beginMediaImport` → `finalizeMediaImport` → `dataFileImport`), so it is a normal dataset: it is added to the recents list and can be reopened from the dataset list later. Media that requires transcoding is converted first, and the viewer opens when the conversion job completes.
+### Multi-camera and stereo
+
+Name each camera with a repeated `--camera` instead of using `--import`:
+
+```bash
+dive-desktop --camera left=/data/left --camera right=/data/right \
+             --annotations left=/data/left.csv --annotations right=/data/right.csv \
+             --calibration /data/calibration_matrices.npz
+```
+
+* **`--camera`, `-c`** — `<name>=<media>`, repeated once per camera (two or more). Each media path is the same set of things `--import` accepts. Only the first `=` separates, so Windows paths survive. Flag order is the display order.
+* **`--annotations`, `-a`** — becomes `<camera>=<file>` in multi-camera mode. Give it once per camera that has annotations; cameras may be omitted.
+* **`--calibration`** — stereo calibration file (`.npz` or `.json`). Multi-camera only.
+* **`--default-display`** — camera shown on open. Defaults to `left` when present, else the first camera.
+
+**Stereo is not a separate flag.** As elsewhere in DIVE, a dataset whose cameras are named exactly `left` and `right` is typed `stereo`; any other set of names is `multicam`. So the example above produces a stereo dataset, and adding a `--calibration` is what makes stereo measurement work.
+
+Every camera must be the same kind of media — all videos or all image sequences — since one dataset type covers them all. `--import` and `--camera` are mutually exclusive.
+
+### Notes
+
+Single-camera datasets go through the same backend calls as the wizard (`beginMediaImport` → `finalizeMediaImport` → `dataFileImport`); multi-camera ones go through `beginMultiCamImport` → `finalizeMediaImport`, which ingests the per-camera track files and copies/normalizes the calibration. Either way the result is a normal dataset: it is added to the recents list and can be reopened from the dataset list later. Media that requires transcoding is converted first, and the viewer opens when the conversion job completes.
 
 If an instance is already running, the single-instance lock forwards the arguments to it and the dataset opens in the existing window.
+
+Glob/keyword multi-camera import (`MultiCamImportKeywordArgs`, one folder matched by per-camera glob) is not exposed on the command line; use one `--camera` per source instead.
 
 Implementation: `backend/cliImport.ts` (argument parsing and import), wired up in `background.ts`. The renderer asks for any pending CLI dataset once mounted (`desktop:cli-open-pending`) and is told to navigate via `desktop:open-dataset`, so an import that finishes before the window is ready is not missed.
 

--- a/client/platform/desktop/README.md
+++ b/client/platform/desktop/README.md
@@ -53,6 +53,32 @@ After `electron-vite build`, **`electron-builder --config electron-builder.json`
 * **`build:electron`** — `electron-vite build` then `electron-builder --config electron-builder.json`.
 * **`build:electron:dir`** — same as `build:electron` but produces an unpacked directory instead of an installer (faster iteration for testing).
 
+## Launching from the command line
+
+DIVE Desktop can be started directly on a dataset, skipping the import wizard:
+
+```bash
+dive-desktop --import <media> [--annotations <file>] [--name <name>]
+```
+
+* **`--import`, `-i`** — the media to open. Anything the import wizard accepts: an image-sequence directory, an image-list text file (one image path per line), or a video.
+* **`--annotations`, `-a`** — optional VIAME CSV or DIVE JSON to load onto the dataset.
+* **`--name`, `-n`** — optional display name; defaults to the media basename.
+
+Relative paths are resolved against the working directory. For example, to review a detector's output over an image list:
+
+```bash
+dive-desktop --import input_list.txt --annotations detections.csv --name "Sea Lions"
+```
+
+The dataset is imported through the same backend calls as the wizard (`beginMediaImport` → `finalizeMediaImport` → `dataFileImport`), so it is a normal dataset: it is added to the recents list and can be reopened from the dataset list later. Media that requires transcoding is converted first, and the viewer opens when the conversion job completes.
+
+If an instance is already running, the single-instance lock forwards the arguments to it and the dataset opens in the existing window.
+
+Implementation: `backend/cliImport.ts` (argument parsing and import), wired up in `background.ts`. The renderer asks for any pending CLI dataset once mounted (`desktop:cli-open-pending`) and is told to navigate via `desktop:open-dataset`, so an import that finishes before the window is ready is not missed.
+
+Note this is distinct from `divecli` (`backend/cli.ts`), a separate headless entrypoint for format conversion and running pipelines, which does not open the GUI.
+
 ## Interactive service (segmentation + stereo)
 
 Desktop-only interactive annotation runs through a single persistent Python subprocess managed by `backend/native/interactive.ts`. It hosts:

--- a/client/platform/desktop/README.md
+++ b/client/platform/desktop/README.md
@@ -92,13 +92,13 @@ Every camera must be the same kind of media — all videos or all image sequence
 
 ### Notes
 
-Single-camera datasets go through the same backend calls as the wizard (`beginMediaImport` → `finalizeMediaImport` → `dataFileImport`); multi-camera ones go through `beginMultiCamImport` → `finalizeMediaImport`, which ingests the per-camera track files and copies/normalizes the calibration. Either way the result is a normal dataset: it is added to the recents list and can be reopened from the dataset list later. Media that requires transcoding is converted first, and the viewer opens when the conversion job completes.
+Single-camera datasets go through the same backend calls as the wizard (`beginMediaImport` → `finalizeMediaImport` → `dataFileImport`); multi-camera ones go through `beginMultiCamImport` → `finalizeMediaImport`, which ingests the per-camera track files and copies/normalizes the calibration. Either way the result is a normal dataset: it is added to the recents list and can be reopened from the dataset list later. Media that requires transcoding is converted first, and the viewer opens when the conversion job completes. In that case the main process logs a message and the renderer gets `desktop:cli-transcoding` so a dialog appears whether the app just started or another dataset is already open; recents also show the converting status immediately.
 
 If an instance is already running, the single-instance lock forwards the arguments to it and the dataset opens in the existing window.
 
 Glob/keyword multi-camera import (`MultiCamImportKeywordArgs`, one folder matched by per-camera glob) is not exposed on the command line; use one `--camera` per source instead.
 
-Implementation: `backend/cliImport.ts` (argument parsing and import), wired up in `background.ts`. The renderer asks for any pending CLI dataset once mounted (`desktop:cli-open-pending`) and is told to navigate via `desktop:open-dataset`, so an import that finishes before the window is ready is not missed.
+Implementation: `backend/cliImport.ts` (argument parsing and import), wired up in `background.ts`. The renderer asks for any pending CLI dataset once mounted (`desktop:cli-open-pending`) and is told to navigate via `desktop:open-dataset`, so an import that finishes before the window is ready is not missed. Transcoding waits use `desktop:cli-transcoding` before that navigation.
 
 Note this is distinct from `divecli` (`backend/cli.ts`), a separate headless entrypoint for format conversion and running pipelines, which does not open the GUI.
 

--- a/client/platform/desktop/backend/cliImport.spec.ts
+++ b/client/platform/desktop/backend/cliImport.spec.ts
@@ -54,3 +54,100 @@ describe('parseCliArgs', () => {
     expect(parseCliArgs(['app', '--import', '--no-sandbox'])).toBeNull();
   });
 });
+
+describe('parseCliArgs multi-camera', () => {
+  it('parses cameras, per-camera annotations and calibration', () => {
+    const args = parseCliArgs([
+      'app',
+      '--camera', 'left=/data/left',
+      '--camera', 'right=/data/right',
+      '--annotations', 'left=/data/left.csv',
+      '--annotations', 'right=/data/right.csv',
+      '--calibration', '/data/cal.npz',
+      '--name', 'Stereo Run',
+    ]);
+    expect(args).toEqual({
+      cameras: { left: '/data/left', right: '/data/right' },
+      cameraOrder: ['left', 'right'],
+      cameraAnnotations: { left: '/data/left.csv', right: '/data/right.csv' },
+      defaultDisplay: 'left',
+      calibrationPath: '/data/cal.npz',
+      name: 'Stereo Run',
+    });
+  });
+
+  it('defaults defaultDisplay to left, else the first camera', () => {
+    expect(parseCliArgs([
+      'app', '--camera', 'right=/d/r', '--camera', 'left=/d/l',
+    ])?.defaultDisplay).toEqual('left');
+    expect(parseCliArgs([
+      'app', '--camera', 'cam2=/d/2', '--camera', 'cam1=/d/1',
+    ])?.defaultDisplay).toEqual('cam2');
+  });
+
+  it('honors an explicit --default-display', () => {
+    expect(parseCliArgs([
+      'app', '--camera', 'left=/d/l', '--camera', 'right=/d/r',
+      '--default-display', 'right',
+    ])?.defaultDisplay).toEqual('right');
+  });
+
+  it('keeps camera order, which is the display order', () => {
+    expect(parseCliArgs([
+      'app', '--camera', 'c=/d/c', '--camera', 'a=/d/a', '--camera', 'b=/d/b',
+    ])?.cameraOrder).toEqual(['c', 'a', 'b']);
+  });
+
+  it('splits on the first = so windows paths survive', () => {
+    expect(parseCliArgs([
+      'app', '--camera', 'left=C:\\data\\left', '--camera', 'right=C:\\data\\right',
+    ])?.cameras?.left).toContain('C:\\data\\left');
+  });
+
+  it('rejects a single camera', () => {
+    expect(() => parseCliArgs(['app', '--camera', 'left=/d/l']))
+      .toThrow(/at least two --camera/);
+  });
+
+  it('rejects --import together with --camera', () => {
+    expect(() => parseCliArgs([
+      'app', '--import', '/d/x', '--camera', 'left=/d/l', '--camera', 'right=/d/r',
+    ])).toThrow(/mutually exclusive/);
+  });
+
+  it('rejects annotations for an unknown camera', () => {
+    expect(() => parseCliArgs([
+      'app', '--camera', 'left=/d/l', '--camera', 'right=/d/r',
+      '--annotations', 'middle=/d/m.csv',
+    ])).toThrow(/unknown camera 'middle'/);
+  });
+
+  it('rejects an unknown --default-display', () => {
+    expect(() => parseCliArgs([
+      'app', '--camera', 'left=/d/l', '--camera', 'right=/d/r',
+      '--default-display', 'middle',
+    ])).toThrow(/unknown camera 'middle'/);
+  });
+
+  it('rejects a duplicate camera name', () => {
+    expect(() => parseCliArgs([
+      'app', '--camera', 'left=/d/l', '--camera', 'left=/d/l2',
+    ])).toThrow(/given more than once/);
+  });
+
+  it('rejects malformed camera arguments', () => {
+    expect(() => parseCliArgs(['app', '--camera', '/d/l', '--camera', 'right=/d/r']))
+      .toThrow(/expects <camera>=<path>/);
+  });
+
+  it('rejects --calibration on a single-camera dataset', () => {
+    expect(() => parseCliArgs(['app', '--import', '/d/x', '--calibration', '/d/c.npz']))
+      .toThrow(/--calibration applies to multi-camera/);
+  });
+
+  it('rejects repeated --annotations on a single-camera dataset', () => {
+    expect(() => parseCliArgs([
+      'app', '--import', '/d/x', '--annotations', '/d/a.csv', '--annotations', '/d/b.csv',
+    ])).toThrow(/may only be given once/);
+  });
+});

--- a/client/platform/desktop/backend/cliImport.spec.ts
+++ b/client/platform/desktop/backend/cliImport.spec.ts
@@ -1,0 +1,56 @@
+import npath from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { parseCliArgs } from './cliImport';
+
+describe('parseCliArgs', () => {
+  it('returns null when no --import is present', () => {
+    expect(parseCliArgs(['/usr/bin/dive-desktop'])).toBeNull();
+    expect(parseCliArgs(['/usr/bin/dive-desktop', '--no-sandbox'])).toBeNull();
+  });
+
+  it('parses media, annotations and name', () => {
+    const args = parseCliArgs([
+      '/usr/bin/dive-desktop',
+      '--import', '/data/input_list.txt',
+      '--annotations', '/data/detections.csv',
+      '--name', 'Sea Lions',
+    ]);
+    expect(args).toEqual({
+      importPath: '/data/input_list.txt',
+      annotationPath: '/data/detections.csv',
+      name: 'Sea Lions',
+    });
+  });
+
+  it('supports = syntax and short flags', () => {
+    expect(parseCliArgs(['app', '--import=/data/imgs', '-a', '/data/x.csv'])).toEqual({
+      importPath: '/data/imgs',
+      annotationPath: '/data/x.csv',
+      name: undefined,
+    });
+    expect(parseCliArgs(['app', '-i', '/data/imgs'])?.importPath).toEqual('/data/imgs');
+  });
+
+  it('resolves relative paths against the working directory', () => {
+    const args = parseCliArgs(['app', '--import', 'list.txt', '-a', 'out.csv']);
+    expect(args?.importPath).toEqual(npath.resolve('list.txt'));
+    expect(args?.annotationPath).toEqual(npath.resolve('out.csv'));
+  });
+
+  it('ignores electron switches interleaved with our flags', () => {
+    const args = parseCliArgs([
+      '/usr/bin/dive-desktop',
+      '--no-sandbox',
+      '--import', '/data/video.mp4',
+      '--ignore-gpu-blacklist',
+    ]);
+    expect(args?.importPath).toEqual('/data/video.mp4');
+    expect(args?.annotationPath).toBeUndefined();
+  });
+
+  it('does not treat a following flag as a value', () => {
+    // --import with no value must not swallow --no-sandbox as its path
+    expect(parseCliArgs(['app', '--import', '--no-sandbox'])).toBeNull();
+  });
+});

--- a/client/platform/desktop/backend/cliImport.ts
+++ b/client/platform/desktop/backend/cliImport.ts
@@ -28,8 +28,14 @@ import mime from 'mime-types';
 import { MultiCamImportFolderArgs } from 'dive-common/apispec';
 import { otherVideoTypes, websafeVideoTypes } from 'dive-common/constants';
 import {
-  ConversionArgs, DesktopJob, DesktopJobUpdate, DesktopMediaImportResponse,
+  CliTranscodingNotice,
+  ConversionArgs,
+  DesktopJob,
+  DesktopJobUpdate,
+  DesktopMediaImportResponse,
 } from 'platform/desktop/constants';
+
+export type { CliTranscodingNotice };
 import { convertMedia } from './native/mediaJobs';
 import beginMultiCamImport from './native/multiCamImport';
 import * as common from './native/common';
@@ -218,11 +224,14 @@ function buildMultiCamArgs(args: CliOpenArgs): MultiCamImportFolderArgs {
  * Media that needs transcoding cannot be viewed until its conversion job
  * finishes, so the id is reported through onReady instead of being returned
  * immediately. onReady fires once the dataset is actually viewable.
+ * onTranscoding fires as soon as conversion is known to be required so the UI
+ * or console can tell the user why the viewer has not opened yet.
  */
 export async function runCliImport(
   args: CliOpenArgs,
   updater: (update: DesktopJobUpdate) => void,
   onReady: (datasetId: string) => void,
+  onTranscoding?: (notice: CliTranscodingNotice) => void,
 ): Promise<string> {
   const currentSettings = settings.get();
 
@@ -247,8 +256,16 @@ export async function runCliImport(
     return datasetId;
   }
 
-  // Transcoding required. Queue the conversion and open the dataset once it
-  // lands, mirroring what the import wizard does with the same ConversionArgs.
+  // Transcoding required. Tell the caller before queuing so cold-start and
+  // second-instance opens can surface the wait (console + in-app notice).
+  onTranscoding?.({
+    datasetId,
+    name: conversionArgs.meta.name,
+    mediaCount: conversionArgs.mediaList.length,
+  });
+
+  // Queue the conversion and open the dataset once it lands, mirroring what
+  // the import wizard does with the same ConversionArgs.
   const job: DesktopJob = await convertMedia(
     currentSettings,
     conversionArgs,

--- a/client/platform/desktop/backend/cliImport.ts
+++ b/client/platform/desktop/backend/cliImport.ts
@@ -1,0 +1,118 @@
+/**
+ * Command-line launch support for DIVE Desktop.
+ *
+ * Allows the app to be started directly on a dataset, skipping the import
+ * wizard:
+ *
+ *   dive-desktop --import <media> [--annotations <file>] [--name <name>]
+ *
+ * <media> is anything beginMediaImport accepts: an image-sequence directory, an
+ * image-list text file, or a video. <file> is a VIAME CSV or DIVE JSON.
+ *
+ * This drives the same backend calls as the import wizard in Recent.vue, so a
+ * CLI-launched dataset is indistinguishable from a hand-imported one.
+ */
+import npath from 'path';
+
+import { ConversionArgs, DesktopJob, DesktopJobUpdate } from 'platform/desktop/constants';
+import { convertMedia } from './native/mediaJobs';
+import * as common from './native/common';
+import settings from './state/settings';
+
+export interface CliOpenArgs {
+  /** Media to import: image directory, image-list text file, or video. */
+  importPath: string;
+  /** Optional VIAME CSV or DIVE JSON annotations to load onto the dataset. */
+  annotationPath?: string;
+  /** Optional dataset display name; defaults to the media basename. */
+  name?: string;
+}
+
+/**
+ * Pull the launch arguments out of an argv.
+ *
+ * Electron hands us its own switches (--no-sandbox, --inspect, the dev entry
+ * path, ...) alongside ours, so scan for known flags rather than assuming
+ * positions. Returns null when no --import was supplied, which is the ordinary
+ * "just open the app" case.
+ */
+export function parseCliArgs(argv: string[]): CliOpenArgs | null {
+  const readFlag = (...names: string[]): string | undefined => {
+    for (let i = 0; i < argv.length; i += 1) {
+      const arg = argv[i];
+      const match = names.find((name) => arg === name || arg.startsWith(`${name}=`));
+      if (match) {
+        if (arg.startsWith(`${match}=`)) {
+          const value = arg.slice(match.length + 1);
+          if (value) return value;
+        } else if (i + 1 < argv.length && !argv[i + 1].startsWith('-')) {
+          return argv[i + 1];
+        }
+      }
+    }
+    return undefined;
+  };
+
+  const importPath = readFlag('--import', '-i');
+  if (!importPath) {
+    return null;
+  }
+  const annotationPath = readFlag('--annotations', '--annotation', '-a');
+  return {
+    importPath: npath.resolve(importPath),
+    annotationPath: annotationPath ? npath.resolve(annotationPath) : undefined,
+    name: readFlag('--name', '-n'),
+  };
+}
+
+/**
+ * Import the media (and annotations, if given) and return the new dataset id.
+ *
+ * Media that needs transcoding cannot be viewed until its conversion job
+ * finishes, so the id is reported through onReady instead of being returned
+ * immediately. onReady fires once the dataset is actually viewable.
+ */
+export async function runCliImport(
+  args: CliOpenArgs,
+  updater: (update: DesktopJobUpdate) => void,
+  onReady: (datasetId: string) => void,
+): Promise<string> {
+  const currentSettings = settings.get();
+
+  const importPayload = await common.beginMediaImport(args.importPath);
+  if (args.name) {
+    importPayload.jsonMeta.name = args.name;
+  }
+
+  const conversionArgs: ConversionArgs = await common.finalizeMediaImport(currentSettings, importPayload);
+  const datasetId = conversionArgs.meta.id;
+
+  if (args.annotationPath) {
+    await common.dataFileImport(currentSettings, datasetId, args.annotationPath);
+  }
+
+  if (conversionArgs.mediaList.length === 0) {
+    onReady(datasetId);
+    return datasetId;
+  }
+
+  // Transcoding required. Queue the conversion and open the dataset once it
+  // lands, mirroring what the import wizard does with the same ConversionArgs.
+  const job: DesktopJob = await convertMedia(
+    currentSettings,
+    conversionArgs,
+    updater,
+    (jobKey, meta) => {
+      common.completeConversion(currentSettings, datasetId, jobKey, meta);
+      onReady(datasetId);
+    },
+    (_jobKey, meta, errorMessage) => common.failConversion(currentSettings, datasetId, meta, errorMessage),
+    true,
+  );
+  updater({
+    ...job,
+    body: [`Converting media for ${conversionArgs.meta.name}...`],
+  });
+
+  return datasetId;
+}

--- a/client/platform/desktop/backend/cliImport.ts
+++ b/client/platform/desktop/backend/cliImport.ts
@@ -2,30 +2,80 @@
  * Command-line launch support for DIVE Desktop.
  *
  * Allows the app to be started directly on a dataset, skipping the import
- * wizard:
+ * wizard.
+ *
+ * Single camera:
  *
  *   dive-desktop --import <media> [--annotations <file>] [--name <name>]
  *
- * <media> is anything beginMediaImport accepts: an image-sequence directory, an
- * image-list text file, or a video. <file> is a VIAME CSV or DIVE JSON.
+ * Multi-camera and stereo, by naming each camera:
  *
- * This drives the same backend calls as the import wizard in Recent.vue, so a
- * CLI-launched dataset is indistinguishable from a hand-imported one.
+ *   dive-desktop --camera left=<media> --camera right=<media> \
+ *                --annotations left=<file> --annotations right=<file> \
+ *                --calibration <file>
+ *
+ * <media> is anything the import wizard accepts: an image-sequence directory,
+ * an image-list text file, or a video. Annotation files are VIAME CSV or DIVE
+ * JSON. A dataset whose cameras are named exactly `left` and `right` is typed
+ * as stereo by the importer; any other set of names is multicam.
+ *
+ * This drives the same backend calls as the import wizard, so a CLI-launched
+ * dataset is indistinguishable from a hand-imported one.
  */
 import npath from 'path';
+import mime from 'mime-types';
 
-import { ConversionArgs, DesktopJob, DesktopJobUpdate } from 'platform/desktop/constants';
+import { MultiCamImportFolderArgs } from 'dive-common/apispec';
+import { otherVideoTypes, websafeVideoTypes } from 'dive-common/constants';
+import {
+  ConversionArgs, DesktopJob, DesktopJobUpdate, DesktopMediaImportResponse,
+} from 'platform/desktop/constants';
 import { convertMedia } from './native/mediaJobs';
+import beginMultiCamImport from './native/multiCamImport';
 import * as common from './native/common';
 import settings from './state/settings';
 
 export interface CliOpenArgs {
   /** Media to import: image directory, image-list text file, or video. */
-  importPath: string;
-  /** Optional VIAME CSV or DIVE JSON annotations to load onto the dataset. */
+  importPath?: string;
+  /**
+   * Annotations to load. A bare path for a single-camera dataset; keyed by
+   * camera name for a multi-camera one.
+   */
   annotationPath?: string;
+  cameraAnnotations?: Record<string, string>;
+  /** Media per camera name. Presence of this selects the multi-camera import. */
+  cameras?: Record<string, string>;
+  /** Camera names in the order given, which is the display order. */
+  cameraOrder?: string[];
+  /** Camera shown by default; defaults to `left`, else the first camera. */
+  defaultDisplay?: string;
+  /** Stereo calibration file (.npz or .json). */
+  calibrationPath?: string;
   /** Optional dataset display name; defaults to the media basename. */
   name?: string;
+}
+
+/** A camera media path is a video if its mimetype says so, else an image sequence. */
+function inferDatasetType(mediaPath: string): 'video' | 'image-sequence' {
+  const mimetype = mime.lookup(mediaPath);
+  if (mimetype && (websafeVideoTypes.includes(mimetype)
+    || otherVideoTypes.includes(mimetype))) {
+    return 'video';
+  }
+  return 'image-sequence';
+}
+
+/**
+ * Split a `name=value` flag argument. Only the first `=` separates, so Windows
+ * paths (`left=C:\data\left`) survive intact.
+ */
+function splitNamed(arg: string, flag: string): [string, string] {
+  const idx = arg.indexOf('=');
+  if (idx <= 0 || idx === arg.length - 1) {
+    throw new Error(`${flag} expects <camera>=<path>, got: ${arg}`);
+  }
+  return [arg.slice(0, idx), arg.slice(idx + 1)];
 }
 
 /**
@@ -33,35 +83,132 @@ export interface CliOpenArgs {
  *
  * Electron hands us its own switches (--no-sandbox, --inspect, the dev entry
  * path, ...) alongside ours, so scan for known flags rather than assuming
- * positions. Returns null when no --import was supplied, which is the ordinary
- * "just open the app" case.
+ * positions. Returns null when neither --import nor --camera was supplied,
+ * which is the ordinary "just open the app" case.
  */
 export function parseCliArgs(argv: string[]): CliOpenArgs | null {
-  const readFlag = (...names: string[]): string | undefined => {
+  /** Every value given for a flag, so repeatable flags collect. */
+  const readFlagAll = (...names: string[]): string[] => {
+    const values: string[] = [];
     for (let i = 0; i < argv.length; i += 1) {
       const arg = argv[i];
       const match = names.find((name) => arg === name || arg.startsWith(`${name}=`));
       if (match) {
         if (arg.startsWith(`${match}=`)) {
           const value = arg.slice(match.length + 1);
-          if (value) return value;
+          if (value) values.push(value);
         } else if (i + 1 < argv.length && !argv[i + 1].startsWith('-')) {
-          return argv[i + 1];
+          values.push(argv[i + 1]);
         }
       }
     }
-    return undefined;
+    return values;
   };
+  const readFlag = (...names: string[]): string | undefined => readFlagAll(...names)[0];
 
   const importPath = readFlag('--import', '-i');
-  if (!importPath) {
+  const cameraArgs = readFlagAll('--camera', '-c');
+  if (!importPath && !cameraArgs.length) {
     return null;
   }
-  const annotationPath = readFlag('--annotations', '--annotation', '-a');
+  if (importPath && cameraArgs.length) {
+    throw new Error('--import and --camera are mutually exclusive: --import is a '
+      + 'single-camera dataset, --camera builds a multi-camera one');
+  }
+
+  const annotationArgs = readFlagAll('--annotations', '--annotation', '-a');
+  const calibration = readFlag('--calibration');
+  const name = readFlag('--name', '-n');
+
+  if (!cameraArgs.length) {
+    // Single camera. A camera-keyed annotation here is a mistake worth naming,
+    // since it would otherwise be silently resolved as a relative file path.
+    if (annotationArgs.length > 1) {
+      throw new Error('--annotations may only be given once for a single-camera '
+        + 'dataset; use --camera to import multiple cameras');
+    }
+    if (calibration) {
+      throw new Error('--calibration applies to multi-camera datasets; '
+        + 'pass cameras with --camera');
+    }
+    return {
+      importPath: npath.resolve(importPath as string),
+      annotationPath: annotationArgs[0] ? npath.resolve(annotationArgs[0]) : undefined,
+      name,
+    };
+  }
+
+  // Multi-camera. Order of the flags is the display order.
+  const cameras: Record<string, string> = {};
+  const cameraOrder: string[] = [];
+  cameraArgs.forEach((arg) => {
+    const [cameraName, mediaPath] = splitNamed(arg, '--camera');
+    if (cameras[cameraName]) {
+      throw new Error(`--camera ${cameraName} given more than once`);
+    }
+    cameras[cameraName] = npath.resolve(mediaPath);
+    cameraOrder.push(cameraName);
+  });
+  if (cameraOrder.length < 2) {
+    throw new Error('a multi-camera dataset needs at least two --camera arguments');
+  }
+
+  const cameraAnnotations: Record<string, string> = {};
+  annotationArgs.forEach((arg) => {
+    const [cameraName, annotationFile] = splitNamed(arg, '--annotations');
+    if (!cameras[cameraName]) {
+      throw new Error(`--annotations names an unknown camera '${cameraName}'; `
+        + `known cameras: ${cameraOrder.join(', ')}`);
+    }
+    cameraAnnotations[cameraName] = npath.resolve(annotationFile);
+  });
+
+  const defaultDisplay = readFlag('--default-display') ?? (
+    cameras.left ? 'left' : cameraOrder[0]
+  );
+  if (!cameras[defaultDisplay]) {
+    throw new Error(`--default-display names an unknown camera '${defaultDisplay}'; `
+      + `known cameras: ${cameraOrder.join(', ')}`);
+  }
+
   return {
-    importPath: npath.resolve(importPath),
-    annotationPath: annotationPath ? npath.resolve(annotationPath) : undefined,
-    name: readFlag('--name', '-n'),
+    cameras,
+    cameraOrder,
+    cameraAnnotations,
+    defaultDisplay,
+    calibrationPath: calibration ? npath.resolve(calibration) : undefined,
+    name,
+  };
+}
+
+/** Build the wizard's multi-camera import args from the parsed CLI arguments. */
+function buildMultiCamArgs(args: CliOpenArgs): MultiCamImportFolderArgs {
+  const cameras = args.cameras as Record<string, string>;
+  const cameraOrder = args.cameraOrder ?? Object.keys(cameras);
+
+  // One dataset type covers every camera, so they must agree: mixing a video
+  // with an image sequence would import one of them as the wrong kind.
+  const types = new Set(cameraOrder.map((c) => inferDatasetType(cameras[c])));
+  if (types.size > 1) {
+    throw new Error('every --camera must be the same kind of media: got a mix of '
+      + 'video and image sequences');
+  }
+
+  const sourceList: MultiCamImportFolderArgs['sourceList'] = {};
+  cameraOrder.forEach((cameraName) => {
+    sourceList[cameraName] = {
+      sourcePath: cameras[cameraName],
+      trackFile: args.cameraAnnotations?.[cameraName] ?? '',
+    };
+  });
+
+  return {
+    datasetName: args.name,
+    defaultDisplay: args.defaultDisplay as string,
+    cameraOrder,
+    sourceList,
+    calibrationFile: args.calibrationPath,
+    type: [...types][0],
   };
 }
 
@@ -79,7 +226,11 @@ export async function runCliImport(
 ): Promise<string> {
   const currentSettings = settings.get();
 
-  const importPayload = await common.beginMediaImport(args.importPath);
+  // Multi-camera datasets carry their annotations per camera through the import
+  // payload; single-camera ones import theirs onto the dataset after finalize.
+  const importPayload: DesktopMediaImportResponse = args.cameras
+    ? await beginMultiCamImport(buildMultiCamArgs(args))
+    : await common.beginMediaImport(args.importPath as string);
   if (args.name) {
     importPayload.jsonMeta.name = args.name;
   }

--- a/client/platform/desktop/backend/cliImport.ts
+++ b/client/platform/desktop/backend/cliImport.ts
@@ -34,12 +34,12 @@ import {
   DesktopJobUpdate,
   DesktopMediaImportResponse,
 } from 'platform/desktop/constants';
-
-export type { CliTranscodingNotice };
 import { convertMedia } from './native/mediaJobs';
 import beginMultiCamImport from './native/multiCamImport';
 import * as common from './native/common';
 import settings from './state/settings';
+
+export type { CliTranscodingNotice };
 
 export interface CliOpenArgs {
   /** Media to import: image directory, image-list text file, or video. */

--- a/client/platform/desktop/background.ts
+++ b/client/platform/desktop/background.ts
@@ -66,6 +66,7 @@ try {
  */
 function notifyCliTranscoding(notice: CliTranscodingNotice) {
   // Terminal / logs: a modal alone is invisible to anyone scripting the open.
+  // eslint-disable-next-line no-console
   console.info(
     `CLI open of "${notice.name}" requires transcoding `
     + `(${notice.mediaCount} item(s)). Viewer opens when conversion finishes.`,

--- a/client/platform/desktop/background.ts
+++ b/client/platform/desktop/background.ts
@@ -36,14 +36,23 @@ let win: BrowserWindow | null;
 let allowClose = false;
 let closeGuardActive = false;
 
-// Dataset requested on the command line, held until the renderer is mounted and
-// asks for it. See backend/cliImport.ts.
-let pendingCliOpen: CliOpenArgs | null = null;
+// CLI opens queued until the renderer is mounted, listening for
+// desktop:open-dataset, and has pulled via desktop:cli-open-pending. Cold-start
+// imports and second-instance forwards share this queue so neither is dropped
+// while the window is still loading (or missing, e.g. macOS with no windows).
+const pendingCliOpens: CliOpenArgs[] = [];
+let cliRendererReady = false;
+let creatingWindow = false;
+let cliOpenChain: Promise<void> = Promise.resolve();
 // Misuse of the launch flags is reported once the app is ready; throwing here,
 // at module scope, would take the process down without telling the user why.
 let cliArgsError: string | null = null;
+let initialCliOpen: CliOpenArgs | null = null;
 try {
-  pendingCliOpen = parseCliArgs(process.argv);
+  initialCliOpen = parseCliArgs(process.argv);
+  if (initialCliOpen) {
+    pendingCliOpens.push(initialCliOpen);
+  }
 } catch (err) {
   cliArgsError = err instanceof Error ? err.message : String(err);
 }
@@ -75,20 +84,32 @@ async function openFromCli(cliArgs: CliOpenArgs) {
   }
 }
 
-// The renderer calls this once it is mounted and listening, so that a dataset
-// ready before the window finishes loading is not missed.
-ipcMain.handle('desktop:cli-open-pending', () => {
-  const cliArgs = pendingCliOpen;
-  pendingCliOpen = null;
-  if (!cliArgs) {
-    return null;
+/** Drain queued CLI opens once the renderer has registered its listener. */
+function flushCliOpens() {
+  if (!cliRendererReady) {
+    return;
   }
-  // Deliberately not awaited: the renderer should not block on the import, and
-  // it learns the dataset id from the desktop:open-dataset event instead.
-  openFromCli(cliArgs);
-  return cliArgs.importPath;
-});
+  while (pendingCliOpens.length > 0) {
+    const cliArgs = pendingCliOpens.shift() as CliOpenArgs;
+    // Chain imports so overlapping second-instance launches do not race.
+    cliOpenChain = cliOpenChain.then(() => openFromCli(cliArgs));
+  }
+}
 
+function enqueueCliOpen(cliArgs: CliOpenArgs) {
+  pendingCliOpens.push(cliArgs);
+  flushCliOpens();
+}
+
+// The renderer calls this once it is mounted and listening, so that a dataset
+// ready before the window finishes loading is not missed. Later second-instance
+// opens also flush through here once this has run at least once for the window.
+ipcMain.handle('desktop:cli-open-pending', () => {
+  cliRendererReady = true;
+  const first = pendingCliOpens[0];
+  flushCliOpens();
+  return first?.importPath ?? null;
+});
 ipcMain.on('desktop:close-guard-active', (event, active: boolean) => {
   if (win && event.sender === win.webContents) {
     closeGuardActive = active;
@@ -129,14 +150,14 @@ ipcMain.handle('desktop:confirm-close-unsaved', async (): Promise<'save' | 'disc
 // The argv Electron forwards to second-instance is Chromium's, which hoists
 // switches ahead of positionals and so detaches `--import <path>` from its
 // value; process.argv here is the raw one, so parse before handing it over.
-const gotTheLock = app.requestSingleInstanceLock(pendingCliOpen ?? undefined);
+const gotTheLock = app.requestSingleInstanceLock(initialCliOpen ?? undefined);
 if (!gotTheLock) {
   // A second launch carrying a dataset is not a mistake: the running instance
   // picks it up via the second-instance event below and opens it, so quit
   // quietly rather than reporting a failure the user did not have.
   if (cliArgsError) {
     dialog.showErrorBox('DIVE Desktop', cliArgsError);
-  } else if (!pendingCliOpen) {
+  } else if (!initialCliOpen) {
     dialog.showErrorBox(
       'DIVE Desktop',
       'Another instance is already running.\n\n'
@@ -178,79 +199,89 @@ async function loadDevUrlWithRetry(window: BrowserWindow, url: string) {
 }
 
 async function createWindow() {
-  const size = screen.getPrimaryDisplay().workAreaSize;
-  const partitionSession = session.fromPartition('persist:dive');
-  // Create the browser window.
-  win = new BrowserWindow({
-    width: Math.min(size.width, 1420),
-    height: Math.min(size.height - 200, 960),
-    autoHideMenuBar: true,
-    title: 'VIAME DIVE Desktop',
-    webPreferences: {
-      nodeIntegration: false,
-      contextIsolation: true,
-      preload: path.join(__dirname, 'preload.js'),
-      plugins: true,
-      // Fix session such that every instance of the applicaton loads
-      // the same session i.e.localStorage
-      session: partitionSession,
-    },
-  });
-
-  listen((server) => {
-    let address = server.address();
-    let port = 0;
-    if (typeof address === 'object' && address !== null) {
-      port = address.port || 0;
-      address = address.address || '';
-    }
-    console.error(`Server listening on ${address}:${port}`);
-  });
-  ipcListen();
-
-  const devServerUrl = process.env.ELECTRON_RENDERER_URL || process.env.VITE_DEV_SERVER_URL;
-  if (devServerUrl) {
-    const desktopDevUrl = devServerUrl.includes('desktop.html')
-      ? devServerUrl
-      : new URL('desktop.html', devServerUrl.endsWith('/') ? devServerUrl : `${devServerUrl}/`).toString();
-    try {
-      await loadDevUrlWithRetry(win, desktopDevUrl);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to load ${desktopDevUrl}: ${msg}`);
-    }
-    if (!process.env.IS_TEST) win.webContents.openDevTools();
-  } else {
-    const desktopEntryCandidates = app.isPackaged
-      ? [path.join(app.getAppPath(), 'dist_desktop', 'desktop.html')]
-      : [
-        path.resolve(__dirname, '..', '..', 'dist_desktop', 'desktop.html'),
-        path.resolve(app.getAppPath(), 'dist_desktop', 'desktop.html'),
-        path.resolve(process.cwd(), 'dist_desktop', 'desktop.html'),
-      ];
-    const desktopEntry = desktopEntryCandidates.find((candidate) => fs.existsSync(candidate))
-      || desktopEntryCandidates[0];
-    try {
-      await win.loadFile(desktopEntry);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to load ${desktopEntry}: ${msg}`);
-    }
+  if (win || creatingWindow) {
+    return;
   }
+  creatingWindow = true;
+  try {
+    const size = screen.getPrimaryDisplay().workAreaSize;
+    const partitionSession = session.fromPartition('persist:dive');
+    // Create the browser window.
+    win = new BrowserWindow({
+      width: Math.min(size.width, 1420),
+      height: Math.min(size.height - 200, 960),
+      autoHideMenuBar: true,
+      title: 'VIAME DIVE Desktop',
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        preload: path.join(__dirname, 'preload.js'),
+        plugins: true,
+        // Fix session such that every instance of the applicaton loads
+        // the same session i.e.localStorage
+        session: partitionSession,
+      },
+    });
 
-  allowClose = false;
-  closeGuardActive = false;
-  win.on('close', (e) => {
-    if (allowClose || !closeGuardActive) return;
-    e.preventDefault();
-    win?.webContents.send('desktop:close-requested');
-  });
+    listen((server) => {
+      let address = server.address();
+      let port = 0;
+      if (typeof address === 'object' && address !== null) {
+        port = address.port || 0;
+        address = address.address || '';
+      }
+      console.error(`Server listening on ${address}:${port}`);
+    });
+    ipcListen();
 
-  win.on('closed', () => {
+    const devServerUrl = process.env.ELECTRON_RENDERER_URL || process.env.VITE_DEV_SERVER_URL;
+    if (devServerUrl) {
+      const desktopDevUrl = devServerUrl.includes('desktop.html')
+        ? devServerUrl
+        : new URL('desktop.html', devServerUrl.endsWith('/') ? devServerUrl : `${devServerUrl}/`).toString();
+      try {
+        await loadDevUrlWithRetry(win, desktopDevUrl);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to load ${desktopDevUrl}: ${msg}`);
+      }
+      if (!process.env.IS_TEST) win.webContents.openDevTools();
+    } else {
+      const desktopEntryCandidates = app.isPackaged
+        ? [path.join(app.getAppPath(), 'dist_desktop', 'desktop.html')]
+        : [
+          path.resolve(__dirname, '..', '..', 'dist_desktop', 'desktop.html'),
+          path.resolve(app.getAppPath(), 'dist_desktop', 'desktop.html'),
+          path.resolve(process.cwd(), 'dist_desktop', 'desktop.html'),
+        ];
+      const desktopEntry = desktopEntryCandidates.find((candidate) => fs.existsSync(candidate))
+        || desktopEntryCandidates[0];
+      try {
+        await win.loadFile(desktopEntry);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to load ${desktopEntry}: ${msg}`);
+      }
+    }
+
     allowClose = false;
     closeGuardActive = false;
-    win = null;
-  });
+    win.on('close', (e) => {
+      if (allowClose || !closeGuardActive) return;
+      e.preventDefault();
+      win?.webContents.send('desktop:close-requested');
+    });
+
+    win.on('closed', () => {
+      allowClose = false;
+      closeGuardActive = false;
+      // The next window must re-pull pending CLI opens after its listener is up.
+      cliRendererReady = false;
+      win = null;
+    });
+  } finally {
+    creatingWindow = false;
+  }
 }
 
 // Quit when all windows are closed.
@@ -306,17 +337,28 @@ if (gotTheLock) {
 }
 
 app.on('second-instance', (_event, _argv, _workingDirectory, additionalData) => {
+  // A second launch carrying a dataset opens it in this window, rather than
+  // being dropped on the floor by the single-instance lock. The args were
+  // parsed by that instance and passed through the lock request, since the
+  // forwarded argv no longer pairs flags with their values.
+  //
+  // Queue until the renderer has called cli-open-pending (listener registered).
+  // If there is no window yet (startup race, or macOS with all windows closed),
+  // create one so the queued open can be pulled.
   if (win) {
     if (win.isMinimized()) win.restore();
     win.focus();
-    // A second launch carrying a dataset opens it in this window, rather than
-    // being dropped on the floor by the single-instance lock. The args were
-    // parsed by that instance and passed through the lock request, since the
-    // forwarded argv no longer pairs flags with their values.
-    const cliArgs = additionalData as CliOpenArgs | undefined;
-    if (cliArgs?.importPath || cliArgs?.cameras) {
-      openFromCli(cliArgs);
-    }
+  } else if (gotTheLock && app.isReady()) {
+    createWindow().catch((err) => {
+      dialog.showErrorBox(
+        'DIVE Desktop',
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+  }
+  const cliArgs = additionalData as CliOpenArgs | undefined;
+  if (cliArgs?.importPath || cliArgs?.cameras) {
+    enqueueCliOpen(cliArgs);
   }
 });
 

--- a/client/platform/desktop/background.ts
+++ b/client/platform/desktop/background.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import { closeAll as closeChildren } from './backend/native/processManager';
 import { listen, close as closeServer } from './backend/server';
 import ipcListen from './backend/ipcService';
+import { CliOpenArgs, parseCliArgs, runCliImport } from './backend/cliImport';
 
 function ensureValidWorkingDirectory() {
   try {
@@ -34,6 +35,45 @@ app.commandLine.appendSwitch('ignore-gpu-blacklist');
 let win: BrowserWindow | null;
 let allowClose = false;
 let closeGuardActive = false;
+
+// Dataset requested on the command line, held until the renderer is mounted and
+// asks for it. See backend/cliImport.ts.
+let pendingCliOpen: CliOpenArgs | null = parseCliArgs(process.argv);
+
+/**
+ * Import the CLI-requested dataset and navigate the renderer to it. Navigation
+ * is driven by an event rather than the return value because media that needs
+ * transcoding only becomes viewable once its conversion job finishes.
+ */
+async function openFromCli(cliArgs: CliOpenArgs) {
+  try {
+    await runCliImport(
+      cliArgs,
+      (update) => sendToRenderer('job-update', update),
+      (datasetId) => sendToRenderer('desktop:open-dataset', datasetId),
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    dialog.showErrorBox(
+      'DIVE Desktop',
+      `Failed to open ${cliArgs.importPath} from the command line:\n\n${message}`,
+    );
+  }
+}
+
+// The renderer calls this once it is mounted and listening, so that a dataset
+// ready before the window finishes loading is not missed.
+ipcMain.handle('desktop:cli-open-pending', () => {
+  const cliArgs = pendingCliOpen;
+  pendingCliOpen = null;
+  if (!cliArgs) {
+    return null;
+  }
+  // Deliberately not awaited: the renderer should not block on the import, and
+  // it learns the dataset id from the desktop:open-dataset event instead.
+  openFromCli(cliArgs);
+  return cliArgs.importPath;
+});
 
 ipcMain.on('desktop:close-guard-active', (event, active: boolean) => {
   if (win && event.sender === win.webContents) {
@@ -70,13 +110,23 @@ ipcMain.handle('desktop:confirm-close-unsaved', async (): Promise<'save' | 'disc
 // This application uses localStorage with persistent sessions.
 // In order to use this mechanism, only one application instance
 // can exist at a time.  Acquire a lock or quit and focus the running window.
-const gotTheLock = app.requestSingleInstanceLock();
+//
+// Hand the parsed launch arguments to the running instance as additionalData.
+// The argv Electron forwards to second-instance is Chromium's, which hoists
+// switches ahead of positionals and so detaches `--import <path>` from its
+// value; process.argv here is the raw one, so parse before handing it over.
+const gotTheLock = app.requestSingleInstanceLock(pendingCliOpen ?? undefined);
 if (!gotTheLock) {
-  dialog.showErrorBox(
-    'DIVE Desktop',
-    'Another instance is already running.\n\n'
-      + 'If you do not see a window, close any existing DIVE Desktop or Electron dev session, then try again.',
-  );
+  // A second launch carrying --import is not a mistake: the running instance
+  // picks the dataset up via the second-instance event below and opens it, so
+  // quit quietly rather than reporting a failure the user did not have.
+  if (!pendingCliOpen) {
+    dialog.showErrorBox(
+      'DIVE Desktop',
+      'Another instance is already running.\n\n'
+        + 'If you do not see a window, close any existing DIVE Desktop or Electron dev session, then try again.',
+    );
+  }
   app.quit();
 }
 
@@ -216,18 +266,32 @@ app.on('before-quit', () => {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.whenReady().then(() => createWindow()).catch((err) => {
-  dialog.showErrorBox(
-    'DIVE Desktop',
-    `The application failed to start:\n\n${err instanceof Error ? err.message : String(err)}`,
-  );
-  app.exit(1);
-});
+//
+// Only the instance holding the single-instance lock opens a window. Without
+// this guard a losing instance races its own app.quit(), builds a window while
+// the app is tearing down, and reports a spurious startup failure.
+if (gotTheLock) {
+  app.whenReady().then(() => createWindow()).catch((err) => {
+    dialog.showErrorBox(
+      'DIVE Desktop',
+      `The application failed to start:\n\n${err instanceof Error ? err.message : String(err)}`,
+    );
+    app.exit(1);
+  });
+}
 
-app.on('second-instance', () => {
+app.on('second-instance', (_event, _argv, _workingDirectory, additionalData) => {
   if (win) {
     if (win.isMinimized()) win.restore();
     win.focus();
+    // A second launch carrying --import opens that dataset in this window,
+    // rather than being dropped on the floor by the single-instance lock. The
+    // args were parsed by that instance and passed through the lock request,
+    // since the forwarded argv no longer pairs flags with their values.
+    const cliArgs = additionalData as CliOpenArgs | undefined;
+    if (cliArgs?.importPath) {
+      openFromCli(cliArgs);
+    }
   }
 });
 

--- a/client/platform/desktop/background.ts
+++ b/client/platform/desktop/background.ts
@@ -8,7 +8,9 @@ import path from 'path';
 import { closeAll as closeChildren } from './backend/native/processManager';
 import { listen, close as closeServer } from './backend/server';
 import ipcListen from './backend/ipcService';
-import { CliOpenArgs, parseCliArgs, runCliImport } from './backend/cliImport';
+import {
+  CliOpenArgs, CliTranscodingNotice, parseCliArgs, runCliImport,
+} from './backend/cliImport';
 
 function ensureValidWorkingDirectory() {
   try {
@@ -62,6 +64,17 @@ try {
  * is driven by an event rather than the return value because media that needs
  * transcoding only becomes viewable once its conversion job finishes.
  */
+function notifyCliTranscoding(notice: CliTranscodingNotice) {
+  // Terminal / logs: a modal alone is invisible to anyone scripting the open.
+  console.info(
+    `CLI open of "${notice.name}" requires transcoding `
+    + `(${notice.mediaCount} item(s)). Viewer opens when conversion finishes.`,
+  );
+  // Renderer: show on the home screen or over an already-open dataset viewer.
+  sendToRenderer('desktop:cli-transcoding', notice);
+}
+
+/** Run one queued CLI import; onTranscoding / onReady drive user-visible wait vs navigate. */
 async function openFromCli(cliArgs: CliOpenArgs) {
   // Multi-camera launches have no single import path; name what was asked for.
   const target = cliArgs.importPath
@@ -71,6 +84,7 @@ async function openFromCli(cliArgs: CliOpenArgs) {
       cliArgs,
       (update) => sendToRenderer('job-update', update),
       (datasetId) => sendToRenderer('desktop:open-dataset', datasetId),
+      notifyCliTranscoding,
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/client/platform/desktop/background.ts
+++ b/client/platform/desktop/background.ts
@@ -38,7 +38,15 @@ let closeGuardActive = false;
 
 // Dataset requested on the command line, held until the renderer is mounted and
 // asks for it. See backend/cliImport.ts.
-let pendingCliOpen: CliOpenArgs | null = parseCliArgs(process.argv);
+let pendingCliOpen: CliOpenArgs | null = null;
+// Misuse of the launch flags is reported once the app is ready; throwing here,
+// at module scope, would take the process down without telling the user why.
+let cliArgsError: string | null = null;
+try {
+  pendingCliOpen = parseCliArgs(process.argv);
+} catch (err) {
+  cliArgsError = err instanceof Error ? err.message : String(err);
+}
 
 /**
  * Import the CLI-requested dataset and navigate the renderer to it. Navigation
@@ -46,6 +54,9 @@ let pendingCliOpen: CliOpenArgs | null = parseCliArgs(process.argv);
  * transcoding only becomes viewable once its conversion job finishes.
  */
 async function openFromCli(cliArgs: CliOpenArgs) {
+  // Multi-camera launches have no single import path; name what was asked for.
+  const target = cliArgs.importPath
+    ?? Object.entries(cliArgs.cameras ?? {}).map(([c, p]) => `${c}=${p}`).join(', ');
   try {
     await runCliImport(
       cliArgs,
@@ -54,9 +65,12 @@ async function openFromCli(cliArgs: CliOpenArgs) {
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // Log as well as prompt: a modal dialog is invisible to anyone driving the
+    // app from a script or reading a log after the fact.
+    console.error(`Failed to open ${target} from the command line: ${message}`);
     dialog.showErrorBox(
       'DIVE Desktop',
-      `Failed to open ${cliArgs.importPath} from the command line:\n\n${message}`,
+      `Failed to open ${target} from the command line:\n\n${message}`,
     );
   }
 }
@@ -117,10 +131,12 @@ ipcMain.handle('desktop:confirm-close-unsaved', async (): Promise<'save' | 'disc
 // value; process.argv here is the raw one, so parse before handing it over.
 const gotTheLock = app.requestSingleInstanceLock(pendingCliOpen ?? undefined);
 if (!gotTheLock) {
-  // A second launch carrying --import is not a mistake: the running instance
-  // picks the dataset up via the second-instance event below and opens it, so
-  // quit quietly rather than reporting a failure the user did not have.
-  if (!pendingCliOpen) {
+  // A second launch carrying a dataset is not a mistake: the running instance
+  // picks it up via the second-instance event below and opens it, so quit
+  // quietly rather than reporting a failure the user did not have.
+  if (cliArgsError) {
+    dialog.showErrorBox('DIVE Desktop', cliArgsError);
+  } else if (!pendingCliOpen) {
     dialog.showErrorBox(
       'DIVE Desktop',
       'Another instance is already running.\n\n'
@@ -271,7 +287,16 @@ app.on('before-quit', () => {
 // this guard a losing instance races its own app.quit(), builds a window while
 // the app is tearing down, and reports a spurious startup failure.
 if (gotTheLock) {
-  app.whenReady().then(() => createWindow()).catch((err) => {
+  app.whenReady().then(() => {
+    // Launch flags were malformed. Say so and stop, rather than opening an app
+    // window that silently ignores what was asked for.
+    if (cliArgsError) {
+      dialog.showErrorBox('DIVE Desktop', cliArgsError);
+      app.exit(1);
+      return Promise.resolve();
+    }
+    return createWindow();
+  }).catch((err) => {
     dialog.showErrorBox(
       'DIVE Desktop',
       `The application failed to start:\n\n${err instanceof Error ? err.message : String(err)}`,
@@ -284,12 +309,12 @@ app.on('second-instance', (_event, _argv, _workingDirectory, additionalData) => 
   if (win) {
     if (win.isMinimized()) win.restore();
     win.focus();
-    // A second launch carrying --import opens that dataset in this window,
-    // rather than being dropped on the floor by the single-instance lock. The
-    // args were parsed by that instance and passed through the lock request,
-    // since the forwarded argv no longer pairs flags with their values.
+    // A second launch carrying a dataset opens it in this window, rather than
+    // being dropped on the floor by the single-instance lock. The args were
+    // parsed by that instance and passed through the lock request, since the
+    // forwarded argv no longer pairs flags with their values.
     const cliArgs = additionalData as CliOpenArgs | undefined;
-    if (cliArgs?.importPath) {
+    if (cliArgs?.importPath || cliArgs?.cameras) {
       openFromCli(cliArgs);
     }
   }

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -220,6 +220,13 @@ export interface ConversionArgs extends JobArgs {
   mediaList: [string, string][];
 }
 
+/** IPC payload when a CLI open must wait on media conversion. */
+export interface CliTranscodingNotice {
+  datasetId: string;
+  name: string;
+  mediaCount: number;
+}
+
 export type Job = ConversionArgs | RunPipeline | RunTraining | ExportTrainedPipeline;
 
 export interface DesktopJob {

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -79,6 +79,8 @@ export default defineComponent({
   async beforeRouteLeave(to, from, next) {
     if (await this.viewerRef.navigateAwayGuard()) {
       next();
+    } else {
+      next(false);
     }
   },
 
@@ -89,6 +91,8 @@ export default defineComponent({
   async beforeRouteUpdate(to, from, next) {
     if (await this.viewerRef.navigateAwayGuard()) {
       next();
+    } else {
+      next(false);
     }
   },
 

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -82,6 +82,16 @@ export default defineComponent({
     }
   },
 
+  // Switching straight from one dataset to another keeps this component mounted
+  // and only changes the :id param, so beforeRouteLeave does not fire. Guard it
+  // too: the id watcher in Viewer reloads by discarding, which would throw away
+  // unsaved edits without asking.
+  async beforeRouteUpdate(to, from, next) {
+    if (await this.viewerRef.navigateAwayGuard()) {
+      next();
+    }
+  },
+
   props: {
     id: { // always the base ID
       type: String,

--- a/client/platform/desktop/main.ts
+++ b/client/platform/desktop/main.ts
@@ -1,13 +1,15 @@
 import Vue from 'vue';
 
-import promptService from 'dive-common/vue-utilities/prompt-service';
+import promptService, { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import vMousetrap from 'dive-common/vue-utilities/v-mousetrap';
 
+import type { CliTranscodingNotice } from './constants';
 import vuetify from './plugins/vuetify';
 import router from './router';
 import * as api from './frontend/api';
 import { migrate } from './frontend/store';
 import { setRecents } from './frontend/store/dataset';
+import { setOrGetConversionJob } from './frontend/store/jobs';
 import { initializedSettings } from './frontend/store/settings';
 import { runCloseGuard } from './frontend/store/closeGuard';
 import App from './App.vue';
@@ -35,6 +37,33 @@ migrate().then(() => {
     }
     if (router.currentRoute.name !== 'viewer' || router.currentRoute.params.id !== datasetId) {
       router.push({ name: 'viewer', params: { id: datasetId } });
+    }
+  });
+
+  // CLI open hit media that needs conversion. Surface that on the home screen
+  // (cold start) and while another dataset is already open (second instance);
+  // do not navigate until desktop:open-dataset after conversion completes.
+  window.diveDesktop.on('desktop:cli-transcoding', async (payload) => {
+    const notice = payload as CliTranscodingNotice;
+    try {
+      setRecents(await api.loadMetadata(notice.datasetId));
+    } catch {
+      // Still show the dialog even if recents cannot be updated yet.
+    }
+    setOrGetConversionJob(notice.datasetId, true);
+    try {
+      const { prompt } = usePrompt();
+      prompt({
+        title: 'Transcoding required',
+        text: [
+          `"${notice.name}" must be transcoded before it can be opened.`,
+          `Converting ${notice.mediaCount} item(s). The viewer will open when conversion finishes.`,
+          'You can follow progress from the Jobs page.',
+        ],
+        positiveButton: 'OK',
+      });
+    } catch {
+      // Prompt service not attached yet; console + Jobs page still cover it.
     }
   });
 

--- a/client/platform/desktop/main.ts
+++ b/client/platform/desktop/main.ts
@@ -5,7 +5,10 @@ import vMousetrap from 'dive-common/vue-utilities/v-mousetrap';
 
 import vuetify from './plugins/vuetify';
 import router from './router';
+import * as api from './frontend/api';
 import { migrate } from './frontend/store';
+import { setRecents } from './frontend/store/dataset';
+import { initializedSettings } from './frontend/store/settings';
 import { runCloseGuard } from './frontend/store/closeGuard';
 import App from './App.vue';
 
@@ -19,6 +22,22 @@ migrate().then(() => {
     window.diveDesktop.send('desktop:close-response', allow);
   });
 
+  // A dataset imported via `dive-desktop --import` opens as soon as it is
+  // viewable. Record it in recents first so it also appears in the dataset list
+  // afterwards, exactly as if it had been imported through the wizard.
+  window.diveDesktop.on('desktop:open-dataset', async (id) => {
+    const datasetId = String(id);
+    try {
+      setRecents(await api.loadMetadata(datasetId));
+    } catch {
+      // A dataset that cannot be summarized can still be opened; recents is
+      // only a convenience listing.
+    }
+    if (router.currentRoute.name !== 'viewer' || router.currentRoute.params.id !== datasetId) {
+      router.push({ name: 'viewer', params: { id: datasetId } });
+    }
+  });
+
   new Vue({
     vuetify,
     router,
@@ -27,4 +46,14 @@ migrate().then(() => {
   })
     .$mount('#app')
     .$promptAttach();
+
+  // Ask the main process whether a dataset was requested on the command line.
+  // Pulling rather than being pushed avoids racing the listener registration
+  // above against an import that finishes before the window is ready.
+  //
+  // Settings live in the renderer and are handed to the background process at
+  // startup; the import needs them (for dataPath), so wait for that handoff to
+  // complete before asking, or the backend throws 'settings has not been
+  // initialized'.
+  initializedSettings.then(() => window.diveDesktop.invoke('desktop:cli-open-pending'));
 });

--- a/docs/Command-Line-Tools.md
+++ b/docs/Command-Line-Tools.md
@@ -2,7 +2,7 @@
 
 !!! note
 
-    This page is **not related** to the VIAME install command line (e.g. `viame`, `kwiver`)
+    This page is **not related** to the VIAME install command line (e.g. `viame`, `kwiver`), and it is also distinct from [launching DIVE Desktop on a dataset](Dive-Desktop.md#launching-from-the-command-line) with `--import` / `--camera`.
 
 Some of the DIVE data conversion features are exposed through `dive`.  
 

--- a/docs/Dive-Desktop.md
+++ b/docs/Dive-Desktop.md
@@ -111,7 +111,7 @@ Every camera must use the same kind of media (all videos or all image sequences)
 #### Behavior notes
 
 * The result is a normal Desktop dataset: it appears in the library / recents list and can be reopened later, the same as if imported through the UI.
-* Media that requires [transcoding](#video-transcoding) is converted first; the viewer opens when conversion finishes.
+* Media that requires [transcoding](#video-transcoding) is converted first; the viewer opens when conversion finishes. When that happens, DIVE shows a notice (and logs to the console) so a cold start or an open while another dataset is already in the viewer is not mistaken for a hang.
 * If DIVE Desktop is already running, a second launch with these flags opens the dataset in the existing window instead of starting another instance.
 * Glob / keyword multi-camera folder layouts from the UI are not available on the command line; pass one `--camera` per source instead.
 

--- a/docs/Dive-Desktop.md
+++ b/docs/Dive-Desktop.md
@@ -60,6 +60,63 @@ Click either ==Open Image Sequence :material-folder-open:== or ==Open Video :mat
 
 The import routine will look for `.csv` and `.json` files in the same directory as the source media, and you will be prompted to manually select an annotation file and a configuration file.  Neither is required.
 
+### Launching from the command line
+
+DIVE Desktop can open a dataset directly from the command line, skipping the import wizard. This is useful for reviewing detector output, scripting open-and-review workflows, or jumping straight into annotation.
+
+Pass the flags to the DIVE Desktop executable (for example `DIVE-Desktop.exe` on Windows, or `./DIVE-Desktop-<version>.AppImage` on Linux). Relative paths are resolved against the current working directory.
+
+#### Single-camera datasets
+
+``` bash
+DIVE-Desktop --import <media> [--annotations <file>] [--name <name>]
+```
+
+| Flag | Short | Description |
+| ---- | ----- | ----------- |
+| `--import` | `-i` | Media to open: an image-sequence directory, an image-list `.txt` file (one image path per line), or a video. Same inputs as the import wizard. |
+| `--annotations` | `-a` | Optional annotation file to load (VIAME CSV or DIVE JSON). |
+| `--name` | `-n` | Optional display name; defaults to the media basename. |
+
+Example — review a detector CSV over an image list:
+
+``` bash
+DIVE-Desktop --import input_list.txt --annotations detections.csv --name "Sea Lions"
+```
+
+#### Multi-camera and stereo datasets
+
+Name each camera with a repeated `--camera` instead of `--import`:
+
+``` bash
+DIVE-Desktop --camera left=/data/left --camera right=/data/right \
+             --annotations left=/data/left.csv --annotations right=/data/right.csv \
+             --calibration /data/calibration_matrices.npz
+```
+
+| Flag | Short | Description |
+| ---- | ----- | ----------- |
+| `--camera` | `-c` | `<name>=<media>`, repeated once per camera (at least two). Media paths accept the same kinds as `--import`. Only the first `=` separates name from path, so Windows paths like `left=C:\data\left` work. Flag order is the display order. |
+| `--annotations` | `-a` | In multi-camera mode, `<camera>=<file>`. Give once per camera that has annotations; cameras without annotations may be omitted. |
+| `--calibration` | | Optional stereo calibration (`.npz` or `.json`). Multi-camera only. |
+| `--default-display` | | Camera shown on open. Defaults to `left` when that camera exists, otherwise the first `--camera`. |
+| `--name` | `-n` | Optional display name. |
+
+!!! note
+
+    There is no separate stereo flag. As elsewhere in DIVE, cameras named exactly `left` and `right` create a **stereo** dataset; any other set of names creates a **multicam** dataset. Pass `--calibration` when you need stereo measurement. See [Multicamera and Stereo Data](Multicamera-data.md).
+
+Every camera must use the same kind of media (all videos or all image sequences). `--import` and `--camera` are mutually exclusive.
+
+#### Behavior notes
+
+* The result is a normal Desktop dataset: it appears in the library / recents list and can be reopened later, the same as if imported through the UI.
+* Media that requires [transcoding](#video-transcoding) is converted first; the viewer opens when conversion finishes.
+* If DIVE Desktop is already running, a second launch with these flags opens the dataset in the existing window instead of starting another instance.
+* Glob / keyword multi-camera folder layouts from the UI are not available on the command line; pass one `--camera` per source instead.
+
+This is separate from the [server `dive` command-line tools](Command-Line-Tools.md) used for format conversion.
+
 ### Video Transcoding
 
 DIVE Desktop is an [Electron](https://www.electronjs.org/) application built on web technologies.  Certain video codecs require automatic transcoding to be usable.  Video will be transcoded unless _all_ the following conditions are met.

--- a/docs/Multicamera-data.md
+++ b/docs/Multicamera-data.md
@@ -50,6 +50,8 @@ For general web upload concepts (permissions, transcoding, zip import), see [Upl
 
 Desktop additionally supports ==:material-view-list-outline: Image List== and glob-based folder filtering for single-camera imports, and glob/keyword layout options for multicam import.
 
+You can also open stereo and multicam datasets from the command line with repeated `--camera` flags (and optional per-camera `--annotations` and `--calibration`). See [Launching from the command line](Dive-Desktop.md#launching-from-the-command-line).
+
 !!! info
 
     Stereoscopic data **requires** a calibration file. Generic multicamera data does **not**.


### PR DESCRIPTION
## Summary

Adds `--import` / `--annotations` / `--name` so DIVE Desktop can be started directly on media plus an annotation file, skipping the import wizard:

```bash
dive-desktop --import input_list.txt --annotations detections.csv --name "Sea Lions"
```

`--import` accepts anything the wizard does (an image-sequence directory, an image-list text file, or a video); `--annotations` accepts a VIAME CSV or DIVE JSON.

This came out of wanting to review detector output over an image list without clicking through the import wizard each time.

## Behavior

The import runs through the same backend calls as the wizard (`beginMediaImport` → `finalizeMediaImport` → `dataFileImport`), so the result is an ordinary dataset — it lands in the recents list and can be reopened later, exactly as if it had been imported by hand. Media that needs transcoding is converted first, and the viewer opens when the conversion job completes.

## Two things worth a look in review

**Renderer pulls, main process does not push.** The renderer asks for the pending dataset (`desktop:cli-open-pending`) once it is mounted. Settings are owned by the renderer and handed to the background process at startup, and the import needs them (for `dataPath`), so the request waits on that handoff — otherwise the backend throws `settings has not been initialized`. Pulling also avoids racing the listener registration against an import that finishes before the window is ready.

**Second-instance forwarding.** A second launch carrying `--import` now opens that dataset in the running window instead of being dropped by the single-instance lock. The args are parsed from the raw `process.argv` and handed over via `requestSingleInstanceLock(additionalData)`, because the argv Chromium forwards to `second-instance` hoists switches ahead of positionals and thereby detaches `--import` from its value:

```
["dive-desktop","--import","--annotations","--name", ...switches..., "/path/list.txt","/path/x.csv","Sea Lions"]
```

Window creation is now guarded on actually holding the lock. Previously a losing instance raced its own `app.quit()`, and with the "already running" dialog no longer blocking that race it would build a window mid-teardown and report a spurious "application failed to start".

## Testing

- New unit tests for the argument parser (6 cases, including `=` syntax, short flags, relative-path resolution, and not swallowing a following flag as a value).
- Built with `build:electron:dir` and exercised end to end on a 3-image list with a VIAME CSV of 570 polygon detections: dataset imports, viewer opens, annotations and polygons render, dataset appears in recents. Second-instance forwarding verified with a separate CSV opening into the already-running window.
- `platform/` suite passes apart from two `web-girder/multicamFileRegistry.spec.ts` failures that reproduce on a clean `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)