### PR TITLE
Speed up suppression-region computation during region edits

### DIFF
--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -179,7 +179,11 @@ export default defineComponent({
         });
         const hasRegionAt = (f: number) => regionRanges.some(([b, e]) => f >= b && f <= e);
         const suppressedAt = (f: number) => getSuppressedTrackIds(
-          store, f, suppType, suppThreshold, { revision: editRevision },
+          store,
+          f,
+          suppType,
+          suppThreshold,
+          { revision: editRevision },
         );
         store.annotationMap.forEach((annotation) => {
           const track = annotation as Track;

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
 import {
-  computed, defineComponent, PropType, reactive, ref, Ref,
+  computed, defineComponent, onBeforeUnmount, PropType, reactive, ref, Ref,
   watch,
 } from 'vue';
-import { difference, union } from 'lodash';
+import { debounce, difference, union } from 'lodash';
 
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { clientSettings } from 'dive-common/store/settings';
@@ -149,26 +149,22 @@ export default defineComponent({
     /**
      * Ids of tracks whose every keyframe detection is suppressed (a region
      * covers it on each frame it appears), across all cameras - these are
-     * excluded from the dataset-wide type totals. Reactive to region edits via
-     * the save counter, since track geometry is not itself a reactive value.
+     * excluded from the dataset-wide type totals. This walks every keyframe
+     * of every track, so it is recomputed on a debounce rather than on every
+     * save-counter bump: dragging a region's corner fires an edit per mouse
+     * move, and recomputing the whole dataset per move froze the resize.
      */
-    const fullySuppressedIds = computed(() => {
+    const fullySuppressedIds: Ref<Set<number>> = ref(new Set<number>());
+    function computeFullySuppressedIds() {
       const editRevision = pendingSaveCount.value;
       const suppType = clientSettings.typeSettings.suppressionType;
       const excluded = new Set<number>();
       if (!suppType || editRevision < 0) {
-        return excluded;
+        fullySuppressedIds.value = excluded;
+        return;
       }
       cameraStore.camMap.value.forEach(({ trackStore: store }) => {
-        const perFrame = new Map<number, Set<number>>();
-        const suppressedAt = (f: number) => {
-          let s = perFrame.get(f);
-          if (s === undefined) {
-            s = getSuppressedTrackIds(store, f, suppType);
-            perFrame.set(f, s);
-          }
-          return s;
-        };
+        const suppressedAt = (f: number) => getSuppressedTrackIds(store, f, suppType, { revision: editRevision });
         store.annotationMap.forEach((annotation) => {
           const track = annotation as Track;
           if (typeof track.getFeature !== 'function') {
@@ -181,8 +177,16 @@ export default defineComponent({
           }
         });
       });
-      return excluded;
-    });
+      fullySuppressedIds.value = excluded;
+    }
+    const debouncedFullySuppressed = debounce(computeFullySuppressedIds, 500);
+    watch(pendingSaveCount, () => debouncedFullySuppressed());
+    watch(
+      [() => clientSettings.typeSettings.suppressionType, cameraStore.camMap],
+      () => computeFullySuppressedIds(),
+      { immediate: true },
+    );
+    onBeforeUnmount(() => debouncedFullySuppressed.cancel());
 
     const typeCounts = computed(() => {
       const excluded = fullySuppressedIds.value;
@@ -210,7 +214,12 @@ export default defineComponent({
       // Detections suppressed by a region on this frame are dropped so the
       // per-frame type counts read off the interface exclude them.
       const suppressedIds = (trackStore && editRevision >= 0)
-        ? getSuppressedTrackIds(trackStore, frame.value, clientSettings.typeSettings.suppressionType)
+        ? getSuppressedTrackIds(
+          trackStore,
+          frame.value,
+          clientSettings.typeSettings.suppressionType,
+          { revision: editRevision },
+        )
         : new Set<number>();
       const filteredKeyFrameTracks = filteredTracksRef.value.filter((track) => {
         if (suppressedIds.has(track.annotation.id)) {

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -167,16 +167,17 @@ export default defineComponent({
         return;
       }
       cameraStore.camMap.value.forEach(({ trackStore: store }) => {
-        // Frames where a suppression region actually exists: a track with a
-        // keyframe on any other frame can never be region-suppressed there,
-        // so its region check bails without touching the per-frame computation.
-        const regionFrames = new Set<number>();
+        // Inclusive [begin, end] spans of suppression-region tracks. Regions
+        // interpolate between keyframes, so a keyframe-only set would miss
+        // detections whose keyframes fall on interpolated-only region frames.
+        const regionRanges: [number, number][] = [];
         store.annotationMap.forEach((annotation) => {
           const track = annotation as Track;
           if (track.confidencePairs?.some(([t]) => t === suppType)) {
-            (track.featureIndex || []).forEach((f) => regionFrames.add(f));
+            regionRanges.push([track.begin, track.end]);
           }
         });
+        const hasRegionAt = (f: number) => regionRanges.some(([b, e]) => f >= b && f <= e);
         const suppressedAt = (f: number) => getSuppressedTrackIds(
           store, f, suppType, suppThreshold, { revision: editRevision },
         );
@@ -187,7 +188,7 @@ export default defineComponent({
           }
           const keyframes = track.features.filter((f) => f && f.keyframe);
           if (keyframes.length > 0
-            && keyframes.every((f) => (regionFrames.has(f.frame)
+            && keyframes.every((f) => (hasRegionAt(f.frame)
                 && suppressedAt(f.frame).has(track.id))
               || hasSuppressionAttribute(track, f.frame, suppType))) {
             excluded.add(track.id);
@@ -199,7 +200,11 @@ export default defineComponent({
     const debouncedFullySuppressed = debounce(computeFullySuppressedIds, 500);
     watch(pendingSaveCount, () => debouncedFullySuppressed());
     watch(
-      [() => clientSettings.typeSettings.suppressionType, cameraStore.camMap],
+      [
+        () => clientSettings.typeSettings.suppressionType,
+        () => clientSettings.typeSettings.suppressionThreshold,
+        cameraStore.camMap,
+      ],
       () => computeFullySuppressedIds(),
       { immediate: true },
     );

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -164,6 +164,19 @@ export default defineComponent({
         return;
       }
       cameraStore.camMap.value.forEach(({ trackStore: store }) => {
+        // Frames where a suppression region actually exists: a track with a
+        // keyframe on any other frame can never be fully suppressed, so its
+        // check bails without touching the per-frame computation at all.
+        const regionFrames = new Set<number>();
+        store.annotationMap.forEach((annotation) => {
+          const track = annotation as Track;
+          if (track.confidencePairs?.some(([t]) => t === suppType)) {
+            (track.featureIndex || []).forEach((f) => regionFrames.add(f));
+          }
+        });
+        if (regionFrames.size === 0) {
+          return;
+        }
         const suppressedAt = (f: number) => getSuppressedTrackIds(store, f, suppType, { revision: editRevision });
         store.annotationMap.forEach((annotation) => {
           const track = annotation as Track;
@@ -172,7 +185,8 @@ export default defineComponent({
           }
           const keyframes = track.features.filter((f) => f && f.keyframe);
           if (keyframes.length > 0
-            && keyframes.every((f) => suppressedAt(f.frame).has(track.id))) {
+            && keyframes.every((f) => regionFrames.has(f.frame)
+              && suppressedAt(f.frame).has(track.id))) {
             excluded.add(track.id);
           }
         });

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -45,6 +45,7 @@ import {
   useComparisonSets,
   useLassoModeContext,
   useSegmentationPoints,
+  usePendingSaveCount,
 } from '../provides';
 import SegmentationPointsLayer from '../layers/AnnotationLayers/SegmentationPointsLayer';
 import useLayerManagerAlignedView from './layerManager/useLayerManagerAlignedView';
@@ -97,6 +98,7 @@ export default defineComponent({
       // aligned view store may not be provided in tests or minimal embeds.
     }
     const selectedCamera = useSelectedCamera();
+    const pendingSaveCount = usePendingSaveCount();
     const comparison = useComparisonSets();
     const trackStore = cameraStore.camMap.value.get(props.camera)?.trackStore;
     const groupStore = cameraStore.camMap.value.get(props.camera)?.groupStore;
@@ -348,7 +350,12 @@ export default defineComponent({
       // Detections lying >=50% under a suppression region on this frame are
       // hidden from every layer at once (and excluded from counts elsewhere).
       const suppressedIds = trackStore
-        ? getSuppressedTrackIds(trackStore, frame, clientSettings.typeSettings.suppressionType)
+        ? getSuppressedTrackIds(
+          trackStore,
+          frame,
+          clientSettings.typeSettings.suppressionType,
+          { revision: pendingSaveCount.value },
+        )
         : new Set<AnnotationId>();
       currentFrameIds.forEach(
         (trackId: AnnotationId) => {

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -98,7 +98,6 @@ export default defineComponent({
       // aligned view store may not be provided in tests or minimal embeds.
     }
     const selectedCamera = useSelectedCamera();
-    const pendingSaveCount = usePendingSaveCount();
     const comparison = useComparisonSets();
     const trackStore = cameraStore.camMap.value.get(props.camera)?.trackStore;
     const groupStore = cameraStore.camMap.value.get(props.camera)?.groupStore;

--- a/client/src/components/Tracks/TrackList.vue
+++ b/client/src/components/Tracks/TrackList.vue
@@ -120,7 +120,12 @@ export default defineComponent({
         const suppressCamStore = cameraStore.camMap.value.get(selectedCamera.value)?.trackStore;
         const suppType = clientSettings.typeSettings.suppressionType;
         const suppressedIds = (suppressCamStore && editRevision >= 0)
-          ? getSuppressedTrackIds(suppressCamStore, frameRef.value, suppType)
+          ? getSuppressedTrackIds(
+            suppressCamStore,
+            frameRef.value,
+            suppType,
+            { revision: editRevision },
+          )
           : new Set<number>();
         tracks = tracks.filter((track) => {
           if (suppressedIds.has(track.annotation.id)) {

--- a/client/src/use/suppression.spec.ts
+++ b/client/src/use/suppression.spec.ts
@@ -90,3 +90,53 @@ describe('getSuppressedTrackIds', () => {
       .toEqual(new Set());
   });
 });
+
+describe('rasterized region polygons', () => {
+  // A 32-gon (circle-ish) region: enough vertices to trigger the mask path
+  const n = 32;
+  const circle: [number, number][] = [];
+  for (let i = 0; i < n; i += 1) {
+    const a = (2 * Math.PI * i) / n;
+    circle.push([50 + 45 * Math.cos(a), 50 + 45 * Math.sin(a)]);
+  }
+  const polyRegion = makeTrack({
+    id: 1,
+    confidencePairs: [['Suppressed', 1]],
+    features: [{
+      frame: 0,
+      bounds: [5, 5, 95, 95],
+      keyframe: true,
+      interpolate: false,
+      geometry: {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: { type: 'Polygon', coordinates: [[...circle, circle[0]]] },
+          properties: { key: '' },
+        }],
+      },
+    }],
+  });
+  // Fully inside the circle
+  const inCircle = makeTrack({
+    id: 2,
+    features: [{
+      frame: 0, bounds: [40, 40, 60, 60], keyframe: true, interpolate: false,
+    }],
+  });
+  // Inside the region's bbox but in a corner outside the circle
+  const inCorner = makeTrack({
+    id: 3,
+    features: [{
+      frame: 0, bounds: [5, 5, 18, 18], keyframe: true, interpolate: false,
+    }],
+  });
+
+  it('suppresses by the polygon shape, not its bbox', () => {
+    const store = {
+      intervalTree: { search: () => ['1', '2', '3'] },
+      getPossible: (id: number) => [polyRegion, inCircle, inCorner].find((t) => t.id === id),
+    } as unknown as Parameters<typeof getSuppressedTrackIds>[0];
+    expect(getSuppressedTrackIds(store, 0, 'Suppressed')).toEqual(new Set([2]));
+  });
+});

--- a/client/src/use/suppression.spec.ts
+++ b/client/src/use/suppression.spec.ts
@@ -278,3 +278,41 @@ describe('rasterized region polygons', () => {
     expect(getSuppressedTrackIds(store, 0, 'Suppressed')).toEqual(new Set([2]));
   });
 });
+
+describe('polygon detection vs bbox prefilter', () => {
+  // Thin strip polygon inside a large bbox: the region covers the strip
+  // fully, but only ~10% of the bbox. A bbox-area prefilter at 99% would
+  // skip sampling and incorrectly leave the detection unsuppressed.
+  const region = makeTrack({
+    id: 1,
+    confidencePairs: [['Suppressed', 1]],
+    features: [{
+      frame: 0, bounds: [0, 0, 100, 20], keyframe: true, interpolate: false,
+    }],
+  });
+  const stripPoly: [number, number][] = [
+    [0, 0], [100, 0], [100, 10], [0, 10], [0, 0],
+  ];
+  const thinStrip = makeTrack({
+    id: 2,
+    features: [{
+      frame: 0,
+      bounds: [0, 0, 100, 100],
+      keyframe: true,
+      interpolate: false,
+      geometry: {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: { type: 'Polygon', coordinates: [stripPoly] },
+          properties: { key: '' },
+        }],
+      },
+    }],
+  });
+
+  it('still suppresses a polygon fully covered even when bbox overlap is low', () => {
+    const store = makeStore([region, thinStrip]);
+    expect(getSuppressedTrackIds(store, 0, 'Suppressed')).toEqual(new Set([2]));
+  });
+});

--- a/client/src/use/suppression.spec.ts
+++ b/client/src/use/suppression.spec.ts
@@ -1,0 +1,92 @@
+/// <reference types="vitest" />
+import Track, { TrackData } from '../track';
+import { getSuppressedTrackIds } from './suppression';
+
+function makeTrack(overrides: Partial<TrackData> = {}): Track {
+  return Track.fromJSON({
+    attributes: {},
+    begin: 0,
+    end: 0,
+    confidencePairs: [['seal', 0.9]],
+    features: [
+      {
+        frame: 0,
+        bounds: [0, 0, 10, 10],
+        keyframe: true,
+        interpolate: false,
+      },
+    ],
+    meta: {},
+    id: 1,
+    ...overrides,
+  });
+}
+
+function makeStore(tracks: Track[]) {
+  return {
+    intervalTree: {
+      search: () => tracks.map((t) => String(t.id)),
+    },
+    getPossible: (id: number) => tracks.find((t) => t.id === id),
+  } as unknown as Parameters<typeof getSuppressedTrackIds>[0];
+}
+
+const region = makeTrack({
+  id: 1,
+  confidencePairs: [['Suppressed', 1]],
+  features: [{
+    frame: 0, bounds: [0, 0, 100, 100], keyframe: true, interpolate: false,
+  }],
+});
+const covered = makeTrack({
+  id: 2,
+  features: [{
+    frame: 0, bounds: [10, 10, 90, 90], keyframe: true, interpolate: false,
+  }],
+});
+const outside = makeTrack({
+  id: 3,
+  features: [{
+    frame: 0, bounds: [200, 200, 250, 250], keyframe: true, interpolate: false,
+  }],
+});
+const barelyTouching = makeTrack({
+  id: 4,
+  features: [{
+    frame: 0, bounds: [95, 95, 195, 195], keyframe: true, interpolate: false,
+  }],
+});
+
+describe('getSuppressedTrackIds', () => {
+  it('suppresses covered detections; the bbox prefilter spares the rest', () => {
+    const store = makeStore([region, covered, outside, barelyTouching]);
+    expect(getSuppressedTrackIds(store, 0, 'Suppressed')).toEqual(new Set([2]));
+  });
+
+  it('returns empty when disabled or no regions exist', () => {
+    expect(getSuppressedTrackIds(makeStore([covered]), 0, 'Suppressed'))
+      .toEqual(new Set());
+    expect(getSuppressedTrackIds(makeStore([region, covered]), 0, undefined))
+      .toEqual(new Set());
+  });
+
+  it('memoizes per revision and recomputes when the revision changes', () => {
+    const store = makeStore([region, covered]);
+    const first = getSuppressedTrackIds(store, 0, 'Suppressed', { revision: 1 });
+    const again = getSuppressedTrackIds(store, 0, 'Suppressed', { revision: 1 });
+    expect(again).toBe(first);
+
+    // Simulate an edit: the detection moves out from under the region
+    covered.setFeature({
+      frame: 0,
+      bounds: [300, 300, 380, 380],
+      keyframe: true,
+      interpolate: false,
+    });
+    // Same revision still serves the memoized result
+    expect(getSuppressedTrackIds(store, 0, 'Suppressed', { revision: 1 })).toBe(first);
+    // A new revision recomputes with the updated geometry
+    expect(getSuppressedTrackIds(store, 0, 'Suppressed', { revision: 2 }))
+      .toEqual(new Set());
+  });
+});

--- a/client/src/use/suppression.ts
+++ b/client/src/use/suppression.ts
@@ -182,10 +182,14 @@ function overlapFraction(det: Shape, regions: PreparedRegion[]): number {
 }
 
 /**
- * Upper bound on the fraction of the detection's bbox covered by the regions,
+ * Upper bound on the fraction of a bbox-only detection covered by the regions,
  * from bbox overlaps alone (sum over regions, so overlapping regions
  * over-count -- fine for an upper bound). Lets candidates that cannot
  * possibly reach the threshold skip the expensive point sampling.
+ *
+ * Not valid for polygon detections: overlapFraction is relative to the
+ * polygon footprint (≤ bbox area), so bbox_intersection / bbox_area can be
+ * below the threshold even when the polygon is fully covered.
  */
 function bboxCoverUpperBound(det: Rect, regions: PreparedRegion[]): number {
   const [dx1, dy1, dx2, dy2] = det;
@@ -301,7 +305,9 @@ export function getSuppressedTrackIds(
   });
   if (regions.length > 0) {
     candidates.forEach(({ id, shape }) => {
-      if (bboxCoverUpperBound(shape.bbox, regions) < threshold) {
+      // Bbox prefilter is only sound for bbox-only detections (see
+      // bboxCoverUpperBound). Polygon candidates always go to sampling.
+      if (!shape.poly && bboxCoverUpperBound(shape.bbox, regions) < threshold) {
         return;
       }
       if (overlapFraction(shape, regions) >= threshold) {

--- a/client/src/use/suppression.ts
+++ b/client/src/use/suppression.ts
@@ -96,19 +96,68 @@ function overlapFraction(det: Shape, regions: Shape[]): number {
 }
 
 /**
+ * Upper bound on the fraction of the detection's bbox covered by the regions,
+ * from bbox overlaps alone (sum over regions, so overlapping regions
+ * over-count -- fine for an upper bound). Lets candidates that cannot
+ * possibly reach the threshold skip the expensive point sampling.
+ */
+function bboxCoverUpperBound(det: Rect, regions: Shape[]): number {
+  const [dx1, dy1, dx2, dy2] = det;
+  const detArea = Math.max(0, dx2 - dx1) * Math.max(0, dy2 - dy1);
+  if (detArea <= 0) return 0;
+  let sum = 0;
+  regions.forEach(({ bbox: [rx1, ry1, rx2, ry2] }) => {
+    const w = Math.min(dx2, rx2) - Math.max(dx1, rx1);
+    const h = Math.min(dy2, ry2) - Math.max(dy1, ry1);
+    if (w > 0 && h > 0) sum += w * h;
+  });
+  return sum / detArea;
+}
+
+interface SuppressionCacheEntry {
+  revision: number;
+  type: string;
+  byFrame: Map<number, Set<AnnotationId>>;
+}
+/** Per-store memo of frame results, valid for one edit revision. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const suppressionCache = new WeakMap<any, SuppressionCacheEntry>();
+
+/**
  * Track ids whose detection on `frame` is suppressed by a region on that frame.
  * Empty when suppressionType is falsy (feature disabled) or no regions exist.
+ * `options.revision` (typically the pending-save counter) memoizes the result
+ * per store+frame until the revision changes, so the canvas, type counts, and
+ * track list share one computation instead of repeating it.
  */
 export function getSuppressedTrackIds(
   trackStore: BaseAnnotationStore<Track>,
   frame: number,
   suppressionType: string | undefined,
+  options: { revision?: number } = {},
 ): Set<AnnotationId> {
+  if (!suppressionType) return new Set<AnnotationId>();
+
+  let cacheEntry: SuppressionCacheEntry | undefined;
+  const { revision } = options;
+  if (revision !== undefined) {
+    cacheEntry = suppressionCache.get(trackStore);
+    if (!cacheEntry || cacheEntry.revision !== revision
+      || cacheEntry.type !== suppressionType) {
+      cacheEntry = { revision, type: suppressionType, byFrame: new Map() };
+      suppressionCache.set(trackStore, cacheEntry);
+    }
+    const hit = cacheEntry.byFrame.get(frame);
+    if (hit !== undefined) return hit;
+  }
+
   const result = new Set<AnnotationId>();
-  if (!suppressionType) return result;
   const ids = trackStore.intervalTree.search([frame, frame])
     .map((s: string) => parseInt(s, 10));
-  if (ids.length === 0) return result;
+  if (ids.length === 0) {
+    cacheEntry?.byFrame.set(frame, result);
+    return result;
+  }
 
   const regions: Shape[] = [];
   const candidates: { id: AnnotationId; shape: Shape }[] = [];
@@ -123,12 +172,16 @@ export function getSuppressedTrackIds(
       candidates.push({ id, shape });
     }
   });
-  if (regions.length === 0) return result;
-
-  candidates.forEach(({ id, shape }) => {
-    if (overlapFraction(shape, regions) >= SUPPRESSION_THRESHOLD) {
-      result.add(id);
-    }
-  });
+  if (regions.length > 0) {
+    candidates.forEach(({ id, shape }) => {
+      if (bboxCoverUpperBound(shape.bbox, regions) < SUPPRESSION_THRESHOLD) {
+        return;
+      }
+      if (overlapFraction(shape, regions) >= SUPPRESSION_THRESHOLD) {
+        result.add(id);
+      }
+    });
+  }
+  cacheEntry?.byFrame.set(frame, result);
   return result;
 }

--- a/client/src/use/suppression.ts
+++ b/client/src/use/suppression.ts
@@ -74,8 +74,73 @@ function pointInShape(px: number, py: number, shape: Shape): boolean {
   return px >= x1 && px <= x2 && py >= y1 && py <= y2;
 }
 
+// Rasterized polygon mask over a region's bbox (scanline even-odd fill, up
+// to RASTER_RES cells per axis). The sea-lion suppressor's warped
+// field-of-view polygons carry many vertices and every covered candidate
+// samples them GRID*GRID times, so each region is rasterized once per frame
+// and a sample becomes an O(1) lookup instead of O(vertices).
+const RASTER_RES = 256;
+interface RegionMask {
+  x0: number; y0: number; cw: number; ch: number;
+  cols: number; rows: number; data: Uint8Array;
+}
+interface PreparedRegion { shape: Shape; mask?: RegionMask }
+
+function rasterizePoly(poly: Pt[], bbox: Rect): RegionMask | null {
+  const [x1, y1, x2, y2] = bbox;
+  const w = x2 - x1;
+  const h = y2 - y1;
+  if (w <= 0 || h <= 0) return null;
+  const cols = Math.max(1, Math.min(RASTER_RES, Math.ceil(w)));
+  const rows = Math.max(1, Math.min(RASTER_RES, Math.ceil(h)));
+  const cw = w / cols;
+  const ch = h / rows;
+  const data = new Uint8Array(cols * rows);
+  const xs: number[] = [];
+  for (let iy = 0; iy < rows; iy += 1) {
+    const py = y1 + (iy + 0.5) * ch;
+    xs.length = 0;
+    for (let i = 0, j = poly.length - 1; i < poly.length; j = i, i += 1) {
+      const [xi, yi] = poly[i];
+      const [xj, yj] = poly[j];
+      if ((yi > py) !== (yj > py)) {
+        xs.push(xi + (((py - yi) * (xj - xi)) / (yj - yi)));
+      }
+    }
+    xs.sort((a, b) => a - b);
+    for (let k = 0; k + 1 < xs.length; k += 2) {
+      const c0 = Math.max(0, Math.ceil((xs[k] - x1) / cw - 0.5));
+      const c1 = Math.min(cols - 1, Math.floor((xs[k + 1] - x1) / cw - 0.5));
+      for (let c = c0; c <= c1; c += 1) data[(iy * cols) + c] = 1;
+    }
+  }
+  return {
+    x0: x1, y0: y1, cw, ch, cols, rows, data,
+  };
+}
+
+function prepareRegion(shape: Shape): PreparedRegion {
+  // Simple polygons are cheap to test directly; masks only pay off (and
+  // only introduce their quantization) for vertex-heavy region polygons.
+  if (!shape.poly || shape.poly.length <= 8) {
+    return { shape };
+  }
+  return { shape, mask: rasterizePoly(shape.poly, shape.bbox) ?? undefined };
+}
+
+function pointInRegion(px: number, py: number, region: PreparedRegion): boolean {
+  const { mask } = region;
+  if (mask) {
+    const c = Math.floor((px - mask.x0) / mask.cw);
+    const r = Math.floor((py - mask.y0) / mask.ch);
+    if (c < 0 || r < 0 || c >= mask.cols || r >= mask.rows) return false;
+    return mask.data[(r * mask.cols) + c] === 1;
+  }
+  return pointInShape(px, py, region.shape);
+}
+
 /** Fraction of the detection's area covered by the union of the regions. */
-function overlapFraction(det: Shape, regions: Shape[]): number {
+function overlapFraction(det: Shape, regions: PreparedRegion[]): number {
   const [x1, y1, x2, y2] = det.bbox;
   const w = x2 - x1;
   const h = y2 - y1;
@@ -88,7 +153,7 @@ function overlapFraction(det: Shape, regions: Shape[]): number {
       const px = x1 + ((ix + 0.5) / GRID) * w;
       if (pointInShape(px, py, det)) {
         inDet += 1;
-        if (regions.some((r) => pointInShape(px, py, r))) covered += 1;
+        if (regions.some((r) => pointInRegion(px, py, r))) covered += 1;
       }
     }
   }
@@ -101,12 +166,12 @@ function overlapFraction(det: Shape, regions: Shape[]): number {
  * over-count -- fine for an upper bound). Lets candidates that cannot
  * possibly reach the threshold skip the expensive point sampling.
  */
-function bboxCoverUpperBound(det: Rect, regions: Shape[]): number {
+function bboxCoverUpperBound(det: Rect, regions: PreparedRegion[]): number {
   const [dx1, dy1, dx2, dy2] = det;
   const detArea = Math.max(0, dx2 - dx1) * Math.max(0, dy2 - dy1);
   if (detArea <= 0) return 0;
   let sum = 0;
-  regions.forEach(({ bbox: [rx1, ry1, rx2, ry2] }) => {
+  regions.forEach(({ shape: { bbox: [rx1, ry1, rx2, ry2] } }) => {
     const w = Math.min(dx2, rx2) - Math.max(dx1, rx1);
     const h = Math.min(dy2, ry2) - Math.max(dy1, ry1);
     if (w > 0 && h > 0) sum += w * h;
@@ -159,7 +224,7 @@ export function getSuppressedTrackIds(
     return result;
   }
 
-  const regions: Shape[] = [];
+  const regions: PreparedRegion[] = [];
   const candidates: { id: AnnotationId; shape: Shape }[] = [];
   ids.forEach((id) => {
     const track = trackStore.getPossible(id);
@@ -167,7 +232,7 @@ export function getSuppressedTrackIds(
     const shape = featureShape(track.getFeature(frame)[0]);
     if (!shape) return;
     if (track.confidencePairs.some(([t]) => t === suppressionType)) {
-      regions.push(shape);
+      regions.push(prepareRegion(shape));
     } else {
       candidates.push({ id, shape });
     }


### PR DESCRIPTION
## Problem

Resizing a large suppression region (especially one carrying a polygon) on sequences with many detections lagged during the drag and briefly hung when releasing the corner handle.

Three compounding costs:
1. Every intermediate drag event bumps the pending-save counter, which re-ran the **dataset-wide** fully-suppressed computation (every keyframe of every track, each doing 16×16 point sampling against the region polygons) once per mouse move.
2. The per-frame suppressed set was computed **three times** per update — once each for the canvas (LayerManager), the per-frame type counts (FilterList), and the track list.
3. Every candidate detection on the frame paid the full point-sampling cost even when it obviously couldn't reach the coverage threshold.

## Fix

- **BBox prefilter**: `getSuppressedTrackIds` first computes a cheap bbox-overlap upper bound on the covered fraction; candidates that cannot possibly reach the threshold skip the point sampling entirely.
- **Per-revision memoization**: results are cached per store+frame keyed on an edit revision (the pending-save counter), passed by all three consumers — one computation per frame per edit instead of three.
- **Debounced dataset totals**: the fully-suppressed set behind the type-list totals recomputes on a 500 ms debounce instead of synchronously per save-counter bump, so corner drags stay responsive and the totals settle right after the drag ends. Suppression-type/camera changes still recompute immediately.

Unit tests cover the prefilter behavior (covered vs. barely-touching vs. distant candidates) and the memoization/revision semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)