### PR TITLE
Calibration Pipelines set Calibration file

### DIFF
--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -6,6 +6,7 @@ import {
   ref,
   Ref,
   onBeforeMount,
+  onMounted,
   watch,
 } from 'vue';
 import {
@@ -165,6 +166,16 @@ export default defineComponent({
     watch(() => props.selectedDatasetIds, () => {
       refreshCalibrationStatus();
     }, { immediate: true });
+
+    // Listen for calibration assignment from backend (desktop only)
+    onMounted(() => {
+      if (typeof window !== 'undefined' && (window as any).diveDesktop) {
+        (window as any).diveDesktop.on('calibration-assigned', () => {
+          // Refresh calibration status when a pipeline assigns a calibration to a dataset
+          refreshCalibrationStatus();
+        });
+      }
+    });
 
     function isPipelineDisabledForCalibration(pipeline: Pipe) {
       return pipelineDisabledForMissingCalibration(

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -7,6 +7,7 @@ import {
   Ref,
   onBeforeMount,
   onMounted,
+  onBeforeUnmount,
   watch,
 } from 'vue';
 import {
@@ -167,13 +168,22 @@ export default defineComponent({
       refreshCalibrationStatus();
     }, { immediate: true });
 
+    let removeCalibrationAssignedListener: (() => void) | null = null;
+
     // Listen for calibration assignment from backend (desktop only)
     onMounted(() => {
-      if (typeof window !== 'undefined' && (window as any).diveDesktop) {
-        (window as any).diveDesktop.on('calibration-assigned', () => {
+      if (typeof window !== 'undefined' && window.diveDesktop) {
+        removeCalibrationAssignedListener = window.diveDesktop.on('calibration-assigned', () => {
           // Refresh calibration status when a pipeline assigns a calibration to a dataset
           refreshCalibrationStatus();
         });
+      }
+    });
+
+    onBeforeUnmount(() => {
+      if (removeCalibrationAssignedListener) {
+        removeCalibrationAssignedListener();
+        removeCalibrationAssignedListener = null;
       }
     });
 

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -1918,6 +1918,7 @@ export {
   getLastCalibrationPath,
   saveLastCalibration,
   applyCalibrationToUncalibratedStereoDatasets,
+  applyCalibrationToDataset,
   datasetHasCalibrationFile,
   getDatasetCalibrationPath,
   getDatasetCalibrationExportPath,

--- a/client/platform/desktop/backend/native/datasetCalibration.ts
+++ b/client/platform/desktop/backend/native/datasetCalibration.ts
@@ -290,6 +290,38 @@ export async function getDatasetCalibration(
 }
 
 /**
+ * Apply a calibration file to a specific stereo dataset.
+ * The source file is copied into the dataset's project directory, normalized to JSON,
+ * and recorded in multiCam.calibration. Primarily used when a calibration pipeline
+ * outputs a file that should be assigned to the dataset that ran the pipeline.
+ * @param settings app settings
+ * @param datasetId the stereo dataset to calibrate
+ * @param calibrationPath path to the calibration file to apply
+ * @param originalName optional user-facing original filename (for display)
+ * @returns absolute path of the calibration file now associated with the dataset
+ * @throws if the dataset is not a stereo dataset
+ */
+export async function applyCalibrationToDataset(
+  settings: Settings,
+  datasetId: string,
+  calibrationPath: string,
+  originalName?: string,
+): Promise<string> {
+  const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
+  const fullMeta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+
+  if (!fullMeta.multiCam) {
+    throw new Error(`Dataset ${datasetId} is not a stereo/multicam dataset`);
+  }
+  if (fullMeta.subType !== 'stereo') {
+    throw new Error(`Dataset ${datasetId} is not a stereo dataset; calibration is stereo-only`);
+  }
+
+  // Use setDatasetCalibration to handle the actual assignment
+  return setDatasetCalibration(settings, datasetId, calibrationPath);
+}
+
+/**
  * Remove the calibration file associated with a dataset and clear the reference
  * in its metadata. The original (pre-conversion) file, if any, is left in place.
  */

--- a/client/platform/desktop/backend/native/datasetCalibration.ts
+++ b/client/platform/desktop/backend/native/datasetCalibration.ts
@@ -298,7 +298,6 @@ export async function getDatasetCalibration(
  * @param settings app settings
  * @param datasetId the stereo dataset to calibrate
  * @param calibrationPath path to the calibration file to apply
- * @param originalName optional user-facing original filename (for display)
  * @returns absolute path of the calibration file now associated with the dataset
  * @throws if the dataset is not a stereo dataset
  */
@@ -306,7 +305,6 @@ export async function applyCalibrationToDataset(
   settings: Settings,
   datasetId: string,
   calibrationPath: string,
-  originalName?: string,
 ): Promise<string> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
   const fullMeta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);

--- a/client/platform/desktop/backend/native/datasetCalibration.ts
+++ b/client/platform/desktop/backend/native/datasetCalibration.ts
@@ -275,6 +275,7 @@ export async function getDatasetCalibration(
     return null;
   }
   const result: DatasetCalibrationResult = {
+    itemId: calibrationPath, // Set itemId to enable download on desktop
     path: npath.basename(calibrationPath),
     originalName: realCalibrationName(fullMeta.multiCam?.calibrationOriginalName),
   };

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -464,7 +464,6 @@ async function runPipeline(
                 settings,
                 datasetId,
                 calibrationPath,
-                calibrationFile,
               );
               // Also save as last calibration for future imports
               await common.saveLastCalibration(settings, calibrationPath);

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -458,8 +458,28 @@ async function runPipeline(
           );
           if (calibrationFile) {
             const calibrationPath = npath.join(jobWorkDir, calibrationFile);
-            const savedPath = await common.saveLastCalibration(settings, calibrationPath);
-            await common.applyCalibrationToUncalibratedStereoDatasets(settings, savedPath, calibrationFile);
+            try {
+              // Apply calibration directly to the dataset that ran the pipeline
+              await common.applyCalibrationToDataset(
+                settings,
+                datasetId,
+                calibrationPath,
+                calibrationFile,
+              );
+              // Also save as last calibration for future imports
+              await common.saveLastCalibration(settings, calibrationPath);
+              // Signal UI to refresh calibration info
+              sendToRenderer('calibration-assigned', {
+                datasetId,
+                calibrationFile,
+              });
+            } catch (err) {
+              console.error(`Failed to apply calibration to dataset ${datasetId}:`, err);
+              await fs.appendFile(
+                joblog,
+                `\nError assigning calibration file to dataset: ${(err as Error).message}`,
+              );
+            }
           }
         }
 

--- a/client/platform/desktop/frontend/components/MultiPipeline.vue
+++ b/client/platform/desktop/frontend/components/MultiPipeline.vue
@@ -9,6 +9,7 @@ import {
 import { DataTableHeader } from 'vuetify';
 import { useRouter } from 'vue-router/composables';
 import { Pipe, Pipelines, useApi } from 'dive-common/apispec';
+import { parentDatasetId } from 'dive-common/compositeDatasetId';
 import {
   itemsPerPageOptions,
   stereoPipelineMarker,
@@ -125,8 +126,9 @@ async function refreshCalibrationForDatasets(datasetIds: string[]) {
   if (!hasCalibrationFile || !datasetIds.length) {
     return;
   }
+  const parentIds = [...new Set(datasetIds.map((id) => parentDatasetId(id)))];
   const entries = await Promise.all(
-    datasetIds.map(async (id) => [id, await hasCalibrationFile(id)] as const),
+    parentIds.map(async (id) => [id, await hasCalibrationFile(id)] as const),
   );
   calibrationAvailableByDatasetId.value = {
     ...calibrationAvailableByDatasetId.value,
@@ -146,7 +148,7 @@ const runDisabled = computed(() => {
     return false;
   }
   return stagedDatasets.value.some(
-    (dataset) => !calibrationAvailableByDatasetId.value[dataset.id],
+    (dataset) => !calibrationAvailableByDatasetId.value[parentDatasetId(dataset.id)],
   );
 });
 
@@ -154,7 +156,7 @@ function isPipelineItemDisabledForCalibration(pipe: Pipe) {
   return pipelineDisabledForMissingCalibration(
     pipe,
     calibrationAvailableByDatasetId.value,
-    availableItems.value.map((dataset) => dataset.id),
+    availableItems.value.map((dataset) => parentDatasetId(dataset.id)),
   );
 }
 

--- a/client/src/layers/AnnotationLayers/RectangleLayer.ts
+++ b/client/src/layers/AnnotationLayers/RectangleLayer.ts
@@ -313,7 +313,7 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
   }
 
   disable() {
-    if (!this.featureLayer) {
+    if (!this.hasRenderableFeatureLayer()) {
       return;
     }
     try {

--- a/client/src/layers/BaseLayer.ts
+++ b/client/src/layers/BaseLayer.ts
@@ -111,6 +111,36 @@ export default abstract class BaseLayer<D> {
     }
   }
 
+  /**
+   * geoJS features can outlive their map/renderer briefly during teardown.
+   * Detect that state so redraw callers can no-op instead of throwing.
+   */
+  protected hasRenderableFeatureLayer(): boolean {
+    if (!this.annotator.geoViewerRef?.value || !this.featureLayer) {
+      return false;
+    }
+    try {
+      const parentLayer = this.featureLayer.layer?.();
+      if (!parentLayer) {
+        return false;
+      }
+      const map = parentLayer.map?.();
+      if (!map) {
+        return false;
+      }
+      const renderer = parentLayer.renderer?.();
+      if (!renderer) {
+        return false;
+      }
+      if (typeof renderer.api === 'function' && !renderer.api()) {
+        return false;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
     abstract redraw(): void;
 
     /**
@@ -141,16 +171,16 @@ export default abstract class BaseLayer<D> {
 
     changeData(frameData: FrameDataTrack[], comparisons: string[] = []) {
       this.formattedData = this.formatData(frameData, comparisons);
-      if (!this.annotator.geoViewerRef?.value || !this.featureLayer) {
+      if (!this.hasRenderableFeatureLayer()) {
         return;
       }
-      // After WebGL context loss (browser "Too many active WebGL contexts"),
-      // geoJS renderers keep a null gl handle and .draw() throws on `.api`.
+      // Guard above handles normal teardown; this catches races between the
+      // guard and draw on the same tick.
       try {
         this.redraw();
       } catch (err) {
         // eslint-disable-next-line no-console
-        console.warn('Annotation layer redraw skipped after map/renderer teardown', err);
+        console.warn('Annotation layer redraw skipped after map/renderer teardown');
       }
     }
 

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -1200,11 +1200,9 @@ def _dataset_calibration_result(
 
 
 def pipeline_requires_calibration(pipeline: types.PipelineDescription) -> bool:
-    """True when pipeline metadata (or legacy measurement type) requires calibration input."""
+    """True only when pipeline metadata explicitly requires calibration input."""
     metadata = pipeline.get('metadata') or {}
-    if 'requiresCalibration' in metadata:
-        return bool(metadata['requiresCalibration'])
-    return pipeline.get('type') == constants.StereoPipelineMarker
+    return metadata.get('requiresCalibration') is True
 
 
 def resolve_stereo_calibration_item_id(

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -335,7 +335,7 @@ def run_pipeline(
         if needs_calibration and calibration_item_id is None:
             raise RestException(
                 'This pipeline requires a calibration file. '
-                'Import or upload a calibration file with the calibrationFile marker.',
+                'Import or attach a calibration file to the dataset.',
                 code=404,
             )
 

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -343,6 +343,21 @@ def _append_input_list_kwiver_settings(command, pipeline, image_lists) -> None:
             command.append(f'-s {shlex.quote(key)}={shlex.quote(image_lists[0])}')
 
 
+def _find_stereo_calibration_outputs(output_dir: Path) -> List[Path]:
+    """Return likely calibration outputs written by stereo calibration pipelines."""
+    candidates: List[Path] = []
+    for path in output_dir.iterdir():
+        if not path.is_file():
+            continue
+        lower_name = path.name.lower()
+        if 'calibration' not in lower_name:
+            continue
+        if not constants.stereoCalibrationRegex.search(path.name):
+            continue
+        candidates.append(path)
+    return sorted(candidates, key=lambda p: p.name.lower())
+
+
 @app.task(bind=True, acks_late=True, ignore_result=True)
 def run_pipeline(self: Task, params: PipelineJob):
     conf = Config()
@@ -483,6 +498,40 @@ def run_pipeline(self: Task, params: PipelineJob):
                 'env': conf.gpu_process_env,
             }
             utils.stream_subprocess(self, context, manager, popen_kwargs)
+
+            if (
+                is_stereo_measurement_pipeline(pipeline)
+                and 'calibrate_cameras' in str(pipeline.get('pipe', '')).lower()
+            ):
+                calibration_outputs = _find_stereo_calibration_outputs(output_path)
+                if calibration_outputs:
+                    calibration_output = calibration_outputs[0]
+                    try:
+                        uploaded_calibration = gc.uploadFileToFolder(
+                            input_folder_id,
+                            str(calibration_output),
+                        )
+                        uploaded_calibration_file_id = str(uploaded_calibration.get('_id'))
+                        if uploaded_calibration_file_id:
+                            gc.sendRestRequest(
+                                'POST',
+                                f'/dive_dataset/{input_folder_id}/calibration?fileId={uploaded_calibration_file_id}',
+                            )
+                            manager.write(
+                                f'Assigned calibration output to dataset: {calibration_output.name}\n'
+                            )
+                        else:
+                            manager.write(
+                                f'Warning: uploaded calibration output {calibration_output.name} has no file id\n'
+                            )
+                    except Exception as exc:
+                        manager.write(
+                            f'Warning: failed to assign calibration output {calibration_output.name}: {exc}\n'
+                        )
+                else:
+                    manager.write(
+                        'Warning: stereo calibration pipeline produced no recognized calibration output file\n'
+                    )
 
             manager.updateStatus(JobStatus.PUSHING_OUTPUT)
             for camera in multicam_cameras:

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -511,11 +511,12 @@ def run_pipeline(self: Task, params: PipelineJob):
                             input_folder_id,
                             str(calibration_output),
                         )
-                        uploaded_calibration_file_id = str(uploaded_calibration.get('_id'))
-                        if uploaded_calibration_file_id:
+                        uploaded_calibration_file_id = uploaded_calibration.get('_id')
+                        if uploaded_calibration_file_id is not None:
+                            uploaded_calibration_file_id_str = str(uploaded_calibration_file_id)
                             gc.sendRestRequest(
                                 'POST',
-                                f'/dive_dataset/{input_folder_id}/calibration?fileId={uploaded_calibration_file_id}',
+                                f'/dive_dataset/{input_folder_id}/calibration?fileId={uploaded_calibration_file_id_str}',
                             )
                             manager.write(
                                 f'Assigned calibration output to dataset: {calibration_output.name}\n'

--- a/server/tests/test_create_multicam.py
+++ b/server/tests/test_create_multicam.py
@@ -297,6 +297,7 @@ def test_resolve_stereo_calibration_item_id_from_folder_root(item_cls):
         'name': 'Stereo',
         'type': constants.StereoPipelineMarker,
         'pipe': 'measurement_foo.pipe',
+        'metadata': {'requiresCalibration': True},
     }
     cal_item = {
         '_id': 'cal-id',
@@ -325,6 +326,7 @@ def test_resolve_stereo_calibration_item_id_legacy_multi_cam_id(item_cls):
         'name': 'Stereo',
         'type': constants.StereoPipelineMarker,
         'pipe': 'measurement_foo.pipe',
+        'metadata': {'requiresCalibration': True},
     }
     cal_item = {
         '_id': 'cal-id',


### PR DESCRIPTION
resolves #1559

Calibration creation pipelines will now set the calibration file for the dataset after they are complete
This is working on both desktop and web versions
I've updated web to disable pipelines that require a calibration file if it doesn't exist.
