### PR TITLE
Display detections flagged with a suppression attribute as suppressed

### DIFF
--- a/client/dive-common/components/AnnotationVisibilityMenu.vue
+++ b/client/dive-common/components/AnnotationVisibilityMenu.vue
@@ -295,6 +295,7 @@ export default defineComponent({
                   >
                     mdi-eye-off
                   </v-icon>
+                  <span class="ml-1 text--secondary">(labels & tooltips)</span>
                 </span>
               </template>
             </v-checkbox>
@@ -511,6 +512,7 @@ export default defineComponent({
                   >
                     mdi-eye-off
                   </v-icon>
+                  <span class="ml-1 text--secondary">(labels & tooltips)</span>
                 </span>
               </template>
             </v-checkbox>
@@ -627,9 +629,9 @@ export default defineComponent({
               </template>
               <span>
                 Detections flagged with a suppression attribute stay visible
-                but can be drawn with a dashed outline, custom fill, and
-                opacity so they are easy to distinguish from normal detections.
-                Enable this to apply those styles.
+                with their real type. When enabled, they can be drawn with a
+                dashed outline, custom fill, and opacity so they are easy to
+                distinguish from normal detections.
               </span>
             </v-tooltip>
           </div>

--- a/client/dive-common/components/AnnotationVisibilityMenu.vue
+++ b/client/dive-common/components/AnnotationVisibilityMenu.vue
@@ -8,6 +8,7 @@ import {
 } from 'vue';
 
 import { VisibleAnnotationTypes } from 'vue-media-annotator/layers';
+import { DEFAULT_SUPPRESSION_DISPLAY, SuppressionDisplaySettings } from 'vue-media-annotator/types';
 
 import OutlinedLabeledGroup from './OutlinedLabeledGroup.vue';
 import ToolbarExpandToggle from './ToolbarExpandToggle.vue';
@@ -40,8 +41,22 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
+    showSuppressedTags: {
+      type: Boolean,
+      default: true,
+    },
+    suppressionDisplay: {
+      type: Object as PropType<SuppressionDisplaySettings>,
+      default: () => ({ ...DEFAULT_SUPPRESSION_DISPLAY }),
+    },
   },
-  emits: ['set-annotation-state', 'update:tail-settings', 'update:show-user-created-icon'],
+  emits: [
+    'set-annotation-state',
+    'update:tail-settings',
+    'update:show-user-created-icon',
+    'update:show-suppressed-tags',
+    'update:suppression-display',
+  ],
   setup(props, { emit }) {
     const STORAGE_KEY = 'annotationVisibilityMenu.expanded';
 
@@ -129,7 +144,9 @@ export default defineComponent({
     );
 
     const advancedVisibilityActive = computed(
-      () => isVisible('tooltip') || isVisible('TrackTail'),
+      () => isVisible('tooltip')
+        || isVisible('TrackTail')
+        || !!props.suppressionDisplay?.enabled,
     );
 
     const updateTailSettings = (type: 'before' | 'after', event: Event) => {
@@ -140,6 +157,36 @@ export default defineComponent({
 
     const toggleShowUserCreatedIcon = () => {
       emit('update:show-user-created-icon', !props.showUserCreatedIcon);
+    };
+
+    const toggleShowSuppressedTags = () => {
+      emit('update:show-suppressed-tags', !props.showSuppressedTags);
+    };
+
+    const patchSuppressionDisplay = (patch: Partial<SuppressionDisplaySettings>) => {
+      emit('update:suppression-display', {
+        ...DEFAULT_SUPPRESSION_DISPLAY,
+        ...props.suppressionDisplay,
+        ...patch,
+      });
+    };
+
+    const toggleSuppressionDisplay = () => {
+      patchSuppressionDisplay({ enabled: !props.suppressionDisplay?.enabled });
+    };
+
+    const updateSuppressionSlider = (
+      key: 'outlineOpacity' | 'fillOpacity',
+      event: Event,
+    ) => {
+      const value = Number.parseFloat((event.target as HTMLInputElement).value);
+      patchSuppressionDisplay({ [key]: value });
+    };
+
+    const updateSuppressionFillColor = (event: Event) => {
+      patchSuppressionDisplay({
+        fillColor: (event.target as HTMLInputElement).value,
+      });
     };
 
     return {
@@ -153,6 +200,11 @@ export default defineComponent({
       toggleExpanded,
       updateTailSettings,
       toggleShowUserCreatedIcon,
+      toggleShowSuppressedTags,
+      toggleSuppressionDisplay,
+      patchSuppressionDisplay,
+      updateSuppressionSlider,
+      updateSuppressionFillColor,
     };
   },
 });
@@ -207,13 +259,45 @@ export default defineComponent({
             <v-checkbox
               v-if="button.id === 'text'"
               :input-value="showUserCreatedIcon"
-              label="Show user created/modified icons"
               dense
               hide-details
               class="mt-0"
               @click.stop
               @change="toggleShowUserCreatedIcon"
-            />
+            >
+              <template #label>
+                <span class="d-inline-flex align-center">
+                  Show user created/modified
+                  <v-icon
+                    small
+                    class="ml-1"
+                  >
+                    mdi-pencil
+                  </v-icon>
+                </span>
+              </template>
+            </v-checkbox>
+            <v-checkbox
+              v-if="button.id === 'text'"
+              :input-value="showSuppressedTags"
+              dense
+              hide-details
+              class="mt-0"
+              @click.stop
+              @change="toggleShowSuppressedTags"
+            >
+              <template #label>
+                <span class="d-inline-flex align-center">
+                  Show suppressed tags
+                  <v-icon
+                    small
+                    class="ml-1"
+                  >
+                    mdi-eye-off
+                  </v-icon>
+                </span>
+              </template>
+            </v-checkbox>
           </v-list-item-content>
         </v-list-item>
         <v-list-item>
@@ -229,6 +313,21 @@ export default defineComponent({
           </v-list-item-icon>
           <v-list-item-content>
             <v-list-item-title>Track Trails</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item>
+          <v-list-item-icon>
+            <v-btn
+              :color="suppressionDisplay.enabled ? 'grey darken-2' : ''"
+              class="mx-1 mode-button"
+              small
+              @click="toggleSuppressionDisplay"
+            >
+              <v-icon>mdi-eye-off</v-icon>
+            </v-btn>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title>Suppression</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
         <v-divider />
@@ -262,6 +361,68 @@ export default defineComponent({
                 max="100"
                 :value="tailSettings.after"
                 @input="updateTailSettings('after', $event)"
+              >
+            </v-card>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item v-if="suppressionDisplay.enabled">
+          <v-list-item-content>
+            <v-card
+              class="pa-4 flex-column d-flex"
+              outlined
+              flat
+            >
+              <v-checkbox
+                :input-value="suppressionDisplay.dashed"
+                label="Dashed outline"
+                dense
+                hide-details
+                class="mt-0"
+                @click.stop
+                @change="patchSuppressionDisplay({ dashed: !suppressionDisplay.dashed })"
+              />
+              <label
+                for="suppression-outline-opacity"
+                class="mt-3"
+              >
+                Outline opacity: {{ Math.round(suppressionDisplay.outlineOpacity * 100) }}%
+              </label>
+              <input
+                id="suppression-outline-opacity"
+                type="range"
+                class="tail-slider-width"
+                min="0"
+                max="1"
+                step="0.05"
+                :value="suppressionDisplay.outlineOpacity"
+                @input="updateSuppressionSlider('outlineOpacity', $event)"
+              >
+              <div class="d-flex align-center mt-3">
+                <label for="suppression-fill-color">Fill color</label>
+                <input
+                  id="suppression-fill-color"
+                  type="color"
+                  class="ml-2 suppression-color-input"
+                  :value="suppressionDisplay.fillColor || '#888888'"
+                  :title="suppressionDisplay.fillColor || '#888888'"
+                  @input="updateSuppressionFillColor"
+                >
+              </div>
+              <label
+                for="suppression-fill-opacity"
+                class="mt-3"
+              >
+                Fill opacity: {{ Math.round(suppressionDisplay.fillOpacity * 100) }}%
+              </label>
+              <input
+                id="suppression-fill-opacity"
+                type="range"
+                class="tail-slider-width"
+                min="0"
+                max="1"
+                step="0.05"
+                :value="suppressionDisplay.fillOpacity"
+                @input="updateSuppressionSlider('fillOpacity', $event)"
               >
             </v-card>
           </v-list-item-content>
@@ -318,11 +479,41 @@ export default defineComponent({
           >
             <v-checkbox
               :input-value="showUserCreatedIcon"
-              label="Show user created/modified icons"
               dense
               hide-details
               @change="toggleShowUserCreatedIcon"
-            />
+            >
+              <template #label>
+                <span class="d-inline-flex align-center">
+                  Show user created/modified
+                  <v-icon
+                    small
+                    class="ml-1"
+                  >
+                    mdi-pencil
+                  </v-icon>
+                </span>
+              </template>
+            </v-checkbox>
+            <v-checkbox
+              :input-value="showSuppressedTags"
+              dense
+              hide-details
+              class="mt-2"
+              @change="toggleShowSuppressedTags"
+            >
+              <template #label>
+                <span class="d-inline-flex align-center">
+                  Show suppressed tags
+                  <v-icon
+                    small
+                    class="ml-1"
+                  >
+                    mdi-eye-off
+                  </v-icon>
+                </span>
+              </template>
+            </v-checkbox>
           </v-card>
         </v-menu>
         <v-btn
@@ -410,6 +601,92 @@ export default defineComponent({
               @input="updateTailSettings('after', $event)"
             >
           </template>
+          <div class="d-flex align-center advanced-menu-row">
+            <v-btn
+              :color="suppressionDisplay.enabled ? 'grey darken-2' : ''"
+              class="mode-button"
+              small
+              @click="toggleSuppressionDisplay"
+            >
+              <v-icon>mdi-eye-off</v-icon>
+            </v-btn>
+            <span class="ml-2">Suppression</span>
+            <v-tooltip
+              open-delay="200"
+              bottom
+              max-width="280"
+            >
+              <template #activator="{ on }">
+                <v-icon
+                  small
+                  class="ml-1"
+                  v-on="on"
+                >
+                  mdi-help
+                </v-icon>
+              </template>
+              <span>
+                Detections flagged with a suppression attribute stay visible
+                but can be drawn with a dashed outline, custom fill, and
+                opacity so they are easy to distinguish from normal detections.
+                Enable this to apply those styles.
+              </span>
+            </v-tooltip>
+          </div>
+          <template v-if="suppressionDisplay.enabled">
+            <v-divider class="my-2" />
+            <v-checkbox
+              :input-value="suppressionDisplay.dashed"
+              label="Dashed outline"
+              dense
+              hide-details
+              class="mt-0"
+              @change="patchSuppressionDisplay({ dashed: !suppressionDisplay.dashed })"
+            />
+            <label
+              for="suppression-outline-opacity-full"
+              class="mt-3"
+            >
+              Outline opacity: {{ Math.round(suppressionDisplay.outlineOpacity * 100) }}%
+            </label>
+            <input
+              id="suppression-outline-opacity-full"
+              type="range"
+              class="tail-slider-width"
+              min="0"
+              max="1"
+              step="0.05"
+              :value="suppressionDisplay.outlineOpacity"
+              @input="updateSuppressionSlider('outlineOpacity', $event)"
+            >
+            <div class="d-flex align-center mt-3">
+              <label for="suppression-fill-color-full">Fill color</label>
+              <input
+                id="suppression-fill-color-full"
+                type="color"
+                class="ml-2 suppression-color-input"
+                :value="suppressionDisplay.fillColor || '#888888'"
+                :title="suppressionDisplay.fillColor || '#888888'"
+                @input="updateSuppressionFillColor"
+              >
+            </div>
+            <label
+              for="suppression-fill-opacity-full"
+              class="mt-3"
+            >
+              Fill opacity: {{ Math.round(suppressionDisplay.fillOpacity * 100) }}%
+            </label>
+            <input
+              id="suppression-fill-opacity-full"
+              type="range"
+              class="tail-slider-width"
+              min="0"
+              max="1"
+              step="0.05"
+              :value="suppressionDisplay.fillOpacity"
+              @input="updateSuppressionSlider('fillOpacity', $event)"
+            >
+          </template>
         </v-card>
       </v-menu>
     </outlined-labeled-group>
@@ -428,5 +705,13 @@ export default defineComponent({
 }
 .advanced-menu-row + .advanced-menu-row {
   margin-top: 8px;
+}
+.suppression-color-input {
+  width: 36px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid grey;
+  background: transparent;
+  cursor: pointer;
 }
 </style>

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -8,7 +8,7 @@ import {
 } from 'vue';
 import { flatten } from 'lodash';
 
-import { Mousetrap } from 'vue-media-annotator/types';
+import { Mousetrap, SuppressionDisplaySettings } from 'vue-media-annotator/types';
 import { EditAnnotationTypes, VisibleAnnotationTypes } from 'vue-media-annotator/layers';
 import Recipe from 'vue-media-annotator/recipe';
 import SegmentationPointClick from 'dive-common/recipes/segmentationpointclick';
@@ -84,6 +84,14 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
+    showSuppressedTags: {
+      type: Boolean,
+      default: true,
+    },
+    suppressionDisplay: {
+      type: Object as PropType<SuppressionDisplaySettings>,
+      default: undefined,
+    },
     textQueryEnabled: {
       type: Boolean,
       default: false,
@@ -97,6 +105,8 @@ export default defineComponent({
     'set-annotation-state',
     'update:tail-settings',
     'update:show-user-created-icon',
+    'update:show-suppressed-tags',
+    'update:suppression-display',
     'text-query-init',
     'text-query',
     'text-query-all-frames',
@@ -587,9 +597,13 @@ export default defineComponent({
         :visible-modes="visibleModes"
         :tail-settings="tailSettings"
         :show-user-created-icon="showUserCreatedIcon"
+        :show-suppressed-tags="showSuppressedTags"
+        :suppression-display="suppressionDisplay"
         @set-annotation-state="$emit('set-annotation-state', $event)"
         @update:tail-settings="$emit('update:tail-settings', $event)"
         @update:show-user-created-icon="$emit('update:show-user-created-icon', $event)"
+        @update:show-suppressed-tags="$emit('update:show-suppressed-tags', $event)"
+        @update:suppression-display="$emit('update:suppression-display', $event)"
       />
     </div>
 

--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -26,7 +26,7 @@ export default defineComponent({
       preventCascadeTypes: 'When a track has multiple types, this will prevent the type from displaying if the max type is not visible in the type list',
       filterTypesByFrame: 'Filters the type list by only types that are visible in the current frame',
       maxCountButton: 'Show a max count button that will jump to the frame with the max count for the type',
-      suppressionType: 'Detections lying at least the Suppression Overlap percent under an annotation of this type are hidden and excluded from counts. A detection carrying an attribute of this name set to true stays visible but displays as this type and is excluded from its own type\'s counts. Leave empty to disable.',
+      suppressionType: 'Detections lying at least the Suppression Overlap percent under an annotation of this type are hidden and excluded from counts. A detection carrying an attribute of this name set to true stays visible with its real type (optional dashed/fill styling and an eye-off tag) and is excluded from its own type\'s counts. Leave empty to disable.',
       suppressionThreshold: 'Minimum percent of a detection that must lie under suppression regions for it to be hidden (default 99).',
     });
     const importInstructions = ref('Please provide a list of types (separated by a new line) that you would like to import');

--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -25,7 +25,8 @@ export default defineComponent({
       preventCascadeTypes: 'When a track has multiple types, this will prevent the type from displaying if the max type is not visible in the type list',
       filterTypesByFrame: 'Filters the type list by only types that are visible in the current frame',
       maxCountButton: 'Show a max count button that will jump to the frame with the max count for the type',
-      suppressionType: 'Detections lying 50% or more under an annotation of this type are hidden and excluded from counts. A detection carrying an attribute of this name set to true stays visible but displays as this type and is excluded from its own type\'s counts. Leave empty to disable.',
+      suppressionType: 'Detections lying at least the Suppression Overlap percent under an annotation of this type are hidden and excluded from counts. A detection carrying an attribute of this name set to true stays visible but displays as this type and is excluded from its own type\'s counts. Leave empty to disable.',
+      suppressionThreshold: 'Minimum percent of a detection that must lie under suppression regions for it to be hidden (default 95).',
     });
     const importInstructions = ref('Please provide a list of types (separated by a new line) that you would like to import');
     const importDialog = ref(false);
@@ -310,6 +311,41 @@ export default defineComponent({
                   </v-icon>
                 </template>
                 <span>{{ help.suppressionType }}</span>
+              </v-tooltip>
+            </v-col>
+          </v-row>
+          <v-row class="mt-2">
+            <v-col class="py-1">
+              <v-text-field
+                v-model.number="clientSettings.typeSettings.suppressionThreshold"
+                label="Suppression Overlap (%)"
+                type="number"
+                min="1"
+                max="100"
+                step="1"
+                class="my-0 ml-1 pt-0"
+                dense
+                hide-details
+              />
+            </v-col>
+            <v-col
+              cols="2"
+              class="py-1"
+              align="right"
+            >
+              <v-tooltip
+                open-delay="200"
+                bottom
+              >
+                <template #activator="{ on }">
+                  <v-icon
+                    small
+                    v-on="on"
+                  >
+                    mdi-help
+                  </v-icon>
+                </template>
+                <span>{{ help.suppressionThreshold }}</span>
               </v-tooltip>
             </v-col>
           </v-row>

--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -25,7 +25,7 @@ export default defineComponent({
       preventCascadeTypes: 'When a track has multiple types, this will prevent the type from displaying if the max type is not visible in the type list',
       filterTypesByFrame: 'Filters the type list by only types that are visible in the current frame',
       maxCountButton: 'Show a max count button that will jump to the frame with the max count for the type',
-      suppressionType: 'Detections lying 50% or more under an annotation of this type are hidden and excluded from counts. Leave empty to disable.',
+      suppressionType: 'Detections lying 50% or more under an annotation of this type are hidden and excluded from counts. A detection carrying an attribute of this name set to true stays visible but displays as this type and is excluded from its own type\'s counts. Leave empty to disable.',
     });
     const importInstructions = ref('Please provide a list of types (separated by a new line) that you would like to import');
     const importDialog = ref(false);

--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -4,6 +4,7 @@ import {
   reactive,
   PropType,
   ref,
+  computed,
 } from 'vue';
 import { clientSettings } from 'dive-common/store/settings';
 
@@ -32,6 +33,12 @@ export default defineComponent({
     const importDialog = ref(false);
     const importTypes = ref('');
     const active = ref(false);
+    // Always offer the default suppression type even when no annotations use it yet.
+    const suppressionTypeItems = computed(() => (
+      props.allTypes.includes('Suppressed')
+        ? props.allTypes
+        : ['Suppressed', ...props.allTypes]
+    ));
 
     const confirmImport = () => {
       // Go through the importTypes and create types for importing
@@ -50,6 +57,7 @@ export default defineComponent({
       importDialog,
       importTypes,
       confirmImport,
+      suppressionTypeItems,
     };
   },
 });
@@ -285,7 +293,7 @@ export default defineComponent({
             <v-col class="py-1">
               <v-select
                 v-model="clientSettings.typeSettings.suppressionType"
-                :items="allTypes"
+                :items="suppressionTypeItems"
                 label="Suppression Region Type"
                 class="my-0 ml-1 pt-0"
                 dense
@@ -314,7 +322,10 @@ export default defineComponent({
               </v-tooltip>
             </v-col>
           </v-row>
-          <v-row class="mt-2">
+          <v-row
+            v-if="clientSettings.typeSettings.suppressionType"
+            class="mt-8"
+          >
             <v-col class="py-1">
               <v-text-field
                 v-model.number="clientSettings.typeSettings.suppressionThreshold"

--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -26,7 +26,7 @@ export default defineComponent({
       filterTypesByFrame: 'Filters the type list by only types that are visible in the current frame',
       maxCountButton: 'Show a max count button that will jump to the frame with the max count for the type',
       suppressionType: 'Detections lying at least the Suppression Overlap percent under an annotation of this type are hidden and excluded from counts. A detection carrying an attribute of this name set to true stays visible but displays as this type and is excluded from its own type\'s counts. Leave empty to disable.',
-      suppressionThreshold: 'Minimum percent of a detection that must lie under suppression regions for it to be hidden (default 95).',
+      suppressionThreshold: 'Minimum percent of a detection that must lie under suppression regions for it to be hidden (default 99).',
     });
     const importInstructions = ref('Please provide a list of types (separated by a new line) that you would like to import');
     const importDialog = ref(false);

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -2167,6 +2167,8 @@ export default defineComponent({
           }"
           :tail-settings.sync="clientSettings.annotatorPreferences.trackTails"
           :show-user-created-icon.sync="clientSettings.annotatorPreferences.showUserCreatedIcon"
+          :show-suppressed-tags.sync="clientSettings.annotatorPreferences.showSuppressedTags"
+          :suppression-display.sync="clientSettings.annotatorPreferences.suppressionDisplay"
           @set-annotation-state="handler.setAnnotationState"
           @exit-edit="handler.trackAbort"
           @text-query-init="$emit('text-query-init')"

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -150,6 +150,14 @@ const defaultSettings: AnnotationSettings = {
       transition: false,
     },
     showUserCreatedIcon: false,
+    showSuppressedTags: true,
+    suppressionDisplay: {
+      enabled: true,
+      dashed: true,
+      outlineOpacity: 1,
+      fillColor: '',
+      fillOpacity: 0.3,
+    },
   },
   timelineCountSettings: {
     totalCount: true,

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -22,12 +22,14 @@ interface AnnotationSettings {
     preventCascadeTypes?: boolean;
     filterTypesByFrame?: boolean;
     maxCountButton?: boolean;
-    // Detections whose geometry lies at least suppressionThreshold percent
-    // under a region of this type are hidden and excluded from counts.
-    // Empty string disables the feature.
+    // Region of this type: detections whose geometry lies at least
+    // suppressionThreshold percent under it are hidden and excluded from
+    // counts. Attribute of this name set true: detection stays visible with
+    // its real type (optional dashed/fill styling and eye-off tag) and is
+    // excluded from its own type's counts. Empty string disables both.
     suppressionType?: string;
-    // Minimum covered percent (0-100] for a detection to count as
-    // suppressed; out-of-range values fall back to the default (99).
+    // Minimum covered percent (0-100] for region suppression;
+    // out-of-range values fall back to the default (99).
     suppressionThreshold?: number;
   };
   trackSettings: {

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -22,9 +22,13 @@ interface AnnotationSettings {
     preventCascadeTypes?: boolean;
     filterTypesByFrame?: boolean;
     maxCountButton?: boolean;
-    // Detections whose geometry lies >=50% under a region of this type are
-    // hidden and excluded from counts. Empty string disables the feature.
+    // Detections whose geometry lies at least suppressionThreshold percent
+    // under a region of this type are hidden and excluded from counts.
+    // Empty string disables the feature.
     suppressionType?: string;
+    // Minimum covered percent (0-100] for a detection to count as
+    // suppressed; out-of-range values fall back to the default (95).
+    suppressionThreshold?: number;
   };
   trackSettings: {
     newTrackSettings: {
@@ -131,6 +135,7 @@ const defaultSettings: AnnotationSettings = {
     preventCascadeTypes: false,
     maxCountButton: false,
     suppressionType: 'Suppressed',
+    suppressionThreshold: 95,
   },
   rowsPerPage: 20,
   annotationFPS: 10,

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -27,7 +27,7 @@ interface AnnotationSettings {
     // Empty string disables the feature.
     suppressionType?: string;
     // Minimum covered percent (0-100] for a detection to count as
-    // suppressed; out-of-range values fall back to the default (95).
+    // suppressed; out-of-range values fall back to the default (99).
     suppressionThreshold?: number;
   };
   trackSettings: {
@@ -135,7 +135,7 @@ const defaultSettings: AnnotationSettings = {
     preventCascadeTypes: false,
     maxCountButton: false,
     suppressionType: 'Suppressed',
-    suppressionThreshold: 95,
+    suppressionThreshold: 99,
   },
   rowsPerPage: 20,
   annotationFPS: 10,

--- a/client/src/StyleManager.spec.ts
+++ b/client/src/StyleManager.spec.ts
@@ -38,3 +38,16 @@ describe('StyleManager', () => {
     expect(sm.getTypeStyles(ref(['foo']))).toEqual({ foo: { color: '#ffe080' } });
   });
 });
+
+describe('suppressed-display style blending', () => {
+  it('blends the suppression style 50/50 with the natural type', () => {
+    const markChangesPending = () => undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sm = new StyleManager({ markChangesPending } as any);
+    sm.updateTypeStyle({ type: 'B', value: { color: '#000000', opacity: 0.5 } });
+    sm.updateTypeStyle({ type: 'Suppressed', value: { color: '#ffffff', opacity: 1.0 } });
+    // 0.5 * 255 + 0.5 * 0 = 127.5 -> 128 = 0x80 per channel
+    expect(sm.typeStyling.value.suppressedColor('B', 'Suppressed')).toBe('#808080');
+    expect(sm.typeStyling.value.suppressedOpacity('B', 'Suppressed')).toBeCloseTo(0.75, 6);
+  });
+});

--- a/client/src/StyleManager.spec.ts
+++ b/client/src/StyleManager.spec.ts
@@ -40,14 +40,15 @@ describe('StyleManager', () => {
 });
 
 describe('suppressed-display style blending', () => {
-  it('blends the suppression style 50/50 with the natural type', () => {
+  it('blends the suppression style 2/3 over the natural type', () => {
     const markChangesPending = () => undefined;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sm = new StyleManager({ markChangesPending } as any);
     sm.updateTypeStyle({ type: 'B', value: { color: '#000000', opacity: 0.5 } });
     sm.updateTypeStyle({ type: 'Suppressed', value: { color: '#ffffff', opacity: 1.0 } });
-    // 0.5 * 255 + 0.5 * 0 = 127.5 -> 128 = 0x80 per channel
-    expect(sm.typeStyling.value.suppressedColor('B', 'Suppressed')).toBe('#808080');
-    expect(sm.typeStyling.value.suppressedOpacity('B', 'Suppressed')).toBeCloseTo(0.75, 6);
+    // (2/3) * 255 + (1/3) * 0 = 170 = 0xaa per channel
+    expect(sm.typeStyling.value.suppressedColor('B', 'Suppressed')).toBe('#aaaaaa');
+    // (2/3) * 1.0 + (1/3) * 0.5
+    expect(sm.typeStyling.value.suppressedOpacity('B', 'Suppressed')).toBeCloseTo(5 / 6, 6);
   });
 });

--- a/client/src/StyleManager.spec.ts
+++ b/client/src/StyleManager.spec.ts
@@ -38,17 +38,3 @@ describe('StyleManager', () => {
     expect(sm.getTypeStyles(ref(['foo']))).toEqual({ foo: { color: '#ffe080' } });
   });
 });
-
-describe('suppressed-display style blending', () => {
-  it('blends the suppression style 2/3 over the natural type', () => {
-    const markChangesPending = () => undefined;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sm = new StyleManager({ markChangesPending } as any);
-    sm.updateTypeStyle({ type: 'B', value: { color: '#000000', opacity: 0.5 } });
-    sm.updateTypeStyle({ type: 'Suppressed', value: { color: '#ffffff', opacity: 1.0 } });
-    // (2/3) * 255 + (1/3) * 0 = 170 = 0xaa per channel
-    expect(sm.typeStyling.value.suppressedColor('B', 'Suppressed')).toBe('#aaaaaa');
-    // (2/3) * 1.0 + (1/3) * 0.5
-    expect(sm.typeStyling.value.suppressedOpacity('B', 'Suppressed')).toBeCloseTo(5 / 6, 6);
-  });
-});

--- a/client/src/StyleManager.ts
+++ b/client/src/StyleManager.ts
@@ -36,18 +36,9 @@ export interface TypeStyling {
   strokeWidth: (type: string, set?: boolean) => number;
   fill: (type: string, set?: boolean) => boolean;
   opacity: (type: string, set?: boolean) => number;
-  /** Weighted blend for suppressed-display detections: SUPPRESSED_STYLE_WEIGHT
-   * of the suppression type's color over the detection's own type color. */
-  suppressedColor: (type: string, suppressionType: string) => string;
-  /** Same weighted blend applied to the opacity. */
-  suppressedOpacity: (type: string, suppressionType: string) => number;
   labelSettings: (type: string, set?: boolean) => { showLabel: boolean; showConfidence: boolean };
   annotationSetColor: (set: string) => string;
 }
-
-/** Fraction of the suppression type's styling used for suppressed-display
- * detections (the remainder comes from the detection's own type). */
-export const SUPPRESSED_STYLE_WEIGHT = 2 / 3;
 
 interface UseStylingParams {
   markChangesPending: () => void;
@@ -211,25 +202,6 @@ export default class StyleManager {
           return this.stateStyles.standard.fill;
         },
         opacity: opacityFor,
-        suppressedColor: (type: string, suppressionType: string) => {
-          const supp = d3.color(colorFor(suppressionType));
-          const natural = d3.color(colorFor(type));
-          if (!supp || !natural) {
-            return colorFor(suppressionType);
-          }
-          const sr = supp.rgb();
-          const nr = natural.rgb();
-          const w = SUPPRESSED_STYLE_WEIGHT;
-          return d3.rgb(
-            (w * sr.r) + ((1 - w) * nr.r),
-            (w * sr.g) + ((1 - w) * nr.g),
-            (w * sr.b) + ((1 - w) * nr.b),
-          ).hex();
-        },
-        suppressedOpacity: (type: string, suppressionType: string) => (
-          (SUPPRESSED_STYLE_WEIGHT * opacityFor(suppressionType))
-          + ((1 - SUPPRESSED_STYLE_WEIGHT) * opacityFor(type))
-        ),
         labelSettings: (type: string, set?: boolean) => {
           let { showLabel, showConfidence } = this.stateStyles.standard;
           if (_customStyles[type]) {

--- a/client/src/StyleManager.ts
+++ b/client/src/StyleManager.ts
@@ -36,9 +36,18 @@ export interface TypeStyling {
   strokeWidth: (type: string, set?: boolean) => number;
   fill: (type: string, set?: boolean) => boolean;
   opacity: (type: string, set?: boolean) => number;
+  /** Weighted blend for suppressed-display detections: SUPPRESSED_STYLE_WEIGHT
+   * of the suppression type's color over the detection's own type color. */
+  suppressedColor: (type: string, suppressionType: string) => string;
+  /** Same weighted blend applied to the opacity. */
+  suppressedOpacity: (type: string, suppressionType: string) => number;
   labelSettings: (type: string, set?: boolean) => { showLabel: boolean; showConfidence: boolean };
   annotationSetColor: (set: string) => string;
 }
+
+/** Fraction of the suppression type's styling used for suppressed-display
+ * detections (the remainder comes from the detection's own type). */
+export const SUPPRESSED_STYLE_WEIGHT = 0.5;
 
 interface UseStylingParams {
   markChangesPending: () => void;
@@ -149,20 +158,30 @@ export default class StyleManager {
       if (this.revisionCounter.value) noop();
       const _customStyles = this.customStyles.value;
       const _annotationSetStyles = this.annotationSetStyles.value;
-      return {
-        color: (type: string, set?: boolean) => {
-          if (set && _annotationSetStyles[type] && _annotationSetStyles[type].color) {
-            return _annotationSetStyles[type].color;
-          }
+      const colorFor = (type: string, set?: boolean) => {
+        if (set && _annotationSetStyles[type] && _annotationSetStyles[type].color) {
+          return _annotationSetStyles[type].color;
+        }
 
-          if (_customStyles[type] && _customStyles[type].color) {
-            return _customStyles[type].color;
-          }
-          if (type === '') {
-            return this.typeColors.range()[0];
-          }
-          return this.typeColors(type);
-        },
+        if (_customStyles[type] && _customStyles[type].color) {
+          return _customStyles[type].color;
+        }
+        if (type === '') {
+          return this.typeColors.range()[0];
+        }
+        return this.typeColors(type);
+      };
+      const opacityFor = (type: string, set?: boolean) => {
+        if (set && _annotationSetStyles[type] && _annotationSetStyles[type].opacity) {
+          return _annotationSetStyles[type].opacity;
+        }
+        if (_customStyles[type] && _customStyles[type].opacity) {
+          return _customStyles[type].opacity;
+        }
+        return this.stateStyles.standard.opacity;
+      };
+      return {
+        color: colorFor,
         annotationSetColor: (set: string) => {
           if (!set) {
             return 'white';
@@ -191,15 +210,26 @@ export default class StyleManager {
           }
           return this.stateStyles.standard.fill;
         },
-        opacity: (type: string, set?: boolean) => {
-          if (set && _annotationSetStyles[type] && _annotationSetStyles[type].opacity) {
-            return _annotationSetStyles[type].opacity;
+        opacity: opacityFor,
+        suppressedColor: (type: string, suppressionType: string) => {
+          const supp = d3.color(colorFor(suppressionType));
+          const natural = d3.color(colorFor(type));
+          if (!supp || !natural) {
+            return colorFor(suppressionType);
           }
-          if (_customStyles[type] && _customStyles[type].opacity) {
-            return _customStyles[type].opacity;
-          }
-          return this.stateStyles.standard.opacity;
+          const sr = supp.rgb();
+          const nr = natural.rgb();
+          const w = SUPPRESSED_STYLE_WEIGHT;
+          return d3.rgb(
+            (w * sr.r) + ((1 - w) * nr.r),
+            (w * sr.g) + ((1 - w) * nr.g),
+            (w * sr.b) + ((1 - w) * nr.b),
+          ).hex();
         },
+        suppressedOpacity: (type: string, suppressionType: string) => (
+          (SUPPRESSED_STYLE_WEIGHT * opacityFor(suppressionType))
+          + ((1 - SUPPRESSED_STYLE_WEIGHT) * opacityFor(type))
+        ),
         labelSettings: (type: string, set?: boolean) => {
           let { showLabel, showConfidence } = this.stateStyles.standard;
           if (_customStyles[type]) {

--- a/client/src/StyleManager.ts
+++ b/client/src/StyleManager.ts
@@ -47,7 +47,7 @@ export interface TypeStyling {
 
 /** Fraction of the suppression type's styling used for suppressed-display
  * detections (the remainder comes from the detection's own type). */
-export const SUPPRESSED_STYLE_WEIGHT = 0.5;
+export const SUPPRESSED_STYLE_WEIGHT = 2 / 3;
 
 interface UseStylingParams {
   markChangesPending: () => void;

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -27,6 +27,7 @@ interface VirtualTypeItem {
   color: string;
   checked: boolean;
   isSuppressionType: boolean;
+  suppressionThreshold: number;
 }
 
 export default defineComponent({
@@ -212,8 +213,8 @@ export default defineComponent({
         .map((str) => parseInt(str, 10));
       // Detections suppressed by a region on this frame are dropped so the
       // per-frame type counts read off the interface exclude them, and
-      // attribute-suppressed detections (visible but displayed as the
-      // suppression type) don't count toward their own type either.
+      // attribute-suppressed detections (visible, real type retained) don't
+      // count toward their own type either.
       const suppType = clientSettings.typeSettings.suppressionType;
       const suppressedIds = (trackStore && editRevision >= 0)
         ? getSuppressedTrackIds(
@@ -286,7 +287,7 @@ export default defineComponent({
       if (filterTypesByFrame.value) {
         filteredTypeList = filteredTypeList.filter((item) => frameTrackTypesDeRef.get(item));
       }
-      const { suppressionType } = clientSettings.typeSettings;
+      const { suppressionType, suppressionThreshold } = clientSettings.typeSettings;
       return filteredTypeList.map((item) => ({
         type: item,
         confidenceFilterNum: confidenceFiltersDeRef[item] || 0,
@@ -294,6 +295,7 @@ export default defineComponent({
         color: typeStylingDeRef.color(item),
         checked: checkedTypesDeRef.includes(item),
         isSuppressionType: !!suppressionType && item === suppressionType,
+        suppressionThreshold: suppressionThreshold ?? 99,
       }));
     });
     const headCheckState = computed(() => {
@@ -508,6 +510,7 @@ export default defineComponent({
             :display-max-button="showMaxFrameButton"
             :disabled="disableAnnotationFilters"
             :is-suppression-type="item.isSuppressionType"
+            :suppression-threshold="item.suppressionThreshold"
             @setCheckedTypes="updateCheckedType($event, item.type)"
             @goToMaxFrame="goToPeakTrackFrame($event)"
             @clickEdit="clickEdit"

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -18,7 +18,7 @@ import BaseFilterControls from '../BaseFilterControls';
 import Track from '../track';
 import Group from '../Group';
 import StyleManager from '../StyleManager';
-import { getSuppressedTrackIds } from '../use/suppression';
+import { getSuppressedTrackIds, hasSuppressionAttribute } from '../use/suppression';
 
 interface VirtualTypeItem {
   type: string;
@@ -147,10 +147,11 @@ export default defineComponent({
     }
 
     /**
-     * Ids of tracks whose every keyframe detection is suppressed (a region
-     * covers it on each frame it appears), across all cameras - these are
-     * excluded from the dataset-wide type totals. Reactive to region edits via
-     * the save counter, since track geometry is not itself a reactive value.
+     * Ids of tracks whose every keyframe detection is suppressed - covered by
+     * a region on each frame it appears, or flagged with the suppression
+     * attribute - across all cameras. These are excluded from the
+     * dataset-wide type totals. Reactive to region/attribute edits via the
+     * save counter, since track geometry is not itself a reactive value.
      */
     const fullySuppressedIds = computed(() => {
       const editRevision = pendingSaveCount.value;
@@ -176,7 +177,8 @@ export default defineComponent({
           }
           const keyframes = track.features.filter((f) => f && f.keyframe);
           if (keyframes.length > 0
-            && keyframes.every((f) => suppressedAt(f.frame).has(track.id))) {
+            && keyframes.every((f) => suppressedAt(f.frame).has(track.id)
+              || hasSuppressionAttribute(track, f.frame, suppType))) {
             excluded.add(track.id);
           }
         });
@@ -208,15 +210,22 @@ export default defineComponent({
         .search([frame.value, frame.value])
         .map((str) => parseInt(str, 10));
       // Detections suppressed by a region on this frame are dropped so the
-      // per-frame type counts read off the interface exclude them.
+      // per-frame type counts read off the interface exclude them, and
+      // attribute-suppressed detections (visible but displayed as the
+      // suppression type) don't count toward their own type either.
+      const suppType = clientSettings.typeSettings.suppressionType;
       const suppressedIds = (trackStore && editRevision >= 0)
-        ? getSuppressedTrackIds(trackStore, frame.value, clientSettings.typeSettings.suppressionType)
+        ? getSuppressedTrackIds(trackStore, frame.value, suppType)
         : new Set<number>();
       const filteredKeyFrameTracks = filteredTracksRef.value.filter((track) => {
         if (suppressedIds.has(track.annotation.id)) {
           return false;
         }
-        const keyframe = trackStore?.getPossible(track.annotation.id)?.getFeature(frame.value)[0];
+        const realTrack = trackStore?.getPossible(track.annotation.id);
+        if (realTrack && hasSuppressionAttribute(realTrack, frame.value, suppType)) {
+          return false;
+        }
+        const keyframe = realTrack?.getFeature(frame.value)[0];
         return !!keyframe?.keyframe;
       });
       return (filteredKeyFrameTracks.filter((track) => trackIdsForFrame?.includes(track.annotation.id)));

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -156,6 +156,7 @@ export default defineComponent({
     const fullySuppressedIds = computed(() => {
       const editRevision = pendingSaveCount.value;
       const suppType = clientSettings.typeSettings.suppressionType;
+      const suppThreshold = clientSettings.typeSettings.suppressionThreshold;
       const excluded = new Set<number>();
       if (!suppType || editRevision < 0) {
         return excluded;
@@ -165,7 +166,7 @@ export default defineComponent({
         const suppressedAt = (f: number) => {
           let s = perFrame.get(f);
           if (s === undefined) {
-            s = getSuppressedTrackIds(store, f, suppType);
+            s = getSuppressedTrackIds(store, f, suppType, suppThreshold);
             perFrame.set(f, s);
           }
           return s;
@@ -215,7 +216,12 @@ export default defineComponent({
       // suppression type) don't count toward their own type either.
       const suppType = clientSettings.typeSettings.suppressionType;
       const suppressedIds = (trackStore && editRevision >= 0)
-        ? getSuppressedTrackIds(trackStore, frame.value, suppType)
+        ? getSuppressedTrackIds(
+          trackStore,
+          frame.value,
+          suppType,
+          clientSettings.typeSettings.suppressionThreshold,
+        )
         : new Set<number>();
       const filteredKeyFrameTracks = filteredTracksRef.value.filter((track) => {
         if (suppressedIds.has(track.annotation.id)) {

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -347,9 +347,9 @@ export default defineComponent({
       }
       // Detections lying >=50% under a suppression region on this frame are
       // hidden from every layer at once (and excluded from counts elsewhere).
-      const { suppressionType } = clientSettings.typeSettings;
+      const { suppressionType, suppressionThreshold } = clientSettings.typeSettings;
       const suppressedIds = trackStore
-        ? getSuppressedTrackIds(trackStore, frame, suppressionType)
+        ? getSuppressedTrackIds(trackStore, frame, suppressionType, suppressionThreshold)
         : new Set<AnnotationId>();
       currentFrameIds.forEach(
         (trackId: AnnotationId) => {
@@ -625,8 +625,9 @@ export default defineComponent({
         toRef(props, 'colorBy'),
         selectedCamera,
         selectedKeyRef,
-        // re-render when the suppression-region type is changed
+        // re-render when the suppression-region type or threshold is changed
         () => clientSettings.typeSettings.suppressionType,
+        () => clientSettings.typeSettings.suppressionThreshold,
       ],
       () => {
         refreshLayers();

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -377,7 +377,7 @@ export default defineComponent({
             // A detection flagged with the suppression attribute (it is NOT
             // under a region - those are hidden above) stays visible but
             // displays as suppressed: layers label it 'Type - SuppressionType'
-            // and blend its styling 50/50 with the suppression type. It keeps
+            // and blend its styling 2/3 toward the suppression type. It keeps
             // its real type everywhere else.
             const styleType: [string, number] = colorBy === 'group' ? groupStyleType : trackStyleType;
             const suppressed = (suppressionType

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -45,6 +45,7 @@ import {
   useComparisonSets,
   useLassoModeContext,
   useSegmentationPoints,
+  usePendingSaveCount,
 } from '../provides';
 import SegmentationPointsLayer from '../layers/AnnotationLayers/SegmentationPointsLayer';
 import useLayerManagerAlignedView from './layerManager/useLayerManagerAlignedView';
@@ -113,6 +114,9 @@ export default defineComponent({
     const trackStyleManager = useTrackStyleManager();
     const groupStyleManager = useGroupStyleManager();
     const annotatorPrefs = useAnnotatorPreferences();
+    // Bumped on every annotation edit (including attribute toggles); needed so
+    // attribute-suppressed dashed outlines / tags redraw without a frame change.
+    const pendingSaveCount = usePendingSaveCount();
     const typeStylingRef = computed(() => {
       if (props.colorBy === 'group') {
         return groupStyleManager.typeStyling.value;
@@ -140,10 +144,15 @@ export default defineComponent({
       editingModeRef,
     });
 
+    const showUserCreatedIconRef = computed(() => annotatorPrefs.value.showUserCreatedIcon ?? true);
+    const showSuppressedTagsRef = computed(() => annotatorPrefs.value.showSuppressedTags ?? true);
+    const suppressionDisplayRef = computed(() => annotatorPrefs.value.suppressionDisplay);
+
     const rectAnnotationLayer = new RectangleLayer({
       annotator,
       stateStyling: trackStyleManager.stateStyles,
       typeStyling: typeStylingRef,
+      suppressionDisplay: suppressionDisplayRef,
     });
     const overlapLayer = new OverlapLayer({
       annotator,
@@ -155,6 +164,7 @@ export default defineComponent({
       annotator,
       stateStyling: trackStyleManager.stateStyles,
       typeStyling: typeStylingRef,
+      suppressionDisplay: suppressionDisplayRef,
     });
 
     const lineLayer = new LineLayer({
@@ -173,13 +183,13 @@ export default defineComponent({
       typeStyling: typeStylingRef,
     }, trackStore);
 
-    const showUserCreatedIconRef = computed(() => annotatorPrefs.value.showUserCreatedIcon ?? true);
     const textLayer = new TextLayer({
       annotator,
       stateStyling: trackStyleManager.stateStyles,
       typeStyling: typeStylingRef,
       formatter: props.formatTextRow,
       showUserCreatedIcon: showUserCreatedIconRef,
+      showSuppressedTags: showSuppressedTagsRef,
     });
 
     const attributeBoxLayer = new AttributeBoxLayer({
@@ -379,8 +389,7 @@ export default defineComponent({
             // A detection flagged with the suppression attribute (it is NOT
             // under a region - those are hidden above) stays visible but
             // displays as suppressed: layers label it 'Type - SuppressionType'
-            // and blend its styling 2/3 toward the suppression type. It keeps
-            // its real type everywhere else.
+            // and draw a dashed outline. It keeps its real type everywhere else.
             const styleType: [string, number] = colorBy === 'group' ? groupStyleType : trackStyleType;
             const suppressed = (suppressionType
               && hasSuppressionAttribute(track, frame, suppressionType))
@@ -638,6 +647,8 @@ export default defineComponent({
         // re-render when the suppression-region type or threshold is changed
         () => clientSettings.typeSettings.suppressionType,
         () => clientSettings.typeSettings.suppressionThreshold,
+        // re-render when attributes/geometry change (e.g. suppression attribute toggle)
+        pendingSaveCount,
       ],
       () => {
         refreshLayers();

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -387,9 +387,9 @@ export default defineComponent({
             );
             const groupStyleType = groups?.[0]?.getType() ?? cameraStore.defaultGroup;
             // A detection flagged with the suppression attribute (it is NOT
-            // under a region - those are hidden above) stays visible but
-            // displays as suppressed: layers label it 'Type - SuppressionType'
-            // and draw a dashed outline. It keeps its real type everywhere else.
+            // under a region — those are hidden above) stays visible but is
+            // marked suppressed: optional dashed/fill styling, an eye-off
+            // tag on the canvas label and hover tooltip. Real type is kept.
             const styleType: [string, number] = colorBy === 'group' ? groupStyleType : trackStyleType;
             const suppressed = (suppressionType
               && hasSuppressionAttribute(track, frame, suppressionType))
@@ -732,10 +732,13 @@ export default defineComponent({
             }
           });
           hoveredVals.push({
-            type: item.suppressed
-              ? `${item.styleType[0]} - ${item.suppressed}` : item.styleType[0],
+            // Keep the real type so color lookup stays correct; the tooltip
+            // widget renders an eye-off icon when suppressed is set (same
+            // preference as canvas labels).
+            type: item.styleType[0],
             confidence: item.styleType[1],
             trackId: item.trackId,
+            suppressed: showSuppressedTagsRef.value ? item.suppressed : undefined,
             maxX,
           });
         }

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -21,7 +21,7 @@ import TextLayer, { FormatTextRow } from '../layers/AnnotationLayers/TextLayer';
 import AttributeLayer from '../layers/AnnotationLayers/AttributeLayer';
 import AttributeBoxLayer from '../layers/AnnotationLayers/AttributeBoxLayer';
 import type { AnnotationId } from '../BaseAnnotation';
-import { getSuppressedTrackIds } from '../use/suppression';
+import { getSuppressedTrackIds, hasSuppressionAttribute } from '../use/suppression';
 import { VisibleAnnotationTypes } from '../layers';
 import UILayer from '../layers/UILayers/UILayer';
 import ToolTipWidget from '../layers/UILayers/ToolTipWidget.vue';
@@ -347,8 +347,9 @@ export default defineComponent({
       }
       // Detections lying >=50% under a suppression region on this frame are
       // hidden from every layer at once (and excluded from counts elsewhere).
+      const { suppressionType } = clientSettings.typeSettings;
       const suppressedIds = trackStore
-        ? getSuppressedTrackIds(trackStore, frame, clientSettings.typeSettings.suppressionType)
+        ? getSuppressedTrackIds(trackStore, frame, suppressionType)
         : new Set<AnnotationId>();
       currentFrameIds.forEach(
         (trackId: AnnotationId) => {
@@ -372,6 +373,14 @@ export default defineComponent({
               enabledTracks[enabledIndex].context.confidencePairIndex,
             );
             const groupStyleType = groups?.[0]?.getType() ?? cameraStore.defaultGroup;
+            // A detection flagged with the suppression attribute (outside any
+            // region) keeps its real type but displays as the suppression
+            // type: styleType feeds the color/opacity/fill styling, the text
+            // label, and the hover tooltip of every layer.
+            let styleType: [string, number] = colorBy === 'group' ? groupStyleType : trackStyleType;
+            if (suppressionType && hasSuppressionAttribute(track, frame, suppressionType)) {
+              styleType = [suppressionType, 1];
+            }
             const trackFrame = {
               selected: ((selectedTrackId === track.trackId)
                 || (multiSelectList.includes(track.trackId))),
@@ -379,7 +388,7 @@ export default defineComponent({
               track,
               groups,
               features,
-              styleType: colorBy === 'group' ? groupStyleType : trackStyleType,
+              styleType,
               set: track.set,
             };
             frameData.push(trackFrame);

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -345,8 +345,9 @@ export default defineComponent({
       if (currentFrameIds === undefined) {
         return;
       }
-      // Detections lying >=50% under a suppression region on this frame are
-      // hidden from every layer at once (and excluded from counts elsewhere).
+      // Detections lying under a suppression region on this frame (by at
+      // least the configured overlap) are hidden from every layer at once
+      // (and excluded from counts elsewhere).
       const { suppressionType, suppressionThreshold } = clientSettings.typeSettings;
       const suppressedIds = trackStore
         ? getSuppressedTrackIds(trackStore, frame, suppressionType, suppressionThreshold)
@@ -373,14 +374,15 @@ export default defineComponent({
               enabledTracks[enabledIndex].context.confidencePairIndex,
             );
             const groupStyleType = groups?.[0]?.getType() ?? cameraStore.defaultGroup;
-            // A detection flagged with the suppression attribute (outside any
-            // region) keeps its real type but displays as the suppression
-            // type: styleType feeds the color/opacity/fill styling, the text
-            // label, and the hover tooltip of every layer.
-            let styleType: [string, number] = colorBy === 'group' ? groupStyleType : trackStyleType;
-            if (suppressionType && hasSuppressionAttribute(track, frame, suppressionType)) {
-              styleType = [suppressionType, 1];
-            }
+            // A detection flagged with the suppression attribute (it is NOT
+            // under a region - those are hidden above) stays visible but
+            // displays as suppressed: layers label it 'Type - SuppressionType'
+            // and blend its styling 50/50 with the suppression type. It keeps
+            // its real type everywhere else.
+            const styleType: [string, number] = colorBy === 'group' ? groupStyleType : trackStyleType;
+            const suppressed = (suppressionType
+              && hasSuppressionAttribute(track, frame, suppressionType))
+              ? suppressionType : undefined;
             const trackFrame = {
               selected: ((selectedTrackId === track.trackId)
                 || (multiSelectList.includes(track.trackId))),
@@ -389,6 +391,7 @@ export default defineComponent({
               groups,
               features,
               styleType,
+              suppressed,
               set: track.set,
             };
             frameData.push(trackFrame);
@@ -693,6 +696,7 @@ export default defineComponent({
     const annotationHoverTooltip = (
       found: {
           styleType: [string, number];
+          suppressed?: string;
           trackId: number;
           polygon: { coordinates: Array<Array<[number, number]>>};
         }[],
@@ -710,7 +714,8 @@ export default defineComponent({
             }
           });
           hoveredVals.push({
-            type: item.styleType[0],
+            type: item.suppressed
+              ? `${item.styleType[0]} - ${item.suppressed}` : item.styleType[0],
             confidence: item.styleType[1],
             trackId: item.trackId,
             maxX,

--- a/client/src/components/Tracks/TrackList.vue
+++ b/client/src/components/Tracks/TrackList.vue
@@ -120,7 +120,12 @@ export default defineComponent({
         const suppressCamStore = cameraStore.camMap.value.get(selectedCamera.value)?.trackStore;
         const suppType = clientSettings.typeSettings.suppressionType;
         const suppressedIds = (suppressCamStore && editRevision >= 0)
-          ? getSuppressedTrackIds(suppressCamStore, frameRef.value, suppType)
+          ? getSuppressedTrackIds(
+            suppressCamStore,
+            frameRef.value,
+            suppType,
+            clientSettings.typeSettings.suppressionThreshold,
+          )
           : new Set<number>();
         tracks = tracks.filter((track) => {
           if (suppressedIds.has(track.annotation.id)) {

--- a/client/src/components/TypeItem.vue
+++ b/client/src/components/TypeItem.vue
@@ -44,6 +44,11 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    /** Configured region-overlap percent (0–100]; invalid values fall back to 99. */
+    suppressionThreshold: {
+      type: Number,
+      default: 99,
+    },
   },
   setup(props, { emit }) {
     /* Horizontal padding is the width of checkbox, scrollbar, and edit button */
@@ -54,11 +59,19 @@ export default defineComponent({
       return 42 + 14 + 20 + 30;
     });
     const cssVars = computed(() => ({ '--content-width': `${props.width - HorizontalPadding.value}px` }));
+    const effectiveOverlapPercent = computed(() => {
+      const p = Number(props.suppressionThreshold);
+      if (!Number.isFinite(p) || p <= 0 || p > 100) {
+        return 99;
+      }
+      return p;
+    });
     const goToFrame = () => {
       emit('goToMaxFrame', props.type);
     };
     return {
       cssVars,
+      effectiveOverlapPercent,
       goToFrame,
     };
   },
@@ -134,7 +147,10 @@ export default defineComponent({
               </template>
               <span>
                 This type is used for suppression.
-                Detections lying 50% or more under its regions are hidden and excluded from counts.
+                Detections lying {{ effectiveOverlapPercent }}% or more under its regions
+                are hidden and excluded from counts.
+                Detections with an attribute of this name set true stay visible
+                with their real type and an eye-off tag.
               </span>
             </v-tooltip>
           </div>

--- a/client/src/layers/AnnotationLayers/PolygonLayer.ts
+++ b/client/src/layers/AnnotationLayers/PolygonLayer.ts
@@ -18,7 +18,7 @@ interface PolyGeoJSData{
   styleType: [string, number] | null;
   polygon: GeoJSON.Polygon;
   polygonKey: string;
-  /** Suppression type name when displaying as suppressed (dashed outline) */
+  /** Suppression type name when attribute-flagged as suppressed (dashed/fill styling). */
   suppressed?: string;
   set?: string;
   dashed?: boolean;

--- a/client/src/layers/AnnotationLayers/PolygonLayer.ts
+++ b/client/src/layers/AnnotationLayers/PolygonLayer.ts
@@ -11,6 +11,8 @@ interface PolyGeoJSData{
   styleType: [string, number] | null;
   polygon: GeoJSON.Polygon;
   polygonKey: string;
+  /** Suppression type name when displaying as suppressed (blended style) */
+  suppressed?: string;
   set?: string;
   isHole?: boolean; // True if this is a hole polygon (for styling)
 }
@@ -157,6 +159,7 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
                 styleType: frameData.styleType,
                 polygon,
                 polygonKey,
+                suppressed: frameData.suppressed,
                 set: frameData.set,
                 isHole: false,
               };
@@ -178,6 +181,7 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
                     styleType: frameData.styleType,
                     polygon: holePolygon,
                     polygonKey, // Same key as parent polygon
+                    suppressed: frameData.suppressed,
                     set: frameData.set,
                     isHole: true,
                   };
@@ -224,6 +228,8 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
         let color: string;
         if (data.selected) {
           color = this.stateStyling.selected.color;
+        } else if (data.suppressed && data.styleType) {
+          color = this.typeStyling.value.suppressedColor(data.styleType[0], data.suppressed);
         } else if (data.styleType) {
           color = this.typeStyling.value.color(data.styleType[0]);
         } else {
@@ -247,7 +253,9 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
       },
       fillColor: (_point, _index, data) => {
         let color: string;
-        if (data.styleType) {
+        if (data.suppressed && data.styleType) {
+          color = this.typeStyling.value.suppressedColor(data.styleType[0], data.suppressed);
+        } else if (data.styleType) {
           color = this.typeStyling.value.color(data.styleType[0]);
         } else {
           color = this.typeStyling.value.color('');
@@ -263,6 +271,9 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
         if (data.set) {
           return this.typeStyling.value.opacity(data.set);
         }
+        if (data.suppressed && data.styleType) {
+          return this.typeStyling.value.suppressedOpacity(data.styleType[0], data.suppressed);
+        }
         if (data.styleType) {
           return this.typeStyling.value.opacity(data.styleType[0]);
         }
@@ -271,6 +282,9 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
       strokeOpacity: (_point, _index, data) => {
         if (data.selected) {
           return this.stateStyling.selected.opacity;
+        }
+        if (data.suppressed && data.styleType) {
+          return this.typeStyling.value.suppressedOpacity(data.styleType[0], data.suppressed);
         }
         if (data.styleType) {
           return this.typeStyling.value.opacity(data.styleType[0]);

--- a/client/src/layers/AnnotationLayers/PolygonLayer.ts
+++ b/client/src/layers/AnnotationLayers/PolygonLayer.ts
@@ -1,8 +1,15 @@
 /* eslint-disable class-methods-use-this */
 import geo, { GeoEvent } from 'geojs';
+import { Ref } from 'vue';
 
+import { cloneDeep } from 'lodash';
+import {
+  resolveSuppressionDisplay,
+  SuppressionDisplaySettings,
+} from '../../types';
 import BaseLayer, { LayerStyle, BaseLayerParams } from '../BaseLayer';
 import { FrameDataTrack } from '../LayerTypes';
+import LineLayer from './LineLayer';
 
 interface PolyGeoJSData{
   trackId: number;
@@ -11,10 +18,15 @@ interface PolyGeoJSData{
   styleType: [string, number] | null;
   polygon: GeoJSON.Polygon;
   polygonKey: string;
-  /** Suppression type name when displaying as suppressed (blended style) */
+  /** Suppression type name when displaying as suppressed (dashed outline) */
   suppressed?: string;
   set?: string;
+  dashed?: boolean;
   isHole?: boolean; // True if this is a hole polygon (for styling)
+}
+
+interface PolygonLayerParams extends BaseLayerParams {
+  suppressionDisplay?: Ref<SuppressionDisplaySettings | undefined>;
 }
 
 /**
@@ -41,12 +53,24 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
 
   hoverOn: boolean;
 
-  constructor(params: BaseLayerParams) {
+  suppressionDisplay: Ref<SuppressionDisplaySettings | undefined>;
+
+  constructor(params: PolygonLayerParams) {
     super(params);
     this.drawingOther = true; // Initialized to true in case polygons aren't supported
     //Only initialize once, prevents recreating Layer each edit
     this.hoverOn = false;
+    this.suppressionDisplay = params.suppressionDisplay
+      || ({ value: undefined } as Ref<SuppressionDisplaySettings | undefined>);
     this.initialize();
+  }
+
+  private suppressionStyle() {
+    return resolveSuppressionDisplay(this.suppressionDisplay.value);
+  }
+
+  private styleSuppressed(data: { suppressed?: string }) {
+    return !!(data.suppressed && this.suppressionStyle().enabled);
   }
 
   initialize() {
@@ -148,9 +172,21 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
     frameDataTracks.forEach((frameData: FrameDataTrack) => {
       if (frameData.features && frameData.features.bounds) {
         if (frameData.features.geometry?.features?.[0]) {
+          const suppStyle = this.suppressionStyle();
+          const dashed = !!(frameData.suppressed && suppStyle.enabled && suppStyle.dashed);
+          const width = frameData.features.bounds[2] - frameData.features.bounds[0];
+          const height = frameData.features.bounds[3] - frameData.features.bounds[1];
+          const dashSize = Math.min(width, height) / 20.0;
           frameData.features.geometry.features.forEach((feature) => {
             if (feature.geometry && feature.geometry.type === 'Polygon') {
-              const polygon = feature.geometry;
+              let polygon = feature.geometry as GeoJSON.Polygon;
+              if (dashed) {
+                const temp = cloneDeep(polygon);
+                temp.coordinates = temp.coordinates.map(
+                  (ring) => LineLayer.dashLine(ring, dashSize),
+                );
+                polygon = temp;
+              }
               const polygonKey = feature.properties?.key || '';
               const annotation: PolyGeoJSData = {
                 trackId: frameData.track.id,
@@ -161,6 +197,7 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
                 polygonKey,
                 suppressed: frameData.suppressed,
                 set: frameData.set,
+                dashed,
                 isHole: false,
               };
               arr.push(annotation);
@@ -183,6 +220,7 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
                     polygonKey, // Same key as parent polygon
                     suppressed: frameData.suppressed,
                     set: frameData.set,
+                    dashed,
                     isHole: true,
                   };
                   arr.push(holeAnnotation);
@@ -228,8 +266,6 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
         let color: string;
         if (data.selected) {
           color = this.stateStyling.selected.color;
-        } else if (data.suppressed && data.styleType) {
-          color = this.typeStyling.value.suppressedColor(data.styleType[0], data.suppressed);
         } else if (data.styleType) {
           color = this.typeStyling.value.color(data.styleType[0]);
         } else {
@@ -243,6 +279,9 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
         if (data.isHole) {
           return true;
         }
+        if (this.styleSuppressed(data)) {
+          return this.suppressionStyle().fillOpacity > 0;
+        }
         if (data.set) {
           return this.typeStyling.value.fill(data.set);
         }
@@ -253,8 +292,8 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
       },
       fillColor: (_point, _index, data) => {
         let color: string;
-        if (data.suppressed && data.styleType) {
-          color = this.typeStyling.value.suppressedColor(data.styleType[0], data.suppressed);
+        if (this.styleSuppressed(data) && this.suppressionStyle().fillColor) {
+          color = this.suppressionStyle().fillColor;
         } else if (data.styleType) {
           color = this.typeStyling.value.color(data.styleType[0]);
         } else {
@@ -268,11 +307,11 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
         if (data.isHole) {
           return 0.5;
         }
+        if (this.styleSuppressed(data)) {
+          return this.suppressionStyle().fillOpacity;
+        }
         if (data.set) {
           return this.typeStyling.value.opacity(data.set);
-        }
-        if (data.suppressed && data.styleType) {
-          return this.typeStyling.value.suppressedOpacity(data.styleType[0], data.suppressed);
         }
         if (data.styleType) {
           return this.typeStyling.value.opacity(data.styleType[0]);
@@ -280,11 +319,14 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
         return this.stateStyling.standard.opacity;
       },
       strokeOpacity: (_point, _index, data) => {
+        if (_index % 2 === 1 && data.dashed) {
+          return 0.0;
+        }
         if (data.selected) {
           return this.stateStyling.selected.opacity;
         }
-        if (data.suppressed && data.styleType) {
-          return this.typeStyling.value.suppressedOpacity(data.styleType[0], data.suppressed);
+        if (this.styleSuppressed(data)) {
+          return this.suppressionStyle().outlineOpacity;
         }
         if (data.styleType) {
           return this.typeStyling.value.opacity(data.styleType[0]);

--- a/client/src/layers/AnnotationLayers/RectangleLayer.ts
+++ b/client/src/layers/AnnotationLayers/RectangleLayer.ts
@@ -1,5 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import geo, { GeoEvent } from 'geojs';
+import { Ref } from 'vue';
 
 import { cloneDeep } from 'lodash';
 import {
@@ -9,6 +10,10 @@ import {
   hasSignificantRotation,
   rotateGeoJSONCoordinates,
 } from '../../utils';
+import {
+  resolveSuppressionDisplay,
+  SuppressionDisplaySettings,
+} from '../../types';
 import BaseLayer, { LayerStyle, BaseLayerParams } from '../BaseLayer';
 import { FrameDataTrack } from '../LayerTypes';
 import LineLayer from './LineLayer';
@@ -20,13 +25,17 @@ interface RectGeoJSData{
   styleType: [string, number] | null;
   polygon: GeoJSON.Polygon;
   hasPoly: boolean;
-  /** Suppression type name when displaying as suppressed (blended style) */
+  /** Suppression type name when displaying as suppressed (dashed outline) */
   suppressed?: string;
   set?: string;
   dashed?: boolean;
   rotation?: number;
   /** Small arrow on the right-edge midpoint when rotation is significant */
   rotationArrow?: GeoJSON.LineString | null;
+}
+
+interface RectangleLayerParams extends BaseLayerParams {
+  suppressionDisplay?: Ref<SuppressionDisplaySettings | undefined>;
 }
 
 export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
@@ -44,13 +53,25 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   arrowFeatureLayer: any;
 
-  constructor(params: BaseLayerParams) {
+  suppressionDisplay: Ref<SuppressionDisplaySettings | undefined>;
+
+  constructor(params: RectangleLayerParams) {
     super(params);
     this.drawingOther = false;
     this.hoverOn = false;
     this.clickTargetsOnly = false;
+    this.suppressionDisplay = params.suppressionDisplay
+      || ({ value: undefined } as Ref<SuppressionDisplaySettings | undefined>);
     //Only initialize once, prevents recreating Layer each edit
     this.initialize();
+  }
+
+  private suppressionStyle() {
+    return resolveSuppressionDisplay(this.suppressionDisplay.value);
+  }
+
+  private styleSuppressed(data: { suppressed?: string }) {
+    return !!(data.suppressed && this.suppressionStyle().enabled);
   }
 
   initialize() {
@@ -177,7 +198,13 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
           polygon.coordinates[0] = updatedCoords;
         }
 
-        const dashed = !!(track.set && comparisonSets?.includes(track.set));
+        // Comparison-set tracks and attribute-suppressed detections both use
+        // dashed outlines (odd stroke segments are made transparent below).
+        const suppStyle = this.suppressionStyle();
+        const dashed = !!(
+          (track.suppressed && suppStyle.enabled && suppStyle.dashed)
+          || (track.set && comparisonSets?.includes(track.set))
+        );
         if (dashed) {
           const temp = cloneDeep(polygon);
           const width = track.features.bounds[2] - track.features.bounds[0];
@@ -246,9 +273,6 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
         if (data.selected) {
           return this.stateStyling.selected.color;
         }
-        if (data.suppressed && data.styleType) {
-          return this.typeStyling.value.suppressedColor(data.styleType[0], data.suppressed);
-        }
         if (data.styleType) {
           return this.typeStyling.value.color(data.styleType[0]);
         }
@@ -263,6 +287,9 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
         if (this.drawingOther && data.hasPoly) {
           return false;
         }
+        if (this.styleSuppressed(data)) {
+          return this.suppressionStyle().fillOpacity > 0;
+        }
         if (data.set) {
           return this.typeStyling.value.fill(data.set, true);
         }
@@ -272,11 +299,14 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
         return this.stateStyling.standard.fill;
       },
       fillColor: (_point, _index, data) => {
+        if (this.styleSuppressed(data)) {
+          const { fillColor } = this.suppressionStyle();
+          if (fillColor) {
+            return fillColor;
+          }
+        }
         if (data.set) {
           return this.typeStyling.value.annotationSetColor(data.set);
-        }
-        if (data.suppressed && data.styleType) {
-          return this.typeStyling.value.suppressedColor(data.styleType[0], data.suppressed);
         }
         if (data.styleType) {
           return this.typeStyling.value.color(data.styleType[0]);
@@ -284,11 +314,11 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
         return this.typeStyling.value.color('');
       },
       fillOpacity: (_point, _index, data) => {
+        if (this.styleSuppressed(data)) {
+          return this.suppressionStyle().fillOpacity;
+        }
         if (data.set) {
           return this.typeStyling.value.opacity(data.set, true);
-        }
-        if (data.suppressed && data.styleType) {
-          return this.typeStyling.value.suppressedOpacity(data.styleType[0], data.suppressed);
         }
         if (data.styleType) {
           return this.typeStyling.value.opacity(data.styleType[0]);
@@ -311,8 +341,8 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
         if (data.selected) {
           return this.stateStyling.selected.opacity;
         }
-        if (data.suppressed && data.styleType) {
-          return this.typeStyling.value.suppressedOpacity(data.styleType[0], data.suppressed);
+        if (this.styleSuppressed(data)) {
+          return this.suppressionStyle().outlineOpacity;
         }
         if (data.styleType) {
           return this.typeStyling.value.opacity(data.styleType[0]);

--- a/client/src/layers/AnnotationLayers/RectangleLayer.ts
+++ b/client/src/layers/AnnotationLayers/RectangleLayer.ts
@@ -25,7 +25,7 @@ interface RectGeoJSData{
   styleType: [string, number] | null;
   polygon: GeoJSON.Polygon;
   hasPoly: boolean;
-  /** Suppression type name when displaying as suppressed (dashed outline) */
+  /** Suppression type name when attribute-flagged as suppressed (dashed/fill styling). */
   suppressed?: string;
   set?: string;
   dashed?: boolean;

--- a/client/src/layers/AnnotationLayers/RectangleLayer.ts
+++ b/client/src/layers/AnnotationLayers/RectangleLayer.ts
@@ -20,6 +20,8 @@ interface RectGeoJSData{
   styleType: [string, number] | null;
   polygon: GeoJSON.Polygon;
   hasPoly: boolean;
+  /** Suppression type name when displaying as suppressed (blended style) */
+  suppressed?: string;
   set?: string;
   dashed?: boolean;
   rotation?: number;
@@ -171,6 +173,7 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
           styleType: track.styleType,
           polygon,
           hasPoly,
+          suppressed: track.suppressed,
           set: track.set,
           dashed,
           rotation,
@@ -222,6 +225,9 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
         if (data.selected) {
           return this.stateStyling.selected.color;
         }
+        if (data.suppressed && data.styleType) {
+          return this.typeStyling.value.suppressedColor(data.styleType[0], data.suppressed);
+        }
         if (data.styleType) {
           return this.typeStyling.value.color(data.styleType[0]);
         }
@@ -240,6 +246,9 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
         if (data.set) {
           return this.typeStyling.value.annotationSetColor(data.set);
         }
+        if (data.suppressed && data.styleType) {
+          return this.typeStyling.value.suppressedColor(data.styleType[0], data.suppressed);
+        }
         if (data.styleType) {
           return this.typeStyling.value.color(data.styleType[0]);
         }
@@ -248,6 +257,9 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
       fillOpacity: (_point, _index, data) => {
         if (data.set) {
           return this.typeStyling.value.opacity(data.set, true);
+        }
+        if (data.suppressed && data.styleType) {
+          return this.typeStyling.value.suppressedOpacity(data.styleType[0], data.suppressed);
         }
         if (data.styleType) {
           return this.typeStyling.value.opacity(data.styleType[0]);
@@ -265,6 +277,9 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
         }
         if (data.selected) {
           return this.stateStyling.selected.opacity;
+        }
+        if (data.suppressed && data.styleType) {
+          return this.typeStyling.value.suppressedOpacity(data.styleType[0], data.suppressed);
         }
         if (data.styleType) {
           return this.typeStyling.value.opacity(data.styleType[0]);

--- a/client/src/layers/AnnotationLayers/TextLayer.ts
+++ b/client/src/layers/AnnotationLayers/TextLayer.ts
@@ -7,6 +7,8 @@ export interface TextData {
   selected: boolean;
   editing: boolean | string;
   type: string;
+  /** Suppression type name when displaying as suppressed (blended color) */
+  suppressed?: string;
   confidence: number;
   text: string;
   x: number;
@@ -57,20 +59,24 @@ function defaultFormatter(
       const userCreated = annotation.track.attributes?.userCreated === true;
       // Show pencil icon if detection is userModified OR if track is userCreated, and showUserCreatedIcon is true
       const modifiedIndicator = (showUserCreatedIcon && (userModified || userCreated)) ? ' ✏️' : '';
+      // Suppressed-display detections label as 'Type - SuppressionType'
+      const displayType = annotation.suppressed
+        ? `${type} - ${annotation.suppressed}` : type;
       if (typeStyling) {
         const { showLabel, showConfidence } = typeStyling.labelSettings(type);
         if (showLabel && !showConfidence) {
-          text = type + modifiedIndicator;
+          text = displayType + modifiedIndicator;
         } else if (showConfidence && !showLabel) {
           text = `${confidence.toFixed(2)}${modifiedIndicator}`;
         } else if (showConfidence && showLabel) {
-          text = `${type}: ${confidence.toFixed(2)}${modifiedIndicator}`;
+          text = `${displayType}: ${confidence.toFixed(2)}${modifiedIndicator}`;
         }
       }
       arr.push({
         selected: annotation.selected,
         editing: annotation.editing,
         type: annotation.styleType[0],
+        suppressed: annotation.suppressed,
         confidence,
         text,
         x: bounds[2],
@@ -161,12 +167,21 @@ export default class TextLayer extends BaseLayer<TextData> {
             if (this.stateStyling.disabled.color !== 'type') {
               return this.stateStyling.disabled.color;
             }
+            // Editing some OTHER detection must not strip the suppressed
+            // blend from this one ('editing' is set on every annotation
+            // while any edit is active).
+            if (data.suppressed) {
+              return this.typeStyling.value.suppressedColor(data.type, data.suppressed);
+            }
             return this.typeStyling.value.color(data.type);
           }
           if (data.selected) {
             return this.stateStyling.selected.color;
           }
           return this.typeStyling.value.color(data.type);
+        }
+        if (data.suppressed) {
+          return this.typeStyling.value.suppressedColor(data.type, data.suppressed);
         }
         return this.typeStyling.value.color(data.type);
       },

--- a/client/src/layers/AnnotationLayers/TextLayer.ts
+++ b/client/src/layers/AnnotationLayers/TextLayer.ts
@@ -7,7 +7,7 @@ export interface TextData {
   selected: boolean;
   editing: boolean | string;
   type: string;
-  /** Suppression type name when displaying as suppressed (blended color) */
+  /** Suppression type name when displaying as suppressed (label indicator) */
   suppressed?: string;
   confidence: number;
   text: string;
@@ -19,11 +19,16 @@ export interface TextData {
 }
 
 export type FormatTextRow = (
-  annotation: FrameDataTrack, typeStyling?: TypeStyling, showUserCreatedIcon?: boolean) => TextData[] | null;
+  annotation: FrameDataTrack,
+  typeStyling?: TypeStyling,
+  showUserCreatedIcon?: boolean,
+  showSuppressedTags?: boolean,
+) => TextData[] | null;
 
 interface TextLayerParams {
   formatter?: FormatTextRow;
   showUserCreatedIcon?: Ref<boolean>;
+  showSuppressedTags?: Ref<boolean>;
 }
 
 /**
@@ -36,6 +41,7 @@ function defaultFormatter(
   annotation: FrameDataTrack,
   typeStyling?: TypeStyling,
   showUserCreatedIcon: boolean = true,
+  showSuppressedTags: boolean = true,
 ): TextData[] | null {
   if (annotation.features && annotation.features.bounds) {
     const { bounds } = annotation.features;
@@ -57,19 +63,18 @@ function defaultFormatter(
       let text = '';
       const userModified = annotation.features?.attributes?.userModified === true;
       const userCreated = annotation.track.attributes?.userCreated === true;
-      // Show pencil icon if detection is userModified OR if track is userCreated, and showUserCreatedIcon is true
-      const modifiedIndicator = (showUserCreatedIcon && (userModified || userCreated)) ? ' ✏️' : '';
-      // Suppressed-display detections label as 'Type - SuppressionType'
-      const displayType = annotation.suppressed
-        ? `${type} - ${annotation.suppressed}` : type;
+      // mdi-pencil (U+F03EB) / mdi-eye-off (U+F0209) — rendered via Material Design Icons
+      const modifiedIndicator = (showUserCreatedIcon && (userModified || userCreated))
+        ? ' \u{F03EB}' : '';
+      const suppressedIndicator = (showSuppressedTags && annotation.suppressed) ? ' \u{F0209}' : '';
       if (typeStyling) {
         const { showLabel, showConfidence } = typeStyling.labelSettings(type);
         if (showLabel && !showConfidence) {
-          text = displayType + modifiedIndicator;
+          text = type + suppressedIndicator + modifiedIndicator;
         } else if (showConfidence && !showLabel) {
-          text = `${confidence.toFixed(2)}${modifiedIndicator}`;
+          text = `${confidence.toFixed(2)}${suppressedIndicator}${modifiedIndicator}`;
         } else if (showConfidence && showLabel) {
-          text = `${displayType}: ${confidence.toFixed(2)}${modifiedIndicator}`;
+          text = `${type}${suppressedIndicator}: ${confidence.toFixed(2)}${modifiedIndicator}`;
         }
       }
       arr.push({
@@ -115,9 +120,12 @@ export default class TextLayer extends BaseLayer<TextData> {
 
   showUserCreatedIcon: Ref<boolean>;
 
+  showSuppressedTags: Ref<boolean>;
+
   constructor(params: BaseLayerParams & TextLayerParams) {
     super(params);
     this.showUserCreatedIcon = params.showUserCreatedIcon || { value: true } as Ref<boolean>;
+    this.showSuppressedTags = params.showSuppressedTags || { value: true } as Ref<boolean>;
     this.formatter = params.formatter || defaultFormatter;
   }
 
@@ -136,8 +144,9 @@ export default class TextLayer extends BaseLayer<TextData> {
     const arr = [] as TextData[];
     const typeStyling = this.typeStyling.value;
     const showIcon = this.showUserCreatedIcon.value;
+    const showTags = this.showSuppressedTags.value;
     frameData.forEach((track: FrameDataTrack) => {
-      const formatted = this.formatter(track, typeStyling, showIcon);
+      const formatted = this.formatter(track, typeStyling, showIcon, showTags);
       if (formatted !== null) {
         arr.push(...formatted);
       }
@@ -158,6 +167,8 @@ export default class TextLayer extends BaseLayer<TextData> {
     const baseStyle = super.createStyle();
     return {
       ...baseStyle,
+      // Include MDI so label glyphs (mdi-pencil, mdi-eye-off) render alongside text
+      font: 'bold 16px sans-serif, "Material Design Icons"',
       color: (data) => {
         if (data.set) {
           return this.typeStyling.value.annotationSetColor(data.set);
@@ -167,21 +178,12 @@ export default class TextLayer extends BaseLayer<TextData> {
             if (this.stateStyling.disabled.color !== 'type') {
               return this.stateStyling.disabled.color;
             }
-            // Editing some OTHER detection must not strip the suppressed
-            // blend from this one ('editing' is set on every annotation
-            // while any edit is active).
-            if (data.suppressed) {
-              return this.typeStyling.value.suppressedColor(data.type, data.suppressed);
-            }
             return this.typeStyling.value.color(data.type);
           }
           if (data.selected) {
             return this.stateStyling.selected.color;
           }
           return this.typeStyling.value.color(data.type);
-        }
-        if (data.suppressed) {
-          return this.typeStyling.value.suppressedColor(data.type, data.suppressed);
         }
         return this.typeStyling.value.color(data.type);
       },

--- a/client/src/layers/AnnotationLayers/TextLayer.ts
+++ b/client/src/layers/AnnotationLayers/TextLayer.ts
@@ -7,7 +7,7 @@ export interface TextData {
   selected: boolean;
   editing: boolean | string;
   type: string;
-  /** Suppression type name when displaying as suppressed (label indicator) */
+  /** Suppression type name when attribute-flagged as suppressed (eye-off tag). */
   suppressed?: string;
   confidence: number;
   text: string;

--- a/client/src/layers/LayerTypes.ts
+++ b/client/src/layers/LayerTypes.ts
@@ -21,9 +21,8 @@ export interface FrameDataTrack {
   styleType: [string, number];
 
   /* Suppression type name when the detection displays as suppressed
-   * (under a region or flagged by the suppression attribute): layers
-   * label it 'Type - SuppressionType' and blend styling 80/20 toward
-   * the suppression type. */
+   * (flagged by the suppression attribute): layers label it
+   * 'Type - SuppressionType' and draw a dashed outline. */
   suppressed?: string;
 
   /* The Set if it exists for the Track */

--- a/client/src/layers/LayerTypes.ts
+++ b/client/src/layers/LayerTypes.ts
@@ -20,6 +20,12 @@ export interface FrameDataTrack {
   /* The exact pair to base the style on  */
   styleType: [string, number];
 
+  /* Suppression type name when the detection displays as suppressed
+   * (under a region or flagged by the suppression attribute): layers
+   * label it 'Type - SuppressionType' and blend styling 80/20 toward
+   * the suppression type. */
+  suppressed?: string;
+
   /* The Set if it exists for the Track */
   set?: string;
 

--- a/client/src/layers/LayerTypes.ts
+++ b/client/src/layers/LayerTypes.ts
@@ -20,9 +20,9 @@ export interface FrameDataTrack {
   /* The exact pair to base the style on  */
   styleType: [string, number];
 
-  /* Suppression type name when the detection displays as suppressed
-   * (flagged by the suppression attribute): layers label it
-   * 'Type - SuppressionType' and draw a dashed outline. */
+  /* Suppression type name when the detection is attribute-flagged as
+   * suppressed: layers may draw a dashed/custom fill outline and show an
+   * eye-off tag on the canvas label and hover tooltip. Real type is unchanged. */
   suppressed?: string;
 
   /* The Set if it exists for the Track */

--- a/client/src/layers/UILayers/ToolTipWidget.vue
+++ b/client/src/layers/UILayers/ToolTipWidget.vue
@@ -66,7 +66,16 @@ export default defineComponent({
         >
           █
         </span>
-        <span>{{ `${item.type}:${item.confidence.toFixed(2)}` }}</span>
+        <span>{{ item.type }}</span>
+        <v-icon
+          v-if="item.suppressed"
+          x-small
+          class="mx-1"
+          :title="`Flagged suppressed (${item.suppressed})`"
+        >
+          mdi-eye-off
+        </v-icon>
+        <span>{{ `:${item.confidence.toFixed(2)}` }}</span>
       </div>
     </div>
   </v-card>

--- a/client/src/layers/UILayers/UILayerTypes.ts
+++ b/client/src/layers/UILayers/UILayerTypes.ts
@@ -2,4 +2,6 @@ export interface ToolTipWidgetData {
     type: string;
     confidence: number;
     trackId: number;
+    /** Suppression type name when the detection is attribute-flagged as suppressed. */
+    suppressed?: string;
 }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -42,7 +42,8 @@ export interface AnnotatorPreferences {
   multiBounds?: false | number;
   };
   showUserCreatedIcon?: boolean;
-  /** When true, annotation text labels include an mdi-eye-off icon for suppressed detections. */
+  /** When true, annotation text labels and hover tooltips include an mdi-eye-off icon for attribute-suppressed detections. */
   showSuppressedTags?: boolean;
+  /** Canvas outline/fill styling for attribute-suppressed detections. */
   suppressionDisplay?: SuppressionDisplaySettings;
 }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -3,6 +3,34 @@ export interface Mousetrap {
   handler: () => unknown;
 }
 
+/** Canvas styling for attribute-suppressed detections. */
+export interface SuppressionDisplaySettings {
+  /** When true, apply dashed/fill/opacity styling to suppressed detections. */
+  enabled: boolean;
+  /** Draw a dashed outline instead of a solid one. */
+  dashed: boolean;
+  /** Outline opacity in [0, 1]. */
+  outlineOpacity: number;
+  /** Fill color hex; empty string uses the detection's type color. */
+  fillColor: string;
+  /** Fill opacity in [0, 1]. Fill is drawn when this is > 0. */
+  fillOpacity: number;
+}
+
+export const DEFAULT_SUPPRESSION_DISPLAY: SuppressionDisplaySettings = {
+  enabled: true,
+  dashed: true,
+  outlineOpacity: 1,
+  fillColor: '',
+  fillOpacity: 0.3,
+};
+
+export function resolveSuppressionDisplay(
+  settings?: Partial<SuppressionDisplaySettings> | null,
+): SuppressionDisplaySettings {
+  return { ...DEFAULT_SUPPRESSION_DISPLAY, ...settings };
+}
+
 export interface AnnotatorPreferences {
   trackTails: {
     before: number;
@@ -14,4 +42,7 @@ export interface AnnotatorPreferences {
   multiBounds?: false | number;
   };
   showUserCreatedIcon?: boolean;
+  /** When true, annotation text labels include an mdi-eye-off icon for suppressed detections. */
+  showSuppressedTags?: boolean;
+  suppressionDisplay?: SuppressionDisplaySettings;
 }

--- a/client/src/use/suppression.spec.ts
+++ b/client/src/use/suppression.spec.ts
@@ -1,6 +1,9 @@
 /// <reference types="vitest" />
 import Track, { TrackData } from '../track';
-import { isSuppressedAttributeValue, hasSuppressionAttribute } from './suppression';
+import {
+  isSuppressedAttributeValue, hasSuppressionAttribute,
+  getSuppressedTrackIds, normalizeSuppressionThreshold, DEFAULT_SUPPRESSION_THRESHOLD,
+} from './suppression';
 
 function makeTrack(overrides: Partial<TrackData> = {}): Track {
   return Track.fromJSON({
@@ -99,5 +102,67 @@ describe('hasSuppressionAttribute', () => {
   it('is false for an unflagged detection', () => {
     const track = makeTrack();
     expect(hasSuppressionAttribute(track, 0, 'Suppressed')).toBe(false);
+  });
+});
+
+describe('normalizeSuppressionThreshold', () => {
+  it('converts a valid percent to a fraction', () => {
+    expect(normalizeSuppressionThreshold(95)).toBeCloseTo(0.95, 6);
+    expect(normalizeSuppressionThreshold(50)).toBeCloseTo(0.5, 6);
+    expect(normalizeSuppressionThreshold(100)).toBeCloseTo(1.0, 6);
+    expect(normalizeSuppressionThreshold(1)).toBeCloseTo(0.01, 6);
+  });
+
+  it('falls back to the default for missing or out-of-range values', () => {
+    expect(normalizeSuppressionThreshold(undefined)).toBe(DEFAULT_SUPPRESSION_THRESHOLD);
+    expect(normalizeSuppressionThreshold(0)).toBe(DEFAULT_SUPPRESSION_THRESHOLD);
+    expect(normalizeSuppressionThreshold(-5)).toBe(DEFAULT_SUPPRESSION_THRESHOLD);
+    expect(normalizeSuppressionThreshold(150)).toBe(DEFAULT_SUPPRESSION_THRESHOLD);
+    expect(normalizeSuppressionThreshold(NaN)).toBe(DEFAULT_SUPPRESSION_THRESHOLD);
+  });
+});
+
+describe('getSuppressedTrackIds threshold', () => {
+  function makeStore(tracks: Track[]) {
+    return {
+      intervalTree: {
+        search: () => tracks.map((t) => String(t.id)),
+      },
+      getPossible: (id: number) => tracks.find((t) => t.id === id),
+    } as unknown as Parameters<typeof getSuppressedTrackIds>[0];
+  }
+  // A 100x100 region and a detection half-covered by it (x in [50, 150))
+  const region = makeTrack({
+    id: 1,
+    confidencePairs: [['Suppressed', 1]],
+    features: [{
+      frame: 0, bounds: [0, 0, 100, 100], keyframe: true, interpolate: false,
+    }],
+  });
+  const halfCovered = makeTrack({
+    id: 2,
+    features: [{
+      frame: 0, bounds: [50, 0, 150, 100], keyframe: true, interpolate: false,
+    }],
+  });
+  const fullyCovered = makeTrack({
+    id: 3,
+    features: [{
+      frame: 0, bounds: [10, 10, 90, 90], keyframe: true, interpolate: false,
+    }],
+  });
+  const store = makeStore([region, halfCovered, fullyCovered]);
+
+  it('at the default (95%) only the fully covered detection is suppressed', () => {
+    expect(getSuppressedTrackIds(store, 0, 'Suppressed')).toEqual(new Set([3]));
+  });
+
+  it('a lower threshold also suppresses the half-covered detection', () => {
+    expect(getSuppressedTrackIds(store, 0, 'Suppressed', 50)).toEqual(new Set([2, 3]));
+  });
+
+  it('out-of-range thresholds fall back to the default', () => {
+    expect(getSuppressedTrackIds(store, 0, 'Suppressed', 0)).toEqual(new Set([3]));
+    expect(getSuppressedTrackIds(store, 0, 'Suppressed', 200)).toEqual(new Set([3]));
   });
 });

--- a/client/src/use/suppression.spec.ts
+++ b/client/src/use/suppression.spec.ts
@@ -153,7 +153,7 @@ describe('getSuppressedTrackIds threshold', () => {
   });
   const store = makeStore([region, halfCovered, fullyCovered]);
 
-  it('at the default (95%) only the fully covered detection is suppressed', () => {
+  it('at the default (99%) only the fully covered detection is suppressed', () => {
     expect(getSuppressedTrackIds(store, 0, 'Suppressed')).toEqual(new Set([3]));
   });
 

--- a/client/src/use/suppression.spec.ts
+++ b/client/src/use/suppression.spec.ts
@@ -1,0 +1,103 @@
+/// <reference types="vitest" />
+import Track, { TrackData } from '../track';
+import { isSuppressedAttributeValue, hasSuppressionAttribute } from './suppression';
+
+function makeTrack(overrides: Partial<TrackData> = {}): Track {
+  return Track.fromJSON({
+    attributes: {},
+    begin: 0,
+    end: 0,
+    confidencePairs: [['seal', 0.9]],
+    features: [
+      {
+        frame: 0,
+        bounds: [0, 0, 10, 10],
+        keyframe: true,
+        interpolate: false,
+      },
+    ],
+    meta: {},
+    id: 1,
+    ...overrides,
+  });
+}
+
+describe('isSuppressedAttributeValue', () => {
+  it('accepts common truthy flag spellings', () => {
+    expect(isSuppressedAttributeValue(true)).toBe(true);
+    expect(isSuppressedAttributeValue(1)).toBe(true);
+    expect(isSuppressedAttributeValue('true')).toBe(true);
+    expect(isSuppressedAttributeValue('True')).toBe(true);
+    expect(isSuppressedAttributeValue('ON')).toBe(true);
+    expect(isSuppressedAttributeValue('yes')).toBe(true);
+    expect(isSuppressedAttributeValue(' 1 ')).toBe(true);
+  });
+
+  it('rejects falsy or unrelated values', () => {
+    expect(isSuppressedAttributeValue(false)).toBe(false);
+    expect(isSuppressedAttributeValue(0)).toBe(false);
+    expect(isSuppressedAttributeValue('false')).toBe(false);
+    expect(isSuppressedAttributeValue('off')).toBe(false);
+    expect(isSuppressedAttributeValue('')).toBe(false);
+    expect(isSuppressedAttributeValue(undefined)).toBe(false);
+    expect(isSuppressedAttributeValue(null)).toBe(false);
+    expect(isSuppressedAttributeValue({})).toBe(false);
+  });
+});
+
+describe('hasSuppressionAttribute', () => {
+  it('is disabled when no suppression type is configured', () => {
+    const track = makeTrack({ attributes: { Suppressed: true } });
+    expect(hasSuppressionAttribute(track, 0, undefined)).toBe(false);
+    expect(hasSuppressionAttribute(track, 0, '')).toBe(false);
+  });
+
+  it('reads a track-level attribute named after the suppression type', () => {
+    const track = makeTrack({ attributes: { Suppressed: true } });
+    expect(hasSuppressionAttribute(track, 0, 'Suppressed')).toBe(true);
+    expect(hasSuppressionAttribute(track, 0, 'OtherName')).toBe(false);
+  });
+
+  it('reads a detection-level attribute on the frame', () => {
+    const track = makeTrack({
+      features: [
+        {
+          frame: 0,
+          bounds: [0, 0, 10, 10],
+          keyframe: true,
+          interpolate: false,
+          attributes: { Suppressed: 'true' },
+        },
+      ],
+    });
+    expect(hasSuppressionAttribute(track, 0, 'Suppressed')).toBe(true);
+  });
+
+  it('falls back to the previous keyframe on interpolated frames', () => {
+    const track = makeTrack({
+      begin: 0,
+      end: 10,
+      features: [
+        {
+          frame: 0,
+          bounds: [0, 0, 10, 10],
+          keyframe: true,
+          interpolate: true,
+          attributes: { Suppressed: true },
+        },
+        {
+          frame: 10,
+          bounds: [10, 10, 20, 20],
+          keyframe: true,
+          interpolate: true,
+        },
+      ],
+    });
+    expect(hasSuppressionAttribute(track, 5, 'Suppressed')).toBe(true);
+  });
+
+  it('is false for an unflagged detection', () => {
+    const track = makeTrack();
+    expect(hasSuppressionAttribute(track, 0, 'Suppressed')).toBe(false);
+  });
+});

--- a/client/src/use/suppression.ts
+++ b/client/src/use/suppression.ts
@@ -4,7 +4,7 @@
  * A "suppression region" is an annotation whose type matches the configured
  * suppression type (clientSettings.typeSettings.suppressionType). Any detection
  * whose geometry lies at least the configured overlap threshold
- * (clientSettings.typeSettings.suppressionThreshold, default 95%) under one
+ * (clientSettings.typeSettings.suppressionThreshold, default 99%) under one
  * or more suppression regions on a given frame is treated as suppressed: it
  * is hidden from the canvas and excluded from type/track/detection counts.
  *
@@ -20,11 +20,11 @@ import type BaseAnnotationStore from 'vue-media-annotator/BaseAnnotationStore';
 import type Track from 'vue-media-annotator/track';
 import type { Feature } from 'vue-media-annotator/track';
 
-export const DEFAULT_SUPPRESSION_THRESHOLD = 0.95;
+export const DEFAULT_SUPPRESSION_THRESHOLD = 0.99;
 
 /**
  * Normalize the stored suppression-overlap setting (a percent, 0-100) to a
- * fraction, falling back to the default (95%) for missing or out-of-range
+ * fraction, falling back to the default (99%) for missing or out-of-range
  * values.
  */
 export function normalizeSuppressionThreshold(percent: number | undefined): number {
@@ -40,7 +40,7 @@ type Rect = [number, number, number, number];
 interface Shape { poly?: Pt[]; bbox: Rect }
 
 // Sampling resolution used to estimate the covered-area fraction. 16x16
-// keeps the per-frame cost low; at a 95% threshold it resolves the covered
+// keeps the per-frame cost low; at a 99% threshold it resolves the covered
 // fraction to ~0.4% granularity on typical detections.
 const GRID = 16;
 
@@ -147,7 +147,7 @@ export function hasSuppressionAttribute(
  * Track ids whose detection on `frame` is suppressed by a region on that frame.
  * Empty when suppressionType is falsy (feature disabled) or no regions exist.
  * `thresholdPercent` is the minimum covered fraction as a percent (0-100];
- * missing or out-of-range values fall back to the default (95%).
+ * missing or out-of-range values fall back to the default (99%).
  */
 export function getSuppressedTrackIds(
   trackStore: BaseAnnotationStore<Track>,

--- a/client/src/use/suppression.ts
+++ b/client/src/use/suppression.ts
@@ -96,6 +96,39 @@ function overlapFraction(det: Shape, regions: Shape[]): number {
 }
 
 /**
+ * Loose truthiness for a suppression attribute value set by a user or
+ * pipeline: true, a nonzero number, or 'true'/'yes'/'on'/'1' (any case).
+ */
+export function isSuppressedAttributeValue(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') {
+    return ['true', 'yes', 'on', '1'].includes(value.trim().toLowerCase());
+  }
+  return false;
+}
+
+/**
+ * True when the detection carries the suppression attribute: an attribute
+ * named after the suppression type, set on the track or on its detection at
+ * `frame` (falling back to the previous keyframe when the frame is
+ * interpolated). Unlike region suppression this is display-only: the
+ * detection stays visible but is styled, labeled, and counted as the
+ * suppression type instead of its own.
+ */
+export function hasSuppressionAttribute(
+  track: Track,
+  frame: number,
+  suppressionType: string | undefined,
+): boolean {
+  if (!suppressionType) return false;
+  if (isSuppressedAttributeValue(track.attributes?.[suppressionType])) return true;
+  const [real, lower] = track.getFeature(frame);
+  const feature = real?.attributes ? real : lower;
+  return isSuppressedAttributeValue(feature?.attributes?.[suppressionType]);
+}
+
+/**
  * Track ids whose detection on `frame` is suppressed by a region on that frame.
  * Empty when suppressionType is falsy (feature disabled) or no regions exist.
  */

--- a/client/src/use/suppression.ts
+++ b/client/src/use/suppression.ts
@@ -3,9 +3,10 @@
  *
  * A "suppression region" is an annotation whose type matches the configured
  * suppression type (clientSettings.typeSettings.suppressionType). Any detection
- * whose geometry lies at least SUPPRESSION_THRESHOLD (50%) under one or more
- * suppression regions on a given frame is treated as suppressed: it is hidden
- * from the canvas and excluded from type/track/detection counts.
+ * whose geometry lies at least the configured overlap threshold
+ * (clientSettings.typeSettings.suppressionThreshold, default 95%) under one
+ * or more suppression regions on a given frame is treated as suppressed: it
+ * is hidden from the canvas and excluded from type/track/detection counts.
  *
  * Overlap uses whichever geometry each side actually has: the region's polygon
  * if it has one, else its bounding box; likewise for the detection. The overlap
@@ -19,14 +20,28 @@ import type BaseAnnotationStore from 'vue-media-annotator/BaseAnnotationStore';
 import type Track from 'vue-media-annotator/track';
 import type { Feature } from 'vue-media-annotator/track';
 
-export const SUPPRESSION_THRESHOLD = 0.5;
+export const DEFAULT_SUPPRESSION_THRESHOLD = 0.95;
+
+/**
+ * Normalize the stored suppression-overlap setting (a percent, 0-100) to a
+ * fraction, falling back to the default (95%) for missing or out-of-range
+ * values.
+ */
+export function normalizeSuppressionThreshold(percent: number | undefined): number {
+  const p = Number(percent);
+  if (!Number.isFinite(p) || p <= 0 || p > 100) {
+    return DEFAULT_SUPPRESSION_THRESHOLD;
+  }
+  return p / 100;
+}
 
 type Pt = [number, number];
 type Rect = [number, number, number, number];
 interface Shape { poly?: Pt[]; bbox: Rect }
 
-// Sampling resolution used to estimate the covered-area fraction. 16x16 is
-// plenty for a 50% threshold and keeps the per-frame cost low.
+// Sampling resolution used to estimate the covered-area fraction. 16x16
+// keeps the per-frame cost low; at a 95% threshold it resolves the covered
+// fraction to ~0.4% granularity on typical detections.
 const GRID = 16;
 
 function bboxOfPoly(poly: Pt[]): Rect {
@@ -131,14 +146,18 @@ export function hasSuppressionAttribute(
 /**
  * Track ids whose detection on `frame` is suppressed by a region on that frame.
  * Empty when suppressionType is falsy (feature disabled) or no regions exist.
+ * `thresholdPercent` is the minimum covered fraction as a percent (0-100];
+ * missing or out-of-range values fall back to the default (95%).
  */
 export function getSuppressedTrackIds(
   trackStore: BaseAnnotationStore<Track>,
   frame: number,
   suppressionType: string | undefined,
+  thresholdPercent?: number,
 ): Set<AnnotationId> {
   const result = new Set<AnnotationId>();
   if (!suppressionType) return result;
+  const threshold = normalizeSuppressionThreshold(thresholdPercent);
   const ids = trackStore.intervalTree.search([frame, frame])
     .map((s: string) => parseInt(s, 10));
   if (ids.length === 0) return result;
@@ -159,7 +178,7 @@ export function getSuppressedTrackIds(
   if (regions.length === 0) return result;
 
   candidates.forEach(({ id, shape }) => {
-    if (overlapFraction(shape, regions) >= SUPPRESSION_THRESHOLD) {
+    if (overlapFraction(shape, regions) >= threshold) {
       result.add(id);
     }
   });

--- a/client/src/use/suppression.ts
+++ b/client/src/use/suppression.ts
@@ -1,5 +1,5 @@
 /**
- * Suppression regions.
+ * Suppression regions and attribute-flagged suppression.
  *
  * A "suppression region" is an annotation whose type matches the configured
  * suppression type (clientSettings.typeSettings.suppressionType). Any detection
@@ -7,6 +7,12 @@
  * (clientSettings.typeSettings.suppressionThreshold, default 99%) under one
  * or more suppression regions on a given frame is treated as suppressed: it
  * is hidden from the canvas and excluded from type/track/detection counts.
+ *
+ * Separately, a detection may carry an attribute named after the suppression
+ * type (track- or detection-level). That flag is display-only: the detection
+ * stays visible with its real type, may get dashed/fill styling and an
+ * eye-off tag, and is excluded from its own type's counts (it is not credited
+ * to the suppression type either).
  *
  * Overlap uses whichever geometry each side actually has: the region's polygon
  * if it has one, else its bounding box; likewise for the detection. The overlap
@@ -128,8 +134,8 @@ export function isSuppressedAttributeValue(value: unknown): boolean {
  * named after the suppression type, set on the track or on its detection at
  * `frame` (falling back to the previous keyframe when the frame is
  * interpolated). Unlike region suppression this is display-only: the
- * detection stays visible but is styled, labeled, and counted as the
- * suppression type instead of its own.
+ * detection stays visible with its real type (optional dashed/fill styling
+ * and an eye-off tag) and is excluded from its own type's counts.
  */
 export function hasSuppressionAttribute(
   track: Track,

--- a/docs/Annotation-User-Interface-Overview.md
+++ b/docs/Annotation-User-Interface-Overview.md
@@ -6,10 +6,11 @@ This documentation section provides a reference guide to the annotation interfac
 
 * **[Navigation and Editing Bar](UI-Navigation-Editing-Bar.md)** - Controls to return back to browser as well as perform higher level functions such as running pipelines. Save Button.  Controls the viewing of annotations on screen and allows for the editing/creation of annotations.
 * **[Annotation View](UI-Annotation-View.md)** - where the image/video is displayed as well as all annotations
-* **[Type List](UI-Type-List.md)** - A list of all the types of tracks/detections on the page that can be used to filter the current view.
+* **[Type List](UI-Type-List.md)** - A list of all the types of tracks/detections on the page that can be used to filter the current view. Type settings also configure [suppression](UI-Suppression.md).
 * **[Track List](UI-Track-List.md)** - List of all the tracks as well as providing a way to perform editing functions on those tracks.
 * **[Timeline](UI-Timeline.md)** - timeline view of tracks and detections, as well as an interface to control the current frame along the video/image-sequence
 * **[Attributes](UI-Attributes.md)** - Attributes panel used to assign attributes to individual tracks or detections.
+* **[Suppression](UI-Suppression.md)** - Hide detections under ignore regions, or flag them with a suppression attribute and optional display styling.
 * **[Interactive Annotation](Interactive-Annotation.md)** (Desktop) - Point-click segmentation and interactive stereo tools for faster polygon and multicam annotation.
 * **Context Sidebar** - Open from the [editing bar](UI-Navigation-Editing-Bar.md#context-sidebar-web) (Web). The right sidebar has several view modes selected from a dropdown at the top of the panel.
     * **[Dataset Info](UI-DatasetInfo.md)** - View dataset properties and attach custom dataset-level metadata that is shown while annotating and included in CSV export.

--- a/docs/UI-Annotation-View.md
+++ b/docs/UI-Annotation-View.md
@@ -27,3 +27,5 @@ The annotation window will look different based on the current mode and what vis
 * **Interpolated Annotation** - If a track has an interpolated box on the current frame it will appear slightly faded.
     
     ![Interpolated Editing](images/InterpolatedEditing.png)
+
+* **Suppressed Annotation** - When [suppression](UI-Suppression.md) is configured, detections covered by a suppression region are hidden. Detections flagged with the suppression attribute stay visible with their real type and may show dashed/fill styling and an ==:material-eye-off:== tag (controlled from the visibility menu).

--- a/docs/UI-Attributes.md
+++ b/docs/UI-Attributes.md
@@ -88,6 +88,10 @@ Click the ==:material-cog:== button next to an existing attribute to edit its de
 1. Or directly edit the value field when in the attribute editing mode
 1. Setting an attribute to the empty value will remove the value from the track/detection
 
+### Suppression attributes
+
+If [suppression](UI-Suppression.md) is enabled, an attribute whose **name matches the Suppression Region Type** (default `Suppressed`) marks a detection or track as attribute-suppressed when set to a truthy value (`true`, `1`, `yes`, `on`, or a nonzero number). The detection stays visible with its real type, can show dashed/fill styling and an eye-off tag, and is excluded from its own type's counts. Create a Boolean track or detection attribute with that name to edit the flag in this panel.
+
 ## Importing and Exporting Attributes
 
 Attributes are part of the dataset configuration that can be imported and exported.

--- a/docs/UI-Navigation-Editing-Bar.md
+++ b/docs/UI-Navigation-Editing-Bar.md
@@ -67,5 +67,8 @@ The **:material-eye: visibility** section contains toggle buttons that control t
 * ==:material-vector-polygon:== toggles **polygon** visibility
 * ==:material-vector-line:== toggles **head/tail line** visibility
 * ==:material-format-text:== toggles annotation type & confidence **text** visibility
+    * **Show user created/modified** — when text is on, optionally show a pencil glyph on annotations you created or edited.
+    * **Show suppressed tags** — when text is on, show an ==:material-eye-off:== glyph on [attribute-suppressed](UI-Suppression.md#attribute-suppression) detections in labels and hover tooltips.
 * ==:material-comment-text-outline:== toggles a **cursor hover tooltip**, helpful for reviewing very dense scenes with lots of overlap.
 * ==:material-navigation:== toggles **track trail** visibility.  The track trail is configurable to show up to 100 frames both ahead and behind each bounding box.  The trail line is made of bounding box midpoints.
+* ==:material-eye-off:== toggles **suppression** styling for attribute-suppressed detections (dashed outline, outline/fill opacity, optional fill color). Region-suppressed detections stay hidden regardless. See [Suppression](UI-Suppression.md#visibility-and-styling).

--- a/docs/UI-Suppression.md
+++ b/docs/UI-Suppression.md
@@ -1,0 +1,56 @@
+# Suppression
+
+Suppression helps review dense scenes by marking detections that should not count toward type totals — for example, animals under ice sheets or other occlusions. Configure it from the [Type List](UI-Type-List.md) settings menu, then optionally tune how attribute-flagged detections look in the [visibility](UI-Navigation-Editing-Bar.md#visibility-toggles) controls.
+
+There are two related mechanisms. Both require a **Suppression Region Type** to be set; leave that field empty to disable suppression entirely. The default type name is `Suppressed`.
+
+## Region suppression
+
+Draw or import annotations whose type matches the configured **Suppression Region Type**. On each frame, any other detection whose geometry lies at least the **Suppression Overlap (%)** under one or more of those regions is treated as region-suppressed:
+
+* It is **hidden** from the annotation canvas.
+* It is **excluded** from type counts and from the track list for that frame.
+* Tracks whose every keyframe detection is region-suppressed (or attribute-flagged) are dropped from type counts entirely.
+
+Overlap uses whichever geometry each side actually has: the region's polygon if present, otherwise its bounding box; likewise for the detection. The covered fraction is estimated by point sampling so concave or warped region polygons work without special handling.
+
+### Configuring region suppression
+
+1. Open the [Type List](UI-Type-List.md) and click ==:material-cog:==.
+1. Set **Suppression Region Type** to the type used for occlusion / ignore regions (or clear it to disable).
+1. Set **Suppression Overlap (%)** to the minimum covered percent required to hide a detection (default **99**). Lower values suppress more aggressively.
+
+The suppression type shows an ==:material-eye-off:== icon in the type list. Hover it for a short reminder of the overlap threshold and attribute behavior.
+
+## Attribute suppression
+
+Separately, a detection (or its track) may carry an [attribute](UI-Attributes.md) **named after the suppression type** (for example `Suppressed`) set to a truthy value (`true`, `1`, `yes`, `on`, or a nonzero number). That flag is **display-only**:
+
+* The detection **stays visible** and keeps its real type (it is not reclassified as the suppression type).
+* It is **excluded from its own type's counts** (and is not credited to the suppression type either).
+* Optional canvas styling and an eye-off tag can mark it as suppressed (see below).
+
+Attribute values can be set manually in the Attributes panel or come from pipeline / CSV import. Create a track- or detection-level attribute definition whose name matches the suppression type if you want to edit the flag in the UI.
+
+!!! tip
+
+    Region suppression **hides** detections under regions. Attribute suppression **keeps them visible** with a visual cue. Use regions when geometry should decide; use the attribute when a pipeline or reviewer has already labeled a detection as suppressed without covering it with a region.
+
+## Visibility and styling
+
+Open the **:material-eye: Visibility** menu on the [editing bar](UI-Navigation-Editing-Bar.md#visibility-toggles).
+
+### Show suppressed tags
+
+Under the text visibility option, **Show suppressed tags** adds an ==:material-eye-off:== glyph next to attribute-suppressed detections in canvas labels and hover tooltips.
+
+### Suppression styling
+
+Enable **Suppression** (==:material-eye-off:==) to apply outline/fill styling to attribute-suppressed detections. When enabled you can adjust:
+
+* **Dashed outline** — draw a dashed border instead of a solid one (on by default).
+* **Outline opacity** — fade the border.
+* **Fill color** — optional fill hex; leave at the default picker value when you want the detection's type color.
+* **Fill opacity** — fill strength (default 30%). Set to 0 for outline-only.
+
+These controls affect attribute-suppressed detections only. Region-suppressed detections remain hidden regardless of this menu.

--- a/docs/UI-Track-List.md
+++ b/docs/UI-Track-List.md
@@ -12,6 +12,8 @@ The track list allows for selecting and editing tracks.  A selected track will l
 * ==:material-delete:=={ .error } deletes all tracks in the track list
 * ==:material-plus: Track/Detection== begins creation of a new annotation.
 
+When [suppression](UI-Suppression.md) is enabled, detections covered by a suppression region on the current frame are omitted from this list (attribute-flagged detections remain listed).
+
 <div style="clear: both;"/>
 
 ## Single Detection

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -58,3 +58,14 @@ In locked mode, only a specified list of classes can be used, and must be select
 
 * Set **Lock Types** to on to constrain annotation types to those already defined.
 * You can add new types using the ==:material-plus: Types== button under type settings.
+
+<div style="clear: both;"/>
+
+### Suppression
+
+Type settings also configure [suppression](UI-Suppression.md):
+
+* **Suppression Region Type** — annotations of this type act as ignore / occlusion regions. Detections covered by at least the overlap threshold are hidden and excluded from counts. Clear the field to disable suppression. Defaults to `Suppressed`.
+* **Suppression Overlap (%)** — minimum percent of a detection that must lie under suppression regions for it to be hidden (default **99**). Shown only when a suppression type is set.
+
+The active suppression type shows an ==:material-eye-off:== icon in the type list. Detections may also be flagged with an attribute of the same name; see [Suppression](UI-Suppression.md) for region vs attribute behavior and display options.

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,3 +76,5 @@ Manual refinement of auto-generated annotations | ✔️ | ✔️
 **Interpolation** - The implicit bounding boxes between keyframes in a track.
 
 **Attributes** - Attributes are free-form secondary characteristics on both tracks and detections. For example, a `fish` type track may have an `is_adult` boolean attribute.
+
+**Suppression** - A review feature that hides detections under configured ignore regions, or visually flags detections that carry a suppression attribute, while excluding them from type counts. See [Suppression](UI-Suppression.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
         - Attributes Configuration: UI-AttributeConfiguration.md
         - Attributes Details: UI-AttributeDetails.md
         - Attribute Track Filtering: UI-AttributeTrackFiltering.md
+      - Suppression: UI-Suppression.md
       - Group Manager: UI-Group-Manager.md
       - Dataset Info: UI-DatasetInfo.md
       - Image Enhancements: UI-Image-Enhancements.md


### PR DESCRIPTION
## Behavior

Suppression regions (#1760) hide detections lying under a region. A detection can also be marked suppressed by an *attribute* — an attribute named after the suppression type ("Suppressed" by default) set true by a pipeline or user — while sitting outside any region. Previously such a detection displayed as its normal type and counted normally, with nothing indicating its suppressed status.

A detection carrying the suppression attribute (on the track, or on the detection at the current frame) is now treated as a display-only special case:

- **Stays visible** (region suppression is unchanged: detections under a region are still hidden).
- **Real type preserved**: canvas label, hover tooltip, and details panel all keep the actual type (editable). The attribute only marks display/counts, never the stored type.
- **Eye-off tag**: canvas text labels and hover tooltips can show an `mdi-eye-off` icon next to the type (Annotation Visibility → "Show suppressed tags").
- **Configurable styling** (Annotation Visibility → Suppression): dashed outline, outline opacity, fill color, and fill opacity. Disabled styling still leaves the detection visible with its normal type color.
- **Doesn't count toward its own type**: excluded from the type list's dataset totals and per-frame counts. Not credited to the suppression type either, and never appears as a composite type-list category.

## Also included

- The suppression-region overlap threshold is configurable (Type Settings → "Suppression Overlap %"), defaulting to **99%**.
- Recognized attribute values: `true`, nonzero numbers, and `'true'` / `'yes'` / `'on'` / `'1'` in any case. On interpolated frames the check falls back to the previous keyframe's detection attributes.
- Unit tests cover attribute parsing, threshold normalization and behavior.