### PR TITLE
Import menu: clearer annotation-set label, no overlap with Import button

### DIFF
--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -476,7 +476,7 @@ export default defineComponent({
               </v-btn>
             </v-row>
             <v-row
-              class="mt-6"
+              class="mt-8"
               dense
             >
               <v-combobox
@@ -486,6 +486,7 @@ export default defineComponent({
                 label="Annotation Set Name"
                 outlined
                 small
+                hide-details
               >
                 <template #selection="{ attrs, item, selected }">
                   <v-chip
@@ -503,6 +504,7 @@ export default defineComponent({
               <v-checkbox
                 :input-value="!additive"
                 label="Overwrite"
+                class="mt-2"
                 @change="additive = !$event"
               />
               <v-checkbox

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -476,14 +476,14 @@ export default defineComponent({
               </v-btn>
             </v-row>
             <v-row
-              class="mt-3"
+              class="mt-6"
               dense
             >
               <v-combobox
                 v-model="currentSet"
                 :items="sets"
                 chips
-                label="Annotation Set"
+                label="Annotation Set Name"
                 outlined
                 small
               >


### PR DESCRIPTION
- Rename the Import menu's set combobox label to `Annotation Set Name`
- Increase the row's top margin so the floating outline label no longer overlaps the Import button