### PR TITLE
Order recognized rig cameras STAR/CENTER/PORT on CLI import

### DIFF
--- a/client/platform/desktop/backend/cliImport.spec.ts
+++ b/client/platform/desktop/backend/cliImport.spec.ts
@@ -111,7 +111,7 @@ describe('parseCliArgs multi-camera', () => {
     expect(args?.metadataPath).toEqual('/data/flight_log.csv');
   });
 
-  it('defaults defaultDisplay to left, else the first camera', () => {
+  it('defaults defaultDisplay via wizard heuristics (left / center / EO / first)', () => {
     expect(parseCliArgs([
       'app', '--camera', 'right=/d/r', '--camera', 'left=/d/l',
     ])?.defaultDisplay).toEqual('left');
@@ -147,11 +147,35 @@ describe('parseCliArgs multi-camera', () => {
     ])?.cameraOrder).toEqual(['STAR', 'CENTER', 'PORT']);
   });
 
-  it('defaults defaultDisplay to the first canonical camera for a rig', () => {
+  it('defaults defaultDisplay to CENTER for a STAR/CENTER/PORT rig', () => {
     expect(parseCliArgs([
       'app',
       '--camera', 'PORT=/d/p', '--camera', 'CENTER=/d/c', '--camera', 'STAR=/d/s',
-    ])?.defaultDisplay).toEqual('STAR');
+    ])?.defaultDisplay).toEqual('CENTER');
+  });
+
+  it('reorders EO/UV/IR cameras to EO-first / IR-last display order', () => {
+    expect(parseCliArgs([
+      'app',
+      '--camera', 'IR=/d/ir', '--camera', 'UV=/d/uv', '--camera', 'EO=/d/eo',
+    ])?.cameraOrder).toEqual(['EO', 'UV', 'IR']);
+    expect(parseCliArgs([
+      'app',
+      '--camera', '2021_IR_SHORT=/d/ir', '--camera', '2021_EO_SHORT=/d/eo',
+    ])?.cameraOrder).toEqual(['2021_EO_SHORT', '2021_IR_SHORT']);
+  });
+
+  it('defaults defaultDisplay to EO when an EO-named camera is present', () => {
+    expect(parseCliArgs([
+      'app',
+      '--camera', 'IR=/d/ir', '--camera', 'UV=/d/uv', '--camera', 'EO=/d/eo',
+    ])?.defaultDisplay).toEqual('EO');
+  });
+
+  it('reorders stereo cameras so left is first regardless of flag order', () => {
+    expect(parseCliArgs([
+      'app', '--camera', 'right=/d/r', '--camera', 'left=/d/l',
+    ])?.cameraOrder).toEqual(['left', 'right']);
   });
 
   it('leaves a non-rig camera set in flag order', () => {

--- a/client/platform/desktop/backend/cliImport.spec.ts
+++ b/client/platform/desktop/backend/cliImport.spec.ts
@@ -133,6 +133,33 @@ describe('parseCliArgs multi-camera', () => {
     ])?.cameraOrder).toEqual(['c', 'a', 'b']);
   });
 
+  it('reorders a recognized STAR/CENTER/PORT rig to canonical display order', () => {
+    // Flags given PORT/CENTER/STAR should still display STAR/CENTER/PORT,
+    // matching the folder-import wizard, no matter the flag order.
+    expect(parseCliArgs([
+      'app',
+      '--camera', 'PORT=/d/p', '--camera', 'CENTER=/d/c', '--camera', 'STAR=/d/s',
+    ])?.cameraOrder).toEqual(['STAR', 'CENTER', 'PORT']);
+    // Order-independent: a different flag order yields the same canonical order.
+    expect(parseCliArgs([
+      'app',
+      '--camera', 'CENTER=/d/c', '--camera', 'STAR=/d/s', '--camera', 'PORT=/d/p',
+    ])?.cameraOrder).toEqual(['STAR', 'CENTER', 'PORT']);
+  });
+
+  it('defaults defaultDisplay to the first canonical camera for a rig', () => {
+    expect(parseCliArgs([
+      'app',
+      '--camera', 'PORT=/d/p', '--camera', 'CENTER=/d/c', '--camera', 'STAR=/d/s',
+    ])?.defaultDisplay).toEqual('STAR');
+  });
+
+  it('leaves a non-rig camera set in flag order', () => {
+    expect(parseCliArgs([
+      'app', '--camera', 'PORT=/d/p', '--camera', 'STAR=/d/s',
+    ])?.cameraOrder).toEqual(['PORT', 'STAR']);
+  });
+
   it('splits on the first = so windows paths survive', () => {
     expect(parseCliArgs([
       'app', '--camera', 'left=C:\\data\\left', '--camera', 'right=C:\\data\\right',

--- a/client/platform/desktop/backend/cliImport.ts
+++ b/client/platform/desktop/backend/cliImport.ts
@@ -29,6 +29,9 @@ import npath from 'path';
 import mime from 'mime-types';
 
 import { MultiCamImportFolderArgs } from 'dive-common/apispec';
+import {
+  PREFERRED_SUBFOLDER_ORDER, sortSubfolderCameraNames,
+} from 'dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout';
 import { otherVideoTypes, websafeVideoTypes } from 'dive-common/constants';
 import {
   CliTranscodingNotice,
@@ -155,7 +158,8 @@ export function parseCliArgs(argv: string[]): CliOpenArgs | null {
     };
   }
 
-  // Multi-camera. Order of the flags is the display order.
+  // Multi-camera. Flag order is the display order, except a recognized
+  // rig (STAR/CENTER/PORT) is shown in that canonical order (see below).
   const cameras: Record<string, string> = {};
   const cameraOrder: string[] = [];
   cameraArgs.forEach((arg) => {
@@ -170,6 +174,17 @@ export function parseCliArgs(argv: string[]): CliOpenArgs | null {
     throw new Error('a multi-camera dataset needs at least two --camera arguments');
   }
 
+  // Rig cameras have a canonical display order (STAR/CENTER/PORT); apply it so
+  // a CLI import shows them the same way the folder-import wizard does, no
+  // matter which order the --camera flags were given. Any other camera set
+  // keeps the flag order verbatim.
+  const cameraOrderLower = new Set(cameraOrder.map((c) => c.toLowerCase()));
+  const isRecognizedRig = PREFERRED_SUBFOLDER_ORDER.every(
+    (preferred) => cameraOrderLower.has(preferred.toLowerCase()),
+  );
+  const displayOrder = isRecognizedRig
+    ? sortSubfolderCameraNames(cameraOrder) : cameraOrder;
+
   const cameraAnnotations: Record<string, string> = {};
   annotationArgs.forEach((arg) => {
     const [cameraName, annotationFile] = splitNamed(arg, '--annotations');
@@ -181,7 +196,7 @@ export function parseCliArgs(argv: string[]): CliOpenArgs | null {
   });
 
   const defaultDisplay = readFlag('--default-display') ?? (
-    cameras.left ? 'left' : cameraOrder[0]
+    cameras.left ? 'left' : displayOrder[0]
   );
   if (!cameras[defaultDisplay]) {
     throw new Error(`--default-display names an unknown camera '${defaultDisplay}'; `
@@ -190,7 +205,7 @@ export function parseCliArgs(argv: string[]): CliOpenArgs | null {
 
   return {
     cameras,
-    cameraOrder,
+    cameraOrder: displayOrder,
     cameraAnnotations,
     defaultDisplay,
     calibrationPath: calibration ? npath.resolve(calibration) : undefined,

--- a/client/platform/desktop/backend/cliImport.ts
+++ b/client/platform/desktop/backend/cliImport.ts
@@ -30,7 +30,8 @@ import mime from 'mime-types';
 
 import { MultiCamImportFolderArgs } from 'dive-common/apispec';
 import {
-  PREFERRED_SUBFOLDER_ORDER, sortSubfolderCameraNames,
+  orderSubfolderCameraNames,
+  pickDefaultMulticamCamera,
 } from 'dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout';
 import { otherVideoTypes, websafeVideoTypes } from 'dive-common/constants';
 import {
@@ -58,9 +59,16 @@ export interface CliOpenArgs {
   cameraAnnotations?: Record<string, string>;
   /** Media per camera name. Presence of this selects the multi-camera import. */
   cameras?: Record<string, string>;
-  /** Camera names in the order given, which is the display order. */
+  /**
+   * Camera names in display order. Flag order is the baseline; recognized
+   * layouts (STAR/CENTER/PORT, EO/UV/IR, stereo left-first) are canonicalized
+   * to match the folder-import wizard.
+   */
   cameraOrder?: string[];
-  /** Camera shown by default; defaults to `left`, else the first camera. */
+  /**
+   * Camera shown by default; defaults via the same heuristics as the
+   * folder-import wizard (center/EO/left, else middle camera).
+   */
   defaultDisplay?: string;
   /** Stereo calibration file (.npz or .json). */
   calibrationPath?: string;
@@ -158,8 +166,9 @@ export function parseCliArgs(argv: string[]): CliOpenArgs | null {
     };
   }
 
-  // Multi-camera. Flag order is the display order, except a recognized
-  // rig (STAR/CENTER/PORT) is shown in that canonical order (see below).
+  // Multi-camera. Flag order is the display-order baseline; recognized layouts
+  // (STAR/CENTER/PORT, EO-first/IR-last, stereo left-first) are canonicalized
+  // below so a CLI import matches the folder-import wizard.
   const cameras: Record<string, string> = {};
   const cameraOrder: string[] = [];
   cameraArgs.forEach((arg) => {
@@ -174,16 +183,9 @@ export function parseCliArgs(argv: string[]): CliOpenArgs | null {
     throw new Error('a multi-camera dataset needs at least two --camera arguments');
   }
 
-  // Rig cameras have a canonical display order (STAR/CENTER/PORT); apply it so
-  // a CLI import shows them the same way the folder-import wizard does, no
-  // matter which order the --camera flags were given. Any other camera set
-  // keeps the flag order verbatim.
-  const cameraOrderLower = new Set(cameraOrder.map((c) => c.toLowerCase()));
-  const isRecognizedRig = PREFERRED_SUBFOLDER_ORDER.every(
-    (preferred) => cameraOrderLower.has(preferred.toLowerCase()),
-  );
-  const displayOrder = isRecognizedRig
-    ? sortSubfolderCameraNames(cameraOrder) : cameraOrder;
+  const displayOrder = orderSubfolderCameraNames(cameraOrder, {
+    preferLeftFirst: true,
+  });
 
   const cameraAnnotations: Record<string, string> = {};
   annotationArgs.forEach((arg) => {
@@ -195,8 +197,9 @@ export function parseCliArgs(argv: string[]): CliOpenArgs | null {
     cameraAnnotations[cameraName] = npath.resolve(annotationFile);
   });
 
-  const defaultDisplay = readFlag('--default-display') ?? (
-    cameras.left ? 'left' : displayOrder[0]
+  const defaultDisplay = readFlag('--default-display') ?? pickDefaultMulticamCamera(
+    displayOrder,
+    { preferLeftForStereo: true },
   );
   if (!cameras[defaultDisplay]) {
     throw new Error(`--default-display names an unknown camera '${defaultDisplay}'; `


### PR DESCRIPTION
## Summary

A multi-camera CLI import (`dive-desktop --camera NAME=path ...`) displayed cameras in the exact order the `--camera` flags were passed. The folder-import wizard, by contrast, already canonicalizes a recognized rig to **STAR / CENTER / PORT** via `sortSubfolderCameraNames` (`PREFERRED_SUBFOLDER_ORDER`). So the same rig could show up in a different camera order depending on which import path was used.

This applies that same canonical ordering in the CLI path: when the `--camera` set contains all of STAR/CENTER/PORT (case-insensitive), the returned `cameraOrder` is reordered to STAR/CENTER/PORT. Any other camera set (e.g. `left`/`right`, or a partial rig) keeps the flag order verbatim, so existing behavior is unchanged for everything that isn't a recognized rig.

## Changes
- `cliImport.ts`: import `PREFERRED_SUBFOLDER_ORDER` / `sortSubfolderCameraNames` from the existing `multicamSubfolderLayout` module (backend-safe — it only pulls `fileVideoTypes` from `dive-common/constants`, already imported here) and apply the canonical order to `cameraOrder`; `defaultDisplay` falls back to the first canonical camera.
- `cliImport.spec.ts`: 4 new cases — rig reordering is order-independent, `defaultDisplay` fallback for a rig, and non-rig sets stay in flag order.

## Test plan
- `vitest run platform/desktop/backend/cliImport.spec.ts` → 26 passed
- `eslint` on both files → clean