### PR TITLE
fix stale Folder().save wiping annotate after large csv file imports

### DIFF
--- a/server/dive_server/crud.py
+++ b/server/dive_server/crud.py
@@ -80,11 +80,30 @@ def get_or_create_source_folder(folder, user):
     return Folder().createFolder(folder, "source", reuseExisting=True, creator=user)
 
 
+def refresh_folder_document(folder: GirderModel) -> GirderModel:
+    """Replace *folder* in place with the latest DB document.
+
+    Async jobs such as convert_video write folder meta via addMetadataToFolder
+    (partial merge). Callers that keep an in-memory folder and later
+    Folder().save() the whole document must refresh first, or they can wipe
+    keys like annotate / originalFps / ffprobe_info.
+    """
+    fresh = Folder().load(folder['_id'], force=True)
+    if fresh is None:
+        raise RestException('Folder not found', code=404)
+    stale_keys = [key for key in folder if key not in fresh]
+    folder.update(fresh)
+    for key in stale_keys:
+        del folder[key]
+    return folder
+
+
 def itemIsWebsafeVideo(item: Item) -> bool:
     return fromMeta(item, "codec") == "h264"
 
 
 def saveImportAttributes(folder, attributes, user):
+    refresh_folder_document(folder)
     attributes_dict = fromMeta(folder, 'attributes', {})
     # we don't overwrite any existing meta attributes
     for attribute in attributes.values():

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -394,6 +394,8 @@ def update_metadata(dsFolder: types.GirderModel, data: dict, verify=True):
     """Update mutable metadata"""
     if verify:
         crud.verify_dataset(dsFolder)
+    # Reload before save so concurrent convert_video metadata is not wiped.
+    crud.refresh_folder_document(dsFolder)
     validated: MetadataMutableUpdateArgs = crud.get_validated_model(
         MetadataMutableUpdateArgs, **data
     )

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -745,9 +745,6 @@ def postprocess(
     """
     job_is_private = user.get(constants.UserPrivateQueueEnabledMarker, False)
     isClone = dsFolder.get(constants.ForeignMediaIdMarker, None) is not None
-    # add default confidence filter threshold to folder metadata
-    dsFolder['meta'][constants.ConfidenceFiltersMarker] = {'default': 0.1}
-
     # Track job IDs for batch processing
     created_job_ids = []
 
@@ -756,6 +753,14 @@ def postprocess(
         raise RestException(f'{constants.FPSMarker} missing from metadata')
     if fromMeta(dsFolder, constants.TypeMarker) is None:
         raise RestException(f'{constants.TypeMarker} missing from metadata')
+
+    # Persist default confidence filter without a full stale meta write. Async
+    # convert_video (esp. skipTranscoding) can finish during CSV import and set
+    # annotate / originalFps / ffprobe_info; a later Folder().save of an old
+    # in-memory doc would wipe those keys.
+    crud.refresh_folder_document(dsFolder)
+    dsFolder.setdefault('meta', {})[constants.ConfidenceFiltersMarker] = {'default': 0.1}
+    Folder().save(dsFolder)
 
     if not skipJobs and not isClone:
         token = Token().createToken(user=user, days=2)
@@ -856,18 +861,17 @@ def postprocess(
             )
             created_job_ids.append(job['_id'])
 
-        elif imageItems.count() > 0:
-            dsFolder["meta"][constants.DatasetMarker] = True
-        elif largeImageItems.count() > 0:
-            dsFolder["meta"][constants.DatasetMarker] = True
-
-        Folder().save(dsFolder)
+        elif imageItems.count() > 0 or largeImageItems.count() > 0:
+            # Safe/web images need annotate now; convert_images sets it when it runs.
+            crud.refresh_folder_document(dsFolder)
+            dsFolder.setdefault('meta', {})[constants.DatasetMarker] = True
+            Folder().save(dsFolder)
 
     aggregate_warnings = process_items(dsFolder, user, additive, additivePrepend, set)
     # Image sequences start at fps=-1 (auto). CSV import may have set a value;
     # otherwise default to 1. convert_images also resolves, but safe-image folders
     # skip that job and need this finalize step.
-    dsFolder = Folder().load(dsFolder['_id'], force=True)
+    crud.refresh_folder_document(dsFolder)
     media_type = fromMeta(dsFolder, constants.TypeMarker)
     if media_type in (constants.ImageSequenceType, constants.LargeImageType):
         requested_fps = fromMeta(dsFolder, constants.FPSMarker)

--- a/server/tests/test_update_metadata.py
+++ b/server/tests/test_update_metadata.py
@@ -3,13 +3,27 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from dive_server import crud_dataset
+from dive_server import crud, crud_dataset
 from dive_server.crud_rpc import process_items, resolve_imported_dataset_info
 
 
+def _stub_folder_load_and_save(folder_cls, folder):
+    """Folder.load returns a deep-ish copy of meta; save returns the doc passed in."""
+
+    def _load(*_a, **_k):
+        return {
+            **folder,
+            'meta': dict(folder.get('meta') or {}),
+        }
+
+    folder_cls.return_value.load = MagicMock(side_effect=_load)
+    folder_cls.return_value.save = MagicMock(side_effect=lambda f: f)
+
+
+@patch('dive_server.crud.Folder')
 @patch('dive_server.crud_dataset.Folder')
 @patch('dive_server.crud_dataset.crud.verify_dataset')
-def test_update_metadata_clears_time_filters_when_null(_verify, folder_cls):
+def test_update_metadata_clears_time_filters_when_null(_verify, folder_cls, crud_folder_cls):
     folder = {
         '_id': 'dataset-id',
         'meta': {
@@ -18,7 +32,8 @@ def test_update_metadata_clears_time_filters_when_null(_verify, folder_cls):
             'timeFilters': [0, 100],
         },
     }
-    folder_cls.return_value.save = MagicMock(side_effect=lambda f: f)
+    _stub_folder_load_and_save(folder_cls, folder)
+    _stub_folder_load_and_save(crud_folder_cls, folder)
 
     crud_dataset.update_metadata(folder, {'timeFilters': None})
 
@@ -26,9 +41,10 @@ def test_update_metadata_clears_time_filters_when_null(_verify, folder_cls):
     folder_cls.return_value.save.assert_called_once()
 
 
+@patch('dive_server.crud.Folder')
 @patch('dive_server.crud_dataset.Folder')
 @patch('dive_server.crud_dataset.crud.verify_dataset')
-def test_update_metadata_clears_calibration_source_when_null(_verify, folder_cls):
+def test_update_metadata_clears_calibration_source_when_null(_verify, folder_cls, crud_folder_cls):
     # A cleared / hand-refined calibration sends cameraRegistrationSource: null to
     # drop a stale producer stamp; exclude_none would otherwise leave it behind.
     folder = {
@@ -39,7 +55,8 @@ def test_update_metadata_clears_calibration_source_when_null(_verify, folder_cls
             'cameraRegistrationSource': {'model': 'colmap-v3', 'swathe': '17'},
         },
     }
-    folder_cls.return_value.save = MagicMock(side_effect=lambda f: f)
+    _stub_folder_load_and_save(folder_cls, folder)
+    _stub_folder_load_and_save(crud_folder_cls, folder)
 
     crud_dataset.update_metadata(folder, {'cameraRegistrationSource': None})
 
@@ -47,9 +64,10 @@ def test_update_metadata_clears_calibration_source_when_null(_verify, folder_cls
     folder_cls.return_value.save.assert_called_once()
 
 
+@patch('dive_server.crud.Folder')
 @patch('dive_server.crud_dataset.Folder')
 @patch('dive_server.crud_dataset.crud.verify_dataset')
-def test_update_metadata_sets_time_filters(_verify, folder_cls):
+def test_update_metadata_sets_time_filters(_verify, folder_cls, crud_folder_cls):
     folder = {
         '_id': 'dataset-id',
         'meta': {
@@ -57,11 +75,67 @@ def test_update_metadata_sets_time_filters(_verify, folder_cls):
             'type': 'video',
         },
     }
-    folder_cls.return_value.save = MagicMock(side_effect=lambda f: f)
+    _stub_folder_load_and_save(folder_cls, folder)
+    _stub_folder_load_and_save(crud_folder_cls, folder)
 
     crud_dataset.update_metadata(folder, {'timeFilters': [10, 50]})
 
     assert folder['meta']['timeFilters'] == [10, 50]
+
+
+@patch('dive_server.crud.Folder')
+@patch('dive_server.crud_dataset.Folder')
+@patch('dive_server.crud_dataset.crud.verify_dataset')
+def test_update_metadata_preserves_concurrent_convert_fields(_verify, folder_cls, crud_folder_cls):
+    """Stale in-memory meta must not wipe annotate/ffprobe written by convert_video."""
+    stale = {
+        '_id': 'dataset-id',
+        'meta': {
+            'type': 'video',
+            'fps': -1,
+            'confidenceFilters': {'default': 0.1},
+        },
+    }
+    db_after_convert = {
+        '_id': 'dataset-id',
+        'meta': {
+            'type': 'video',
+            'fps': 20,
+            'confidenceFilters': {'default': 0.1},
+            'annotate': True,
+            'originalFps': 29.97,
+            'ffprobe_info': {'codec_name': 'h264'},
+        },
+    }
+    crud_folder_cls.return_value.load = MagicMock(return_value=dict(db_after_convert))
+    folder_cls.return_value.save = MagicMock(side_effect=lambda f: f)
+
+    crud_dataset.update_metadata(stale, {'datasetInfo': {'cruise': '2403'}}, verify=False)
+
+    saved = folder_cls.return_value.save.call_args.args[0]
+    assert saved['meta']['annotate'] is True
+    assert saved['meta']['originalFps'] == 29.97
+    assert saved['meta']['ffprobe_info']['codec_name'] == 'h264'
+    assert saved['meta']['fps'] == 20
+    assert saved['meta']['datasetInfo'] == {'cruise': '2403'}
+    # Caller's folder dict is refreshed in place
+    assert stale['meta']['annotate'] is True
+
+
+def test_refresh_folder_document_replaces_stale_meta_in_place():
+    folder = {'_id': 'dataset-id', 'meta': {'type': 'video'}, 'extra': 'gone'}
+    fresh = {
+        '_id': 'dataset-id',
+        'meta': {'type': 'video', 'annotate': True},
+        'name': 'bigfish',
+    }
+    with patch('dive_server.crud.Folder') as folder_cls:
+        folder_cls.return_value.load.return_value = fresh
+        crud.refresh_folder_document(folder)
+
+    assert folder['meta']['annotate'] is True
+    assert folder['name'] == 'bigfish'
+    assert 'extra' not in folder
 
 
 # --- datasetInfo re-import resolution ---


### PR DESCRIPTION
- During postprocess, `convert_video` can finish (especially with `skipTranscoding`) while a large sibling CSV is still being imported. Concurrent `Folder().save()` of an in-memory folder doc then overwrote partial metadata from `addMetadataToFolder`, dropping `annotate`, `originalFps`, and `ffprobe_info`.
- Reload the folder from the DB before metadata-mutating saves (`update_metadata`, `saveImportAttributes`, and the confidence-filter / safe-image writes in `postprocess`) so convert’s keys are preserved.
- Add unit coverage for the stale-save race.
