### PR TITLE
allow moving polygons by their bbox

### DIFF
--- a/client/dive-common/use/useModeManager.spec.ts
+++ b/client/dive-common/use/useModeManager.spec.ts
@@ -222,6 +222,29 @@ describe('useModeManager polygon clip on box resize', () => {
     });
   });
 
+  it('translates polygons with the box on a pure move (does not clip)', () => {
+    const { cameraStore, modeManager } = makeSingleCamHarness();
+    const trackId = modeManager.handler.trackAdd();
+    // Polygon inset inside the box so a naive clip-on-move would shrink it.
+    const insetPolygon = {
+      type: 'Feature' as const,
+      geometry: {
+        type: 'Polygon' as const,
+        coordinates: [[[5, 5], [25, 5], [25, 25], [5, 25], [5, 5]]],
+      },
+      properties: { key: '' },
+    };
+    modeManager.handler.setTrackFeature(0, [0, 0, 40, 40], [insetPolygon]);
+    modeManager.handler.trackSelect(trackId, true);
+    modeManager.handler.updateRectBounds(0, 0, [10, 5, 50, 45]);
+
+    const poly = cameraStore.getTrack(trackId).features[0]?.geometry?.features[0];
+    expect(poly?.geometry).toEqual({
+      type: 'Polygon',
+      coordinates: [[[15, 10], [35, 10], [35, 30], [15, 30], [15, 10]]],
+    });
+  });
+
   it('does not clip when the detection already has significant stored rotation', () => {
     const { cameraStore, modeManager } = makeSingleCamHarness();
     const trackId = modeManager.handler.trackAdd();

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -11,6 +11,8 @@ import {
   hasSignificantRotation,
   polygonWithinBounds,
   polygonEqualsBounds,
+  translatePolygon,
+  isBoundsTranslation,
   clipPolygonToBounds,
   ROTATION_ATTRIBUTE_NAME,
 } from 'vue-media-annotator/utils';
@@ -706,31 +708,51 @@ export default function useModeManager({
             track.features[frameNum]?.attributes ?? real?.attributes,
           );
 
-        // Trim any polygon on this detection to fit the new box. setFeature
-        // rounds bounds, so clip against the rounded values to stay
-        // consistent with what gets stored. Rotated boxes are skipped: their
-        // stored bounds are the unrotated envelope, so an axis-aligned clip
-        // would cut the wrong region.
-        const clippedGeometry: GeoJSON.Feature<TrackSupportedFeature>[] = [];
+        // Keep polygons in sync with box edits. setFeature rounds bounds, so
+        // compare/clip against rounded values. Rotated boxes are skipped:
+        // their stored bounds are the unrotated envelope, so an axis-aligned
+        // clip would cut the wrong region.
+        // - Pure move (same size, new origin): translate polygons by the delta.
+        // - Resize: trim polygons that stick outside the new box.
+        const updatedGeometry: GeoJSON.Feature<TrackSupportedFeature>[] = [];
         const removedPolygonKeys: string[] = [];
         if (!hasSignificantRotation(effectiveRotation)) {
           const roundedBounds: RectBounds = [
             Math.round(bounds[0]), Math.round(bounds[1]),
             Math.round(bounds[2]), Math.round(bounds[3]),
           ];
-          track.getFeatureGeometry(frameNum, { type: 'Polygon' }).forEach((polyFeature) => {
-            const polygon = polyFeature.geometry as GeoJSON.Polygon;
-            if (!polygonWithinBounds(polygon, roundedBounds)) {
-              const clipped = clipPolygonToBounds(polygon, roundedBounds);
-              // A clip that leaves the polygon identical to the box carries
-              // no information beyond the box itself, so drop it too.
-              if (clipped && !polygonEqualsBounds(clipped, roundedBounds)) {
-                clippedGeometry.push({ ...polyFeature, geometry: clipped });
-              } else {
-                removedPolygonKeys.push(polyFeature.properties?.key ?? '');
+          const oldBounds: RectBounds | null = real?.bounds
+            ? [
+              Math.round(real.bounds[0]), Math.round(real.bounds[1]),
+              Math.round(real.bounds[2]), Math.round(real.bounds[3]),
+            ]
+            : null;
+          const polygons = track.getFeatureGeometry(frameNum, { type: 'Polygon' });
+          if (oldBounds && isBoundsTranslation(oldBounds, roundedBounds)) {
+            const dx = roundedBounds[0] - oldBounds[0];
+            const dy = roundedBounds[1] - oldBounds[1];
+            polygons.forEach((polyFeature) => {
+              const polygon = polyFeature.geometry as GeoJSON.Polygon;
+              updatedGeometry.push({
+                ...polyFeature,
+                geometry: translatePolygon(polygon, dx, dy),
+              });
+            });
+          } else {
+            polygons.forEach((polyFeature) => {
+              const polygon = polyFeature.geometry as GeoJSON.Polygon;
+              if (!polygonWithinBounds(polygon, roundedBounds)) {
+                const clipped = clipPolygonToBounds(polygon, roundedBounds);
+                // A clip that leaves the polygon identical to the box carries
+                // no information beyond the box itself, so drop it too.
+                if (clipped && !polygonEqualsBounds(clipped, roundedBounds)) {
+                  updatedGeometry.push({ ...polyFeature, geometry: clipped });
+                } else {
+                  removedPolygonKeys.push(polyFeature.properties?.key ?? '');
+                }
               }
-            }
-          });
+            });
+          }
         }
 
         track.setFeature({
@@ -739,7 +761,7 @@ export default function useModeManager({
           bounds,
           keyframe: true,
           interpolate: _shouldInterpolate(interpolate),
-        }, clippedGeometry);
+        }, updatedGeometry);
         removedPolygonKeys.forEach((key) => {
           track.removeFeatureGeometry(frameNum, { key, type: 'Polygon' });
         });

--- a/client/src/utils.spec.ts
+++ b/client/src/utils.spec.ts
@@ -19,6 +19,8 @@ import {
   featureHasSegmentationPolygon,
   polygonWithinBounds,
   polygonEqualsBounds,
+  translatePolygon,
+  isBoundsTranslation,
   clipPolygonToBounds,
   pointInPolygon,
   pointInRing,
@@ -458,6 +460,31 @@ describe('polygonWithinBounds / clipPolygonToBounds', () => {
       [[0, 20], [0, 0], [20, 0], [20, 20], [0, 20]],
       [[5, 5], [8, 5], [8, 8], [5, 8], [5, 5]],
     ]));
+  });
+});
+
+describe('translatePolygon / isBoundsTranslation', () => {
+  const poly = (rings: GeoJSON.Position[][]): GeoJSON.Polygon => ({
+    type: 'Polygon',
+    coordinates: rings,
+  });
+
+  it('translatePolygon shifts every vertex including holes', () => {
+    const withHole = poly([
+      [[0, 0], [40, 0], [40, 40], [0, 40], [0, 0]],
+      [[5, 5], [8, 5], [8, 8], [5, 8], [5, 5]],
+    ]);
+    expect(translatePolygon(withHole, 10, -3)).toEqual(poly([
+      [[10, -3], [50, -3], [50, 37], [10, 37], [10, -3]],
+      [[15, 2], [18, 2], [18, 5], [15, 5], [15, 2]],
+    ]));
+  });
+
+  it('isBoundsTranslation is true only for same-size origin shifts', () => {
+    expect(isBoundsTranslation([0, 0, 40, 40], [10, 5, 50, 45])).toBe(true);
+    expect(isBoundsTranslation([0, 0, 40, 40], [0, 0, 40, 40])).toBe(false);
+    expect(isBoundsTranslation([0, 0, 40, 40], [0, 0, 20, 40])).toBe(false);
+    expect(isBoundsTranslation([0, 0, 40, 40], [10, 0, 40, 40])).toBe(false);
   });
 });
 

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -261,6 +261,32 @@ function polygonWithinBounds(polygon: GeoJSON.Polygon, bounds: RectBounds): bool
 }
 
 /**
+ * Translate every vertex of a polygon by (dx, dy). Holes move with the exterior.
+ */
+function translatePolygon(
+  polygon: GeoJSON.Polygon,
+  dx: number,
+  dy: number,
+): GeoJSON.Polygon {
+  return {
+    type: 'Polygon',
+    coordinates: polygon.coordinates.map((ring) => (
+      ring.map((pos) => [pos[0] + dx, pos[1] + dy])
+    )),
+  };
+}
+
+/**
+ * True when `next` is the same width/height as `prev` but at a different origin
+ * (a pure translation / box move, not a resize).
+ */
+function isBoundsTranslation(prev: RectBounds, next: RectBounds): boolean {
+  return (prev[2] - prev[0]) === (next[2] - next[0])
+    && (prev[3] - prev[1]) === (next[3] - next[1])
+    && (prev[0] !== next[0] || prev[1] !== next[1]);
+}
+
+/**
  * True when the polygon is just the full axis-aligned rectangle of `bounds`:
  * no holes, its extent matches the bounds, and its area fills the whole box
  * (a simple polygon whose area equals its bounding box's area must be that
@@ -664,6 +690,8 @@ export {
   withinBounds,
   polygonWithinBounds,
   polygonEqualsBounds,
+  translatePolygon,
+  isBoundsTranslation,
   clipPolygonToBounds,
   frameToTimestamp,
   isAxisAligned,


### PR DESCRIPTION
In #1783 there was functionality added to trim a polygon using the bbox.  This also had a side effect where when moving the bbox it would cut off or erase the polygon.

This PR addresses this by allowing a user to move a bbox and the corresponding polygon will move.  It also preserves the functionality of resizing the bbocx and cutting off the sides of the polygon.