### PR TITLE
Job-failure dialog: fall back to the Python exception line

### DIFF
--- a/client/dive-common/vue-utilities/prompt-service/Prompt.vue
+++ b/client/dive-common/vue-utilities/prompt-service/Prompt.vue
@@ -99,9 +99,11 @@ export default defineComponent({
 <template>
   <v-dialog
     v-model="show"
-    max-width="400"
+    max-width="560"
   >
     <v-card>
+      <!-- Vuetify's v-card-title defaults to word-break: break-all, which
+        splits words (e.g. long pipeline names) mid-word across lines. -->
       <v-card-title
         v-if="title"
         v-mousetrap="[
@@ -110,6 +112,7 @@ export default defineComponent({
           { bind: 'enter', handler: () => select(), disable: !show },
         ]"
         class="title"
+        style="word-break: normal;"
       >
         {{ title }}
       </v-card-title>

--- a/client/platform/desktop/frontend/store/jobs.ts
+++ b/client/platform/desktop/frontend/store/jobs.ts
@@ -113,6 +113,18 @@ export function updateHistory(args: DesktopJobUpdate) {
       .map((line) => line.trim())
       .filter((line) => line.startsWith('ERROR:'))
       .map((line) => line.replace(/^ERROR:\s*/, ''));
+    if (errorLines.length === 0) {
+      // No DIVE-convention "ERROR:" lines. Fall back to the last Python /
+      // native exception line (e.g. "RuntimeError: ...") so the dialog shows
+      // the actual cause instead of only the exit code. A traceback echoes the
+      // same exception line more than once; keep only the final occurrence.
+      const exceptionLines = existing.truncatedLogs
+        .map((line) => line.trim())
+        .filter((line) => /^[A-Za-z_][\w.]*(?:Error|Exception)\s*:\s+\S/.test(line));
+      if (exceptionLines.length > 0) {
+        errorLines.push(exceptionLines[exceptionLines.length - 1]);
+      }
+    }
     const text = errorLines.length > 0
       ? errorLines
       : [


### PR DESCRIPTION
- When a failed job's log has no `ERROR:` lines, surface the last Python/native exception line (`RuntimeError: ...`) in the failure dialog instead of only the exit code