### PR TITLE
Single cam pipelines in multicam web

### DIFF
--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -20,6 +20,7 @@ import {
   stereoPipelineMarker,
   multiCamPipelineMarkers,
 } from 'dive-common/constants';
+import { parseCompositeDatasetId } from 'dive-common/compositeDatasetId';
 import {
   isFilterPipeline,
   pipelineCreatesNewDataset,
@@ -181,6 +182,21 @@ async function runPipeline(
   const projectInfo = await common.getValidatedProjectDir(settings, datasetId);
   const meta = await common.loadJsonMetadata(projectInfo.metaFileAbsPath);
   const jobWorkDir = await createWorkingDirectory(settings, [meta], pipeline.name);
+
+  const { parentId, cameraName } = parseCompositeDatasetId(datasetId);
+  let cameraLogLine: string | null = null;
+  if (cameraName) {
+    try {
+      const parentInfo = await common.getValidatedProjectDir(settings, parentId);
+      const parentMeta = await common.loadJsonMetadata(parentInfo.metaFileAbsPath);
+      const defaultDisplay = parentMeta.multiCam?.defaultDisplay;
+      if (cameraName !== defaultDisplay) {
+        cameraLogLine = `Running pipeline on camera: ${cameraName}`;
+      }
+    } catch {
+      cameraLogLine = `Running pipeline on camera: ${cameraName}`;
+    }
+  }
 
   const timestamp = (new Date()).toISOString().replace(/[:.]/g, '-');
   const outputDirName = `${runPipelineArgs.pipeline.name}_${runPipelineArgs.datasetId}_${timestamp}`;
@@ -399,9 +415,13 @@ async function runPipeline(
 
   fs.writeFile(npath.join(jobWorkDir, DiveJobManifestName), JSON.stringify(jobBase, null, 2));
 
+  if (cameraLogLine) {
+    await fs.appendFile(joblog, `${cameraLogLine}\n`);
+  }
+
   updater({
     ...jobBase,
-    body: [''],
+    body: cameraLogLine ? [cameraLogLine, ''] : [''],
   });
 
   job.stdout.on('data', jobFileEchoMiddleware(jobBase, updater, joblog));

--- a/client/platform/web-girder/api/rpc.service.ts
+++ b/client/platform/web-girder/api/rpc.service.ts
@@ -1,6 +1,7 @@
 import girderRest from 'platform/web-girder/plugins/girder';
 import type { GirderModel } from '@girder/components/src';
 import type { Pipe, PipelineParams } from 'dive-common/apispec';
+import { resolveDatasetFolderId } from './multicamResolve';
 
 function postProcess(folderId: string, skipJobs = false, skipTranscoding = false, additive = false, additivePrepend = '', set: string | undefined = undefined) {
   return girderRest.post<{folder: GirderModel, warnings: string[], job_ids: string[]}>(`dive_rpc/postprocess/${folderId}`, null, {
@@ -10,9 +11,12 @@ function postProcess(folderId: string, skipJobs = false, skipTranscoding = false
   });
 }
 
-function runPipeline(itemId: string, pipeline: Pipe, pipelineParams?: PipelineParams) {
+async function runPipeline(itemId: string, pipeline: Pipe, pipelineParams?: PipelineParams) {
+  // Composite multicam ids (parent/camera) resolve to the camera folder so
+  // single-camera pipelines can run on the selected camera.
+  const { folderId } = await resolveDatasetFolderId(itemId);
   const params: Record<string, unknown> = {
-    folderId: itemId,
+    folderId,
     pipeline,
   };
   if (pipelineParams) {

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -117,7 +117,7 @@ export default defineComponent({
       if (Number.isNaN(parsed)) return undefined;
       return parsed;
     });
-    const currentJob = computed(() => jobs.getDatasetCompleteJobs(props.id));
+    const currentJob = computed(() => jobs.getDatasetCompleteJobs(parentDatasetId(props.id)));
 
     const typeList = computed((): DatasetType[] => {
       const t = datasetMeta.value?.type;
@@ -126,12 +126,47 @@ export default defineComponent({
     const subTypeList = computed((): SubType[] => [datasetMeta.value?.subType ?? null]);
     const cameraNumbers = computed(() => [getMultiCamCameraCount(datasetMeta.value)]);
     const timeFilter: Ref<[number, number] | null> = ref(null);
+    // Track the active camera so single-camera pipelines target that folder
+    // (parentId/cameraName), matching desktop ViewerLoader behavior.
+    const selectedCamera = ref('');
+    function changeCamera(cameraName: string) {
+      selectedCamera.value = cameraName;
+    }
+    // Prefer the @change-camera event, then Viewer's live selection, then the
+    // multicam defaultDisplay once meta for this dataset is loaded. Avoids a
+    // window where modifiedId is still the parent id and single-cam pipes 400.
+    const modifiedId = computed(() => {
+      const parentId = parentDatasetId(props.id);
+      const viewerCam = viewerRef.value?.selectedCamera as string | undefined;
+      const meta = datasetMeta.value;
+      const metaMatches = meta != null && (meta.id === parentId || meta.id === props.id);
+      const camera = selectedCamera.value
+        || (viewerCam && viewerCam !== 'singleCam' ? viewerCam : '')
+        || (metaMatches ? meta.multiCamMedia?.defaultDisplay : undefined)
+        || '';
+      if (camera) {
+        return `${parentId}/${camera}`;
+      }
+      return props.id;
+    });
 
     watch(() => props.id, (datasetId) => {
+      selectedCamera.value = '';
       loadDataset(datasetId).catch((reason) => {
         reportHandledPromiseRejection('ViewerLoader: loadDataset', reason);
       });
     }, { immediate: true });
+
+    // Seed as soon as parent meta arrives so pipeline menus don't wait on Viewer emit.
+    watch(datasetMeta, (meta) => {
+      if (selectedCamera.value || !meta?.multiCamMedia?.defaultDisplay) {
+        return;
+      }
+      const parentId = parentDatasetId(props.id);
+      if (meta.id === parentId || meta.id === props.id) {
+        selectedCamera.value = meta.multiCamMedia.defaultDisplay;
+      }
+    });
 
     async function refreshCalibrationFile() {
       if (!getDatasetCalibration || subTypeList.value[0] !== 'stereo') {
@@ -173,8 +208,10 @@ export default defineComponent({
     );
     const runningPipelines = computed(() => {
       const results: string[] = [];
-      if (jobs.getDatasetRunningState(props.id)) {
-        results.push(props.id);
+      // Jobs on a camera child are attributed to the multicam parent id.
+      if (jobs.getDatasetRunningState(parentDatasetId(props.id))) {
+        results.push(modifiedId.value);
+        results.push(parentDatasetId(props.id));
       }
       return results;
     });
@@ -196,7 +233,7 @@ export default defineComponent({
             positiveButton: 'Reload',
             negativeButton: '',
           });
-          jobs.removeCompleteJob({ datasetId: props.id });
+          jobs.removeCompleteJob({ datasetId: parentDatasetId(props.id) });
           if (result) {
             viewerRef.value.reloadAnnotations();
           }
@@ -207,7 +244,7 @@ export default defineComponent({
               'either failed or was cancelled by the user',
             ],
           });
-          jobs.removeCompleteJob({ datasetId: props.id });
+          jobs.removeCompleteJob({ datasetId: parentDatasetId(props.id) });
         }
       }
     });
@@ -295,6 +332,8 @@ export default defineComponent({
       calibrationFile,
       onCalibrationImported,
       onCalibrationDeleted,
+      changeCamera,
+      modifiedId,
     };
   },
 });
@@ -311,6 +350,7 @@ export default defineComponent({
     :comparison-sets="comparisonSets"
     @large-image-warning="largeImageWarning()"
     @update:set="routeSet"
+    @change-camera="changeCamera"
   >
     <template #title>
       <ViewerAlert />
@@ -338,7 +378,7 @@ export default defineComponent({
           subTypeList,
           cameraNumbers,
         }"
-        :selected-dataset-ids="[id]"
+        :selected-dataset-ids="[modifiedId]"
         :running-pipelines="runningPipelines"
         :read-only-mode="revisionNum !== undefined"
         :time-filter="timeFilter"
@@ -348,7 +388,7 @@ export default defineComponent({
         :button-options="buttonOptions"
         :menu-options="menuOptions"
         :read-only-mode="!!jobs.getDatasetRunningState(id) || revisionNum !== undefined"
-        :dataset-id="id"
+        :dataset-id="modifiedId"
         :sub-type="subTypeList[0]"
         :calibration-file="calibrationFile"
         block-on-unsaved

--- a/server/dive_server/crud.py
+++ b/server/dive_server/crud.py
@@ -4,7 +4,7 @@ from enum import Enum
 import functools
 import os
 from pathlib import Path
-from typing import List, Type
+from typing import List, Optional, Type
 
 from girder.constants import AccessType
 from girder.exceptions import RestException, ValidationException
@@ -144,6 +144,17 @@ def get_multicam_parent_folder(folder: GirderModel, user: GirderUserModel):
     if not any(str(cam.get('folderId')) == folder_id for cam in cameras.values()):
         return None
     return parent
+
+
+def get_multicam_camera_name(folder: GirderModel, parent: GirderModel) -> Optional[str]:
+    """Return the camera name for ``folder`` within multicam ``parent``, else None."""
+    multi_cam = fromMeta(parent, constants.MultiCamMarker, default={}) or {}
+    cameras = multi_cam.get('cameras') or {}
+    folder_id = str(folder['_id'])
+    for name, cam in cameras.items():
+        if str(cam.get('folderId')) == folder_id:
+            return name
+    return None
 
 
 def pick_multicam_shared_mutable(meta: dict) -> dict:

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -240,11 +240,23 @@ def run_pipeline(
     verify_pipe(user, pipeline)
     crud.getCloneRoot(user, folder)
     folder_id_str = str(folder["_id"])
+
+    # Single-camera pipelines may target a per-camera child folder. Attribute the
+    # job to the multicam parent so the viewer tracks running/complete state.
+    multicam_parent = crud.get_multicam_parent_folder(folder, user)
+    camera_name: Optional[str] = None
+    job_dataset_id = folder_id_str
+    if multicam_parent is not None:
+        camera_name = crud.get_multicam_camera_name(folder, multicam_parent)
+        job_dataset_id = str(multicam_parent["_id"])
+
     # First, verify that no other outstanding jobs are running on this dataset
-    if _check_running_jobs(folder_id_str):
+    if _check_running_jobs(job_dataset_id) or (
+        job_dataset_id != folder_id_str and _check_running_jobs(folder_id_str)
+    ):
         raise RestException(
             (
-                f"A pipeline for {folder_id_str} is already running. "
+                f"A pipeline for {job_dataset_id} is already running. "
                 "Only one outstanding job may be run at a time for "
                 "a dataset."
             )
@@ -346,6 +358,12 @@ def run_pipeline(
         'runtime_params': runtime_params,
         'kwiver_params': kwiver_params,
     }
+    if camera_name:
+        params['camera_name'] = camera_name
+        multi_cam_meta = fromMeta(multicam_parent, constants.MultiCamMarker, default={}) or {}
+        default_display = multi_cam_meta.get('defaultDisplay')
+        if default_display:
+            params['multicam_default_display'] = default_display
     if multicam_cameras:
         params['multicam_cameras'] = multicam_cameras
         params['multicam_default_display'] = multicam_default_display
@@ -355,11 +373,19 @@ def run_pipeline(
     if metadata_file_key and metadata_file_item_id:
         params['metadata_file_key'] = metadata_file_key
         params['metadata_file_item_id'] = metadata_file_item_id
+
+    job_title = f"Running {pipeline['name']} on {str(folder['name'])}"
+    if multicam_parent is not None and camera_name:
+        job_title = (
+            f"Running {pipeline['name']} on {str(multicam_parent['name'])} "
+            f"with camera: {camera_name}"
+        )
+
     newjob = tasks.run_pipeline.apply_async(
         queue=_get_queue_name(user, "pipelines"),
         kwargs=dict(
             params=params,
-            girder_job_title=f"Running {pipeline['name']} on {str(folder['name'])}",
+            girder_job_title=job_title,
             girder_client_token=str(token["_id"]),
             girder_job_type="private" if job_is_private else "pipelines",
         ),
@@ -369,7 +395,7 @@ def run_pipeline(
         access_source=folder,
         **{
             constants.JOBCONST_PRIVATE_QUEUE: job_is_private,
-            constants.JOBCONST_DATASET_ID: folder_id_str,
+            constants.JOBCONST_DATASET_ID: job_dataset_id,
             constants.JOBCONST_PARAMS: params,
             constants.JOBCONST_CREATOR: str(user['_id']),
         },

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -368,6 +368,12 @@ def run_pipeline(self: Task, params: PipelineJob):
     frame_range = runtime_params.get('frameRange')
     multicam_params: MulticamPipelineJob = params
     multicam_cameras: List[MulticamCameraJob] = multicam_params.get('multicam_cameras') or []
+    camera_name = params.get('camera_name')
+    if camera_name:
+        # Log non-default camera targets so job history shows which view ran.
+        default_display = multicam_params.get('multicam_default_display')
+        if not default_display or camera_name != default_display:
+            print(f'Running pipeline on camera: {camera_name}')
     with tempfile.TemporaryDirectory() as _working_directory, suppress(utils.CanceledError):
         _working_directory_path = Path(_working_directory)
         input_path = utils.make_directory(_working_directory_path / 'input')

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -138,6 +138,8 @@ class PipelineJob(TypedDict):
     # target declared by the pipe's `# Metadata File:` header.
     metadata_file_item_id: NotRequired[Optional[str]]
     metadata_file_key: NotRequired[Optional[str]]
+    # Set when a single-camera pipeline runs on one camera folder of a multicam parent.
+    camera_name: NotRequired[Optional[str]]
 
 
 class MulticamPipelineJob(PipelineJob, total=False):

--- a/server/tests/test_update_metadata.py
+++ b/server/tests/test_update_metadata.py
@@ -487,3 +487,25 @@ def test_get_multicam_parent_folder_ignores_unregistered_child(folder_cls):
     folder_cls.return_value.load.return_value = parent
 
     assert crud.get_multicam_parent_folder(camera, {'_id': 'user-id'}) is None
+
+
+def test_get_multicam_camera_name_returns_matching_camera():
+    from dive_server import crud
+    from dive_utils import constants
+
+    parent = {
+        '_id': 'parent-id',
+        'meta': {
+            'type': constants.MultiType,
+            'multiCam': {
+                'defaultDisplay': 'left',
+                'cameras': {
+                    'left': {'folderId': 'left-id', 'type': 'image-sequence'},
+                    'right': {'folderId': 'right-id', 'type': 'image-sequence'},
+                },
+            },
+        },
+    }
+    assert crud.get_multicam_camera_name({'_id': 'left-id'}, parent) == 'left'
+    assert crud.get_multicam_camera_name({'_id': 'right-id'}, parent) == 'right'
+    assert crud.get_multicam_camera_name({'_id': 'other-id'}, parent) is None


### PR DESCRIPTION
Fixes an issue where single camera pipelines couldn't run properly in the girder/web version

- Enable running single-camera pipelines on the currently selected camera in multicam datasets on web (matching desktop behavior via `parentId/cameraName` composite IDs).
- Backend resolves camera child folders, attributes jobs to the multicam parent for running/complete state tracking, and includes camera context in job titles and logs.
- Desktop pipeline runs also log when targeting a non-default camera; unit coverage added for camera-name lookup.


Client:
- `ViewerLoader.vue`: track active camera (`@change-camera` + meta `defaultDisplay`), pass composite `modifiedId` into pipeline menus / selected dataset IDs, and key job state off the multicam parent.
- `rpc.service.ts`: resolve composite multicam IDs to the camera folder before calling `run_pipeline`.

Server:
- Attribute single-cam pipeline jobs on a camera child to the multicam parent dataset ID.
- Pass `camera_name` (and default display) through pipeline params; surface camera in job title and worker logs when not the default view.
- Add `get_multicam_camera_name` helper + tests.
