### PR TITLE
Persist multicam camera order and align its fallback across platforms

### DIFF
--- a/client/platform/desktop/backend/native/multiCamImport.ts
+++ b/client/platform/desktop/backend/native/multiCamImport.ts
@@ -10,6 +10,7 @@ import {
 import {
   websafeImageTypes, websafeVideoTypes, otherImageTypes, otherVideoTypes, MultiType,
 } from 'dive-common/constants';
+import { preferEoIrSubfolderOrder } from 'dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout';
 import {
   JsonMeta, JsonMetaCurrentVersion,
   DesktopMediaImportResponse,
@@ -42,6 +43,24 @@ function isKeywordArgs(s: MultiCamImportArgs): s is MultiCamImportKeywordArgs {
     return true;
   }
   return false;
+}
+
+/**
+ * The display order persisted with the dataset: the import dialog's order
+ * when given (matching what the web import stores), seeded from the
+ * EO-first/IR-last name heuristic otherwise, with any unmentioned cameras
+ * appended so the stored list always covers every camera.
+ */
+function buildCameraOrder(
+  args: MultiCamImportArgs,
+  cameras: Record<string, Camera>,
+): string[] {
+  const requested = (isFolderArgs(args) && args.cameraOrder) || [];
+  const ordered = requested.filter((name) => name in cameras);
+  const remaining = preferEoIrSubfolderOrder(
+    Object.keys(cameras).filter((name) => !ordered.includes(name)),
+  );
+  return [...ordered, ...remaining];
 }
 
 async function asyncForEach<T>(array: T[], callback: (item: T, index: number, arr: T[]) => void) {
@@ -176,6 +195,7 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
       : 'Multi-camera data',
     multiCam: {
       cameras,
+      cameraOrder: buildCameraOrder(args, cameras),
       calibration: args.calibrationFile,
       defaultDisplay: args.defaultDisplay,
     },

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -50,6 +50,10 @@ export interface Camera {
 
 export interface MultiCamDesktop {
   cameras: Record<string, Camera>;
+  // Camera names in display order, chosen at import. Display and pipeline
+  // camera ordering both read this; the EO-first/IR-last name heuristic is
+  // only a fallback for datasets imported before the order was persisted.
+  cameraOrder?: string[];
   //Calibration file in .npz format used for stereo or other cameras
   calibration?: string;
   // Name of the user's original calibration file (preserved for display, since

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -23,6 +23,7 @@ from dive_utils import (
     constants,
     fromMeta,
     models,
+    multicam_camera_order,
     types,
 )
 from dive_utils.serializers import kwcoco
@@ -244,12 +245,8 @@ def list_datasets(
 
 
 def _multicam_camera_order(multi_cam: dict) -> List[str]:
-    """Return camera names in display order (stored order, else dict insertion order)."""
-    cameras_meta = multi_cam.get('cameras') or {}
-    stored_order = multi_cam.get('cameraOrder') or []
-    if stored_order:
-        return [name for name in stored_order if name in cameras_meta]
-    return list(cameras_meta.keys())
+    """Return camera names in display order (shared helper, matches the client)."""
+    return multicam_camera_order(multi_cam)
 
 
 def get_multi_cam_media(

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -16,7 +16,7 @@ from girder_client import GirderClient
 from girder_worker.task import Task
 from girder_worker.utils import JobManager, JobStatus
 
-from dive_utils import constants, models
+from dive_utils import constants, models, multicam_camera_order
 
 TIMEOUT_COUNT = 'timeout_count'
 TIMEOUT_LAST_CHECKED = 'last_checked'
@@ -408,11 +408,8 @@ def is_path_under_multicam_export(path: str, multicam_export_roots: set) -> bool
 
 
 def _multicam_camera_order(multi_cam: dict) -> List[str]:
-    cameras = multi_cam.get('cameras') or {}
-    stored_order = multi_cam.get('cameraOrder') or []
-    if stored_order:
-        return [name for name in stored_order if name in cameras]
-    return list(cameras.keys())
+    """Return camera names in display order (shared helper, matches the client)."""
+    return multicam_camera_order(multi_cam)
 
 
 def _upload_stereo_calibration_files(

--- a/server/dive_utils/__init__.py
+++ b/server/dive_utils/__init__.py
@@ -13,10 +13,33 @@ TRUTHY_META_VALUES = ['yes', '1', 1, 'true', 't', 'True', True]
 NUMBERS_REGEX = re.compile(r'(\d+)')
 NOT_NUMBERS_REGEX = re.compile(r'[^\d]+')
 
+# Mirror the client's isEoSubfolderName / isIrSubfolderName
+# (dive-common multicamSubfolderLayout)
+_EO_CAMERA_NAME = re.compile(r'(^|_)EO(_|$)', re.IGNORECASE)
+_IR_CAMERA_NAME = re.compile(r'(^|_)IR(_|$)', re.IGNORECASE)
+
 
 def asbool(value: Union[str, None, bool]) -> bool:
     """Convert freeform mongo metadata value into a boolean"""
     return str(value).lower() in TRUTHY_META_VALUES
+
+
+def multicam_camera_order(multi_cam: dict) -> List[str]:
+    """
+    Camera names in display order: the order stored at import, else the
+    EO-first/IR-last name heuristic matching the client's
+    orderedMultiCamCameraNames, so every reader (web client, girder, worker)
+    agrees for datasets imported before the order was persisted.
+    """
+    cameras = multi_cam.get('cameras') or {}
+    stored_order = multi_cam.get('cameraOrder') or []
+    if stored_order:
+        return [name for name in stored_order if name in cameras]
+    names = list(cameras.keys())
+    eo = [name for name in names if _EO_CAMERA_NAME.search(name)]
+    ir = [name for name in names if _IR_CAMERA_NAME.search(name) and name not in eo]
+    middle = [name for name in names if name not in eo and name not in ir]
+    return eo + middle + ir
 
 
 def fromMeta(

--- a/testutils/multicam.spec.json
+++ b/testutils/multicam.spec.json
@@ -24,8 +24,7 @@
           "right2.tiff": "",
           "right3.tiff": ""
         },
-        "empty": {
-        }
+        "empty": {}
       },
       "stereoLeftRightImages": {
         "left": {
@@ -72,8 +71,14 @@
       "input": {
         "defaultDisplay": "left",
         "sourceList": {
-          "left": {"sourcePath": "/home/user/data/stereoLeftRightImages/left", "trackFile": "" },
-          "right": { "sourcePath": "/home/user/data/stereoLeftRightImages/right", "trackFile": ""}
+          "left": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/left",
+            "trackFile": ""
+          },
+          "right": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/right",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "image-sequence"
@@ -104,9 +109,12 @@
               "originalVideoFile": "",
               "transcodedImageFiles": [],
               "transcodedVideoFile": ""
-      
             }
           },
+          "cameraOrder": [
+            "left",
+            "right"
+          ],
           "calibration": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
           "defaultDisplay": "left"
         },
@@ -117,8 +125,14 @@
       "input": {
         "defaultDisplay": "left",
         "sourceList": {
-          "left": {"sourcePath": "/home/user/data/stereoLeftRightImages/left/tiff", "trackFile": "" },
-          "right": { "sourcePath": "/home/user/data/stereoLeftRightImages/right/tiff", "trackFile": ""}
+          "left": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/left/tiff",
+            "trackFile": ""
+          },
+          "right": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/right/tiff",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "image-sequence"
@@ -151,6 +165,10 @@
               "transcodedVideoFile": ""
             }
           },
+          "cameraOrder": [
+            "left",
+            "right"
+          ],
           "calibration": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
           "defaultDisplay": "left"
         },
@@ -168,8 +186,14 @@
       "input": {
         "defaultDisplay": "right",
         "sourceList": {
-          "left": {"sourcePath": "/home/user/data/stereoLeftRightImages/left/tiff", "trackFile": ""},
-          "right": {"sourcePath": "/home/user/data/stereoLeftRightImages/right/same", "trackFile": ""}
+          "left": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/left/tiff",
+            "trackFile": ""
+          },
+          "right": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/right/same",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "image-sequence"
@@ -202,6 +226,10 @@
               "transcodedVideoFile": ""
             }
           },
+          "cameraOrder": [
+            "left",
+            "right"
+          ],
           "calibration": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
           "defaultDisplay": "right"
         },
@@ -219,8 +247,14 @@
       "input": {
         "defaultDisplay": "left",
         "sourceList": {
-          "left": {"sourcePath": "/home/user/data/stereoLeftRightImages/left/left.mp4", "trackFile": ""},
-          "right": {"sourcePath": "/home/user/data/stereoLeftRightImages/right/right.mp4", "trackFile": ""}
+          "left": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/left/left.mp4",
+            "trackFile": ""
+          },
+          "right": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/right/right.mp4",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "video"
@@ -243,9 +277,12 @@
               "originalVideoFile": "right.mp4",
               "transcodedImageFiles": [],
               "transcodedVideoFile": ""
-
             }
           },
+          "cameraOrder": [
+            "left",
+            "right"
+          ],
           "calibration": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
           "defaultDisplay": "left"
         },
@@ -256,8 +293,14 @@
       "input": {
         "defaultDisplay": "left",
         "sourceList": {
-          "left": {"sourcePath": "/home/user/data/stereoLeftRightImages/left/left.mpg", "trackFile":""},
-          "right": {"sourcePath": "/home/user/data/stereoLeftRightImages/right/right.mpg", "trackFile":""}
+          "left": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/left/left.mpg",
+            "trackFile": ""
+          },
+          "right": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/right/right.mpg",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "video"
@@ -282,6 +325,10 @@
               "transcodedVideoFile": ""
             }
           },
+          "cameraOrder": [
+            "left",
+            "right"
+          ],
           "calibration": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
           "defaultDisplay": "left"
         },
@@ -298,8 +345,14 @@
         "defaultDisplay": "left",
         "sourcePath": "/home/user/data/stereoLeftRightCombinedImages",
         "globList": {
-          "left": {"glob": "*left*.png", "trackFile": "" },
-          "right": {"glob": "*right*.png", "trackFile": "" }
+          "left": {
+            "glob": "*left*.png",
+            "trackFile": ""
+          },
+          "right": {
+            "glob": "*right*.png",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "image-sequence"
@@ -318,7 +371,6 @@
               "originalVideoFile": "",
               "transcodedImageFiles": [],
               "transcodedVideoFile": ""
-
             },
             "right": {
               "type": "image-sequence",
@@ -333,6 +385,10 @@
               "transcodedVideoFile": ""
             }
           },
+          "cameraOrder": [
+            "left",
+            "right"
+          ],
           "calibration": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
           "defaultDisplay": "left"
         },
@@ -344,8 +400,14 @@
         "defaultDisplay": "left",
         "sourcePath": "/home/user/data/stereoLeftRightCombinedImages/tiff",
         "globList": {
-          "left": {"glob": "*left*.tiff", "trackFile": "" },
-          "right": {"glob": "*right*.tiff", "trackFile": "" }
+          "left": {
+            "glob": "*left*.tiff",
+            "trackFile": ""
+          },
+          "right": {
+            "glob": "*right*.tiff",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "image-sequence"
@@ -378,6 +440,10 @@
               "transcodedVideoFile": ""
             }
           },
+          "cameraOrder": [
+            "left",
+            "right"
+          ],
           "calibration": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
           "defaultDisplay": "left"
         },
@@ -397,8 +463,14 @@
       "input": {
         "defaultDisplay": "left",
         "sourceList": {
-          "left": {"sourcePath": "/home/user/data/stereoLeftRightImages/left2/left.mpg", "trackFile": ""},
-          "right": {"sourcePath": "/home/user/data/stereoLeftRightImages/right2/right.mpg", "trackFile": ""}
+          "left": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/left2/left.mpg",
+            "trackFile": ""
+          },
+          "right": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/right2/right.mpg",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "video"
@@ -411,8 +483,14 @@
       "input": {
         "defaultDisplay": "left2",
         "sourceList": {
-          "left": {"sourcePath": "/home/user/data/stereoLeftRightImages/left/left.mp4", "trackFile": ""},
-          "right":{"sourcePath": "/home/user/data/stereoLeftRightImages/right/right.mp4", "trackFile": ""}
+          "left": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/left/left.mp4",
+            "trackFile": ""
+          },
+          "right": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/right/right.mp4",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "video"
@@ -425,8 +503,14 @@
       "input": {
         "defaultDisplay": "left",
         "sourceList": {
-          "left": {"sourcePath": "/home/user/data/stereoLeftRightImages/left/left1.png", "trackFile": ""},
-          "right": {"sourcePath": "/home/user/data/stereoLeftRightImages/right/right1.png", "trackFile": ""}
+          "left": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/left/left1.png",
+            "trackFile": ""
+          },
+          "right": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/right/right1.png",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "video"
@@ -439,8 +523,14 @@
       "input": {
         "defaultDisplay": "nomimeleft",
         "sourceList": {
-          "nomimeleft": {"sourcePath": "/home/user/data/stereoLeftRightImages/left/nomimeleft/left.zxy", "trackFile": "" },
-          "nomimeright": {"sourcePath": "/home/user/data/stereoLeftRightImages/right/nomimeright/right.zxy", "trackFile": ""}
+          "nomimeleft": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/left/nomimeleft/left.zxy",
+            "trackFile": ""
+          },
+          "nomimeright": {
+            "sourcePath": "/home/user/data/stereoLeftRightImages/right/nomimeright/right.zxy",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "video"
@@ -453,8 +543,14 @@
       "input": {
         "defaultDisplay": "left",
         "sourceList": {
-          "left": {"sourcePath": "/home/user/data/stereoLeftRightCombinedImages/empty", "trackFile" : "" },
-          "right": {"sourcePath": "/home/user/data/stereoLeftRightCombinedImages/empty", "trackFile": "" }
+          "left": {
+            "sourcePath": "/home/user/data/stereoLeftRightCombinedImages/empty",
+            "trackFile": ""
+          },
+          "right": {
+            "sourcePath": "/home/user/data/stereoLeftRightCombinedImages/empty",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "image-sequence"
@@ -463,7 +559,6 @@
         "error": "no images found in"
       }
     }
-
   },
   "failingKeywordTests": {
     "glob not supported in video": {
@@ -471,8 +566,14 @@
         "defaultDisplay": "left",
         "sourcePath": "/home/user/data/stereoLeftRightCombinedImages/tiff",
         "globList": {
-          "left": {"glob": "*left*.png", "trackFile": "" },
-          "right": {"glob": "*right*.png", "trackFile": "" }
+          "left": {
+            "glob": "*left*.png",
+            "trackFile": ""
+          },
+          "right": {
+            "glob": "*right*.png",
+            "trackFile": ""
+          }
         },
         "calibrationFile": "/home/user/data/stereoLeftRightImages/stereoCalibration.npz",
         "type": "video"
@@ -481,5 +582,5 @@
         "error": "glob pattern matching is not supported for multi-cam videos"
       }
     }
-  }  
+  }
 }


### PR DESCRIPTION
- Desktop now persists cameraOrder in dataset meta at import (the dialog's order when given, seeded from the EO-first/IR-last name heuristic otherwise), matching what the web import already stored.
- New shared dive_utils.multicam_camera_order gives the girder server and worker the same EO-first/IR-last fallback the clients use, so legacy datasets without a stored order agree everywhere too.