### PR TITLE
Parse filename-like attribute values as full strings, not leading digits

### DIFF
--- a/client/platform/desktop/backend/native/attributeProcessor.ts
+++ b/client/platform/desktop/backend/native/attributeProcessor.ts
@@ -47,7 +47,11 @@ function processTrackAttributes(tracks: TrackData[]):
             lowCount = val;
           }
           values.push(key);
-          if (attributeType === 'number' && Number.isNaN(parseFloat(key))) {
+          // Full-string numeric check: parseFloat would accept the leading
+          // digits of filename-like values ('0123ABC456') and mistype the
+          // attribute as a number.
+          if (attributeType === 'number'
+            && (key.trim() === '' || Number.isNaN(Number(key)))) {
             attributeType = 'boolean';
           }
           if (attributeType === 'boolean' && key !== 'true' && key !== 'false') {

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -249,6 +249,28 @@ describe('VIAME Python Compatibility Check', () => {
   });
 });
 
+describe('Attribute value parsing', () => {
+  it('keeps filename-like attribute values as full strings', async () => {
+    const csv = [
+      '0,1.png,0,10,10,20,20,1,-1,seal,0.9,'
+      + '(atr) source_image 0123ABC456,'
+      + '(atr) other_file 20240624_120000_C0_0042.jpg,'
+      + '(atr) score 12.5,(atr) flag true',
+    ].join('\n');
+    const results = await parse(Readable.from([csv]));
+    const track = Object.values(results[0].tracks)[0];
+    const attrs = track.features[0].attributes || {};
+    expect(attrs.source_image).toBe('0123ABC456');
+    expect(attrs.other_file).toBe('20240624_120000_C0_0042.jpg');
+    expect(attrs.score).toBe(12.5);
+    expect(attrs.flag).toBe(true);
+    const attData = processTrackAttributes(Object.values(results[0].tracks));
+    expect(attData.attributes.detection_source_image.datatype).toBe('text');
+    expect(attData.attributes.detection_other_file.datatype).toBe('text');
+    expect(attData.attributes.detection_score.datatype).toBe('number');
+  });
+});
+
 describe('VIAME serialize testing', () => {
   it('testing exporting with viame CSV and proper order', async () => {
     const path = '/home/test.json';

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -268,6 +268,7 @@ describe('Attribute value parsing', () => {
     expect(attData.attributes.detection_source_image.datatype).toBe('text');
     expect(attData.attributes.detection_other_file.datatype).toBe('text');
     expect(attData.attributes.detection_score.datatype).toBe('number');
+    expect(attData.attributes.detection_flag.datatype).toBe('boolean');
   });
 });
 

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -179,9 +179,14 @@ function _deduceType(value: string): boolean | number | string {
   if (value === 'false') {
     return false;
   }
-  const float = parseFloat(value);
-  if (!Number.isNaN(float)) {
-    return float;
+  // Number() rejects partial parses — parseFloat would truncate
+  // filename-like values such as '0123ABC456' to their leading digits.
+  // Empty/whitespace strings coerce to 0, so they explicitly stay strings.
+  if (value.trim() !== '') {
+    const float = Number(value);
+    if (!Number.isNaN(float)) {
+      return float;
+    }
   }
   return value;
 }

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -85,6 +85,16 @@ def _resolve_detection_length(
     return {**(attributes or {}), 'length': resolved}, resolved
 
 
+# A fully numeric string. float() alone is too permissive for attribute
+# values: it accepts underscore digit separators ('20240624_120000') and
+# inf/nan spellings, which corrupts filename-like values.
+NUMERIC_VALUE_REGEX = re.compile(r'[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?')
+
+
+def _is_numeric_string(value: Any) -> bool:
+    return bool(NUMERIC_VALUE_REGEX.fullmatch(str(value).strip()))
+
+
 def _deduceType(value: Any) -> Union[bool, float, str, None]:
     if isinstance(value, dict) or isinstance(value, list):
         return None
@@ -95,11 +105,11 @@ def _deduceType(value: Any) -> Union[bool, float, str, None]:
         return True
     if value == "false":
         return False
-    try:
-        number = float(value)
-        return number
-    except ValueError:
-        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    if _is_numeric_string(value):
+        return float(value)
+    return value
 
 
 def get_next_polygon_key(features: Dict[str, Any]) -> str:
@@ -313,11 +323,8 @@ def calculate_attribute_types(
                 if val <= low_count:
                     low_count = val
                 values.append(key)
-                if attribute_type == 'number':
-                    try:
-                        float(key)
-                    except ValueError:
-                        attribute_type = 'boolean'
+                if attribute_type == 'number' and not _is_numeric_string(key):
+                    attribute_type = 'boolean'
                 if attribute_type == 'boolean' and key != 'True' and key != 'False':
                     attribute_type = 'text'
             # If all text values are used 3 or more times they are defined values

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -566,6 +566,34 @@ def test_fps_parsed_case_insensitively_from_metadata():
     assert float(fps) == 23.976
 
 
+def test_filename_like_attribute_values_stay_strings():
+    """Filename-like (atr) values must not be truncated or coerced to numbers.
+
+    Regression for parsers that used ``float()`` / ``parseFloat`` on attribute
+    values: leading digits of ``0123ABC456`` became ``123``, and underscore
+    digit separators (``20240624_120000``) were accepted by Python's ``float()``.
+    Real numbers and booleans still convert as before; inferred datatypes follow.
+    """
+    rows = [
+        "0,1.png,0,10,10,20,20,1,-1,seal,0.9,"
+        "(atr) source_image 0123ABC456,"
+        "(atr) other_file 20240624_120000_C0_0042.jpg,"
+        "(atr) score 12.5,(atr) flag true",
+    ]
+    annotations, attributes, _warnings, _fps, _info = viame.load_csv_as_tracks_and_attributes(
+        rows
+    )
+    attrs = annotations['tracks']['0']['features'][0]['attributes']
+    assert attrs['source_image'] == '0123ABC456'
+    assert attrs['other_file'] == '20240624_120000_C0_0042.jpg'
+    assert attrs['score'] == 12.5
+    assert attrs['flag'] is True
+    assert attributes['detection_source_image']['datatype'] == 'text'
+    assert attributes['detection_other_file']['datatype'] == 'text'
+    assert attributes['detection_score']['datatype'] == 'number'
+    assert attributes['detection_flag']['datatype'] == 'boolean'
+
+
 def test_notes_round_trip_through_csv_export():
     """Detection notes survive an export -> import cycle.
 


### PR DESCRIPTION
## Problem

A detection attribute whose value is a filename like `0123ABC456` (numbers, letters, numbers — e.g. the `source_image` attributes the sea-lion suppressor writes) displayed as just `123`: only the first digit group survived import.

## Cause

- **Desktop CSV parser** (`_deduceType` in `serializers/viame.ts`) used `parseFloat`, which parses a leading numeric prefix (`parseFloat('0123ABC456') === 123`), replacing the string with a number.
- **Desktop attribute-definition inference** (`attributeProcessor.ts`) used the same `parseFloat` check, so such attributes were also *typed* as numbers.
- **Server parser** (`dive_utils/serializers/viame.py`) had the adjacent Python gotcha: `float()` accepts underscore digit separators (`float('20240624_120000') == 20240624120000.0`) and `inf`/`nan` spellings, corrupting underscore-separated filename stems the same way.

## Fix

- Desktop `_deduceType` uses `Number()`, which converts only fully numeric strings (with an explicit empty/whitespace guard, since `Number('') === 0`).
- Desktop `attributeProcessor` infers `number` only for fully numeric values.
- Server value parsing and type inference both require a strictly numeric string (regex full-match) before converting.

Real numbers (`12.5`, `-3`, `1e5`) and booleans still convert exactly as before. Regression test parses `(atr)` values with filename-like, underscore-separated, numeric, and boolean content and checks both values and inferred datatypes.

Note: values already truncated in previously saved annotations can't be recovered — re-importing the source CSV restores them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)