### PR TITLE
Fix DIVE config import not sticking on multicam datasets (desktop)

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -226,6 +226,21 @@ interface DatasetMetaMutable {
   error?: string;
 }
 const DatasetMetaMutableKeys = ['attributes', 'confidenceFilters', 'timeFilters', 'imageEnhancements', 'customTypeStyling', 'customGroupStyling', 'attributeTrackFilters', 'datasetInfo', 'cameraHomographies', 'cameraCorrespondences', 'cameraTransformTypes', 'cameraRegistrationSource'];
+/**
+ * Mutable keys the multicam/stereo viewer loads from the parent dataset.
+ * Camera-targeted imports sync only these onto the parent — not per-camera
+ * imageEnhancements, and not camera registration (homographies / correspondences /
+ * transform types / registration source), which must not be clobbered by config import.
+ */
+const MulticamSharedMutableKeys = [
+  'attributes',
+  'confidenceFilters',
+  'timeFilters',
+  'customTypeStyling',
+  'customGroupStyling',
+  'attributeTrackFilters',
+  'datasetInfo',
+];
 
 interface DatasetMeta extends DatasetMetaMutable {
   id: Readonly<string>;
@@ -576,6 +591,7 @@ export {
   DatasetMeta,
   DatasetMetaMutable,
   DatasetMetaMutableKeys,
+  MulticamSharedMutableKeys,
   DatasetType,
   DiveParam,
   CameraCalibration,

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -79,6 +79,14 @@ export default defineComponent({
       const parts = (props.datasetId || '').split('/');
       return parts.length > 1 ? parts[1] : null;
     });
+    // Multicam imports target the active camera folder; shared mutable config
+    // is also written to the parent by desktop/web backends so the viewer sees it.
+    const importDatasetId = computed(() => {
+      if (isMulticamDataset.value && activeCameraName.value) {
+        return `${parentDatasetId(props.datasetId)}/${activeCameraName.value}`;
+      }
+      return props.datasetId;
+    });
     // Camera/calibration file import requires importCalibrationFile (web + desktop)
     // and is only meaningful for stereo datasets.
     const cameraFileSupported = computed(
@@ -161,7 +169,7 @@ export default defineComponent({
           const set = currentSet.value === 'default' ? undefined : currentSet.value;
           if (ret.fileList?.length) {
             importFile = await importAnnotationFile(
-              props.datasetId,
+              importDatasetId.value,
               path,
               ret.fileList[0],
               additive.value,
@@ -170,7 +178,7 @@ export default defineComponent({
             );
           } else {
             importFile = await importAnnotationFile(
-              props.datasetId,
+              importDatasetId.value,
               path,
               undefined,
               additive.value,

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -5,7 +5,7 @@ import { Console } from 'console';
 
 import {
   AnnotationsCurrentVersion, DesktopJob,
-  DesktopJobUpdate, JobType, JsonMeta, RunTraining, Settings,
+  DesktopJobUpdate, JobType, JsonMeta, ProjectsFolderName, RunTraining, Settings,
 } from 'platform/desktop/constants';
 import { makeEmptyAnnotationFile } from 'platform/desktop/backend/serializers/dive';
 
@@ -664,6 +664,33 @@ describe('native.common', () => {
       ...existingDatasetInfo,
       ...importedDatasetInfo,
     });
+  });
+
+  it('dataFileImport config targeted at a multicam camera updates the base metadata', async () => {
+    const basePayload = await common.beginMediaImport(
+      '/home/user/data/imageLists/success/image_list.txt',
+    );
+    const baseRes = await common.finalizeMediaImport(settings, basePayload);
+    const baseId = baseRes.meta.id;
+    const cameraPayload = await common.beginMediaImport(
+      '/home/user/data/imageLists/success/image_list.txt',
+    );
+    const cameraRes = await common.finalizeMediaImport(settings, cameraPayload);
+    // Relocate the second project to be a camera subfolder of the first,
+    // forming the `<base>/<camera>` composite layout of a multicam dataset.
+    const projects = npath.join(settings.dataPath, ProjectsFolderName);
+    await fs.move(
+      npath.join(projects, cameraRes.meta.id),
+      npath.join(projects, baseId, 'left'),
+    );
+
+    await common.dataFileImport(settings, `${baseId}/left`, '/home/user/data/annotationImport/foreign.meta.json');
+    // The camera's own metadata receives the config,
+    const cameraMeta = await common.loadMetadata(settings, `${baseId}/left`, urlMapper);
+    expect(cameraMeta.confidenceFilters).toStrictEqual({ default: 0.8 });
+    // and so does the base metadata, which is what the viewer reads.
+    const baseMeta = await common.loadMetadata(settings, baseId, urlMapper);
+    expect(baseMeta.confidenceFilters).toStrictEqual({ default: 0.8 });
   });
 
   it('saveMetadata writes per-camera registration files (pairs + points) and reloads them', async () => {

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -203,6 +203,20 @@ beforeEach(() => {
       annotationImport: {
         'viame.csv': emptyCsvString,
         'foreign.meta.json': '{ "confidenceFilters": {"default": 0.8}, "type": "invalidtype" }',
+        'foreign.meta.withExtras.json': JSON.stringify({
+          confidenceFilters: { default: 0.8 },
+          customTypeStyling: { fish: { color: 'green' } },
+          imageEnhancements: { brightness: 1.1 },
+          cameraHomographies: {
+            'left::right': {
+              AtoB: [[9, 0, 0], [0, 9, 0], [0, 0, 1]],
+              BtoA: [[9, 0, 0], [0, 9, 0], [0, 0, 1]],
+            },
+          },
+          cameraCorrespondences: { 'left::right': [{ id: 9, a: [9, 9], b: [8, 8] }] },
+          cameraTransformTypes: { 'left::right': 'affine' },
+          cameraRegistrationSource: { model: 'from-import' },
+        }),
         'dataset-info.config.json': JSON.stringify({
           datasetInfo: {
             year: '2025',
@@ -684,13 +698,41 @@ describe('native.common', () => {
       npath.join(projects, baseId, 'left'),
     );
 
-    await common.dataFileImport(settings, `${baseId}/left`, '/home/user/data/annotationImport/foreign.meta.json');
-    // The camera's own metadata receives the config,
+    // Seed parent registration so a config import must not clobber it.
+    const baseDir = common.getProjectDir(settings, baseId);
+    const seededBase = await common.loadJsonMetadata(baseDir.metaFileAbsPath);
+    seededBase.cameraHomographies = {
+      'left::right': {
+        AtoB: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        BtoA: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+      },
+    };
+    seededBase.cameraCorrespondences = {
+      'left::right': [{ id: 1, a: [0, 0], b: [1, 1] }],
+    };
+    seededBase.cameraTransformTypes = { 'left::right': 'similarity' };
+    seededBase.cameraRegistrationSource = { model: 'seeded' };
+    await fs.writeJSON(baseDir.metaFileAbsPath, seededBase);
+
+    await common.dataFileImport(
+      settings,
+      `${baseId}/left`,
+      '/home/user/data/annotationImport/foreign.meta.withExtras.json',
+    );
+    // The camera's own metadata receives the full imported config,
     const cameraMeta = await common.loadMetadata(settings, `${baseId}/left`, urlMapper);
     expect(cameraMeta.confidenceFilters).toStrictEqual({ default: 0.8 });
-    // and so does the base metadata, which is what the viewer reads.
+    expect(cameraMeta.imageEnhancements).toStrictEqual({ brightness: 1.1 });
+    // Shared keys land on the base metadata the viewer reads,
     const baseMeta = await common.loadMetadata(settings, baseId, urlMapper);
     expect(baseMeta.confidenceFilters).toStrictEqual({ default: 0.8 });
+    expect(baseMeta.customTypeStyling).toStrictEqual({ fish: { color: 'green' } });
+    // but per-camera enhancements and registration must stay untouched on the parent.
+    expect(baseMeta.imageEnhancements).toBeUndefined();
+    expect(baseMeta.cameraHomographies).toStrictEqual(seededBase.cameraHomographies);
+    expect(baseMeta.cameraCorrespondences).toStrictEqual(seededBase.cameraCorrespondences);
+    expect(baseMeta.cameraTransformTypes).toStrictEqual(seededBase.cameraTransformTypes);
+    expect(baseMeta.cameraRegistrationSource).toStrictEqual(seededBase.cameraRegistrationSource);
   });
 
   it('saveMetadata writes per-camera registration files (pairs + points) and reloads them', async () => {

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -50,6 +50,7 @@ import {
   cleanString, filterByGlob, makeid, strNumericCompare,
 } from 'platform/desktop/sharedUtils';
 import { parseFrameTimestamp } from 'dive-common/frameTimestamp';
+import { parseCompositeDatasetId } from 'dive-common/compositeDatasetId';
 
 import processTrackAttributes from './attributeProcessor';
 import { upgrade } from './migrations';
@@ -1528,6 +1529,24 @@ async function dataFileImport(settings: Settings, id: string, path: string, addi
       : result.meta.datasetInfo;
   }
   await _saveAsJson(npath.join(projectDirData.basePath, JsonMetaFileName), jsonMeta);
+  // Mutable config (custom styling, confidence thresholds, attributes, ...) is
+  // loaded by the viewer from the base dataset's metadata, so an import
+  // targeted at one camera of a multicam dataset must update the base too.
+  const { parentId, cameraName } = parseCompositeDatasetId(id);
+  if (cameraName && DatasetMetaMutableKeys.some((key) => key in result.meta)) {
+    const baseProjectDir = getProjectDir(settings, parentId);
+    if (await fs.pathExists(baseProjectDir.metaFileAbsPath)) {
+      const baseMeta = await loadJsonMetadata(baseProjectDir.metaFileAbsPath);
+      const existingBaseDatasetInfo = baseMeta.datasetInfo;
+      merge(baseMeta, pick(result.meta, DatasetMetaMutableKeys));
+      if (result.meta.datasetInfo) {
+        baseMeta.datasetInfo = additive
+          ? { ...(existingBaseDatasetInfo ?? {}), ...result.meta.datasetInfo }
+          : result.meta.datasetInfo;
+      }
+      await _saveAsJson(baseProjectDir.metaFileAbsPath, baseMeta);
+    }
+  }
   return result;
 }
 

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -21,6 +21,7 @@ import {
   FrameImage, DatasetMetaMutable, TrainingConfig, TrainingConfigs, SaveAttributeArgs,
   MultiCamMedia,
   DatasetMetaMutableKeys,
+  MulticamSharedMutableKeys,
   AnnotationSchema,
   SaveAttributeTrackFilterArgs,
   Pipe,
@@ -1529,16 +1530,17 @@ async function dataFileImport(settings: Settings, id: string, path: string, addi
       : result.meta.datasetInfo;
   }
   await _saveAsJson(npath.join(projectDirData.basePath, JsonMetaFileName), jsonMeta);
-  // Mutable config (custom styling, confidence thresholds, attributes, ...) is
+  // Shared mutable config (styling, thresholds, attributes, datasetInfo, ...) is
   // loaded by the viewer from the base dataset's metadata, so an import
   // targeted at one camera of a multicam dataset must update the base too.
+  // Do not sync per-camera imageEnhancements or camera-registration fields.
   const { parentId, cameraName } = parseCompositeDatasetId(id);
-  if (cameraName && DatasetMetaMutableKeys.some((key) => key in result.meta)) {
+  if (cameraName && MulticamSharedMutableKeys.some((key) => key in result.meta)) {
     const baseProjectDir = getProjectDir(settings, parentId);
     if (await fs.pathExists(baseProjectDir.metaFileAbsPath)) {
       const baseMeta = await loadJsonMetadata(baseProjectDir.metaFileAbsPath);
       const existingBaseDatasetInfo = baseMeta.datasetInfo;
-      merge(baseMeta, pick(result.meta, DatasetMetaMutableKeys));
+      merge(baseMeta, pick(result.meta, MulticamSharedMutableKeys));
       if (result.meta.datasetInfo) {
         baseMeta.datasetInfo = additive
           ? { ...(existingBaseDatasetInfo ?? {}), ...result.meta.datasetInfo }

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -135,14 +135,18 @@ function makeViameFolder({
   );
 }
 
-async function importAnnotationFile(parentId: string, path: string, file?: HTMLFile, additive = false, additivePrepend = '', set: string | undefined = undefined): Promise<boolean | string[]> {
+async function importAnnotationFile(datasetId: string, path: string, file?: HTMLFile, additive = false, additivePrepend = '', set: string | undefined = undefined): Promise<boolean | string[]> {
   if (file === undefined) {
     return false;
   }
+  // Resolve composite multicam ids (parent/camera) to the camera folder so
+  // annotations land on the active camera; mutable config is synced to the
+  // parent by server process_items (same behavior as desktop dataFileImport).
+  const { folderId } = await resolveDatasetFolderId(datasetId);
   const resp = await girderRest.post('/file', null, {
     params: {
       parentType: 'folder',
-      parentId,
+      parentId: folderId,
       name: file.name,
       size: file.size,
       mimeType: file.type,
@@ -157,7 +161,7 @@ async function importAnnotationFile(parentId: string, path: string, file?: HTMLF
       headers: { 'Content-Type': 'application/octet-stream' },
     });
     if (uploadResponse.status === 200) {
-      const final = await postProcess(parentId, true, false, additive, additivePrepend, set);
+      const final = await postProcess(folderId, true, false, additive, additivePrepend, set);
       if (final.data.warnings !== undefined) {
         const { warnings } = final.data;
         return warnings;

--- a/server/dive_server/crud.py
+++ b/server/dive_server/crud.py
@@ -96,6 +96,42 @@ def saveImportAttributes(folder, attributes, user):
     Folder().save(folder)
 
 
+# Mutable config keys the multicam/stereo viewer loads from the parent folder.
+# Camera-targeted imports sync only these onto the parent — not per-camera
+# imageEnhancements, and not camera registration fields (which must not be
+# clobbered by a DIVE configuration import).
+MULTICAM_SHARED_MUTABLE_KEYS = (
+    'attributes',
+    'confidenceFilters',
+    'timeFilters',
+    'customTypeStyling',
+    'customGroupStyling',
+    'attributeTrackFilters',
+    'datasetInfo',
+)
+
+
+def get_multicam_parent_folder(folder: GirderModel, user: GirderUserModel):
+    """Return the multicam parent if ``folder`` is one of its camera children, else None."""
+    parent_id = folder.get('parentId')
+    if not parent_id:
+        return None
+    parent = Folder().load(parent_id, level=AccessType.WRITE, user=user)
+    if parent is None or fromMeta(parent, constants.TypeMarker) != constants.MultiType:
+        return None
+    multi_cam = fromMeta(parent, constants.MultiCamMarker, default={}) or {}
+    cameras = multi_cam.get('cameras') or {}
+    folder_id = str(folder['_id'])
+    if not any(str(cam.get('folderId')) == folder_id for cam in cameras.values()):
+        return None
+    return parent
+
+
+def pick_multicam_shared_mutable(meta: dict) -> dict:
+    """Return only mutable keys shared across multicam parent/camera metadata."""
+    return {key: meta[key] for key in MULTICAM_SHARED_MUTABLE_KEYS if key in meta}
+
+
 def verify_dataset(folder: GirderModel):
     """Verify that a given folder is a DIVE dataset"""
     if not asbool(fromMeta(folder, constants.DatasetMarker, False)):

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -717,6 +717,19 @@ def process_items(
                 fromMeta(folder, 'datasetInfo', {}), results['meta'], additive
             )
             crud_dataset.update_metadata(folder, meta, False)
+        # Mutable config (styling, thresholds, attributes, ...) is loaded by the
+        # viewer from the multicam parent's metadata, so an import targeted at
+        # one camera must update the parent too (mirrors desktop dataFileImport).
+        parent = crud.get_multicam_parent_folder(folder, user)
+        if parent is not None:
+            if results['attributes']:
+                crud.saveImportAttributes(parent, results['attributes'], user)
+            shared_meta = crud.pick_multicam_shared_mutable(results['meta'] or {})
+            if shared_meta:
+                parent_meta = resolve_imported_dataset_info(
+                    fromMeta(parent, 'datasetInfo', {}), shared_meta, additive
+                )
+                crud_dataset.update_metadata(parent, parent_meta, False)
     return aggregate_warnings
 
 

--- a/server/tests/test_update_metadata.py
+++ b/server/tests/test_update_metadata.py
@@ -174,3 +174,242 @@ def test_process_items_resolves_dataset_info_from_dive_configuration_import(
     assert update_payload['datasetInfo'] == expected
     assert update_payload['version'] == 1
     assert verify is False
+
+
+@patch('dive_server.crud_rpc.crud_dataset.update_metadata')
+@patch('dive_server.crud_rpc.crud.saveImportAttributes')
+@patch('dive_server.crud_rpc.crud.get_multicam_parent_folder')
+@patch('dive_server.crud_rpc.crud.get_or_create_auxiliary_folder')
+@patch('dive_server.crud_rpc.File')
+@patch('dive_server.crud_rpc.Item')
+@patch('dive_server.crud_rpc.Folder')
+def test_process_items_syncs_mutable_config_to_multicam_parent(
+    folder_cls,
+    item_cls,
+    file_cls,
+    get_auxiliary_folder,
+    get_multicam_parent,
+    save_import_attributes,
+    update_metadata,
+):
+    """Camera-targeted DIVE config also updates the multicam parent the viewer reads."""
+    # Use video so process_items skips valid_images (needs Mongo).
+    camera_folder = {
+        '_id': 'left-id',
+        'parentId': 'parent-id',
+        'meta': {
+            'annotate': True,
+            'type': 'video',
+            'fps': 5,
+        },
+    }
+    parent_folder = {
+        '_id': 'parent-id',
+        'meta': {
+            'annotate': True,
+            'type': 'multi',
+            'fps': 5,
+            'datasetInfo': {'cruise': '2403'},
+        },
+    }
+    item = {'_id': 'item-id', 'name': 'metadata.config.json', 'meta': {}}
+    file = {'_id': 'file-id', 'name': 'metadata.config.json', 'exts': ['json']}
+    payload = {
+        'confidenceFilters': {'default': 0.8},
+        'customTypeStyling': {'fish': {'color': '#00ff00'}},
+        'datasetInfo': {'year': '2025'},
+        'fps': 30,
+        'imageEnhancements': {'brightness': 1.1},
+        'cameraHomographies': {'left::right': {'AtoB': [[1]], 'BtoA': [[1]]}},
+        'cameraCorrespondences': {'left::right': []},
+        'cameraTransformTypes': {'left::right': 'similarity'},
+        'cameraRegistrationSource': {'model': 'from-import'},
+    }
+
+    folder_cls.return_value.childItems.return_value = [item]
+    item_cls.return_value.childFiles.return_value = iter([file])
+    file_cls.return_value.download.return_value = lambda: [json.dumps(payload).encode()]
+    get_auxiliary_folder.return_value = {'_id': 'auxiliary-id'}
+    get_multicam_parent.return_value = parent_folder
+
+    warnings = process_items(camera_folder, {'_id': 'user-id'}, additive=False)
+
+    assert warnings == []
+    get_multicam_parent.assert_called_once_with(camera_folder, {'_id': 'user-id'})
+    save_import_attributes.assert_not_called()
+    assert update_metadata.call_count == 2
+
+    camera_call, parent_call = update_metadata.call_args_list
+    assert camera_call.args[0] is camera_folder
+    assert camera_call.args[1]['confidenceFilters'] == {'default': 0.8}
+    assert camera_call.args[1]['datasetInfo'] == {'year': '2025'}
+    assert camera_call.args[1]['fps'] == 30
+    assert camera_call.args[2] is False
+
+    assert parent_call.args[0] is parent_folder
+    parent_payload = parent_call.args[1]
+    assert parent_payload['confidenceFilters'] == {'default': 0.8}
+    assert parent_payload['customTypeStyling'] == {'fish': {'color': '#00ff00'}}
+    # Overwrite replaces parent datasetInfo; camera-local / registration keys stay off parent.
+    assert parent_payload['datasetInfo'] == {'year': '2025'}
+    assert 'fps' not in parent_payload
+    assert 'imageEnhancements' not in parent_payload
+    assert 'cameraHomographies' not in parent_payload
+    assert 'cameraCorrespondences' not in parent_payload
+    assert 'cameraTransformTypes' not in parent_payload
+    assert 'cameraRegistrationSource' not in parent_payload
+    assert parent_call.args[2] is False
+
+
+@patch('dive_server.crud_rpc.crud_annotation.save_annotations')
+@patch('dive_server.crud_rpc.dive.migrate')
+@patch('dive_server.crud_rpc.viame.load_json_as_track_and_attributes')
+@patch('dive_server.crud_rpc.crud_dataset.update_metadata')
+@patch('dive_server.crud_rpc.crud.saveImportAttributes')
+@patch('dive_server.crud_rpc.crud.get_multicam_parent_folder')
+@patch('dive_server.crud_rpc.crud.get_or_create_auxiliary_folder')
+@patch('dive_server.crud_rpc.File')
+@patch('dive_server.crud_rpc.Item')
+@patch('dive_server.crud_rpc.Folder')
+def test_process_items_syncs_track_attributes_to_multicam_parent(
+    folder_cls,
+    item_cls,
+    file_cls,
+    get_auxiliary_folder,
+    get_multicam_parent,
+    save_import_attributes,
+    update_metadata,
+    load_json,
+    migrate,
+    save_annotations,
+):
+    """Annotation imports that derive attributes also union them onto the parent."""
+    camera_folder = {
+        '_id': 'left-id',
+        'parentId': 'parent-id',
+        'meta': {'annotate': True, 'type': 'video', 'fps': 5},
+    }
+    parent_folder = {
+        '_id': 'parent-id',
+        'meta': {'annotate': True, 'type': 'multi', 'fps': 5},
+    }
+    item = {'_id': 'item-id', 'name': 'tracks.dive.json', 'meta': {}}
+    file = {'_id': 'file-id', 'name': 'tracks.dive.json', 'exts': ['json']}
+    payload = {
+        'tracks': {
+            '1': {
+                'id': 1,
+                'begin': 0,
+                'end': 0,
+                'confidencePairs': [['fish', 1.0]],
+                'features': [{'frame': 0, 'bounds': [0, 0, 1, 1]}],
+                'attributes': {},
+            }
+        },
+        'groups': {},
+        'version': 2,
+    }
+    attributes = {
+        'species': {
+            'key': 'species',
+            'name': 'species',
+            'belongs': 'track',
+            'datatype': 'text',
+        }
+    }
+
+    folder_cls.return_value.childItems.return_value = [item]
+    item_cls.return_value.childFiles.return_value = iter([file])
+    file_cls.return_value.download.return_value = lambda: [json.dumps(payload).encode()]
+    get_auxiliary_folder.return_value = {'_id': 'auxiliary-id'}
+    get_multicam_parent.return_value = parent_folder
+    migrate.return_value = payload
+    load_json.return_value = (payload, attributes)
+
+    warnings = process_items(camera_folder, {'_id': 'user-id'})
+
+    assert warnings == []
+    save_annotations.assert_called_once()
+    assert save_import_attributes.call_count == 2
+    assert save_import_attributes.call_args_list[0].args[0] is camera_folder
+    assert save_import_attributes.call_args_list[1].args[0] is parent_folder
+    update_metadata.assert_not_called()
+
+
+def test_pick_multicam_shared_mutable_keeps_only_shared_keys():
+    from dive_server import crud
+
+    picked = crud.pick_multicam_shared_mutable(
+        {
+            'fps': 30,
+            'version': 1,
+            'confidenceFilters': {'default': 0.5},
+            'datasetInfo': {'year': '2025'},
+            'imageEnhancements': {'brightness': 1.2},
+            'cameraHomographies': {'left::right': {'AtoB': [], 'BtoA': []}},
+            'cameraCorrespondences': {'left::right': []},
+            'cameraTransformTypes': {'left::right': 'similarity'},
+            'cameraRegistrationSource': {'model': 'colmap'},
+            'customTypeStyling': {'fish': {'color': '#0f0'}},
+        }
+    )
+    assert picked == {
+        'confidenceFilters': {'default': 0.5},
+        'datasetInfo': {'year': '2025'},
+        'customTypeStyling': {'fish': {'color': '#0f0'}},
+    }
+    assert 'imageEnhancements' not in picked
+    assert 'cameraHomographies' not in picked
+    assert 'cameraCorrespondences' not in picked
+    assert 'cameraTransformTypes' not in picked
+    assert 'cameraRegistrationSource' not in picked
+
+
+@patch('dive_server.crud.Folder')
+def test_get_multicam_parent_folder_returns_parent_for_registered_camera(folder_cls):
+    from girder.constants import AccessType
+
+    from dive_server import crud
+    from dive_utils import constants
+
+    camera = {'_id': 'left-id', 'parentId': 'parent-id', 'meta': {'type': 'image-sequence'}}
+    parent = {
+        '_id': 'parent-id',
+        'meta': {
+            'type': constants.MultiType,
+            'multiCam': {
+                'defaultDisplay': 'left',
+                'cameras': {'left': {'folderId': 'left-id', 'type': 'image-sequence'}},
+            },
+        },
+    }
+    folder_cls.return_value.load.return_value = parent
+    user = {'_id': 'user-id'}
+
+    assert crud.get_multicam_parent_folder(camera, user) is parent
+    folder_cls.return_value.load.assert_called_once_with(
+        'parent-id',
+        level=AccessType.WRITE,
+        user=user,
+    )
+
+
+@patch('dive_server.crud.Folder')
+def test_get_multicam_parent_folder_ignores_unregistered_child(folder_cls):
+    from dive_server import crud
+    from dive_utils import constants
+
+    camera = {'_id': 'other-id', 'parentId': 'parent-id', 'meta': {'type': 'image-sequence'}}
+    parent = {
+        '_id': 'parent-id',
+        'meta': {
+            'type': constants.MultiType,
+            'multiCam': {
+                'defaultDisplay': 'left',
+                'cameras': {'left': {'folderId': 'left-id', 'type': 'image-sequence'}},
+            },
+        },
+    }
+    folder_cls.return_value.load.return_value = parent
+
+    assert crud.get_multicam_parent_folder(camera, {'_id': 'user-id'}) is None


### PR DESCRIPTION
## Problem

Importing a DIVE configuration file (custom type colors, confidence thresholds, ...) works in single-camera mode but silently does nothing in multi-camera mode: neither the thresholds nor the colors apply or persist.

## Cause

In multi-camera mode the desktop viewer hands the importer the camera-qualified dataset id (`<base>/<camera>`), so `dataFileImport` wrote the config into that camera's `meta.json`. The viewer, however, only reads `confidenceFilters` / `customTypeStyling` (and the other mutable config keys) from the **base** dataset's metadata, so the imported values were never seen.

## Fix

When an import targets a camera of a multicam dataset and produces mutable-config keys, `dataFileImport` now also merges those keys into the base dataset's `meta.json`, using the same overwrite/additive `datasetInfo` semantics as the per-camera write. Since `reloadAnnotations` re-reads the base metadata after import, the imported config now applies immediately as well.

Includes a regression test covering the camera-targeted config import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)