### PR TITLE
Fill only the polygon, not the rectangle, when a detection has both

### DIFF
--- a/client/src/layers/AnnotationLayers/RectangleLayer.ts
+++ b/client/src/layers/AnnotationLayers/RectangleLayer.ts
@@ -228,9 +228,9 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
         return this.typeStyling.value.color('');
       },
       fill: (data) => {
-        // When the detection has a polygon the fill belongs to the polygon,
-        // never the surrounding rectangle
-        if (data.hasPoly) {
+        // When the polygon is also drawn, fill belongs to the polygon.
+        // If the poly exists but isn't visible, keep fill on the rectangle.
+        if (this.drawingOther && data.hasPoly) {
           return false;
         }
         if (data.set) {

--- a/client/src/layers/AnnotationLayers/RectangleLayer.ts
+++ b/client/src/layers/AnnotationLayers/RectangleLayer.ts
@@ -228,6 +228,11 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
         return this.typeStyling.value.color('');
       },
       fill: (data) => {
+        // When the detection has a polygon the fill belongs to the polygon,
+        // never the surrounding rectangle
+        if (data.hasPoly) {
+          return false;
+        }
         if (data.set) {
           return this.typeStyling.value.fill(data.set, true);
         }


### PR DESCRIPTION
## Problem

With the per-type "Fill" style enabled, a detection that has a polygon gets both its polygon *and* its bounding rectangle filled, shading the whole box area.

## Fix

When a detection has polygon geometry, the fill setting now applies solely to the polygon; the bounding rectangle stays unfilled. Detections with only a rectangle keep the existing fill behavior. The rectangle layer already computed a per-detection `hasPoly` flag, which the fill style function now respects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)