### PR TITLE
Type list: space out the total : frame counts for readability

### DIFF
--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -275,7 +275,7 @@ export default defineComponent({
       return filteredTypeList.map((item) => ({
         type: item,
         confidenceFilterNum: confidenceFiltersDeRef[item] || 0,
-        displayText: `${typeCountsDeRef.get(item) || 0} : ${frameTrackTypesDeRef.get(item) || 0} ${item}`,
+        displayText: `${typeCountsDeRef.get(item) || 0} : ${frameTrackTypesDeRef.get(item) || 0}\u00A0 ${item}`,
         color: typeStylingDeRef.color(item),
         checked: checkedTypesDeRef.includes(item),
         isSuppressionType: !!suppressionType && item === suppressionType,

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -275,7 +275,7 @@ export default defineComponent({
       return filteredTypeList.map((item) => ({
         type: item,
         confidenceFilterNum: confidenceFiltersDeRef[item] || 0,
-        displayText: `${typeCountsDeRef.get(item) || 0}:${frameTrackTypesDeRef.get(item) || 0} ${item}`,
+        displayText: `${typeCountsDeRef.get(item) || 0} : ${frameTrackTypesDeRef.get(item) || 0} ${item}`,
         color: typeStylingDeRef.color(item),
         checked: checkedTypesDeRef.includes(item),
         isSuppressionType: !!suppressionType && item === suppressionType,

--- a/client/src/components/TypeItem.vue
+++ b/client/src/components/TypeItem.vue
@@ -213,6 +213,7 @@ export default defineComponent({
   color: #222;
   font-weight: 600;
   border-radius: 6px;
+  margin-left: 4px;
   padding: 0 5px;
   font-size: 12px;
 }


### PR DESCRIPTION
Small display tweak: the type list's per-type counts now render as `1 : 0 seal` (total count, space, colon, space, current-frame count) instead of the cramped `1:0 seal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)