### PR TITLE
Stereo Import menu: hide registration section, align Warp to All, interactive-stereo warp

### DIFF
--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -529,22 +529,38 @@ export default defineComponent({
                 </template>
               </v-combobox>
             </v-row>
-            <v-row align="start">
+            <v-row
+              class="flex-nowrap"
+              align="center"
+            >
               <v-checkbox
                 :input-value="!additive"
                 label="Overwrite"
                 class="mt-2"
+                dense
+                hide-details
                 @change="additive = !$event"
               />
-              <v-checkbox
+              <v-tooltip
                 v-if="isMulticamDataset"
-                v-model="warpToAllCameras"
-                :disabled="!canWarpToAllCameras"
-                label="Warp to All"
-                :hint="warpToAllCamerasHint"
-                persistent-hint
-                class="mt-2 ml-4"
-              />
+                bottom
+                :disabled="!warpToAllCamerasHint"
+                open-delay="200"
+              >
+                <template #activator="{ on }">
+                  <div v-on="on">
+                    <v-checkbox
+                      v-model="warpToAllCameras"
+                      :disabled="!canWarpToAllCameras"
+                      label="Warp to All"
+                      class="mt-2 ml-2"
+                      dense
+                      hide-details
+                    />
+                  </div>
+                </template>
+                <span>{{ warpToAllCamerasHint }}</span>
+              </v-tooltip>
             </v-row>
             <div v-if="additive">
               <div

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -85,10 +85,12 @@ export default defineComponent({
       () => !!api.importCalibrationFile && props.subType === 'stereo',
     );
     // Camera registration import (per-camera transform files) is meaningful
-    // for any multicam dataset.
+    // for multicam datasets; stereo rigs use the calibration (camera file)
+    // import instead, so the registration section is hidden there.
     const cameraRegistration = useCameraRegistration();
     const registrationSupported = computed(
-      () => !!api.importCameraRegistration && isMulticamDataset.value,
+      () => !!api.importCameraRegistration && isMulticamDataset.value
+        && props.subType !== 'stereo',
     );
     // One import button per non-reference camera pair, labeled in the
     // direction of the mapping -- "Import ir → eo" registers ir onto the

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 import { useApi } from 'dive-common/apispec';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
-import { clientSettings } from 'dive-common/store/settings';
+import { clientSettings, isStereoInteractiveModeEnabled } from 'dive-common/store/settings';
 import clearLengthAttributes from 'dive-common/utils/clearLengthAttributes';
 import warpAnnotationsAcrossCameras from 'dive-common/utils/warpAnnotationsAcrossCameras';
 import { cloneDeep } from 'lodash';
@@ -47,7 +47,7 @@ export default defineComponent({
       default: false,
     },
   },
-  emits: ['calibration-imported'],
+  emits: ['calibration-imported', 'stereo-warp-imported'],
   setup(props, { emit }) {
     const api = useApi();
     const { openFromDisk, importAnnotationFile } = api;
@@ -57,13 +57,35 @@ export default defineComponent({
     const selectedCamera = useSelectedCamera();
     const alignedView = useAlignedView();
     const isMulticamDataset = computed(() => cameraStore.camMap.value.size > 1);
-    // Warping detections onto other cameras requires the whole rig to be
-    // registered (a native->reference transform for every camera).
-    const canWarpToAllCameras = computed(
-      () => isMulticamDataset.value && alignedView.available.value,
+    const isStereoDataset = computed(() => props.subType === 'stereo');
+    // Stereo warping goes through the interactive stereo service, which
+    // needs its features enabled and a camera calibration loaded.
+    const stereoWarpAvailable = computed(
+      () => isStereoDataset.value && isStereoInteractiveModeEnabled()
+        && !!props.calibrationFile,
     );
+    // Multicam (non-stereo) warping instead requires the whole rig to be
+    // registered (a native->reference transform for every camera).
+    const canWarpToAllCameras = computed(() => {
+      if (!isMulticamDataset.value) {
+        return false;
+      }
+      if (isStereoDataset.value) {
+        return stereoWarpAvailable.value;
+      }
+      return alignedView.available.value;
+    });
     const warpToAllCameras = ref(false);
     const warpToAllCamerasHint = computed(() => {
+      if (isStereoDataset.value) {
+        if (!isStereoInteractiveModeEnabled()) {
+          return 'Requires interactive stereo to be enabled';
+        }
+        if (!props.calibrationFile) {
+          return 'Requires a camera calibration';
+        }
+        return 'Warps imported detections to the other camera';
+      }
       const progress = alignedView.registrationProgress.value;
       return progress
         ? `${progress.registered}/${progress.total} cameras registered`
@@ -197,15 +219,20 @@ export default defineComponent({
               warpToAllCameras.value
               && canWarpToAllCameras.value
               && activeCameraName.value
-              && alignedView.toReference.value
             ) {
-              const warped = warpAnnotationsAcrossCameras(
-                cameraStore,
-                alignedView.toReference.value,
-                activeCameraName.value,
-              );
-              if (warped.tracks > 0) {
-                await save();
+              if (isStereoDataset.value) {
+                // The platform (desktop) performs the warp through the
+                // interactive stereo service, one detection at a time.
+                emit('stereo-warp-imported', activeCameraName.value);
+              } else if (alignedView.toReference.value) {
+                const warped = warpAnnotationsAcrossCameras(
+                  cameraStore,
+                  alignedView.toReference.value,
+                  activeCameraName.value,
+                );
+                if (warped.tracks > 0) {
+                  await save();
+                }
               }
             }
           }
@@ -502,7 +529,7 @@ export default defineComponent({
                 </template>
               </v-combobox>
             </v-row>
-            <v-row>
+            <v-row align="start">
               <v-checkbox
                 :input-value="!additive"
                 label="Overwrite"
@@ -516,7 +543,7 @@ export default defineComponent({
                 label="Warp to All"
                 :hint="warpToAllCamerasHint"
                 persistent-hint
-                class="ml-4"
+                class="mt-2 ml-4"
               />
             </v-row>
             <div v-if="additive">

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -223,7 +223,11 @@ export default defineComponent({
               if (isStereoDataset.value) {
                 // The platform (desktop) performs the warp through the
                 // interactive stereo service, one detection at a time.
-                emit('stereo-warp-imported', activeCameraName.value);
+                // Await completion via resolve callback so processing stays
+                // true until warp + save finish (emit alone is fire-and-forget).
+                await new Promise<void>((resolve) => {
+                  emit('stereo-warp-imported', activeCameraName.value, resolve);
+                });
               } else if (alignedView.toReference.value) {
                 const warped = warpAnnotationsAcrossCameras(
                   cameraStore,

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -1356,10 +1356,16 @@ export default defineComponent({
      * Handle stereo annotation complete event from Viewer
      * Warps annotation from source camera to the other camera
      */
+    /**
+     * @param quiet When true, skip per-transfer dialog updates and return a
+     *   result status instead — used by bulk import "Warp to All" so failures
+     *   can be aggregated rather than cleared by the next job.
+     */
     async function handleStereoAnnotationComplete(
       params: StereoAnnotationCompleteParams,
       forceAutoCompute = false,
-    ) {
+      quiet = false,
+    ): Promise<'transferred' | 'skipped' | 'failed'> {
       // This handler only fires on human edits — the stereo warp writes
       // geometry directly, bypassing the annotation-complete event — so the
       // camera the user just drew/edited is now human-authored. Mark it
@@ -1378,17 +1384,19 @@ export default defineComponent({
       // for it rather than dropping the annotation's stereo work -- the
       // other-camera state below is re-read after the wait, so lines drawn on
       // both cameras in the meantime still get their length computed.
-      if (!stereoEnabled.value && !(await stereoServiceReady())) return;
+      if (!stereoEnabled.value && !(await stereoServiceReady())) {
+        return quiet ? 'failed' : 'skipped';
+      }
 
       const viewer = viewerRef.value;
-      if (!viewer) return;
+      if (!viewer) return quiet ? 'failed' : 'skipped';
 
       const { cameraStore, multiCamList } = viewer;
-      if (multiCamList.length < 2) return;
+      if (multiCamList.length < 2) return quiet ? 'failed' : 'skipped';
 
       // Determine the other camera
       const otherCamera = multiCamList.find((c: string) => c !== params.camera);
-      if (!otherCamera) return;
+      if (!otherCamera) return quiet ? 'failed' : 'skipped';
 
       const otherTrack = cameraStore.getPossibleTrack(params.trackId, otherCamera);
       const [otherFeature] = otherTrack ? otherTrack.getFeature(params.frameNum) : [null];
@@ -1419,31 +1427,34 @@ export default defineComponent({
               console.warn('[Stereo] Measurement update failed:', err);
             }
           }
-          return;
+          return 'skipped';
         }
         // Otherwise (auto-compute on, other side absent or still machine-generated)
         // fall through and (re)warp source -> other so the auto-generated line
         // keeps tracking edits.
       } else if (otherHasFeature) {
         // Box / polygon / segmentation: warp only once; leave existing untouched.
-        return;
+        return 'skipped';
       } else if (!autoCompute) {
         // Creating geometry on the other camera is gated by auto-compute.
-        return;
+        return 'skipped';
       }
 
-      // Show loading indicator while waiting for stereo transfer
-      stereoLoadingMessage.value = 'Computing stereo correspondence...';
-      stereoLoadingError.value = '';
-      stereoLoadingDialog.value = true;
-
-      // Guarantee the backend has this frame's images before transferring. The
-      // proactive watcher only fires on frame-number changes, so a draw on the
-      // frame where stereo was enabled would otherwise stall in the backend's
-      // deferred disparity wait.
-      await ensureStereoFrame(params.frameNum);
+      // Show loading indicator while waiting for stereo transfer (interactive
+      // single-transfer path only; bulk import owns the dialog itself).
+      if (!quiet) {
+        stereoLoadingMessage.value = 'Computing stereo correspondence...';
+        stereoLoadingError.value = '';
+        stereoLoadingDialog.value = true;
+      }
 
       try {
+        // Guarantee the backend has this frame's images before transferring. The
+        // proactive watcher only fires on frame-number changes, so a draw on the
+        // frame where stereo was enabled would otherwise stall in the backend's
+        // deferred disparity wait.
+        await ensureStereoFrame(params.frameNum);
+
         if (params.type === 'line') {
           const response = await stereoTransferLine({ line: params.line });
           if (!response.success || !response.transferredLine) {
@@ -1679,18 +1690,26 @@ export default defineComponent({
             }
           }
         }
-        // Success — hide loading dialog
-        stereoLoadingDialog.value = false;
+        // Success — hide loading dialog (interactive path only)
+        if (!quiet) {
+          stereoLoadingDialog.value = false;
+        }
+        return 'transferred';
       } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (quiet) {
+          console.warn('[Stereo] Transfer failed:', err);
+          return 'failed';
+        }
         // Surface the failure in the SAME dialog that was showing the
         // "Computing stereo correspondence..." spinner: switch it to its error
         // state (title + message + Close button) rather than hiding it and
         // popping a separate prompt, which flashed two windows in sequence.
-        const message = err instanceof Error ? err.message : String(err);
         stereoErrorTitle.value = 'Stereo Transfer Error';
         stereoErrorSeverity.value = 'warning';
         stereoLoadingError.value = `Failed to transfer annotation to the other camera. ${message}`;
         stereoLoadingDialog.value = true;
+        return 'failed';
       }
     }
 
@@ -1703,67 +1722,122 @@ export default defineComponent({
      * the other camera already has are left untouched. Head/tail lines
      * transfer as lines (which also computes the stereo measurement),
      * polygons as polygons, and plain boxes as boxes.
+     *
+     * resolve completes the Promise ImportAnnotations awaits so its
+     * processing spinner stays up through warp + save.
      */
-    async function handleStereoWarpImported(sourceCamera: string) {
-      const viewer = viewerRef.value;
-      if (!viewer) return;
-      const { cameraStore, multiCamList } = viewer;
-      if (multiCamList.length < 2) return;
-      const otherCamera = multiCamList.find((c: string) => c !== sourceCamera);
-      const store = cameraStore.camMap.value.get(sourceCamera)?.trackStore;
-      if (!store || !otherCamera) return;
-      const jobs: StereoAnnotationCompleteParams[] = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      store.annotationMap.forEach((track: any) => {
-        if (typeof track.getFeature !== 'function') return;
-        (track.featureIndex || []).forEach((frameNum: number) => {
-          const [feature] = track.getFeature(frameNum);
-          if (!feature || !feature.keyframe || !feature.bounds) return;
-          // Only fill in missing counterparts; never touch geometry the
-          // other camera already has for this frame.
-          const otherTrack = cameraStore.getPossibleTrack(track.id, otherCamera);
-          const [otherFeature] = otherTrack ? otherTrack.getFeature(frameNum) : [null];
-          if (otherFeature) return;
-          const geoFeatures = feature.geometry?.features || [];
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const line = geoFeatures.find((g: any) => g.geometry?.type === 'LineString'
-            && g.geometry.coordinates?.length === 2);
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const poly = geoFeatures.find((g: any) => g.geometry?.type === 'Polygon');
-          const base = { camera: sourceCamera, trackId: track.id, frameNum };
-          if (line) {
-            jobs.push({
-              ...base,
-              type: 'line',
-              line: line.geometry.coordinates as [[number, number], [number, number]],
-              key: line.properties?.key ?? '',
-            });
-          } else if (poly) {
-            jobs.push({
-              ...base,
-              type: 'polygon',
-              polygon: poly.geometry.coordinates[0] as [number, number][],
-              key: poly.properties?.key ?? '',
-            });
-          } else {
-            jobs.push({
-              ...base,
-              type: 'box',
-              bounds: feature.bounds as [number, number, number, number],
-            });
-          }
-        });
-      });
-      for (let i = 0; i < jobs.length; i += 1) {
-        try {
-          // eslint-disable-next-line no-await-in-loop
-          await handleStereoAnnotationComplete(jobs[i], true);
-        } catch (err) {
-          console.warn('[Stereo] Import warp failed:', err);
+    async function handleStereoWarpImported(
+      sourceCamera: string,
+      resolve?: () => void,
+    ) {
+      try {
+        const viewer = viewerRef.value;
+        if (!viewer) {
+          resolve?.();
+          return;
         }
-      }
-      if (jobs.length) {
-        await viewer.save();
+        const { cameraStore, multiCamList } = viewer;
+        if (multiCamList.length < 2) {
+          resolve?.();
+          return;
+        }
+        const otherCamera = multiCamList.find((c: string) => c !== sourceCamera);
+        const store = cameraStore.camMap.value.get(sourceCamera)?.trackStore;
+        if (!store || !otherCamera) {
+          resolve?.();
+          return;
+        }
+        const jobs: StereoAnnotationCompleteParams[] = [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        store.annotationMap.forEach((track: any) => {
+          if (typeof track.getFeature !== 'function') return;
+          (track.featureIndex || []).forEach((frameNum: number) => {
+            const [feature] = track.getFeature(frameNum);
+            if (!feature || !feature.keyframe || !feature.bounds) return;
+            // Only fill in missing counterparts; never touch geometry the
+            // other camera already has for this frame.
+            const otherTrack = cameraStore.getPossibleTrack(track.id, otherCamera);
+            const [otherFeature] = otherTrack ? otherTrack.getFeature(frameNum) : [null];
+            if (otherFeature) return;
+            const geoFeatures = feature.geometry?.features || [];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const line = geoFeatures.find((g: any) => g.geometry?.type === 'LineString'
+              && g.geometry.coordinates?.length === 2);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const poly = geoFeatures.find((g: any) => g.geometry?.type === 'Polygon');
+            const base = { camera: sourceCamera, trackId: track.id, frameNum };
+            if (line) {
+              jobs.push({
+                ...base,
+                type: 'line',
+                line: line.geometry.coordinates as [[number, number], [number, number]],
+                key: line.properties?.key ?? '',
+              });
+            } else if (poly) {
+              jobs.push({
+                ...base,
+                type: 'polygon',
+                polygon: poly.geometry.coordinates[0] as [number, number][],
+                key: poly.properties?.key ?? '',
+              });
+            } else {
+              jobs.push({
+                ...base,
+                type: 'box',
+                bounds: feature.bounds as [number, number, number, number],
+              });
+            }
+          });
+        });
+
+        if (!jobs.length) {
+          resolve?.();
+          return;
+        }
+
+        let transferred = 0;
+        let failed = 0;
+        stereoLoadingError.value = '';
+        stereoLoadingMessage.value = `Warping detections to other camera (0/${jobs.length})...`;
+        stereoLoadingDialog.value = true;
+
+        for (let i = 0; i < jobs.length; i += 1) {
+          stereoLoadingMessage.value = `Warping detections to other camera (${i + 1}/${jobs.length})...`;
+          // eslint-disable-next-line no-await-in-loop
+          const result = await handleStereoAnnotationComplete(jobs[i], true, true);
+          if (result === 'transferred') {
+            transferred += 1;
+          } else if (result === 'failed') {
+            failed += 1;
+          }
+        }
+
+        if (transferred) {
+          await viewer.save();
+        }
+
+        if (failed) {
+          stereoErrorTitle.value = 'Stereo Transfer Error';
+          stereoErrorSeverity.value = 'warning';
+          stereoLoadingError.value = failed === jobs.length
+            ? `Failed to warp all ${jobs.length} detections to the other camera.`
+            : `Warped ${transferred} of ${jobs.length} detections; ${failed} failed.`;
+          stereoLoadingDialog.value = true;
+        } else {
+          stereoLoadingDialog.value = false;
+        }
+        resolve?.();
+      } catch (err) {
+        console.warn('[Stereo] Import warp failed:', err);
+        stereoErrorTitle.value = 'Stereo Transfer Error';
+        stereoErrorSeverity.value = 'warning';
+        stereoLoadingError.value = `Failed to warp imported detections. ${
+          err instanceof Error ? err.message : String(err)
+        }`;
+        stereoLoadingDialog.value = true;
+        // Resolve (don't reject) so Import doesn't treat a post-import warp
+        // failure as an import failure; the stereo dialog reports it.
+        resolve?.();
       }
     }
 

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -1356,7 +1356,10 @@ export default defineComponent({
      * Handle stereo annotation complete event from Viewer
      * Warps annotation from source camera to the other camera
      */
-    async function handleStereoAnnotationComplete(params: StereoAnnotationCompleteParams) {
+    async function handleStereoAnnotationComplete(
+      params: StereoAnnotationCompleteParams,
+      forceAutoCompute = false,
+    ) {
       // This handler only fires on human edits — the stereo warp writes
       // geometry directly, bypassing the annotation-complete event — so the
       // camera the user just drew/edited is now human-authored. Mark it
@@ -1397,7 +1400,10 @@ export default defineComponent({
       //  - autoCompute: warp the annotation to the other camera when it has no
       //    detection for it yet (or its line is still machine-generated).
       const updateLengths = clientSettings.stereoSettings.updateLengthsOnModify;
-      const autoCompute = clientSettings.stereoSettings.autoComputeOtherCamera;
+      // forceAutoCompute bypasses the auto-compute preference for explicit
+      // requests (the Import menu's "Warp to All").
+      const autoCompute = forceAutoCompute
+        || clientSettings.stereoSettings.autoComputeOtherCamera;
 
       if (params.type === 'line') {
         const otherIsHuman = otherHasFeature
@@ -1689,6 +1695,79 @@ export default defineComponent({
     }
 
     /**
+     * Import menu "Warp to All" on a stereo dataset: warp every detection
+     * loaded on the source camera to the other camera through the
+     * interactive stereo service. Reuses the per-annotation transfer
+     * (service-ready wait, frame preparation) with the auto-compute
+     * preference bypassed — the user asked for the warp explicitly. Frames
+     * the other camera already has are left untouched. Head/tail lines
+     * transfer as lines (which also computes the stereo measurement),
+     * polygons as polygons, and plain boxes as boxes.
+     */
+    async function handleStereoWarpImported(sourceCamera: string) {
+      const viewer = viewerRef.value;
+      if (!viewer) return;
+      const { cameraStore, multiCamList } = viewer;
+      if (multiCamList.length < 2) return;
+      const otherCamera = multiCamList.find((c: string) => c !== sourceCamera);
+      const store = cameraStore.camMap.value.get(sourceCamera)?.trackStore;
+      if (!store || !otherCamera) return;
+      const jobs: StereoAnnotationCompleteParams[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      store.annotationMap.forEach((track: any) => {
+        if (typeof track.getFeature !== 'function') return;
+        (track.featureIndex || []).forEach((frameNum: number) => {
+          const [feature] = track.getFeature(frameNum);
+          if (!feature || !feature.keyframe || !feature.bounds) return;
+          // Only fill in missing counterparts; never touch geometry the
+          // other camera already has for this frame.
+          const otherTrack = cameraStore.getPossibleTrack(track.id, otherCamera);
+          const [otherFeature] = otherTrack ? otherTrack.getFeature(frameNum) : [null];
+          if (otherFeature) return;
+          const geoFeatures = feature.geometry?.features || [];
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const line = geoFeatures.find((g: any) => g.geometry?.type === 'LineString'
+            && g.geometry.coordinates?.length === 2);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const poly = geoFeatures.find((g: any) => g.geometry?.type === 'Polygon');
+          const base = { camera: sourceCamera, trackId: track.id, frameNum };
+          if (line) {
+            jobs.push({
+              ...base,
+              type: 'line',
+              line: line.geometry.coordinates as [[number, number], [number, number]],
+              key: line.properties?.key ?? '',
+            });
+          } else if (poly) {
+            jobs.push({
+              ...base,
+              type: 'polygon',
+              polygon: poly.geometry.coordinates[0] as [number, number][],
+              key: poly.properties?.key ?? '',
+            });
+          } else {
+            jobs.push({
+              ...base,
+              type: 'box',
+              bounds: feature.bounds as [number, number, number, number],
+            });
+          }
+        });
+      });
+      for (let i = 0; i < jobs.length; i += 1) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await handleStereoAnnotationComplete(jobs[i], true);
+        } catch (err) {
+          console.warn('[Stereo] Import warp failed:', err);
+        }
+      }
+      if (jobs.length) {
+        await viewer.save();
+      }
+    }
+
+    /**
      * Undo stereo side effects from interactive segmentation on reset.
      * Restores the other camera and clears saved undo state for the frame.
      */
@@ -1829,6 +1908,7 @@ export default defineComponent({
       stereoLengthMessage,
       closeStereoLoadingDialog,
       handleStereoAnnotationComplete,
+      handleStereoWarpImported,
       handleStereoAnnotationReset,
       handleStereoSegmentationFinalize,
       handleStereoTrackLinked,
@@ -1897,6 +1977,7 @@ export default defineComponent({
           v-bind="{ buttonOptions, menuOptions, readOnlyMode }"
           block-on-unsaved
           @calibration-imported="onCalibrationImported"
+          @stereo-warp-imported="handleStereoWarpImported"
         />
         <Export
           v-if="datasets[id]"


### PR DESCRIPTION
Two related Import-menu changes for stereo datasets:

## 1. Hide the Import Registration section on stereo datasets

Per-camera registration transform import is meant for (non-stereo) multicam rigs; stereo rigs use the calibration (camera file) import instead. `registrationSupported` now also requires the dataset subtype not be `stereo`.

## 2. "Warp to All" alignment + interactive-stereo behavior

- The "Warp to All" checkbox now lines up with the "Overwrite" checkbox instead of sitting partially below it.
- On **stereo** datasets the option now operates through the interactive stereo service: when interactive stereo is enabled and a camera calibration is present, checking it warps every imported detection from the active camera to the other camera — head/tail lines transfer as lines (also computing the stereo measurement), polygons as polygons, plain boxes as boxes — skipping any frame the other camera already has, then saving. The per-annotation transfer machinery is reused with the auto-compute preference bypassed (the user asked for the warp explicitly).
- When interactive stereo is off or no calibration is loaded, the checkbox is **greyed out** with a hint explaining what's missing.
- **Multi-camera (non-stereo)** datasets keep the existing registration-based warp, gated on rig registration as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)