### PR TITLE
Optional per-dataset metadata file passed to opt-in pipelines

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -62,11 +62,10 @@ interface PipeMetadata {
    */
   metadataFileKey?: string;
   /**
-   * KWIVER config keys (e.g. "stabilizer:image_list", "stabilizer:frame_list")
-   * that should each receive the run's input image list(s) — one image list per
-   * camera (single-camera: the one manifest; multicam: the per-camera manifests
-   * comma-joined). Parsed from a `# Image List Keys:` header; every listed key
-   * gets the same value.
+   * KWIVER config key templates (e.g. "stabilizer:image_list{cam}") bound to the
+   * run's per-camera input image lists — one single-file, line-separated list per
+   * camera. A `{cam}` placeholder is expanded per camera (1-based); a key without
+   * it gets the first camera's list. Parsed from a `# Image List Keys:` header.
    */
   imageListKeys?: string[];
 }

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -240,6 +240,10 @@ interface DatasetMeta extends DatasetMetaMutable {
   calibration?: Readonly<string | null>;
   /** Optional metadata file associated with the dataset, passed to opt-in pipelines. */
   metadataFile?: Readonly<string | null>;
+  /** Girder item id of the optional per-dataset metadata file (web). */
+  metadataFileItemId?: Readonly<string | null>;
+  /** Original filename of the optional per-dataset metadata file (web). */
+  metadataFileOriginalName?: Readonly<string | null>;
 }
 
 interface CameraCalibration {

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -61,6 +61,18 @@ interface PipeMetadata {
    * metadata file and none is injected.
    */
   metadataFileKey?: string;
+  /**
+   * KWIVER config keys (e.g. "stabilizer:image_list") that should receive the
+   * primary (first-camera / single) input image-list manifest path, parsed from
+   * a `# Image List Keys:` header.
+   */
+  imageListKeys?: string[];
+  /**
+   * KWIVER config keys (e.g. "stabilizer:frame_list") that should receive the
+   * comma-joined per-camera input manifest paths, parsed from a
+   * `# Frame List Keys:` header.
+   */
+  frameListKeys?: string[];
 }
 
 interface PipelineRuntimeParams {

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -54,6 +54,13 @@ interface PipeMetadata {
   outputType?: string;
   diveParams?: DiveParam[];
   requiresCalibration?: boolean;
+  /**
+   * KWIVER config key (e.g. "stabilizer:flight_log") that the dataset's optional
+   * metadata file should be bound to at run time. Parsed from a pipe header
+   * `# Metadata File: <block>:<key>`. When unset, the pipe does not consume a
+   * metadata file and none is injected.
+   */
+  metadataFileKey?: string;
 }
 
 interface PipelineRuntimeParams {
@@ -154,6 +161,7 @@ export interface MultiCamImportFolderArgs {
     glob?: string;
   }>; // path/track file per camera
   calibrationFile?: string; // NPZ calibation matrix file
+  metadataFile?: string; // Optional per-dataset metadata file (e.g. sea-lion flight log)
   type: 'image-sequence' | 'video' | 'large-image';
 }
 
@@ -165,6 +173,7 @@ export interface MultiCamImportKeywordArgs {
     trackFile: string;
   }>; // glob pattern for base folder
   calibrationFile?: string; // NPZ calibation matrix file
+  metadataFile?: string; // Optional per-dataset metadata file (e.g. sea-lion flight log)
   type: 'image-sequence'; // Always image-sequence type for glob matching
 }
 
@@ -222,6 +231,8 @@ interface DatasetMeta extends DatasetMetaMutable {
   multiCamMedia: Readonly<MultiCamMedia | null>;
   /** Stereo calibration / camera file currently associated with the dataset (desktop). */
   calibration?: Readonly<string | null>;
+  /** Optional metadata file associated with the dataset, passed to opt-in pipelines. */
+  metadataFile?: Readonly<string | null>;
 }
 
 interface CameraCalibration {
@@ -297,7 +308,7 @@ interface Api {
   saveAttributeTrackFilters(datasetId: string,
     args: SaveAttributeTrackFilterArgs): Promise<unknown>;
   // Non-Endpoint shared functions
-  openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 'annotation' | 'text' | 'zip' | 'transform', directory?: boolean):
+  openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 'annotation' | 'text' | 'zip' | 'transform' | 'metadata', directory?: boolean):
     Promise<{canceled?: boolean; filePaths: string[]; fileList?: File[]; root?: string}>;
   /** Desktop: immediate child directory names under a parent folder (multicam subfolder import). */
   listImmediateSubfolders?(parentPath: string): Promise<string[]>;

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -62,17 +62,13 @@ interface PipeMetadata {
    */
   metadataFileKey?: string;
   /**
-   * KWIVER config keys (e.g. "stabilizer:image_list") that should receive the
-   * primary (first-camera / single) input image-list manifest path, parsed from
-   * a `# Image List Keys:` header.
+   * KWIVER config keys (e.g. "stabilizer:image_list", "stabilizer:frame_list")
+   * that should each receive the run's input image list(s) — one image list per
+   * camera (single-camera: the one manifest; multicam: the per-camera manifests
+   * comma-joined). Parsed from a `# Image List Keys:` header; every listed key
+   * gets the same value.
    */
   imageListKeys?: string[];
-  /**
-   * KWIVER config keys (e.g. "stabilizer:frame_list") that should receive the
-   * comma-joined per-camera input manifest paths, parsed from a
-   * `# Frame List Keys:` header.
-   */
-  frameListKeys?: string[];
 }
 
 interface PipelineRuntimeParams {

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamDialog.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamDialog.vue
@@ -14,6 +14,7 @@ import ImportMultiCamMultiFolder from './ImportMultiCamMultiFolder.vue';
 import ImportMultiCamKeyword from './ImportMultiCamKeyword.vue';
 import ImportMultiCamFinalizeStep from './ImportMultiCamFinalizeStep.vue';
 import ImportMultiCamCalibration from './ImportMultiCamCalibration.vue';
+import ImportMultiCamMetadata from './ImportMultiCamMetadata.vue';
 
 export default defineComponent({
   name: 'ImportMultiCamDialog',
@@ -24,6 +25,7 @@ export default defineComponent({
     ImportMultiCamKeyword,
     ImportMultiCamFinalizeStep,
     ImportMultiCamCalibration,
+    ImportMultiCamMetadata,
   },
   props: {
     stereo: {
@@ -114,6 +116,11 @@ export default defineComponent({
 
       <ImportMultiCamCalibration
         v-if="stereo && importType"
+        :ctx="ctx"
+      />
+
+      <ImportMultiCamMetadata
+        v-if="importType"
         :ctx="ctx"
       />
 

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamMetadata.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamMetadata.vue
@@ -1,0 +1,65 @@
+<!--
+  Optional per-dataset metadata file picker (e.g. sea-lion flight log). Requires
+  `ctx`; uses metadataFile and open from ctx. Unlike calibration this is not gated
+  to stereo datasets.
+-->
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { importMultiCamContextProp } from './importMultiCamContext';
+
+export default defineComponent({
+  name: 'ImportMultiCamMetadata',
+  props: {
+    ...importMultiCamContextProp,
+  },
+  setup(props) {
+    const {
+      metadataFile,
+      open,
+      clearMetadataFile,
+    } = props.ctx;
+    return {
+      metadataFile,
+      open,
+      clearMetadataFile,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-row
+    no-gutters
+    class="align-center my-3"
+  >
+    <v-text-field
+      label="Metadata File (Optional)"
+      placeholder="Not selected"
+      readonly
+      outlined
+      dense
+      hide-details
+      :value="metadataFile"
+      hint="A .json, .txt, or .csv file passed to pipelines that request it."
+      class="mr-3"
+    />
+    <v-btn
+      v-if="metadataFile"
+      icon
+      class="mr-2"
+      aria-label="Clear metadata file"
+      @click="clearMetadataFile"
+    >
+      <v-icon>mdi-close</v-icon>
+    </v-btn>
+    <v-btn
+      color="primary"
+      @click="open('metadata', 'metadata')"
+    >
+      Choose metadata
+      <v-icon class="ml-2">
+        mdi-file-cog
+      </v-icon>
+    </v-btn>
+  </v-row>
+</template>

--- a/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
@@ -96,6 +96,9 @@ export function useImportMultiCamDialog(
   const calibrationFile = ref('');
   const lastCalibrationPath = ref('');
   const calibrationAutoDiscoveryFailed = ref(false);
+  // Optional per-dataset metadata file (e.g. sea-lion flight log). Not gated to
+  // stereo; applies to any multicam import.
+  const metadataFile = ref('');
   const datasetName = ref('');
   const subfolderOriginalNames: Ref<Record<string, string>> = ref({});
   const cameraOrder: Ref<string[]> = ref([]);
@@ -656,8 +659,8 @@ export function useImportMultiCamDialog(
   }
 
   async function open(
-    dstype: DatasetType | 'calibration' | 'text',
-    folder: string | 'calibration',
+    dstype: DatasetType | 'calibration' | 'text' | 'metadata',
+    folder: string | 'calibration' | 'metadata',
     directory = false,
   ) {
     const ret = await openFromDisk(dstype, directory || dstype === 'image-sequence');
@@ -670,6 +673,8 @@ export function useImportMultiCamDialog(
         if (saveCalibration) {
           saveCalibration(path);
         }
+      } else if (folder === 'metadata') {
+        metadataFile.value = path;
       } else if (importType.value === 'multi') {
         if (ret.root) {
           folderList.value[folder].sourcePath = ret.root;
@@ -781,6 +786,7 @@ export function useImportMultiCamDialog(
         cameraOrder: orderedCameraKeys.value,
         sourceList,
         calibrationFile: calibrationFile.value,
+        metadataFile: metadataFile.value || undefined,
         type: props.dataType,
       };
       emit('begin-multicam-import', args);
@@ -790,6 +796,7 @@ export function useImportMultiCamDialog(
         sourcePath: keywordFolder.value,
         globList: globList.value,
         calibrationFile: calibrationFile.value,
+        metadataFile: metadataFile.value || undefined,
         type: 'image-sequence',
       };
       emit('begin-multicam-import', args);
@@ -815,6 +822,10 @@ export function useImportMultiCamDialog(
 
   function clearCalibration() {
     calibrationFile.value = '';
+  }
+
+  function clearMetadataFile() {
+    metadataFile.value = '';
   }
 
   function applyLastCalibration() {
@@ -951,5 +962,7 @@ export function useImportMultiCamDialog(
     openTransformFile,
     clearTransformFile,
     clearCalibration,
+    metadataFile,
+    clearMetadataFile,
   };
 }

--- a/client/dive-common/constants.ts
+++ b/client/dive-common/constants.ts
@@ -60,6 +60,14 @@ const calibrationFileTypes = [
   'zip',
 ];
 
+// Optional per-dataset metadata file (e.g. sea-lion flight log) that is stored
+// alongside the dataset and handed to opt-in pipelines at run time.
+const metadataFileTypes = [
+  'json',
+  'txt',
+  'csv',
+];
+
 const fileVideoTypes = [
   'mp4',
   'webm',
@@ -182,6 +190,8 @@ const stereoPipelineMarker = 'measurement';
 const calibrationFileMarker = 'calibrationFile';
 /** Girder item meta key marking the JSON camera-rig used for calibration display. */
 const jsonCalibrationFileMarker = 'jsonCalibrationFile';
+/** Girder item meta key marking the optional per-dataset metadata file upload. */
+const metadataFileMarker = 'metadataFile';
 /** Legacy common_stereo category key; never shown in the run-pipeline menu. */
 const hiddenPipelineCategories = ['stereo'];
 /** Pipeline name/category substrings hidden from the web run-pipeline menu. */
@@ -205,6 +215,7 @@ export {
   FPSOptions,
   itemsPerPageOptions,
   calibrationFileTypes,
+  metadataFileTypes,
   fileVideoTypes,
   otherImageTypes,
   otherVideoTypes,
@@ -225,6 +236,7 @@ export {
   stereoPipelineMarker,
   calibrationFileMarker,
   jsonCalibrationFileMarker,
+  metadataFileMarker,
   hiddenPipelineCategories,
   webExcludedPipelineTerms,
   multiCamPipelineMarkers,

--- a/client/platform/desktop/README.md
+++ b/client/platform/desktop/README.md
@@ -58,11 +58,12 @@ After `electron-vite build`, **`electron-builder --config electron-builder.json`
 DIVE Desktop can be started directly on a dataset, skipping the import wizard:
 
 ```bash
-dive-desktop --import <media> [--annotations <file>] [--name <name>]
+dive-desktop --import <media> [--annotations <file>] [--metadata <file>] [--name <name>]
 ```
 
 * **`--import`, `-i`** — the media to open. Anything the import wizard accepts: an image-sequence directory, an image-list text file (one image path per line), or a video.
 * **`--annotations`, `-a`** — optional VIAME CSV or DIVE JSON to load onto the dataset.
+* **`--metadata`** — optional pipeline metadata sidecar (`.json` / `.txt` / `.csv`), e.g. a flight log. Same as the import wizard's Metadata File picker.
 * **`--name`, `-n`** — optional display name; defaults to the media basename.
 
 Relative paths are resolved against the working directory. For example, to review a detector's output over an image list:
@@ -78,12 +79,14 @@ Name each camera with a repeated `--camera` instead of using `--import`:
 ```bash
 dive-desktop --camera left=/data/left --camera right=/data/right \
              --annotations left=/data/left.csv --annotations right=/data/right.csv \
-             --calibration /data/calibration_matrices.npz
+             --calibration /data/calibration_matrices.npz \
+             --metadata /data/flight_log.csv
 ```
 
 * **`--camera`, `-c`** — `<name>=<media>`, repeated once per camera (two or more). Each media path is the same set of things `--import` accepts. Only the first `=` separates, so Windows paths survive. Flag order is the display order.
 * **`--annotations`, `-a`** — becomes `<camera>=<file>` in multi-camera mode. Give it once per camera that has annotations; cameras may be omitted.
 * **`--calibration`** — stereo calibration file (`.npz` or `.json`). Multi-camera only.
+* **`--metadata`** — optional pipeline metadata sidecar; available for single-camera and multi-camera imports alike.
 * **`--default-display`** — camera shown on open. Defaults to `left` when present, else the first camera.
 
 **Stereo is not a separate flag.** As elsewhere in DIVE, a dataset whose cameras are named exactly `left` and `right` is typed `stereo`; any other set of names is `multicam`. So the example above produces a stereo dataset, and adding a `--calibration` is what makes stereo measurement work.

--- a/client/platform/desktop/backend/cliImport.spec.ts
+++ b/client/platform/desktop/backend/cliImport.spec.ts
@@ -23,6 +23,31 @@ describe('parseCliArgs', () => {
     });
   });
 
+  it('parses an optional metadata file', () => {
+    const args = parseCliArgs([
+      'app',
+      '--import', '/data/imgs',
+      '--metadata', '/data/flight_log.csv',
+    ]);
+    expect(args).toEqual({
+      importPath: '/data/imgs',
+      annotationPath: undefined,
+      metadataPath: '/data/flight_log.csv',
+      name: undefined,
+    });
+  });
+
+  it('supports = syntax for --metadata', () => {
+    expect(parseCliArgs([
+      'app', '--import=/data/imgs', '--metadata=/data/log.json',
+    ])?.metadataPath).toEqual('/data/log.json');
+  });
+
+  it('resolves a relative metadata path against the working directory', () => {
+    const args = parseCliArgs(['app', '--import', 'list.txt', '--metadata', 'log.csv']);
+    expect(args?.metadataPath).toEqual(npath.resolve('log.csv'));
+  });
+
   it('supports = syntax and short flags', () => {
     expect(parseCliArgs(['app', '--import=/data/imgs', '-a', '/data/x.csv'])).toEqual({
       importPath: '/data/imgs',
@@ -74,6 +99,16 @@ describe('parseCliArgs multi-camera', () => {
       calibrationPath: '/data/cal.npz',
       name: 'Stereo Run',
     });
+  });
+
+  it('parses an optional metadata file for multi-camera', () => {
+    const args = parseCliArgs([
+      'app',
+      '--camera', 'left=/data/left',
+      '--camera', 'right=/data/right',
+      '--metadata', '/data/flight_log.csv',
+    ]);
+    expect(args?.metadataPath).toEqual('/data/flight_log.csv');
   });
 
   it('defaults defaultDisplay to left, else the first camera', () => {

--- a/client/platform/desktop/backend/cliImport.ts
+++ b/client/platform/desktop/backend/cliImport.ts
@@ -6,18 +6,21 @@
  *
  * Single camera:
  *
- *   dive-desktop --import <media> [--annotations <file>] [--name <name>]
+ *   dive-desktop --import <media> [--annotations <file>] [--metadata <file>] \
+ *                [--name <name>]
  *
  * Multi-camera and stereo, by naming each camera:
  *
  *   dive-desktop --camera left=<media> --camera right=<media> \
  *                --annotations left=<file> --annotations right=<file> \
- *                --calibration <file>
+ *                --calibration <file> [--metadata <file>]
  *
  * <media> is anything the import wizard accepts: an image-sequence directory,
  * an image-list text file, or a video. Annotation files are VIAME CSV or DIVE
- * JSON. A dataset whose cameras are named exactly `left` and `right` is typed
- * as stereo by the importer; any other set of names is multicam.
+ * JSON. Metadata is an optional pipeline sidecar (`.json` / `.txt` / `.csv`),
+ * the same file the import wizard's Metadata File picker accepts. A dataset
+ * whose cameras are named exactly `left` and `right` is typed as stereo by
+ * the importer; any other set of names is multicam.
  *
  * This drives the same backend calls as the import wizard, so a CLI-launched
  * dataset is indistinguishable from a hand-imported one.
@@ -58,6 +61,11 @@ export interface CliOpenArgs {
   defaultDisplay?: string;
   /** Stereo calibration file (.npz or .json). */
   calibrationPath?: string;
+  /**
+   * Optional per-dataset metadata file (e.g. flight log). Same role as the
+   * import dialog's Metadata File picker; copied into the project on finalize.
+   */
+  metadataPath?: string;
   /** Optional dataset display name; defaults to the media basename. */
   name?: string;
 }
@@ -124,7 +132,9 @@ export function parseCliArgs(argv: string[]): CliOpenArgs | null {
 
   const annotationArgs = readFlagAll('--annotations', '--annotation', '-a');
   const calibration = readFlag('--calibration');
+  const metadata = readFlag('--metadata');
   const name = readFlag('--name', '-n');
+  const metadataPath = metadata ? npath.resolve(metadata) : undefined;
 
   if (!cameraArgs.length) {
     // Single camera. A camera-keyed annotation here is a mistake worth naming,
@@ -140,6 +150,7 @@ export function parseCliArgs(argv: string[]): CliOpenArgs | null {
     return {
       importPath: npath.resolve(importPath as string),
       annotationPath: annotationArgs[0] ? npath.resolve(annotationArgs[0]) : undefined,
+      ...(metadataPath ? { metadataPath } : {}),
       name,
     };
   }
@@ -183,6 +194,7 @@ export function parseCliArgs(argv: string[]): CliOpenArgs | null {
     cameraAnnotations,
     defaultDisplay,
     calibrationPath: calibration ? npath.resolve(calibration) : undefined,
+    ...(metadataPath ? { metadataPath } : {}),
     name,
   };
 }
@@ -214,6 +226,7 @@ function buildMultiCamArgs(args: CliOpenArgs): MultiCamImportFolderArgs {
     cameraOrder,
     sourceList,
     calibrationFile: args.calibrationPath,
+    metadataFile: args.metadataPath,
     type: [...types][0],
   };
 }
@@ -242,6 +255,11 @@ export async function runCliImport(
     : await common.beginMediaImport(args.importPath as string);
   if (args.name) {
     importPayload.jsonMeta.name = args.name;
+  }
+  // Single-camera metadata rides on the finalize payload; multicam stashes the
+  // source path on jsonMeta during beginMultiCamImport (same as the wizard).
+  if (args.metadataPath && !args.cameras) {
+    importPayload.metadataFileAbsPath = args.metadataPath;
   }
 
   const conversionArgs: ConversionArgs = await common.finalizeMediaImport(currentSettings, importPayload);

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -141,7 +141,7 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
       }
 
       if (inDescription) {
-        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output|Requires\s+Calibration):/i.test(line) || !line.startsWith('#')) {
+        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File):/i.test(line) || !line.startsWith('#')) {
           inDescription = false;
         } else {
           fullDescription += ` ${line.replace(/^#\s*/, '').trim()}`;
@@ -161,6 +161,16 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
       if (calibrationMatch) {
         const value = calibrationMatch[1].trim().toLowerCase();
         metadata.requiresCalibration = ['true', 'yes', '1'].includes(value);
+      }
+
+      // `# Metadata File: <block>:<key>` opts a pipe in to receiving the
+      // dataset's optional metadata file as a `-s <block>:<key>=<path>` override.
+      const metadataFileMatch = line.match(/^#\s*Metadata\s+File:\s*(.+)/i);
+      if (metadataFileMatch) {
+        const value = metadataFileMatch[1].trim();
+        if (value) {
+          metadata.metadataFileKey = value;
+        }
       }
     });
     metadata.description = fullDescription.trim() || undefined;
@@ -1496,6 +1506,25 @@ async function finalizeMediaImport(
       calibrationSourcePath,
     );
     jsonMeta.multiCam.calibrationSourcePath = preservedOriginalPath;
+  }
+
+  // Store any optional metadata file alongside the media (keeping the original
+  // name). Single imports pass it on the response; multicam imports stash the
+  // source path on jsonMeta.metadataFile during beginMultiCamImport.
+  const metadataSourcePath = args.metadataFileAbsPath || jsonMeta.metadataFile;
+  if (metadataSourcePath) {
+    const resolvedMetadataSource = npath.resolve(metadataSourcePath);
+    const metadataDest = npath.join(
+      projectDirAbsPath,
+      npath.basename(resolvedMetadataSource),
+    );
+    await fs.copy(resolvedMetadataSource, metadataDest);
+    jsonMeta.metadataOriginalName = npath.basename(resolvedMetadataSource);
+    jsonMeta.metadataFile = metadataDest;
+  } else {
+    // Ensure a stale source path never survives when no file was chosen.
+    jsonMeta.metadataFile = undefined;
+    jsonMeta.metadataOriginalName = undefined;
   }
 
   // Filter all parts of the input based on glob pattern

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -141,7 +141,7 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
       }
 
       if (inDescription) {
-        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File|Image\s+List\s+Keys?|Frame\s+List\s+Keys?):/i.test(line) || !line.startsWith('#')) {
+        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File|Image\s+List\s+Keys?):/i.test(line) || !line.startsWith('#')) {
           inDescription = false;
         } else {
           fullDescription += ` ${line.replace(/^#\s*/, '').trim()}`;
@@ -173,22 +173,15 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
         }
       }
 
-      // `# Image List Keys: <k> [k...]` binds the primary (first-camera / single)
-      // input image-list manifest to each key; `# Frame List Keys: <k> [k...]`
-      // binds the comma-joined per-camera manifests. Lets pipes (e.g. the sea-lion
-      // registration stabilizer) read the same image list DIVE feeds the reader.
+      // `# Image List Keys: <k> [k...]` binds the run's input image list(s) (one
+      // per camera; multicam comma-joined) to each key, so pipes (e.g. the
+      // sea-lion registration stabilizer) read the same image list DIVE feeds the
+      // input reader.
       const imageListMatch = line.match(/^#\s*Image\s+List\s+Keys?:\s*(.+)/i);
       if (imageListMatch) {
         const keys = imageListMatch[1].trim().split(/[\s,]+/).filter((k) => k);
         if (keys.length) {
           metadata.imageListKeys = keys;
-        }
-      }
-      const frameListMatch = line.match(/^#\s*Frame\s+List\s+Keys?:\s*(.+)/i);
-      if (frameListMatch) {
-        const keys = frameListMatch[1].trim().split(/[\s,]+/).filter((k) => k);
-        if (keys.length) {
-          metadata.frameListKeys = keys;
         }
       }
     });

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -141,7 +141,7 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
       }
 
       if (inDescription) {
-        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File):/i.test(line) || !line.startsWith('#')) {
+        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File|Image\s+List\s+Keys?|Frame\s+List\s+Keys?):/i.test(line) || !line.startsWith('#')) {
           inDescription = false;
         } else {
           fullDescription += ` ${line.replace(/^#\s*/, '').trim()}`;
@@ -170,6 +170,25 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
         const value = metadataFileMatch[1].trim();
         if (value) {
           metadata.metadataFileKey = value;
+        }
+      }
+
+      // `# Image List Keys: <k> [k...]` binds the primary (first-camera / single)
+      // input image-list manifest to each key; `# Frame List Keys: <k> [k...]`
+      // binds the comma-joined per-camera manifests. Lets pipes (e.g. the sea-lion
+      // registration stabilizer) read the same image list DIVE feeds the reader.
+      const imageListMatch = line.match(/^#\s*Image\s+List\s+Keys?:\s*(.+)/i);
+      if (imageListMatch) {
+        const keys = imageListMatch[1].trim().split(/[\s,]+/).filter((k) => k);
+        if (keys.length) {
+          metadata.imageListKeys = keys;
+        }
+      }
+      const frameListMatch = line.match(/^#\s*Frame\s+List\s+Keys?:\s*(.+)/i);
+      if (frameListMatch) {
+        const keys = frameListMatch[1].trim().split(/[\s,]+/).filter((k) => k);
+        if (keys.length) {
+          metadata.frameListKeys = keys;
         }
       }
     });

--- a/client/platform/desktop/backend/native/multiCamImport.ts
+++ b/client/platform/desktop/backend/native/multiCamImport.ts
@@ -199,6 +199,9 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
       calibration: args.calibrationFile,
       defaultDisplay: args.defaultDisplay,
     },
+    // Stash the metadata source path; finalizeMediaImport copies it into the
+    // project directory and rewrites this to the stored copy's path.
+    metadataFile: args.metadataFile || undefined,
     subType: null,
   };
   if (Object.keys(seedHomographies).length || Object.keys(seedCorrespondences).length) {

--- a/client/platform/desktop/backend/native/multicamExport.ts
+++ b/client/platform/desktop/backend/native/multicamExport.ts
@@ -136,6 +136,13 @@ export async function exportMulticamEverything(
       await fs.copy(calibrationPath, npath.join(datasetDir, calibrationName));
     }
 
+    // Optional pipeline metadata sidecar (e.g. flight log), same as web full export.
+    if (parentMeta.metadataFile && await fs.pathExists(parentMeta.metadataFile)) {
+      const metadataName = parentMeta.metadataOriginalName
+        ?? npath.basename(parentMeta.metadataFile);
+      await fs.copy(parentMeta.metadataFile, npath.join(datasetDir, metadataName));
+    }
+
     // Regenerate the camera registration as its per-camera files so the
     // zip carries it even when only the import-time seed exists.
     const rigRegistration = await loadEffectiveRegistration(parentDirInfo.basePath, parentMeta);

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -220,11 +220,10 @@ async function runPipeline(
   let command: string[] = [];
   const stereoOrMultiCam = (pipeline.type === stereoPipelineMarker
     || multiCamPipelineMarkers.includes(pipeline.type));
-  // Input image-list manifest(s) so opt-in pipes (sea-lion registration) can read
-  // the same list DIVE feeds the input reader. primary = first/single manifest;
-  // all = comma-joined per-camera manifests (single-cam: same value).
-  let primaryInputManifest = '';
-  let allInputManifests = '';
+  // Input image list(s) so opt-in pipes (sea-lion registration) can read the same
+  // list DIVE feeds the input reader. One list per camera; multicam lists are
+  // comma-joined (single-cam: the one manifest).
+  let inputImageList = '';
 
   if (metaType === 'video') {
     let videoAbsPath = npath.join(meta.originalBasePath, meta.originalVideoFile);
@@ -255,8 +254,7 @@ async function runPipeline(
       command.push(`-s input:video_filename="${videoAbsPath}"`);
       command.push(`-s detector_writer:file_name="${detectorOutput}"`);
       command.push(`-s track_writer:file_name="${trackOutput}"`);
-      primaryInputManifest = videoAbsPath;
-      allInputManifests = videoAbsPath;
+      inputImageList = videoAbsPath;
     }
   } else if (metaType === 'image-sequence') {
     // Create frame image manifest
@@ -283,8 +281,7 @@ async function runPipeline(
       command.push(`-s input:video_filename="${manifestFile}"`);
       command.push(`-s detector_writer:file_name="${detectorOutput}"`);
       command.push(`-s track_writer:file_name="${trackOutput}"`);
-      primaryInputManifest = manifestFile;
-      allInputManifests = manifestFile;
+      inputImageList = manifestFile;
     }
   }
 
@@ -312,13 +309,14 @@ async function runPipeline(
     Object.entries(argFilePair).forEach(([arg, file]) => {
       command.push(`-s ${arg}="${file}"`);
     });
+    // One image list per camera, comma-joined (matches the pipe default
+    // frame_list of input_list_1..n.txt).
     const orderedInputManifests = Object.keys(argFilePair)
       .filter((arg) => /^input\d+:video_filename$/.test(arg))
       .sort((a, b) => parseInt(a.match(/\d+/)![0], 10) - parseInt(b.match(/\d+/)![0], 10))
       .map((arg) => argFilePair[arg]);
     if (orderedInputManifests.length) {
-      [primaryInputManifest] = orderedInputManifests;
-      allInputManifests = orderedInputManifests.join(',');
+      inputImageList = orderedInputManifests.join(',');
     }
     multiOutFiles = {};
     Object.entries(outFiles).forEach(([cameraName, fileName]) => {
@@ -341,18 +339,13 @@ async function runPipeline(
     command.push(`-s ${metadataFileKey}="${meta.metadataFile}"`);
   }
 
-  // Bind the input image-list manifest(s) to any keys a pipe declares via
-  // `# Image List Keys:` (primary manifest) / `# Frame List Keys:` (comma-joined),
-  // so the sea-lion registration stabilizer reads the same frames DIVE runs on.
-  const { imageListKeys, frameListKeys } = runPipelineArgs.pipeline.metadata ?? {};
-  if (primaryInputManifest) {
+  // Bind the input image list(s) to every key a pipe declares via
+  // `# Image List Keys:` (one list per camera; multicam comma-joined), so the
+  // sea-lion registration stabilizer reads the same frames DIVE runs on.
+  const { imageListKeys } = runPipelineArgs.pipeline.metadata ?? {};
+  if (inputImageList) {
     (imageListKeys ?? []).forEach((key) => {
-      command.push(`-s ${key}="${primaryInputManifest}"`);
-    });
-  }
-  if (allInputManifests) {
-    (frameListKeys ?? []).forEach((key) => {
-      command.push(`-s ${key}="${allInputManifests}"`);
+      command.push(`-s ${key}="${inputImageList}"`);
     });
   }
 

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -317,6 +317,13 @@ async function runPipeline(
     throw new Error('Attempting to run a multicam pipeline on non multicam data');
   }
 
+  // Hand the dataset's optional metadata file to pipelines that opt in via a
+  // `# Metadata File: <block>:<key>` header (e.g. sea-lion stabilizer:flight_log).
+  const metadataFileKey = runPipelineArgs.pipeline.metadata?.metadataFileKey;
+  if (metadataFileKey && meta.metadataFile) {
+    command.push(`-s ${metadataFileKey}="${meta.metadataFile}"`);
+  }
+
   // Add any custom pipeline parameters
   const kwiverParams = runPipelineArgs.pipelineParams?.kwiverParams;
   if (kwiverParams) {

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -220,6 +220,11 @@ async function runPipeline(
   let command: string[] = [];
   const stereoOrMultiCam = (pipeline.type === stereoPipelineMarker
     || multiCamPipelineMarkers.includes(pipeline.type));
+  // Input image-list manifest(s) so opt-in pipes (sea-lion registration) can read
+  // the same list DIVE feeds the input reader. primary = first/single manifest;
+  // all = comma-joined per-camera manifests (single-cam: same value).
+  let primaryInputManifest = '';
+  let allInputManifests = '';
 
   if (metaType === 'video') {
     let videoAbsPath = npath.join(meta.originalBasePath, meta.originalVideoFile);
@@ -250,6 +255,8 @@ async function runPipeline(
       command.push(`-s input:video_filename="${videoAbsPath}"`);
       command.push(`-s detector_writer:file_name="${detectorOutput}"`);
       command.push(`-s track_writer:file_name="${trackOutput}"`);
+      primaryInputManifest = videoAbsPath;
+      allInputManifests = videoAbsPath;
     }
   } else if (metaType === 'image-sequence') {
     // Create frame image manifest
@@ -276,6 +283,8 @@ async function runPipeline(
       command.push(`-s input:video_filename="${manifestFile}"`);
       command.push(`-s detector_writer:file_name="${detectorOutput}"`);
       command.push(`-s track_writer:file_name="${trackOutput}"`);
+      primaryInputManifest = manifestFile;
+      allInputManifests = manifestFile;
     }
   }
 
@@ -303,6 +312,14 @@ async function runPipeline(
     Object.entries(argFilePair).forEach(([arg, file]) => {
       command.push(`-s ${arg}="${file}"`);
     });
+    const orderedInputManifests = Object.keys(argFilePair)
+      .filter((arg) => /^input\d+:video_filename$/.test(arg))
+      .sort((a, b) => parseInt(a.match(/\d+/)![0], 10) - parseInt(b.match(/\d+/)![0], 10))
+      .map((arg) => argFilePair[arg]);
+    if (orderedInputManifests.length) {
+      [primaryInputManifest] = orderedInputManifests;
+      allInputManifests = orderedInputManifests.join(',');
+    }
     multiOutFiles = {};
     Object.entries(outFiles).forEach(([cameraName, fileName]) => {
       multiOutFiles[cameraName] = npath.join(jobWorkDir, fileName);
@@ -322,6 +339,21 @@ async function runPipeline(
   const metadataFileKey = runPipelineArgs.pipeline.metadata?.metadataFileKey;
   if (metadataFileKey && meta.metadataFile) {
     command.push(`-s ${metadataFileKey}="${meta.metadataFile}"`);
+  }
+
+  // Bind the input image-list manifest(s) to any keys a pipe declares via
+  // `# Image List Keys:` (primary manifest) / `# Frame List Keys:` (comma-joined),
+  // so the sea-lion registration stabilizer reads the same frames DIVE runs on.
+  const { imageListKeys, frameListKeys } = runPipelineArgs.pipeline.metadata ?? {};
+  if (primaryInputManifest) {
+    (imageListKeys ?? []).forEach((key) => {
+      command.push(`-s ${key}="${primaryInputManifest}"`);
+    });
+  }
+  if (allInputManifests) {
+    (frameListKeys ?? []).forEach((key) => {
+      command.push(`-s ${key}="${allInputManifests}"`);
+    });
   }
 
   // Add any custom pipeline parameters

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -221,9 +221,9 @@ async function runPipeline(
   const stereoOrMultiCam = (pipeline.type === stereoPipelineMarker
     || multiCamPipelineMarkers.includes(pipeline.type));
   // Input image list(s) so opt-in pipes (sea-lion registration) can read the same
-  // list DIVE feeds the input reader. One list per camera; multicam lists are
-  // comma-joined (single-cam: the one manifest).
-  let inputImageList = '';
+  // lists DIVE feeds the input reader — one single-file, line-separated list per
+  // camera (single-cam: one entry).
+  let inputImageLists: string[] = [];
 
   if (metaType === 'video') {
     let videoAbsPath = npath.join(meta.originalBasePath, meta.originalVideoFile);
@@ -254,7 +254,7 @@ async function runPipeline(
       command.push(`-s input:video_filename="${videoAbsPath}"`);
       command.push(`-s detector_writer:file_name="${detectorOutput}"`);
       command.push(`-s track_writer:file_name="${trackOutput}"`);
-      inputImageList = videoAbsPath;
+      inputImageLists = [videoAbsPath];
     }
   } else if (metaType === 'image-sequence') {
     // Create frame image manifest
@@ -281,7 +281,7 @@ async function runPipeline(
       command.push(`-s input:video_filename="${manifestFile}"`);
       command.push(`-s detector_writer:file_name="${detectorOutput}"`);
       command.push(`-s track_writer:file_name="${trackOutput}"`);
-      inputImageList = manifestFile;
+      inputImageLists = [manifestFile];
     }
   }
 
@@ -309,14 +309,13 @@ async function runPipeline(
     Object.entries(argFilePair).forEach(([arg, file]) => {
       command.push(`-s ${arg}="${file}"`);
     });
-    // One image list per camera, comma-joined (matches the pipe default
-    // frame_list of input_list_1..n.txt).
+    // One image list per camera (each a single line-separated file).
     const orderedInputManifests = Object.keys(argFilePair)
       .filter((arg) => /^input\d+:video_filename$/.test(arg))
       .sort((a, b) => parseInt(a.match(/\d+/)![0], 10) - parseInt(b.match(/\d+/)![0], 10))
       .map((arg) => argFilePair[arg]);
     if (orderedInputManifests.length) {
-      inputImageList = orderedInputManifests.join(',');
+      inputImageLists = orderedInputManifests;
     }
     multiOutFiles = {};
     Object.entries(outFiles).forEach(([cameraName, fileName]) => {
@@ -339,13 +338,20 @@ async function runPipeline(
     command.push(`-s ${metadataFileKey}="${meta.metadataFile}"`);
   }
 
-  // Bind the input image list(s) to every key a pipe declares via
-  // `# Image List Keys:` (one list per camera; multicam comma-joined), so the
-  // sea-lion registration stabilizer reads the same frames DIVE runs on.
+  // Bind the per-camera input image lists to the keys a pipe declares via
+  // `# Image List Keys:`, so the sea-lion registration stabilizer reads the same
+  // frames DIVE runs on. A `{cam}` placeholder is expanded per camera (1-based);
+  // a key without it gets the first camera's list.
   const { imageListKeys } = runPipelineArgs.pipeline.metadata ?? {};
-  if (inputImageList) {
+  if (inputImageLists.length) {
     (imageListKeys ?? []).forEach((key) => {
-      command.push(`-s ${key}="${inputImageList}"`);
+      if (key.includes('{cam}')) {
+        inputImageLists.forEach((imageList, idx) => {
+          command.push(`-s ${key.replace('{cam}', String(idx + 1))}="${imageList}"`);
+        });
+      } else {
+        command.push(`-s ${key}="${inputImageLists[0]}"`);
+      }
     });
   }
 

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -145,6 +145,13 @@ export interface JsonMeta extends DatasetMetaMutable {
   // Stereo or multi-camera datasets with uniform type (all images, all video)
   subType: SubType;
 
+  // Optional per-dataset metadata file (e.g. sea-lion flight log), copied into
+  // the project directory at import. Absolute path to the stored copy; handed to
+  // opt-in pipelines at run time (see the pipe `# Metadata File:` header).
+  metadataFile?: string;
+  // The user's original metadata file name, preserved for display.
+  metadataOriginalName?: string;
+
   // execTime is athe execution time for desktop runs
   execTime?: number
 }
@@ -266,6 +273,8 @@ export interface DesktopMediaImportResponse extends MediaImportResponse {
   multiCamTrackFiles: null | Record<string, string>;
   forceMediaTranscode: boolean;
   metaFileAbsPath?: string;
+  // Absolute path of an optional metadata file chosen in the import dialog.
+  metadataFileAbsPath?: string;
   // Non-fatal problems found while preparing the import (e.g. a registration
   // file naming cameras this dataset doesn't have), shown in the import dialog.
   importWarnings?: string[];

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -14,6 +14,7 @@ import {
   fileVideoTypes, calibrationFileTypes,
   inputAnnotationFileTypes, listFileTypes,
   largeImageDesktopTypes, transformFileTypes,
+  metadataFileTypes,
 } from 'dive-common/constants';
 import {
   DesktopMetadata, NvidiaSmiReply,
@@ -47,7 +48,7 @@ function joinPath(dir: string, filename: string) {
  * Native functions that run entirely in the renderer
  */
 
-async function openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 'annotation' | 'text' | 'transform', directory = false) {
+async function openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 'annotation' | 'text' | 'transform' | 'metadata', directory = false) {
   let filters: FileFilter[] = [];
   const allFiles = { name: 'All Files', extensions: ['*'] };
   if (datasetType === 'video') {
@@ -82,6 +83,12 @@ async function openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 
   if (datasetType === 'text') {
     filters = [
       { name: 'text', extensions: listFileTypes },
+      allFiles,
+    ];
+  }
+  if (datasetType === 'metadata') {
+    filters = [
+      { name: 'metadata', extensions: metadataFileTypes },
       allFiles,
     ];
   }

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -69,9 +69,18 @@ export default defineComponent({
     });
 
     const { openFromDisk } = useApi();
-    const openUpload = async (type: 'annotation' | 'meta') => {
-      const argMap = { annotation: 'trackFileAbsPath', meta: 'metaFileAbsPath' };
-      const ret = await openFromDisk('annotation');
+    const openUpload = async (type: 'annotation' | 'meta' | 'metadata') => {
+      const argMap = {
+        annotation: 'trackFileAbsPath',
+        meta: 'metaFileAbsPath',
+        metadata: 'metadataFileAbsPath',
+      } as const;
+      const openTypeMap = {
+        annotation: 'annotation',
+        meta: 'annotation',
+        metadata: 'metadata',
+      } as const;
+      const ret = await openFromDisk(openTypeMap[type]);
       if (!ret.canceled) {
         if (ret.filePaths?.length) {
           const path = ret.filePaths[0];
@@ -253,6 +262,22 @@ export default defineComponent({
           @click="openUpload('meta')"
           @click:prepend-inner="openUpload('meta')"
           @click:clear="argCopy.metaFileAbsPath = ''"
+        />
+        <v-text-field
+          :value="argCopy.metadataFileAbsPath"
+          outlined
+          clearable
+          dense
+          class="mt-3"
+          prepend-inner-icon="mdi-file-cog"
+          label="Metadata File (Optional)"
+          hint="Optional. A .json, .txt, or .csv file passed to pipelines that request it
+            (e.g. a sea-lion flight log)."
+          persistent-hint
+          @input="argCopy.metadataFileAbsPath = $event"
+          @click="openUpload('metadata')"
+          @click:prepend-inner="openUpload('metadata')"
+          @click:clear="argCopy.metadataFileAbsPath = ''"
         />
         <v-text-field
           v-if="argCopy.jsonMeta.type === 'image-sequence'"

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -7,7 +7,7 @@ import {
 import {
   DatasetMetaMutable, FrameImage, SaveAttributeArgs, SaveAttributeTrackFilterArgs,
 } from 'dive-common/apispec';
-import { calibrationFileMarker, jsonCalibrationFileMarker } from 'dive-common/constants';
+import { calibrationFileMarker, jsonCalibrationFileMarker, metadataFileMarker } from 'dive-common/constants';
 import { attachFrameTimestamps } from 'dive-common/frameTimestamp';
 import { parentDatasetId } from 'dive-common/compositeDatasetId';
 import { isStereoCalibrationFileName } from 'dive-common/stereoParentFolder';
@@ -265,11 +265,13 @@ export interface CreateMulticamDatasetArgs {
   cameras: Record<string, { folderId: string; type?: 'video' | 'image-sequence' | 'large-image' }>;
   cameraOrder?: string[];
   calibrationFileId?: string;
+  metadataFileId?: string;
 }
 
 function createMulticamDataset(args: CreateMulticamDatasetArgs) {
   const {
     parentFolderId, name, fps, type, subType, defaultDisplay, cameras, cameraOrder, calibrationFileId,
+    metadataFileId,
   } = args;
   return girderRest.post<GirderModel>(
     'dive_dataset/multicam',
@@ -282,6 +284,7 @@ function createMulticamDataset(args: CreateMulticamDatasetArgs) {
       cameras,
       cameraOrder,
       calibrationFileId,
+      metadataFileId,
     },
     {
       params: { parentFolderId },
@@ -321,6 +324,48 @@ async function uploadCalibrationItem(parentFolderId: string, file: File): Promis
   // Girder item metadata is set via PUT item/:id/metadata (not PUT item/:id).
   await girderRest.put(`item/${itemId}/metadata`, calibrationMeta);
   return itemId;
+}
+
+/**
+ * Upload an optional per-dataset metadata file as a marked Girder item in the
+ * dataset (parent) folder and return its item id.
+ */
+async function uploadMetadataFileItem(parentFolderId: string, file: File): Promise<string> {
+  const metadataMeta = { [metadataFileMarker]: 'true' };
+  const itemResp = await girderRest.post<GirderModel>('/item', null, {
+    params: {
+      folderId: parentFolderId,
+      name: file.name,
+      metadata: JSON.stringify(metadataMeta),
+    },
+  });
+  const itemId = itemResp.data._id;
+  const fileResp = await girderRest.post('/file', null, {
+    params: {
+      parentType: 'item',
+      parentId: itemId,
+      name: file.name,
+      size: file.size,
+      mimeType: file.type || 'application/octet-stream',
+    },
+  });
+  await girderRest.post('file/chunk', file, {
+    params: {
+      uploadId: fileResp.data._id,
+      offset: 0,
+    },
+    headers: { 'Content-Type': 'application/octet-stream' },
+  });
+  // Girder item metadata is set via PUT item/:id/metadata (not PUT item/:id).
+  await girderRest.put(`item/${itemId}/metadata`, metadataMeta);
+  return itemId;
+}
+
+/** Mark an already-uploaded metadata item as the dataset's metadata file. */
+function setDatasetMetadataFile(folderId: string, itemId: string) {
+  return girderRest.post(`dive_dataset/${folderId}/metadata_file`, null, {
+    params: { itemId },
+  });
 }
 
 function calibrationMarkerTruthy(meta: Record<string, unknown> | undefined, key: string): boolean {
@@ -394,5 +439,7 @@ export {
   saveAttributeTrackFilters,
   saveMetadata,
   uploadCalibrationItem,
+  uploadMetadataFileItem,
+  setDatasetMetadataFile,
   validateUploadGroup,
 };

--- a/client/platform/web-girder/constants.ts
+++ b/client/platform/web-girder/constants.ts
@@ -23,6 +23,10 @@ interface GirderMetadataStatic extends DatasetMetaMutable {
   originalFps?: number;
   ffprobe_info?: Record<string, string>;
   foreign_media_id?: string;
+  /** Girder item id of the optional per-dataset metadata file. */
+  metadataFileItemId?: string;
+  /** Original filename of the optional per-dataset metadata file. */
+  metadataFileOriginalName?: string;
 }
 
 /**

--- a/client/platform/web-girder/multicamFileRegistry.ts
+++ b/client/platform/web-girder/multicamFileRegistry.ts
@@ -10,6 +10,7 @@ const filesByKey = new Map<string, File[]>();
 const annotationFilesByKey = new Map<string, File>();
 const calibrationFilesByKey = new Map<string, File>();
 const transformFilesByKey = new Map<string, File>();
+const metadataFilesByKey = new Map<string, File>();
 
 function commonDirectoryRoot(paths: string[]): string {
   if (!paths.length) {
@@ -149,11 +150,33 @@ export function getCalibrationFile(key: string): File | undefined {
   return [...calibrationFilesByKey.values()].find((file) => file.name === key);
 }
 
+/** Stash the chosen per-dataset metadata File for later upload lookup by path or name. */
+export function stashMetadataFile(key: string, file: File): void {
+  calibrationLookupKeys(key).forEach((lookupKey) => {
+    metadataFilesByKey.set(lookupKey, file);
+  });
+  metadataFilesByKey.set(file.name, file);
+}
+
+export function getMetadataFile(key: string): File | undefined {
+  if (!key) {
+    return undefined;
+  }
+  const lookupMatch = calibrationLookupKeys(key)
+    .map((lookupKey) => metadataFilesByKey.get(lookupKey))
+    .find((file) => file !== undefined);
+  if (lookupMatch) {
+    return lookupMatch;
+  }
+  return [...metadataFilesByKey.values()].find((file) => file.name === key);
+}
+
 export function clearMulticamFileRegistry(): void {
   filesByKey.clear();
   annotationFilesByKey.clear();
   calibrationFilesByKey.clear();
   transformFilesByKey.clear();
+  metadataFilesByKey.clear();
 }
 
 export async function openFromDiskWithRegistry(
@@ -168,6 +191,8 @@ export async function openFromDiskWithRegistry(
       stashCalibrationFile(ret.filePaths[0], ret.fileList[0]);
     } else if (datasetType === 'transform') {
       stashTransformFile(ret.filePaths[0], ret.fileList[0]);
+    } else if (datasetType === 'metadata') {
+      stashMetadataFile(ret.filePaths[0], ret.fileList[0]);
     } else {
       stashFileSelection(ret);
     }

--- a/client/platform/web-girder/utils.ts
+++ b/client/platform/web-girder/utils.ts
@@ -1,6 +1,6 @@
 import { UploadManager, Location } from '@girder/components/src';
 import {
-  calibrationFileTypes, inputAnnotationFileTypes, inputAnnotationTypes,
+  calibrationFileTypes, metadataFileTypes, inputAnnotationFileTypes, inputAnnotationTypes,
   getLargeImageAllowedExtensions, getLargeImageFileAccept,
   otherImageTypes, otherVideoTypes, transformFileTypes,
   websafeImageTypes, websafeVideoTypes, zipFileTypes,
@@ -39,13 +39,13 @@ function getRouteFromLocation(location: LocationType): string {
 }
 
 async function openFromDisk(
-  datasetType: DatasetType | 'calibration' | 'annotation' | 'text' | 'zip' | 'transform',
+  datasetType: DatasetType | 'calibration' | 'annotation' | 'text' | 'zip' | 'transform' | 'metadata',
   directory = false,
 ): Promise<{ canceled: boolean; filePaths: string[]; fileList?: File[]; root?: string }> {
   const input: HTMLInputElement = document.createElement('input');
   input.type = 'file';
   const baseTypes: string[] = inputAnnotationFileTypes.map((item) => `.${item}`);
-  if (!['calibration', 'annotation', 'zip'].includes(datasetType)) {
+  if (!['calibration', 'annotation', 'zip', 'metadata'].includes(datasetType)) {
     input.multiple = true;
   }
   if (directory && (datasetType === 'image-sequence' || datasetType === 'video')) {
@@ -72,6 +72,9 @@ async function openFromDisk(
     input.multiple = false;
   } else if (datasetType === 'text') {
     input.accept = '.txt,.text';
+    input.multiple = false;
+  } else if (datasetType === 'metadata') {
+    input.accept = metadataFileTypes.map((item) => `.${item}`).join(',');
     input.multiple = false;
   }
 

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -8,6 +8,7 @@ import {
   ImageSequenceType, VideoType, DefaultVideoFPS, FPSOptions,
   inputAnnotationFileTypes, websafeVideoTypes, otherVideoTypes,
   websafeImageTypes, otherImageTypes, JsonMetaRegEx, getLargeImageFileAccept, LargeImageType,
+  metadataFileTypes,
 } from 'dive-common/constants';
 
 import {
@@ -27,6 +28,7 @@ import {
   deleteResources,
   saveMetadata,
   uploadCalibrationItem,
+  uploadMetadataFileItem,
   validateUploadGroup,
   waitForFolderDatasetReady,
 } from 'platform/web-girder/api';
@@ -34,6 +36,7 @@ import {
   clearMulticamFileRegistry,
   getAnnotationFile,
   getCalibrationFile,
+  getMetadataFile,
   getFilesForSourceKey,
   getTransformFile,
   flattenUploadFiles,
@@ -73,6 +76,7 @@ export interface PendingUpload {
   name: string;
   files: InteralFiles[];
   meta: null | File;
+  metadataFile: null | File;
   annotationFile: null | File;
   mediaList: File[];
   type: DatasetType | 'zip';
@@ -191,6 +195,7 @@ export default defineComponent({
         name: defaultFilename,
         files: [], //Will be set in the GirderUpload Component
         meta: null,
+        metadataFile: null,
         annotationFile: null,
         mediaList: allFiles,
         type: 'zip',
@@ -236,6 +241,7 @@ export default defineComponent({
             : defaultFilename,
         files: [], //Will be set in the GirderUpload Component
         meta,
+        metadataFile: null,
         annotationFile,
         mediaList,
         type: uploadType,
@@ -339,9 +345,11 @@ export default defineComponent({
       multiCamOpenType.value = args.openType;
       importMultiCamDialog.value = true;
     };
-    const filterFileUpload = (type: DatasetType | 'meta' | 'annotation') => {
+    const filterFileUpload = (type: DatasetType | 'meta' | 'annotation' | 'metadata') => {
       if (type === 'meta') {
         return '.json';
+      } if (type === 'metadata') {
+        return metadataFileTypes.map((item) => `.${item}`).join(',');
       } if (type === 'annotation') {
         return inputAnnotationFileTypes.map((item) => `.${item}`).join(',');
       } if (type === 'video') {
@@ -535,6 +543,18 @@ export default defineComponent({
           calibrationFileId = await uploadCalibrationItem(datasetFolder._id, calFile);
         }
 
+        let metadataFileId: string | undefined;
+        if (args.metadataFile) {
+          setMulticamImportProgress(95, `${labelPrefix}Uploading metadata file…`);
+          const metadataFile = getMetadataFile(args.metadataFile);
+          if (!metadataFile) {
+            throw new Error(
+              'Metadata file was not found. Use "Choose metadata" in the import dialog to select the file again.',
+            );
+          }
+          metadataFileId = await uploadMetadataFileItem(datasetFolder._id, metadataFile);
+        }
+
         const subType = stereo.value ? 'stereo' : 'multicam';
         setMulticamImportProgress(97, `${labelPrefix}Linking cameras…`);
         const { data: parentFolder } = await createMulticamDataset({
@@ -547,6 +567,7 @@ export default defineComponent({
           cameras,
           cameraOrder,
           calibrationFileId,
+          metadataFileId,
         });
         multicamLinked = true;
 
@@ -981,6 +1002,19 @@ export default defineComponent({
                     hint="Optional"
                     :disabled="pendingUpload.uploading"
                     :accept="filterFileUpload('meta')"
+                  />
+                </v-row>
+                <v-row>
+                  <v-file-input
+                    v-model="pendingUpload.metadataFile"
+                    show-size
+                    counter
+                    prepend-icon="mdi-file-cog"
+                    label="Metadata File (Optional)"
+                    hint="Optional. A .json, .txt, or .csv file passed to pipelines that request it."
+                    persistent-hint
+                    :disabled="pendingUpload.uploading"
+                    :accept="filterFileUpload('metadata')"
                   />
                 </v-row>
               </v-col>

--- a/client/platform/web-girder/views/UploadGirder.vue
+++ b/client/platform/web-girder/views/UploadGirder.vue
@@ -7,7 +7,9 @@ import {
   fileSuffixRegex,
 } from 'platform/web-girder/constants';
 
-import { makeViameFolder, postProcess } from 'platform/web-girder/api';
+import {
+  makeViameFolder, postProcess, uploadMetadataFileItem, setDatasetMetadataFile,
+} from 'platform/web-girder/api';
 import { GirderUploadManager } from 'platform/web-girder/utils';
 
 export default Vue.extend({
@@ -90,9 +92,10 @@ export default Vue.extend({
     },
     async uploadPending(pendingUpload, uploaded) {
       const {
-        name, createSubFolders, meta, annotationFile, mediaList,
+        name, createSubFolders, meta, annotationFile, mediaList, metadataFile,
       } = pendingUpload;
-      //Combine the files for uploading
+      //Combine the files for uploading. The optional metadata file is uploaded
+      //separately (as a marked item) so postprocess does not classify it.
       let files = mediaList.map((item) => this.convertFileToInternal(item));
       files.push(this.convertFileToInternal(meta));
       files.push(this.convertFileToInternal(annotationFile));
@@ -110,6 +113,10 @@ export default Vue.extend({
         folder = await this.createUploadFolder(name, fps, pendingUpload.type);
         if (folder) {
           await this.uploadFiles(pendingUpload.name, folder, files, uploaded, skipTranscoding);
+          if (metadataFile) {
+            const itemId = await uploadMetadataFileItem(folder._id, metadataFile);
+            await setDatasetMetadataFile(folder._id, itemId);
+          }
           this.remove(pendingUpload);
         }
       } else {

--- a/docs/Dive-Desktop.md
+++ b/docs/Dive-Desktop.md
@@ -70,13 +70,14 @@ Pass the flags to the DIVE Desktop executable (for example `DIVE-Desktop.exe` on
 #### Single-camera datasets
 
 ``` bash
-DIVE-Desktop --import <media> [--annotations <file>] [--name <name>]
+DIVE-Desktop --import <media> [--annotations <file>] [--metadata <file>] [--name <name>]
 ```
 
 | Flag | Short | Description |
 | ---- | ----- | ----------- |
 | `--import` | `-i` | Media to open: an image-sequence directory, an image-list `.txt` file (one image path per line), or a video. Same inputs as the import wizard. |
 | `--annotations` | `-a` | Optional annotation file to load (VIAME CSV or DIVE JSON). |
+| `--metadata` | | Optional pipeline metadata sidecar (`.json`, `.txt`, or `.csv`), e.g. a flight log. Same as the import wizard's Metadata File picker; only used by pipelines that declare `# Metadata File:`. |
 | `--name` | `-n` | Optional display name; defaults to the media basename. |
 
 Example — review a detector CSV over an image list:
@@ -92,7 +93,8 @@ Name each camera with a repeated `--camera` instead of `--import`:
 ``` bash
 DIVE-Desktop --camera left=/data/left --camera right=/data/right \
              --annotations left=/data/left.csv --annotations right=/data/right.csv \
-             --calibration /data/calibration_matrices.npz
+             --calibration /data/calibration_matrices.npz \
+             --metadata /data/flight_log.csv
 ```
 
 | Flag | Short | Description |
@@ -100,6 +102,7 @@ DIVE-Desktop --camera left=/data/left --camera right=/data/right \
 | `--camera` | `-c` | `<name>=<media>`, repeated once per camera (at least two). Media paths accept the same kinds as `--import`. Only the first `=` separates name from path, so Windows paths like `left=C:\data\left` work. Flag order is the display order. |
 | `--annotations` | `-a` | In multi-camera mode, `<camera>=<file>`. Give once per camera that has annotations; cameras without annotations may be omitted. |
 | `--calibration` | | Optional stereo calibration (`.npz` or `.json`). Multi-camera only. |
+| `--metadata` | | Optional pipeline metadata sidecar (`.json`, `.txt`, or `.csv`). Available for single-camera and multi-camera imports alike. |
 | `--default-display` | | Camera shown on open. Defaults to `left` when that camera exists, otherwise the first `--camera`. |
 | `--name` | `-n` | Optional display name. |
 

--- a/docs/Dive-Desktop.md
+++ b/docs/Dive-Desktop.md
@@ -59,7 +59,9 @@ Click either ==Open Image Sequence :material-folder-open:== or ==Open Video :mat
 * ==:material-camera-burst: Multi-Cam== will prompt you to describe the multi-cam configuration by naming several cameras and picking the source media for each.
 * ==:material-folder-multiple-image: MultiCam Batch== will prompt you to choose a root folder of **collect** subfolders and import one multicam image-sequence dataset per collect. See [Batch multicam import](Multicamera-data.md#batch-multicam-import) for the expected folder layout.
 
-The import routine will look for `.csv` and `.json` files in the same directory as the source media, and you will be prompted to manually select an annotation file and a configuration file.  Neither is required.
+The import routine will look for `.csv` and `.json` files in the same directory as the source media, and you will be prompted to manually select an annotation file and a **Configuration File** (DIVE JSON). Neither is required.
+
+Advanced options also include an optional **Metadata File** (`.json`, `.txt`, or `.csv`) — a pipeline sidecar such as a flight log. This is **not** the same as the Configuration File: DIVE does not parse it, and only pipelines that declare `# Metadata File:` receive it at run time. Metadata can be attached on single-camera, stereo, and multicam imports. See [Pipe file headers](Pipeline-Import-Export.md#pipe-file-headers).
 
 ### Launching from the command line
 

--- a/docs/Multicamera-data.md
+++ b/docs/Multicamera-data.md
@@ -54,7 +54,7 @@ For general web upload concepts (permissions, transcoding, zip import), see [Upl
 
 Desktop additionally supports ==:material-view-list-outline: Image List== and glob-based folder filtering for single-camera imports, and glob/keyword layout options for multicam import.
 
-You can also open stereo and multicam datasets from the command line with repeated `--camera` flags (and optional per-camera `--annotations` and `--calibration`). See [Launching from the command line](Dive-Desktop.md#launching-from-the-command-line).
+You can also open stereo and multicam datasets from the command line with repeated `--camera` flags (and optional per-camera `--annotations`, `--calibration`, and `--metadata`). See [Launching from the command line](Dive-Desktop.md#launching-from-the-command-line).
 
 !!! info
 

--- a/docs/Multicamera-data.md
+++ b/docs/Multicamera-data.md
@@ -35,8 +35,9 @@ Multicam import is available from the standard upload dialog on [viame.kitware.c
     * ==:material-folder-multiple-image: MultiCam Batch== — import many multicam datasets at once from a folder of **collect** subfolders (image sequences only). See [Batch multicam import](#batch-multicam-import).
 6. In the import dialog, assign a source folder or video file to each camera. All cameras must use the same media type (all image sequences or all videos). By default, every camera must have the same number of frames (or matching video duration). For **image-sequence** imports with capture timestamps in filenames, enable **Infer frame index from filename** to allow unequal per-camera counts — see [Infer frame index from filename](#infer-frame-index-from-filename).
 7. Optionally attach a per-camera annotation file during import.
-8. Enter a dataset name, choose the default display camera, and click ==Begin Import==.
-9. When upload finishes, DIVE opens the new multicam dataset in the annotator.
+8. Optionally attach a **Metadata File** (`.json`, `.txt`, or `.csv`) — for example a flight log used by registration pipelines. This is **not** stereo-only and is independent of the calibration file. See [Pipe file headers](Pipeline-Import-Export.md#pipe-file-headers).
+9. Enter a dataset name, choose the default display camera, and click ==Begin Import==.
+10. When upload finishes, DIVE opens the new multicam dataset in the annotator.
 
 !!! note
 
@@ -58,7 +59,7 @@ You can also open stereo and multicam datasets from the command line with repeat
 
 !!! info
 
-    Stereoscopic data **requires** a calibration file. Generic multicamera data does **not**.
+    Stereoscopic data **requires** a calibration file. Generic multicamera data does **not**. An optional **Metadata File** (pipeline sidecar) can be attached on stereo, multicam, or single-camera imports; it is not a substitute for stereo calibration.
 
 ### Batch multicam import
 

--- a/docs/Pipeline-Documentation.md
+++ b/docs/Pipeline-Documentation.md
@@ -31,6 +31,10 @@ Best for a series of images that have no temporal relationship, such as arial ph
 | <pre>scallop netharn left</pre>  | deep learning detector for benthic images, process left half of each frame only |
 | <pre>sea lion multi class</pre>  | detects bulls, cows, pups, etc |
 | <pre>sea lion single class</pre>  | detector |
+
+!!! note
+
+    Some sea-lion **registration** add-on pipes expect an optional per-dataset **Metadata File** (typically a flight log) and may declare `# Metadata File:` / `# Image List Keys:` in the pipe header. Attach the sidecar at import on desktop or web; see [Pipe file headers](Pipeline-Import-Export.md#pipe-file-headers).
 | <pre>sefsc bw group</pre>  | black-and-white fish detector (18 class, lower granularity) (oldest, v1) |
 | <pre>sefsc bw species v2</pre>  | black-and-white fish species detector (updated, v2) |
 
@@ -125,4 +129,4 @@ By default, training runs include all frames from the chosen input datasets, and
 
 ## Pipeline Import and Export
 
-Pipelines created outside of VIAME Web can be upload and shared with other users.  See [Pipeline Import and Export](Pipeline-Import-Export.md) for details.
+Pipelines created outside of VIAME Web can be upload and shared with other users.  See [Pipeline Import and Export](Pipeline-Import-Export.md) for upload steps and [pipe file headers](Pipeline-Import-Export.md#pipe-file-headers) (including `# Metadata File:` and `# Image List Keys:`).

--- a/docs/Pipeline-Import-Export.md
+++ b/docs/Pipeline-Import-Export.md
@@ -51,3 +51,45 @@ User-uploaded pipelines may depend on any pipe already installed from the base i
 !!! tip
 
     KWIVER pipe files can be exported for use with DIVE using [kwiver pipe-config](https://kwiver.readthedocs.io/en/latest/tools/pipe-config.html?highlight=pipe-config)
+
+## Pipe file headers
+
+DIVE reads optional comment headers at the top of a `.pipe` file to decide how to present and run the pipeline. Headers are case-insensitive. Pipes without these headers behave as they always have.
+
+Example:
+
+``` text
+# Description: Sea-lion registration stabilizer
+# Metadata File: stabilizer:flight_log
+# Image List Keys: stabilizer:image_list{cam}
+# Input: image
+# Output: image
+# Requires Calibration: False
+```
+
+| Header | Meaning |
+| ------ | ------- |
+| `# Description:` | Human-readable summary shown in the Run Pipeline UI. May continue on following `#` comment lines until the next named header. |
+| `# Input:` / `# Output:` | Declared media/annotation kinds for the pipe (used when discovering and categorizing static pipelines). |
+| `# Requires Calibration: True` | Restricts the pipe to stereo datasets that have a calibration file attached. Values `true`, `yes`, and `1` are accepted. |
+| `# Metadata File: <block>:<key>` | Opt-in: when the dataset has an attached **Metadata File**, DIVE appends a KWIVER override `-s <block>:<key>=<path>` at run time. Without this header, no metadata file is injected. |
+| `# Image List Keys: <k> [k…]` | Opt-in: binds the run's per-camera input image list(s) to each listed KWIVER key. Keys may be space- or comma-separated. A key containing `{cam}` is expanded once per camera (1-based), e.g. `stabilizer:image_list{cam}` → `image_list1`, `image_list2`, …. A key without `{cam}` receives camera 1's list only. |
+
+### Metadata File vs Configuration File
+
+These are different files with different jobs:
+
+| Import field | What it is | Consumed by |
+| ------------ | ---------- | ----------- |
+| **Configuration File** | DIVE JSON (`meta` / attributes, styles, FPS, …) | DIVE itself |
+| **Metadata File** | Opaque sidecar (`.json`, `.txt`, or `.csv`), e.g. a UAV flight log | Only pipelines that declare `# Metadata File:` |
+
+DIVE does **not** auto-discover a flight log in the media folder — the user must pick it at import (UI or CLI `--metadata`). The file format is opaque to DIVE; the KWIVER process behind the pipe owns the schema. Metadata is available on **single-camera and multicamera** imports alike; it is not stereo-gated (unlike calibration).
+
+!!! note
+
+    Injection is opt-in and silent when either side is missing: if a pipe declares `# Metadata File:` but the dataset has no attached file (or the reverse), the job still runs without that `-s` override. Prefer attaching the sidecar at import for registration pipes that need it.
+
+!!! tip
+
+    `# Image List Keys:` is intended for **image-sequence** (and multicam image) runs where DIVE builds line-separated image manifests. On video runs the bound value is the video path, which may not be what a registration-style process expects.

--- a/docs/Web-Version.md
+++ b/docs/Web-Version.md
@@ -27,6 +27,7 @@ A user account is required to store data and run pipelines on viame.kitware.com.
 * Select a video or multi-select a group of image frames.
     * Use ++ctrl++ or ++shift++ to click every file you want to upload.
     * If you already have `annotations.csv` or an annotation or configuration JSON select that too.
+    * Optionally select a **Metadata File** (`.json`, `.txt`, or `.csv`) such as a flight log. This is separate from the DIVE configuration JSON; only pipelines that declare `# Metadata File:` use it. See [Pipe file headers](Pipeline-Import-Export.md#pipe-file-headers).
     * Uploads that contain only `.tif` / `.tiff` files are classified as [large-image](Large-Image-Support.md) datasets rather than image sequences.
 * Choose a name for the dataset and enter the optional playback frame rate or select other optional files.
 * Press ==Start Upload==
@@ -58,9 +59,9 @@ DIVE Web supports importing **stereo** (2 cameras + calibration) and **multicam*
     * ==:material-binoculars: Stereoscopic== — 2 cameras plus a calibration `.npz` file.
     * ==:material-camera-burst: MultiCam== — assign media to each of 2 or 3 cameras for **one** dataset.
     * ==:material-folder-multiple-image: MultiCam Batch== — import **many** multicam image-sequence datasets from a root folder of collect subfolders (see [Batch multicam import](Multicamera-data.md#batch-multicam-import)).
-5. For Stereoscopic or MultiCam, assign media to each camera, set a dataset name and default display camera, then start the import. For MultiCam Batch, choose the root folder, review the scan table, edit dataset names, select collects, and start the batch.
+5. For Stereoscopic or MultiCam, assign media to each camera, optionally attach annotations and a **Metadata File**, set a dataset name and default display camera, then start the import. For MultiCam Batch, choose the root folder, review the scan table, edit dataset names, select collects, and start the batch.
 
-All cameras in one import must share the same media type. By default, every camera must have the same frame count (or matching video duration). For image-sequence ==MultiCam== imports with capture timestamps in filenames, enable **Infer frame index from filename** in the import dialog to allow unequal per-camera counts — see [Multicamera and Stereo Data](Multicamera-data.md#infer-frame-index-from-filename). Stereoscopic imports require a calibration `.npz` file. MultiCam Batch is **image-sequence only** (not video or stereo).
+All cameras in one import must share the same media type. By default, every camera must have the same frame count (or matching video duration). For image-sequence ==MultiCam== imports with capture timestamps in filenames, enable **Infer frame index from filename** in the import dialog to allow unequal per-camera counts — see [Multicamera and Stereo Data](Multicamera-data.md#infer-frame-index-from-filename). Stereoscopic imports require a calibration `.npz` file. The optional Metadata File is independent of calibration and is available for single-camera and multicam imports. MultiCam Batch is **image-sequence only** (not video or stereo).
 
 For camera selection, linked tracks, MultiCamera Tools, timestamp-aligned playback, and pipeline details, see [Multicamera and Stereo Data](Multicamera-data.md).
 

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -896,6 +896,7 @@ class CreateMulticamArgs(BaseModel):
     cameras: Dict[str, Dict[str, str]]
     cameraOrder: Optional[List[str]] = None
     calibrationFileId: Optional[str] = None
+    metadataFileId: Optional[str] = None
 
     class Config:
         extra = 'forbid'
@@ -1074,6 +1075,27 @@ def _mark_calibration_source_and_json_item(cal_item: dict) -> None:
             constants.JsonCalibrationFileMarker: 'true',
         },
     )
+
+
+def _mark_metadata_file_item(md_item: dict) -> None:
+    Item().setMetadata(md_item, {constants.MetadataFileMarker: 'true'})
+
+
+def _validate_metadata_file_item(
+    user: types.GirderUserModel,
+    folder: types.GirderModel,
+    item_id: str,
+) -> types.GirderModel:
+    """Validate and mark a Girder item as the dataset's optional metadata file."""
+    md_item = Item().load(item_id, level=AccessType.WRITE, user=user)
+    if md_item is None:
+        raise RestException('Metadata file was not found', code=404)
+    if str(md_item.get('folderId')) != str(folder['_id']):
+        raise RestException('Metadata file must be stored in the dataset folder', code=400)
+    if not constants.metadataFileRegex.search(md_item['name']):
+        raise RestException('Metadata file must be .json, .txt, or .csv', code=400)
+    _mark_metadata_file_item(md_item)
+    return md_item
 
 
 def _optional_calibration_number(data: dict, key: str) -> float | None:
@@ -1339,11 +1361,28 @@ def create_multicam(
             _mark_calibration_source_item(cal_item)
             enqueue_calibration_conversion(user, calibration_source_item_id, cal_item['name'])
 
+    metadata_file_item_id = None
+    metadata_file_name = None
+    if validated.metadataFileId:
+        md_item = _validate_metadata_file_item(user, parent_folder_doc, validated.metadataFileId)
+        metadata_file_item_id = str(md_item['_id'])
+        metadata_file_name = md_item['name']
+
     parent_folder_doc['meta'] = {
         constants.DatasetMarker: True,
         constants.TypeMarker: constants.MultiType,
         constants.SubTypeMarker: validated.subType,
         constants.FPSMarker: fromMeta(default_child, constants.FPSMarker),
+        **(
+            {constants.MetadataFileItemIdMarker: metadata_file_item_id}
+            if metadata_file_item_id
+            else {}
+        ),
+        **(
+            {constants.MetadataFileOriginalNameMarker: metadata_file_name}
+            if metadata_file_item_id
+            else {}
+        ),
         constants.MultiCamMarker: {
             'defaultDisplay': validated.defaultDisplay,
             'cameraOrder': camera_order,
@@ -1559,3 +1598,31 @@ def set_calibration(
         'calibrationItemId': str(cal_item['_id']),
         'jsonCalibrationItemId': multi_cam.get(constants.JsonCalibrationItemIdMarker),
     }
+
+
+def set_metadata_file(
+    user: types.GirderUserModel,
+    folder: types.GirderModel,
+    item_id: str,
+) -> dict:
+    """
+    Mark an already-uploaded Girder item as the dataset's optional metadata file.
+
+    Applies to single and multicam datasets. The item must live in the dataset
+    folder root. Handed to opt-in pipelines at run time (see the pipe
+    `# Metadata File:` header).
+    """
+    md_item = _validate_metadata_file_item(user, folder, item_id)
+    folder['meta'][constants.MetadataFileItemIdMarker] = str(md_item['_id'])
+    folder['meta'][constants.MetadataFileOriginalNameMarker] = md_item['name']
+    Folder().save(folder)
+    return {
+        'metadataFileItemId': str(md_item['_id']),
+        'metadataFileOriginalName': md_item['name'],
+    }
+
+
+def resolve_metadata_file_item_id(folder: types.GirderModel) -> Optional[str]:
+    """Return the dataset's metadata file item id, if one is attached."""
+    item_id = folder.get('meta', {}).get(constants.MetadataFileItemIdMarker)
+    return str(item_id) if item_id else None

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -635,6 +635,32 @@ def _yield_calibration_files(
             break
 
 
+def _yield_metadata_file(
+    z: ziputil.ZipGenerator,
+    zip_path: str,
+    folder: types.GirderModel,
+) -> Generator[bytes, None, None]:
+    """Add the optional per-dataset metadata file when one is attached.
+
+    Mirrors calibration inclusion in full exports so pipeline sidecars
+    (e.g. flight logs) survive dataset zip round-trips.
+    """
+    item_id = resolve_metadata_file_item_id(folder)
+    if not item_id:
+        return
+    md_item = Item().findOne({'_id': _mongo_id(item_id)})
+    if md_item is None:
+        return
+    # Prefer the preserved original filename when present so re-import can
+    # match the name users attached at import time.
+    original_name = folder.get('meta', {}).get(constants.MetadataFileOriginalNameMarker)
+    for path, file in Item().fileList(md_item):
+        out_name = original_name or path
+        for data in z.addFile(file, Path(f'{zip_path}{out_name}')):
+            yield data
+        break
+
+
 def _yield_single_dataset_export(
     z: ziputil.ZipGenerator,
     zip_path: str,
@@ -720,6 +746,10 @@ def _yield_single_dataset_export(
         for data in z.addFile(gen, Path(f'{zip_path}annotations.viame.csv')):
             yield data
 
+    if includeMedia:
+        for data in _yield_metadata_file(z, zip_path, dsFolder):
+            yield data
+
 
 def _yield_multicam_dataset_export(
     z: ziputil.ZipGenerator,
@@ -754,6 +784,11 @@ def _yield_multicam_dataset_export(
 
     if includeMedia:
         for data in _yield_calibration_files(z, zip_path, str(dsFolder['_id'])):
+            yield data
+        # Parent folder holds the optional metadata sidecar (not camera children).
+        # Parent _yield_single_dataset_export runs with includeMedia=False, so
+        # yield it here alongside calibration.
+        for data in _yield_metadata_file(z, zip_path, dsFolder):
             yield data
 
     for cam_name in _multicam_camera_order(multi_cam):

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -326,6 +326,13 @@ def run_pipeline(
                 code=404,
             )
 
+    # Resolve the dataset's optional metadata file for pipelines that opt in via a
+    # `# Metadata File: <block>:<key>` header. Applies to single and multicam.
+    metadata_file_key = (pipeline.get("metadata") or {}).get("metadataFileKey")
+    metadata_file_item_id: Optional[str] = None
+    if metadata_file_key:
+        metadata_file_item_id = crud_dataset.resolve_metadata_file_item_id(folder)
+
     params: types.MulticamPipelineJob = {
         "pipeline": pipeline,
         "input_folder": folder_id_str,
@@ -344,6 +351,9 @@ def run_pipeline(
         params['multicam_requires_input'] = multicam_requires_input
         if calibration_item_id:
             params['calibration_item_id'] = calibration_item_id
+    if metadata_file_key and metadata_file_item_id:
+        params['metadata_file_key'] = metadata_file_key
+        params['metadata_file_item_id'] = metadata_file_item_id
     newjob = tasks.run_pipeline.apply_async(
         queue=_get_queue_name(user, "pipelines"),
         kwargs=dict(

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -39,6 +39,7 @@ class DatasetResource(Resource):
         self.route("GET", (":id",), self.get_meta)
         self.route("GET", ("calibration",), self.get_dataset_calibration)
         self.route("POST", (":id", "calibration"), self.set_dataset_calibration)
+        self.route("POST", (":id", "metadata_file"), self.set_dataset_metadata_file)
         self.route("GET", (":id", "media"), self.get_media)
         self.route("GET", ("export",), self.export)
         self.route("GET", (":id", "configuration"), self.get_configuration)
@@ -235,6 +236,19 @@ class DatasetResource(Resource):
     )
     def set_dataset_calibration(self, folder, fileId):
         return crud_dataset.set_calibration(self.getCurrentUser(), folder, fileId)
+
+    @access.user
+    @autoDescribeRoute(
+        Description("Set the optional metadata file for a dataset")
+        .modelParam("id", level=AccessType.WRITE, **DatasetModelParam)
+        .param(
+            "itemId",
+            "Girder item id of a metadata file already uploaded to the dataset folder",
+            required=True,
+        )
+    )
+    def set_dataset_metadata_file(self, folder, itemId):
+        return crud_dataset.set_metadata_file(self.getCurrentUser(), folder, itemId)
 
     @access.public(scope=TokenScope.DATA_READ, cookie=True)
     @rawResponse

--- a/server/dive_tasks/multicam_pipeline.py
+++ b/server/dive_tasks/multicam_pipeline.py
@@ -55,6 +55,18 @@ def append_stereo_calibration_kwiver_settings(
     command.append(f'-s calibration_reader:file={cal_path}')
 
 
+def append_metadata_file_kwiver_settings(
+    command: List[str],
+    metadata_path: Path,
+    kwiver_key: str,
+) -> None:
+    """
+    Bind the dataset's optional metadata file to the KWIVER config key the pipe
+    declared via its `# Metadata File:` header (e.g. stabilizer:flight_log).
+    """
+    command.append(f'-s {shlex.quote(kwiver_key)}={shlex.quote(str(metadata_path))}')
+
+
 def build_multicam_kwiver_settings(
     work_dir: Path,
     cameras: List[MulticamCameraJob],

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -130,7 +130,8 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                         re.match(r'^#\s*$', line_raw)
                         or re.match(r'^#\s*=', line_raw)
                         or re.match(
-                            r'^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File):',
+                            r'^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File'
+                            r'|Image\s+List\s+Keys?|Frame\s+List\s+Keys?):',
                             line_raw,
                             re.IGNORECASE,
                         )
@@ -172,6 +173,27 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                     value = metadata_file_match.group(1).strip()
                     if value:
                         metadata["metadataFileKey"] = value
+
+                # `# Image List Keys: <k> [k...]` binds the primary (first-camera /
+                # single) input image-list manifest to each listed KWIVER key.
+                # `# Frame List Keys: <k> [k...]` binds the comma-joined per-camera
+                # manifests. Lets pipes (e.g. the sea-lion registration stabilizer)
+                # read the same image list DIVE feeds the input reader.
+                image_list_match = re.match(
+                    r'^#\s*Image\s+List\s+Keys?:\s*(.+)', line_raw, re.IGNORECASE
+                )
+                if image_list_match:
+                    keys = [k for k in re.split(r'[\s,]+', image_list_match.group(1).strip()) if k]
+                    if keys:
+                        metadata["imageListKeys"] = keys
+
+                frame_list_match = re.match(
+                    r'^#\s*Frame\s+List\s+Keys?:\s*(.+)', line_raw, re.IGNORECASE
+                )
+                if frame_list_match:
+                    keys = [k for k in re.split(r'[\s,]+', frame_list_match.group(1).strip()) if k]
+                    if keys:
+                        metadata["frameListKeys"] = keys
 
         if full_description_parts:
             metadata["description"] = " ".join(full_description_parts)

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -131,7 +131,7 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                         or re.match(r'^#\s*=', line_raw)
                         or re.match(
                             r'^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File'
-                            r'|Image\s+List\s+Keys?|Frame\s+List\s+Keys?):',
+                            r'|Image\s+List\s+Keys?):',
                             line_raw,
                             re.IGNORECASE,
                         )
@@ -174,10 +174,9 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                     if value:
                         metadata["metadataFileKey"] = value
 
-                # `# Image List Keys: <k> [k...]` binds the primary (first-camera /
-                # single) input image-list manifest to each listed KWIVER key.
-                # `# Frame List Keys: <k> [k...]` binds the comma-joined per-camera
-                # manifests. Lets pipes (e.g. the sea-lion registration stabilizer)
+                # `# Image List Keys: <k> [k...]` binds the run's input image
+                # list(s) (one per camera; multicam comma-joined) to each listed
+                # KWIVER key, so pipes (e.g. the sea-lion registration stabilizer)
                 # read the same image list DIVE feeds the input reader.
                 image_list_match = re.match(
                     r'^#\s*Image\s+List\s+Keys?:\s*(.+)', line_raw, re.IGNORECASE
@@ -186,14 +185,6 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                     keys = [k for k in re.split(r'[\s,]+', image_list_match.group(1).strip()) if k]
                     if keys:
                         metadata["imageListKeys"] = keys
-
-                frame_list_match = re.match(
-                    r'^#\s*Frame\s+List\s+Keys?:\s*(.+)', line_raw, re.IGNORECASE
-                )
-                if frame_list_match:
-                    keys = [k for k in re.split(r'[\s,]+', frame_list_match.group(1).strip()) if k]
-                    if keys:
-                        metadata["frameListKeys"] = keys
 
         if full_description_parts:
             metadata["description"] = " ".join(full_description_parts)

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -130,7 +130,9 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                         re.match(r'^#\s*$', line_raw)
                         or re.match(r'^#\s*=', line_raw)
                         or re.match(
-                            r'^#\s*(Input|Output|Requires\s+Calibration):', line_raw, re.IGNORECASE
+                            r'^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File):',
+                            line_raw,
+                            re.IGNORECASE,
                         )
                         or not line_raw.startswith('#')
                     )
@@ -160,6 +162,16 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                         'yes',
                         '1',
                     )
+
+                # `# Metadata File: <block>:<key>` opts a pipe in to receiving the
+                # dataset's optional metadata file as a `-s <block>:<key>=<path>` override.
+                metadata_file_match = re.match(
+                    r'^#\s*Metadata\s+File:\s*(.+)', line_raw, re.IGNORECASE
+                )
+                if metadata_file_match:
+                    value = metadata_file_match.group(1).strip()
+                    if value:
+                        metadata["metadataFileKey"] = value
 
         if full_description_parts:
             metadata["description"] = " ".join(full_description_parts)

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -323,17 +323,24 @@ def _inject_dataset_metadata_file(command, gc, working_dir: Path, params, manage
         )
 
 
-def _append_input_list_kwiver_settings(command, pipeline, image_list) -> None:
+def _append_input_list_kwiver_settings(command, pipeline, image_lists) -> None:
     """
-    Bind the run's input image list(s) to every KWIVER key a pipe declares via
-    `# Image List Keys:` (one list per camera; multicam lists comma-joined). Every
-    listed key gets the same value. Sea-lion registration needs the list here in
-    addition to the input reader's video_filename.
+    Bind the run's per-camera input image lists to the KWIVER keys a pipe declares
+    via `# Image List Keys:`. image_lists is one single-file, line-separated list
+    per camera. A key template containing `{cam}` is expanded per camera (1-based)
+    — e.g. `stabilizer:image_list{cam}` -> image_list1, image_list2, ...; a key
+    without `{cam}` gets the first camera's list. Sea-lion registration needs the
+    list here in addition to the input reader's video_filename.
     """
-    if not image_list:
+    if not image_lists:
         return
     for key in (pipeline.get('metadata') or {}).get('imageListKeys') or []:
-        command.append(f'-s {shlex.quote(key)}={shlex.quote(image_list)}')
+        if '{cam}' in key:
+            for idx, image_list in enumerate(image_lists, start=1):
+                expanded = key.replace('{cam}', str(idx))
+                command.append(f'-s {shlex.quote(expanded)}={shlex.quote(image_list)}')
+        else:
+            command.append(f'-s {shlex.quote(key)}={shlex.quote(image_lists[0])}')
 
 
 @app.task(bind=True, acks_late=True, ignore_result=True)
@@ -444,14 +451,13 @@ def run_pipeline(self: Task, params: PipelineJob):
                         f'has no recognized calibration file under {cal_dir}\n'
                     )
 
-            # One image list per camera, comma-joined (matches the pipe default
-            # frame_list of input_list_1..n.txt).
+            # One image list per camera (each a single line-separated file).
             input_manifests = [
                 arg_file_pair[f'input{i + 1}:video_filename']
                 for i in range(len(multicam_cameras))
                 if f'input{i + 1}:video_filename' in arg_file_pair
             ]
-            _append_input_list_kwiver_settings(command, pipeline, ','.join(input_manifests))
+            _append_input_list_kwiver_settings(command, pipeline, input_manifests)
 
             _inject_dataset_metadata_file(
                 command, gc, _working_directory_path, params, manager
@@ -553,7 +559,7 @@ def run_pipeline(self: Task, params: PipelineJob):
             if input_type == constants.ImageSequenceType
             else input_media_list[0]
         )
-        _append_input_list_kwiver_settings(command, pipeline, single_input_manifest)
+        _append_input_list_kwiver_settings(command, pipeline, [single_input_manifest])
 
         _inject_dataset_metadata_file(command, gc, _working_directory_path, params, manager)
 

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -323,20 +323,17 @@ def _inject_dataset_metadata_file(command, gc, working_dir: Path, params, manage
         )
 
 
-def _append_input_list_kwiver_settings(command, pipeline, primary_manifest, all_manifests) -> None:
+def _append_input_list_kwiver_settings(command, pipeline, image_list) -> None:
     """
-    Bind the input image-list manifest(s) to the KWIVER keys a pipe declares via
-    `# Image List Keys:` (primary / first-camera manifest) and `# Frame List Keys:`
-    (comma-joined per-camera manifests). Sea-lion registration needs the list here
-    in addition to the input reader's video_filename.
+    Bind the run's input image list(s) to every KWIVER key a pipe declares via
+    `# Image List Keys:` (one list per camera; multicam lists comma-joined). Every
+    listed key gets the same value. Sea-lion registration needs the list here in
+    addition to the input reader's video_filename.
     """
-    meta = pipeline.get('metadata') or {}
-    if primary_manifest:
-        for key in meta.get('imageListKeys') or []:
-            command.append(f'-s {shlex.quote(key)}={shlex.quote(primary_manifest)}')
-    if all_manifests:
-        for key in meta.get('frameListKeys') or []:
-            command.append(f'-s {shlex.quote(key)}={shlex.quote(all_manifests)}')
+    if not image_list:
+        return
+    for key in (pipeline.get('metadata') or {}).get('imageListKeys') or []:
+        command.append(f'-s {shlex.quote(key)}={shlex.quote(image_list)}')
 
 
 @app.task(bind=True, acks_late=True, ignore_result=True)
@@ -447,17 +444,14 @@ def run_pipeline(self: Task, params: PipelineJob):
                         f'has no recognized calibration file under {cal_dir}\n'
                     )
 
+            # One image list per camera, comma-joined (matches the pipe default
+            # frame_list of input_list_1..n.txt).
             input_manifests = [
                 arg_file_pair[f'input{i + 1}:video_filename']
                 for i in range(len(multicam_cameras))
                 if f'input{i + 1}:video_filename' in arg_file_pair
             ]
-            _append_input_list_kwiver_settings(
-                command,
-                pipeline,
-                input_manifests[0] if input_manifests else '',
-                ','.join(input_manifests),
-            )
+            _append_input_list_kwiver_settings(command, pipeline, ','.join(input_manifests))
 
             _inject_dataset_metadata_file(
                 command, gc, _working_directory_path, params, manager
@@ -559,9 +553,7 @@ def run_pipeline(self: Task, params: PipelineJob):
             if input_type == constants.ImageSequenceType
             else input_media_list[0]
         )
-        _append_input_list_kwiver_settings(
-            command, pipeline, single_input_manifest, single_input_manifest
-        )
+        _append_input_list_kwiver_settings(command, pipeline, single_input_manifest)
 
         _inject_dataset_metadata_file(command, gc, _working_directory_path, params, manager)
 

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -323,6 +323,22 @@ def _inject_dataset_metadata_file(command, gc, working_dir: Path, params, manage
         )
 
 
+def _append_input_list_kwiver_settings(command, pipeline, primary_manifest, all_manifests) -> None:
+    """
+    Bind the input image-list manifest(s) to the KWIVER keys a pipe declares via
+    `# Image List Keys:` (primary / first-camera manifest) and `# Frame List Keys:`
+    (comma-joined per-camera manifests). Sea-lion registration needs the list here
+    in addition to the input reader's video_filename.
+    """
+    meta = pipeline.get('metadata') or {}
+    if primary_manifest:
+        for key in meta.get('imageListKeys') or []:
+            command.append(f'-s {shlex.quote(key)}={shlex.quote(primary_manifest)}')
+    if all_manifests:
+        for key in meta.get('frameListKeys') or []:
+            command.append(f'-s {shlex.quote(key)}={shlex.quote(all_manifests)}')
+
+
 @app.task(bind=True, acks_late=True, ignore_result=True)
 def run_pipeline(self: Task, params: PipelineJob):
     conf = Config()
@@ -431,6 +447,18 @@ def run_pipeline(self: Task, params: PipelineJob):
                         f'has no recognized calibration file under {cal_dir}\n'
                     )
 
+            input_manifests = [
+                arg_file_pair[f'input{i + 1}:video_filename']
+                for i in range(len(multicam_cameras))
+                if f'input{i + 1}:video_filename' in arg_file_pair
+            ]
+            _append_input_list_kwiver_settings(
+                command,
+                pipeline,
+                input_manifests[0] if input_manifests else '',
+                ','.join(input_manifests),
+            )
+
             _inject_dataset_metadata_file(
                 command, gc, _working_directory_path, params, manager
             )
@@ -525,6 +553,15 @@ def run_pipeline(self: Task, params: PipelineJob):
             quoted_input_file = shlex.quote(str(pipeline_input_file))
             command.append(f'-s detection_reader:file_name={quoted_input_file}')
             command.append(f'-s track_reader:file_name={quoted_input_file}')
+
+        single_input_manifest = (
+            str(img_list_path)
+            if input_type == constants.ImageSequenceType
+            else input_media_list[0]
+        )
+        _append_input_list_kwiver_settings(
+            command, pipeline, single_input_manifest, single_input_manifest
+        )
 
         _inject_dataset_metadata_file(command, gc, _working_directory_path, params, manager)
 

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -21,6 +21,7 @@ from dive_tasks import utils
 from dive_tasks.frame_alignment import check_and_fix_frame_alignment, is_frame_misaligned
 from dive_tasks.manager import patch_manager
 from dive_tasks.multicam_pipeline import (
+    append_metadata_file_kwiver_settings,
     append_stereo_calibration_kwiver_settings,
     build_multicam_kwiver_settings,
     find_downloaded_calibration_file,
@@ -299,6 +300,29 @@ def _append_frame_range_video_settings(
     command.append(f"-s downsampler:adjust_timestamps={str(renumber).lower()}")
 
 
+def _inject_dataset_metadata_file(command, gc, working_dir: Path, params, manager) -> None:
+    """
+    Download the dataset's optional metadata file (if the pipeline opted in) and
+    append its `-s <key>=<path>` override. Shared by the single and multicam
+    command-building branches.
+    """
+    metadata_file_item_id = params.get('metadata_file_item_id')
+    metadata_file_key = params.get('metadata_file_key')
+    if not (metadata_file_item_id and metadata_file_key):
+        return
+    md_item = gc.getItem(metadata_file_item_id)
+    md_dir = utils.make_directory(working_dir / 'metadata_file')
+    gc.downloadItem(metadata_file_item_id, str(md_dir), name=md_item.get('name'))
+    md_path = md_dir / md_item.get('name')
+    if md_path.exists():
+        append_metadata_file_kwiver_settings(command, md_path, metadata_file_key)
+    else:
+        manager.write(
+            f'Warning: metadata item {metadata_file_item_id} '
+            f'has no downloadable file under {md_dir}\n'
+        )
+
+
 @app.task(bind=True, acks_late=True, ignore_result=True)
 def run_pipeline(self: Task, params: PipelineJob):
     conf = Config()
@@ -407,6 +431,10 @@ def run_pipeline(self: Task, params: PipelineJob):
                         f'has no recognized calibration file under {cal_dir}\n'
                     )
 
+            _inject_dataset_metadata_file(
+                command, gc, _working_directory_path, params, manager
+            )
+
             kwiver_params = params.get('kwiver_params')
             if kwiver_params:
                 for key, value in kwiver_params.items():
@@ -497,6 +525,8 @@ def run_pipeline(self: Task, params: PipelineJob):
             quoted_input_file = shlex.quote(str(pipeline_input_file))
             command.append(f'-s detection_reader:file_name={quoted_input_file}')
             command.append(f'-s track_reader:file_name={quoted_input_file}')
+
+        _inject_dataset_metadata_file(command, gc, _working_directory_path, params, manager)
 
         # Apply user-provided KWIVER parameter overrides.
         kwiver_params = params.get('kwiver_params')

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -59,6 +59,8 @@ zipRegex = re.compile(r"\.zip$", re.IGNORECASE)
 npzRegex = re.compile(r"\.npz$", re.IGNORECASE)
 # Stereo/multicam calibration uploads (aligned with dive-common calibrationFileTypes)
 stereoCalibrationRegex = re.compile(r"\.(?:npz|json|cam|yml|zip)$", re.IGNORECASE)
+# Optional per-dataset metadata file uploads (aligned with dive-common metadataFileTypes)
+metadataFileRegex = re.compile(r"\.(?:json|txt|csv)$", re.IGNORECASE)
 metaRegex = re.compile(r"^.*\.?(meta|config)\.json$", re.IGNORECASE)
 # .json or .csv file
 possibleAnnotationRegex = re.compile(r"\.(json|csv)$", re.IGNORECASE)
@@ -119,6 +121,11 @@ CalibrationOriginalNameMarker = "calibrationOriginalName"
 CalibrationConversionErrorMarker = "calibrationConversionError"
 # Girder item meta: original stereoscopic calibration upload (npz, yml, etc.)
 CalibrationFileMarker = "calibrationFile"
+# Optional per-dataset metadata file (folder marker points at a Girder item id;
+# the item itself carries MetadataFileMarker). Applies to single and multicam.
+MetadataFileItemIdMarker = "metadataFileItemId"
+MetadataFileOriginalNameMarker = "metadataFileOriginalName"
+MetadataFileMarker = "metadataFile"
 # Girder item meta: JSON camera-rig used for calibration display
 JsonCalibrationFileMarker = "jsonCalibrationFile"
 AssetstoreSourceMarker = "import_source"

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -340,6 +340,11 @@ class GirderMetadataStatic(MetadataMutable):
     foreign_media_id: Optional[str]
     subType: Optional[Literal['stereo', 'multicam']] = None
     multiCamMedia: Optional[MultiCamMedia] = None
+    # Optional per-dataset metadata file (folder meta; mirrors calibrationItemId
+    # / calibrationOriginalName on multiCam). Must be declared so get_dataset
+    # does not drop them when constructing from folder meta.
+    metadataFileItemId: Optional[str] = None
+    metadataFileOriginalName: Optional[str] = None
 
 
 class DatasetSourceMedia(BaseModel):

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -81,6 +81,11 @@ class PipeMetadata(TypedDict):
     # KWIVER config key (e.g. "stabilizer:flight_log") that the dataset's optional
     # metadata file is bound to at run time, parsed from `# Metadata File: <key>`.
     metadataFileKey: NotRequired[Optional[str]]
+    # KWIVER config keys bound to the input image-list manifest(s) at run time.
+    # imageListKeys get the primary (first-camera / single) manifest path;
+    # frameListKeys get the comma-joined per-camera manifest paths.
+    imageListKeys: NotRequired[Optional[list[str]]]
+    frameListKeys: NotRequired[Optional[list[str]]]
 
 
 class PipelineDescription(TypedDict):

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -81,11 +81,10 @@ class PipeMetadata(TypedDict):
     # KWIVER config key (e.g. "stabilizer:flight_log") that the dataset's optional
     # metadata file is bound to at run time, parsed from `# Metadata File: <key>`.
     metadataFileKey: NotRequired[Optional[str]]
-    # KWIVER config keys bound to the input image-list manifest(s) at run time.
-    # imageListKeys get the primary (first-camera / single) manifest path;
-    # frameListKeys get the comma-joined per-camera manifest paths.
+    # KWIVER config keys each bound to the run's input image list(s) at run time
+    # (one list per camera; multicam lists are comma-joined). All keys get the
+    # same value.
     imageListKeys: NotRequired[Optional[list[str]]]
-    frameListKeys: NotRequired[Optional[list[str]]]
 
 
 class PipelineDescription(TypedDict):

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -81,9 +81,9 @@ class PipeMetadata(TypedDict):
     # KWIVER config key (e.g. "stabilizer:flight_log") that the dataset's optional
     # metadata file is bound to at run time, parsed from `# Metadata File: <key>`.
     metadataFileKey: NotRequired[Optional[str]]
-    # KWIVER config keys each bound to the run's input image list(s) at run time
-    # (one list per camera; multicam lists are comma-joined). All keys get the
-    # same value.
+    # KWIVER config key templates bound to the run's per-camera input image lists
+    # (one single-file list per camera). A `{cam}` placeholder is expanded per
+    # camera (1-based); a key without it gets the first camera's list.
     imageListKeys: NotRequired[Optional[list[str]]]
 
 

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -78,6 +78,9 @@ class PipeMetadata(TypedDict):
     outputType: Optional[str]
     diveParams: Optional[list[DiveParam]]
     requiresCalibration: Optional[bool]
+    # KWIVER config key (e.g. "stabilizer:flight_log") that the dataset's optional
+    # metadata file is bound to at run time, parsed from `# Metadata File: <key>`.
+    metadataFileKey: NotRequired[Optional[str]]
 
 
 class PipelineDescription(TypedDict):
@@ -124,6 +127,11 @@ class PipelineJob(TypedDict):
     force_transcoded: Optional[bool]
     runtime_params: Optional[PipelineRuntimeParams]
     kwiver_params: Optional[Dict[str, str]]
+    # Optional per-dataset metadata file handed to opt-in pipelines. The item id
+    # points at a Girder item in the dataset folder; the key is the KWIVER config
+    # target declared by the pipe's `# Metadata File:` header.
+    metadata_file_item_id: NotRequired[Optional[str]]
+    metadata_file_key: NotRequired[Optional[str]]
 
 
 class MulticamPipelineJob(PipelineJob, total=False):

--- a/server/tests/test_multicam_dataset.py
+++ b/server/tests/test_multicam_dataset.py
@@ -133,6 +133,32 @@ def test_get_dataset_includes_multicam_media(_verify, folder_cls, get_media_mock
 
 
 @patch('dive_server.crud_dataset.crud.verify_dataset')
+def test_get_dataset_includes_metadata_file_markers(_verify):
+    """Folder meta metadataFileItemId / OriginalName must survive get_dataset."""
+    folder = {
+        '_id': 'ds-id',
+        'name': 'survey',
+        'created': '2020-01-01T00:00:00',
+        'meta': {
+            'annotate': True,
+            'type': constants.ImageSequenceType,
+            'fps': 5,
+            constants.MetadataFileItemIdMarker: 'md-item-id',
+            constants.MetadataFileOriginalNameMarker: 'flight_log.csv',
+        },
+    }
+
+    result = crud_dataset.get_dataset(folder, {'login': 'tester'})
+
+    assert isinstance(result, GirderMetadataStatic)
+    assert result.metadataFileItemId == 'md-item-id'
+    assert result.metadataFileOriginalName == 'flight_log.csv'
+    as_dict = result.dict(exclude_none=True)
+    assert as_dict['metadataFileItemId'] == 'md-item-id'
+    assert as_dict['metadataFileOriginalName'] == 'flight_log.csv'
+
+
+@patch('dive_server.crud_dataset.crud.verify_dataset')
 def test_get_media_multi_parent_returns_empty(_verify):
     parent = _multi_parent_folder()
     user = {'login': 'tester'}

--- a/server/tests/test_multicam_export_clone.py
+++ b/server/tests/test_multicam_export_clone.py
@@ -133,12 +133,18 @@ def test_create_multicam_soft_clone_copies_calibration(
 
 
 @patch('dive_server.crud_dataset._yield_single_dataset_export')
+@patch('dive_server.crud_dataset._yield_metadata_file')
 @patch('dive_server.crud_dataset._yield_calibration_files')
 @patch('dive_server.crud_dataset.get_multi_cam_media')
 @patch('dive_server.crud_dataset.Folder')
 @patch('dive_server.crud_dataset.ziputil.ZipGenerator')
 def test_export_multicam_zip_includes_multicam_json_and_cameras(
-    zip_gen_cls, folder_cls, get_multi_cam_media_mock, yield_cal_mock, yield_single_mock
+    zip_gen_cls,
+    folder_cls,
+    get_multi_cam_media_mock,
+    yield_cal_mock,
+    yield_metadata_mock,
+    yield_single_mock,
 ):
     parent = _multi_parent_folder()
     left = _child_folder('left-id', 'left')
@@ -157,6 +163,7 @@ def test_export_multicam_zip_includes_multicam_json_and_cameras(
     zip_gen_cls.return_value = z
     yield_single_mock.return_value = iter([b'camera-chunk'])
     yield_cal_mock.return_value = iter([b'cal-chunk'])
+    yield_metadata_mock.return_value = iter([b'metadata-chunk'])
     get_multi_cam_media_mock.return_value = MagicMock()
 
     stream = crud_dataset.export_datasets_zipstream(
@@ -176,6 +183,42 @@ def test_export_multicam_zip_includes_multicam_json_and_cameras(
     assert './stereo-dataset/left/' in camera_paths
     assert './stereo-dataset/right/' in camera_paths
     yield_cal_mock.assert_called_once()
+    yield_metadata_mock.assert_called_once_with(z, './stereo-dataset/', parent)
+    assert b'metadata-chunk' in chunks
+
+
+@patch('dive_server.crud_dataset.Item')
+def test_yield_metadata_file_uses_original_name(item_cls):
+    z = MagicMock()
+
+    def add_file_side_effect(_maker, path):
+        yield str(path).encode('utf-8')
+
+    z.addFile.side_effect = add_file_side_effect
+    folder = {
+        '_id': 'parent-id',
+        'meta': {
+            constants.MetadataFileItemIdMarker: 'md-item-id',
+            constants.MetadataFileOriginalNameMarker: 'flight_log.csv',
+        },
+    }
+    item_cls.return_value.findOne.return_value = {'_id': 'md-item-id', 'name': 'renamed.csv'}
+    item_cls.return_value.fileList.return_value = [('renamed.csv', MagicMock())]
+
+    chunks = list(crud_dataset._yield_metadata_file(z, './stereo-dataset/', folder))
+
+    z.addFile.assert_called_once()
+    assert str(z.addFile.call_args.args[1]) == 'stereo-dataset/flight_log.csv'
+    assert any(b'flight_log.csv' in chunk for chunk in chunks)
+
+
+@patch('dive_server.crud_dataset.Item')
+def test_yield_metadata_file_skips_when_unset(item_cls):
+    z = MagicMock()
+    chunks = list(crud_dataset._yield_metadata_file(z, './ds/', {'_id': 'id', 'meta': {}}))
+    assert chunks == []
+    item_cls.return_value.findOne.assert_not_called()
+    z.addFile.assert_not_called()
 
 
 @patch('dive_server.crud_dataset.crud_annotation.get_annotations')


### PR DESCRIPTION
## Summary

Adds an **optional metadata file** (`.json` / `.txt` / `.csv`) to **single-image** and **multi-camera image-sequence** imports, mirroring how calibration files are optionally attached to stereo datasets — but without the stereo gating. DIVE keeps a link to the file per dataset and hands it to pipelines that opt in.

Built for the **sea-lion add-on**, whose registration pipelines consume it as `-s stabilizer:flight_log=<path>`.

## How it works

A pipe opts in with a header directive:

```
# Metadata File: stabilizer:flight_log
```

Both pipe-metadata readers (server `pipeline_discovery.extract_pipe_metadata` and desktop `extractPipeMetadata`) parse this into `PipeMetadata.metadataFileKey`. At run time DIVE appends `-s <key>="<path>"` **only** for pipes that declare the header, so all other pipelines are unaffected.

## Changes

**Contract / parsing**
- `# Metadata File: <block>:<key>` → `metadataFileKey` (server + desktop + shared types); added to the description-block stop conditions.

**Desktop**
- "Metadata File (Optional)" picker in the single-import dialog and a new non-stereo-gated `ImportMultiCamMetadata` picker in the multicam dialog.
- File copied into the project dir at import (`JsonMeta.metadataFile` / `metadataOriginalName`); `viame.ts` injects `-s <key>="<path>"` for opt-in pipes (single + multicam).

**Web + server**
- File uploaded as a marked Girder item; folder-level `metadataFileItemId` marker (via `create_multicam` `metadataFileId` for multicam, and a new `POST dive_dataset/:id/metadata_file` endpoint for single).
- `crud_rpc.run_pipeline` resolves the item for opt-in pipes; the run task downloads it and appends the override for single and multicam alike.

## Testing
- `vite build` (web) and `electron-vite build` (desktop) both succeed.
- `eslint` clean on `dive-common/` and `platform/`.
- Server modules `py_compile` clean; pipe-header parser verified against the sea-lion pipes.
- No new unit-test regressions (pre-existing `File is not defined` env failures are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)