### PR TITLE
Upload exactly the server-validated package

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -222,16 +222,16 @@ interface MultiCamMedia {
 }
 
 interface MediaImportResponse {
-  jsonMeta: {
+  jsonConfig: {
     originalImageFiles: string[];
   };
   globPattern: string;
   mediaConvertList: string[];
 }
 /**
- * The parts of metadata a user should be able to modify.
+ * The parts of dataset config a user should be able to modify.
  */
-interface DatasetMetaMutable {
+interface DatasetConfigMutable {
   customTypeStyling?: Record<string, CustomStyle>;
   customGroupStyling?: Record<string, CustomStyle>;
   confidenceFilters?: Record<string, number>;
@@ -247,7 +247,7 @@ interface DatasetMetaMutable {
   cameraRegistrationSource?: RegistrationSource | null;
   error?: string;
 }
-const DatasetMetaMutableKeys = ['attributes', 'confidenceFilters', 'timeFilters', 'imageEnhancements', 'customTypeStyling', 'customGroupStyling', 'attributeTrackFilters', 'datasetInfo', 'cameraHomographies', 'cameraCorrespondences', 'cameraTransformTypes', 'cameraRegistrationSource'];
+const DatasetConfigMutableKeys = ['attributes', 'confidenceFilters', 'timeFilters', 'imageEnhancements', 'customTypeStyling', 'customGroupStyling', 'attributeTrackFilters', 'datasetInfo', 'cameraHomographies', 'cameraCorrespondences', 'cameraTransformTypes', 'cameraRegistrationSource'];
 /**
  * Mutable keys the multicam/stereo viewer loads from the parent dataset.
  * Camera-targeted imports sync only these onto the parent — not per-camera
@@ -264,7 +264,7 @@ const MulticamSharedMutableKeys = [
   'datasetInfo',
 ];
 
-interface DatasetMeta extends DatasetMetaMutable {
+interface DatasetConfig extends DatasetConfigMutable {
   id: Readonly<string>;
   imageData: Readonly<FrameImage[]>;
   videoUrl: Readonly<string | undefined>;
@@ -349,16 +349,16 @@ interface Api {
     },
   ): Promise<unknown>;
 
-  loadMetadata(datasetId: string): Promise<DatasetMeta>;
+  loadConfig(datasetId: string): Promise<DatasetConfig>;
   loadDetections(datasetId: string, revision?: number, set?: string): Promise<AnnotationSchemaList>;
 
   saveDetections(datasetId: string, args: SaveDetectionsArgs): Promise<unknown>;
-  saveMetadata(datasetId: string, metadata: DatasetMetaMutable): Promise<unknown>;
+  saveConfig(datasetId: string, config: DatasetConfigMutable): Promise<unknown>;
   saveAttributes(datasetId: string, args: SaveAttributeArgs): Promise<unknown>;
   saveAttributeTrackFilters(datasetId: string,
     args: SaveAttributeTrackFilterArgs): Promise<unknown>;
   // Non-Endpoint shared functions
-  openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 'annotation' | 'text' | 'zip' | 'transform' | 'metadata', directory?: boolean):
+  openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 'annotation' | 'config' | 'text' | 'zip' | 'transform' | 'metadata', directory?: boolean):
     Promise<{canceled?: boolean; filePaths: string[]; fileList?: File[]; root?: string}>;
   /** Desktop: immediate child directory names under a parent folder (multicam subfolder import). */
   listImmediateSubfolders?(parentPath: string): Promise<string[]>;
@@ -610,9 +610,9 @@ export {
 export {
   AnnotationSchema,
   Api,
-  DatasetMeta,
-  DatasetMetaMutable,
-  DatasetMetaMutableKeys,
+  DatasetConfig,
+  DatasetConfigMutable,
+  DatasetConfigMutableKeys,
   MulticamSharedMutableKeys,
   DatasetType,
   DiveParam,

--- a/client/dive-common/components/CameraRegistration/RegistrationTools.vue
+++ b/client/dive-common/components/CameraRegistration/RegistrationTools.vue
@@ -26,7 +26,7 @@ export default defineComponent({
     const registration = useCameraRegistration();
     const datasetId = useDatasetId();
     const alignedView = useAlignedView();
-    const { saveMetadata } = useApi();
+    const { saveConfig } = useApi();
     const { prompt } = usePrompt();
 
     const cameras = computed(() => [...cameraStore.camMap.value.keys()]);
@@ -357,7 +357,7 @@ export default defineComponent({
       }
       saving.value = true;
       try {
-        await saveMetadata(datasetId.value, {
+        await saveConfig(datasetId.value, {
           cameraHomographies: registration.homographies.value,
           cameraCorrespondences: registration.correspondences.value,
           cameraTransformTypes: registration.transformTypes.value,

--- a/client/dive-common/components/DatasetConfigEditorDialog.vue
+++ b/client/dive-common/components/DatasetConfigEditorDialog.vue
@@ -4,7 +4,7 @@ import {
 } from 'vue';
 
 export default defineComponent({
-  name: 'DatasetMetaEditorDialog',
+  name: 'DatasetConfigEditorDialog',
 
   props: {
     value: {

--- a/client/dive-common/components/DatasetInfo.vue
+++ b/client/dive-common/components/DatasetInfo.vue
@@ -3,21 +3,21 @@ import {
   computed, defineComponent, ref, watch,
 } from 'vue';
 import { useDatasetId, useReadOnlyMode } from 'vue-media-annotator/provides';
-import { useApi, DatasetMeta } from 'dive-common/apispec';
+import { useApi, DatasetConfig } from 'dive-common/apispec';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
-import DatasetMetaEditorDialog from 'dive-common/components/DatasetMetaEditorDialog.vue';
+import DatasetConfigEditorDialog from 'dive-common/components/DatasetConfigEditorDialog.vue';
 
 export default defineComponent({
   name: 'DatasetInfo',
 
-  components: { DatasetMetaEditorDialog },
+  components: { DatasetConfigEditorDialog },
 
   setup() {
     const datasetId = useDatasetId();
     const readOnlyMode = useReadOnlyMode();
-    const { loadMetadata, saveMetadata } = useApi();
+    const { loadConfig, saveConfig } = useApi();
     const { prompt } = usePrompt();
-    const meta = ref<DatasetMeta | null>(null);
+    const meta = ref<DatasetConfig | null>(null);
     const customMeta = ref<Record<string, unknown>>({});
     const newKey = ref('');
     const newValue = ref('');
@@ -31,7 +31,7 @@ export default defineComponent({
         customMeta.value = {};
         return;
       }
-      meta.value = await loadMetadata(datasetId.value);
+      meta.value = await loadConfig(datasetId.value);
       customMeta.value = { ...(meta.value.datasetInfo || {}) };
     };
 
@@ -73,7 +73,7 @@ export default defineComponent({
         return;
       }
       try {
-        await saveMetadata(datasetId.value, { datasetInfo: { ...customMeta.value } });
+        await saveConfig(datasetId.value, { datasetInfo: { ...customMeta.value } });
       } catch (err) {
         const saveErr = err as { response?: { status?: number } };
         const status = saveErr.response?.status;
@@ -300,7 +300,7 @@ export default defineComponent({
       </div>
     </v-container>
 
-    <DatasetMetaEditorDialog
+    <DatasetConfigEditorDialog
       v-model="editorOpen"
       :field-name="editorKey"
       :field-value="editorValue"

--- a/client/dive-common/components/ImportAnnotations.vue
+++ b/client/dive-common/components/ImportAnnotations.vue
@@ -317,7 +317,7 @@ export default defineComponent({
         // hydrate() clears it, and the camera list doesn't change on import,
         // so nothing else would re-establish the panel's state.
         const priorPair = cameraRegistration.activePair.value;
-        const meta = await api.loadMetadata(parentDatasetId(props.datasetId));
+        const meta = await api.loadConfig(parentDatasetId(props.datasetId));
         cameraRegistration.hydrate(
           meta.cameraHomographies,
           meta.cameraCorrespondences,

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamKeyword.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamKeyword.vue
@@ -84,7 +84,7 @@ export default defineComponent({
           class="ml-3"
         >
           "{{ globList[key].glob }}" matches {{ filteredImages[key].length }}
-          out of {{ pendingImportPayloads.keyword.jsonMeta.originalImageFiles.length }} images
+          out of {{ pendingImportPayloads.keyword.jsonConfig.originalImageFiles.length }} images
         </v-chip>
       </v-row>
       <ImportMultiCamChooseAnnotation

--- a/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/useImportMultiCamDialog.ts
@@ -261,7 +261,7 @@ export function useImportMultiCamDialog(
     const filtered: Record<string, string[]> = {};
     Object.entries(globList.value).forEach(([cameraName, val]) => {
       const payload = pendingImportPayloads.value.keyword;
-      filtered[cameraName] = filterByGlob(val.glob, payload?.jsonMeta.originalImageFiles);
+      filtered[cameraName] = filterByGlob(val.glob, payload?.jsonConfig.originalImageFiles);
     });
     return filtered;
   });
@@ -270,7 +270,7 @@ export function useImportMultiCamDialog(
     const filtered: Record<string, string[]> = {};
     Object.entries(folderList.value).forEach(([cameraName, entry]) => {
       const payload = pendingImportPayloads.value[cameraName];
-      const images = payload?.jsonMeta.originalImageFiles || [];
+      const images = payload?.jsonConfig.originalImageFiles || [];
       filtered[cameraName] = entry.glob ? filterByGlob(entry.glob, images) : images;
     });
     return filtered;
@@ -352,7 +352,7 @@ export function useImportMultiCamDialog(
         // Not importable as a flat image folder; fall back to subfolder handling
         return false;
       }
-      imageNames = sharedPayload.jsonMeta.originalImageFiles || [];
+      imageNames = sharedPayload.jsonConfig.originalImageFiles || [];
     }
     const modalities = detectFolderModalities(imageNames);
     if (!modalities.length) {

--- a/client/dive-common/components/TypeThreshold.vue
+++ b/client/dive-common/components/TypeThreshold.vue
@@ -17,10 +17,10 @@ export default defineComponent({
   setup() {
     const trackFilters = useTrackFilters();
     const datasetIdRef = useDatasetId();
-    const { saveMetadata } = useApi();
+    const { saveConfig } = useApi();
 
     function saveThreshold() {
-      saveMetadata(datasetIdRef.value, {
+      saveConfig(datasetIdRef.value, {
         confidenceFilters: trackFilters.confidenceFilters.value,
       });
     }

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -191,7 +191,7 @@ export default defineComponent({
     const saveInProgress = ref(false);
     const videoUrl: Ref<Record<string, string>> = ref({});
     const {
-      loadDetections, loadMetadata, saveMetadata, getTiles, getTileURL, getTileHistogram,
+      loadDetections, loadConfig, saveConfig, getTiles, getTileURL, getTileHistogram,
     } = useApi();
     const progress = reactive({
       // Loaded flag prevents annotator window from populating
@@ -857,13 +857,13 @@ export default defineComponent({
     }
 
     function saveThreshold() {
-      saveMetadata(datasetId.value, {
+      saveConfig(datasetId.value, {
         confidenceFilters: trackFilters.confidenceFilters.value,
       });
     }
 
     function saveTimeFilter() {
-      saveMetadata(datasetId.value, {
+      saveConfig(datasetId.value, {
         timeFilters: trackFilters.timeFilters.value,
       });
     }
@@ -879,7 +879,7 @@ export default defineComponent({
     function getDebouncedSave(camera: string) {
       if (!debouncedSaves[camera]) {
         debouncedSaves[camera] = debounce(
-          () => saveMetadata(
+          () => saveConfig(
             getCameraId(camera),
             { imageEnhancements: imageEnhancementsByCamera.value[camera] },
           ),
@@ -1162,7 +1162,7 @@ export default defineComponent({
         return;
       }
       cameraRegistration.maybeFitActivePair();
-      await saveMetadata(datasetId.value, {
+      await saveConfig(datasetId.value, {
         cameraHomographies: cameraRegistration.homographies.value,
         cameraCorrespondences: cameraRegistration.correspondences.value,
         cameraTransformTypes: cameraRegistration.transformTypes.value,
@@ -1388,7 +1388,7 @@ export default defineComponent({
       try {
         // Close and reset sideBar
         context.resetActive();
-        const meta = await loadMetadata(datasetId.value);
+        const meta = await loadConfig(datasetId.value);
         baseMulticamDatasetId.value = datasetId.value;
         if (meta.multiCamMedia) {
           /* We're loading a multicamera dataset */
@@ -1442,7 +1442,7 @@ export default defineComponent({
             cameraId = `${baseMulticamDatasetId.value}/${camera}`;
           }
           // eslint-disable-next-line no-await-in-loop
-          const subCameraMeta = await loadMetadata(cameraId);
+          const subCameraMeta = await loadConfig(cameraId);
           VueSet(cameraTypesByCamera.value, camera, subCameraMeta.type as DatasetType);
           if (multiCamList.value.length <= 1) {
             datasetType.value = subCameraMeta.type as DatasetType;

--- a/client/dive-common/constants.ts
+++ b/client/dive-common/constants.ts
@@ -199,7 +199,7 @@ const webExcludedPipelineTerms = ['seagis'];
 const multiCamPipelineMarkers = ['2-cam', '3-cam'];
 const pipelineCreatesDatasetMarkers = ['transcode', 'filter'];
 
-const JsonMetaRegEx = /^.*\.?(meta|config)\.json$/;
+const JsonConfigRegEx = /^.*\.?(meta|config)\.json$/;
 
 function simplifyTrainingName(item: string) {
   return item.replace('.conf', '');
@@ -241,6 +241,6 @@ export {
   webExcludedPipelineTerms,
   multiCamPipelineMarkers,
   pipelineCreatesDatasetMarkers,
-  JsonMetaRegEx,
+  JsonConfigRegEx,
   simplifyTrainingName,
 };

--- a/client/dive-common/constants.ts
+++ b/client/dive-common/constants.ts
@@ -146,6 +146,14 @@ const websafeImageTypes = [
   // 'image/webp',
 ];
 
+/** Dotted extensions for HTML file-input accept (multi-dot names like a.b.c.png need these). */
+const websafeImageFileExtensions = [
+  'gif',
+  'jpg',
+  'jpeg',
+  'png',
+];
+
 const otherImageTypes = [
   'image/avif',
   'image/tiff',
@@ -154,6 +162,25 @@ const otherImageTypes = [
   'image/sgi',
   'image/x-portable-graymap',
 ];
+
+const otherImageFileExtensions = [
+  'avif',
+  'tif',
+  'tiff',
+  'bmp',
+  'sgi',
+  'pgm',
+];
+
+/** MIME types plus dotted extensions for image-sequence file inputs. */
+function getImageSequenceFileAccept(): string {
+  return [
+    ...websafeImageFileExtensions.map((ext) => `.${ext}`),
+    ...otherImageFileExtensions.map((ext) => `.${ext}`),
+    ...websafeImageTypes,
+    ...otherImageTypes,
+  ].join(',');
+}
 
 const inputAnnotationTypes = [
   'application/json',
@@ -218,9 +245,12 @@ export {
   metadataFileTypes,
   fileVideoTypes,
   otherImageTypes,
+  otherImageFileExtensions,
   otherVideoTypes,
   websafeImageTypes,
+  websafeImageFileExtensions,
   websafeVideoTypes,
+  getImageSequenceFileAccept,
   inputAnnotationTypes,
   largeImageTypes,
   largeImageFileExtensions,

--- a/client/dive-common/multicamDisplay.spec.ts
+++ b/client/dive-common/multicamDisplay.spec.ts
@@ -2,9 +2,9 @@ import {
   getMultiCamIcon,
   getMultiCamSubType,
   getMultiCamTooltip,
-  isMultiCamDatasetMeta,
+  isMultiCamDatasetConfig,
   isMultiCamTrainingTarget,
-  isStereoscopicDatasetMeta,
+  isStereoscopicDatasetConfig,
   orderedMultiCamCameraNames,
   referenceCameraName,
 } from './multicamDisplay';
@@ -46,14 +46,14 @@ describe('multicamDisplay', () => {
   });
 
   it('detects multicam dataset meta for training guards', () => {
-    expect(isMultiCamDatasetMeta({ type: 'multi', subType: 'stereo' })).toBe(true);
-    expect(isMultiCamDatasetMeta({ type: 'video', subType: null })).toBe(false);
+    expect(isMultiCamDatasetConfig({ type: 'multi', subType: 'stereo' })).toBe(true);
+    expect(isMultiCamDatasetConfig({ type: 'video', subType: null })).toBe(false);
   });
 
   it('detects stereoscopic vs plain multicam datasets', () => {
-    expect(isStereoscopicDatasetMeta({ type: 'multi', subType: 'stereo' })).toBe(true);
-    expect(isStereoscopicDatasetMeta({ type: 'multi', subType: 'multicam' })).toBe(false);
-    expect(isStereoscopicDatasetMeta({ type: 'video', subType: 'stereo' })).toBe(false);
+    expect(isStereoscopicDatasetConfig({ type: 'multi', subType: 'stereo' })).toBe(true);
+    expect(isStereoscopicDatasetConfig({ type: 'multi', subType: 'multicam' })).toBe(false);
+    expect(isStereoscopicDatasetConfig({ type: 'video', subType: 'stereo' })).toBe(false);
   });
 
   it('disables training for multicam parent and child camera selection', () => {

--- a/client/dive-common/multicamDisplay.ts
+++ b/client/dive-common/multicamDisplay.ts
@@ -61,24 +61,24 @@ export function isMultiCamSubType(subType: SubType | string | null | undefined):
   return subType === 'stereo' || subType === 'multicam';
 }
 
-export type DatasetMetaLike = {
+export type DatasetConfigLike = {
   type?: string;
   subType?: string;
 };
 
 export type FolderMetaLike = {
-  meta?: DatasetMetaLike;
+  meta?: DatasetConfigLike;
   parentId?: string;
   _id?: string;
 };
 
 /** True when folder meta describes a stereoscopic or multicam parent dataset. */
-export function isMultiCamDatasetMeta(meta: DatasetMetaLike | null | undefined): boolean {
+export function isMultiCamDatasetConfig(meta: DatasetConfigLike | null | undefined): boolean {
   return getMultiCamSubType(meta) !== null;
 }
 
 /** True when folder meta describes a stereoscopic (not plain multicam) parent dataset. */
-export function isStereoscopicDatasetMeta(meta: DatasetMetaLike | null | undefined): boolean {
+export function isStereoscopicDatasetConfig(meta: DatasetConfigLike | null | undefined): boolean {
   return getMultiCamSubType(meta) === 'stereo';
 }
 
@@ -90,10 +90,10 @@ export function isMultiCamTrainingTarget(
   folders: FolderMetaLike[],
   browseLocation: FolderMetaLike | null,
 ): boolean {
-  if (folders.some((folder) => isMultiCamDatasetMeta(folder.meta))) {
+  if (folders.some((folder) => isMultiCamDatasetConfig(folder.meta))) {
     return true;
   }
-  if (!browseLocation || !isMultiCamDatasetMeta(browseLocation.meta) || !browseLocation._id) {
+  if (!browseLocation || !isMultiCamDatasetConfig(browseLocation.meta) || !browseLocation._id) {
     return false;
   }
   if (folders.length === 0) {

--- a/client/dive-common/use/useSave.ts
+++ b/client/dive-common/use/useSave.ts
@@ -3,7 +3,7 @@ import { readonly, ref, Ref } from 'vue';
 import Track, { TrackId } from 'vue-media-annotator/track';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 
-import { useApi, DatasetMetaMutable } from 'dive-common/apispec';
+import { useApi, DatasetConfigMutable } from 'dive-common/apispec';
 import { AnnotationId } from 'vue-media-annotator/BaseAnnotation';
 import Group from 'vue-media-annotator/Group';
 import { AttributeTrackFilter } from 'vue-media-annotator/AttributeTrackFilterControls';
@@ -55,11 +55,11 @@ export default function useSave(
     },
   };
   const {
-    saveDetections, saveMetadata, saveAttributes, saveAttributeTrackFilters,
+    saveDetections, saveConfig, saveAttributes, saveAttributeTrackFilters,
   } = useApi();
 
   async function save(
-    datasetMeta?: DatasetMetaMutable,
+    datasetMeta?: DatasetConfigMutable,
     set?: string,
   ) {
     if (readonlyMode.value) {
@@ -92,7 +92,7 @@ export default function useSave(
       }
       if (datasetMeta && pendingChangeMap.meta > 0) {
         // Save once for each camera into their own metadata file
-        promiseList.push(saveMetadata(saveId, datasetMeta).then(() => {
+        promiseList.push(saveConfig(saveId, datasetMeta).then(() => {
           // eslint-disable-next-line no-param-reassign
           pendingChangeMap.meta = 0;
         }));
@@ -123,7 +123,7 @@ export default function useSave(
     });
     // Final save into the multi-cam metadata if multiple cameras exists
     if (globalMetadataUpdated && datasetMeta && pendingChangeMaps) {
-      promiseList.push(saveMetadata(datasetId.value, datasetMeta));
+      promiseList.push(saveConfig(datasetId.value, datasetMeta));
     }
     await Promise.all(promiseList);
     pendingSaveCount.value = 0;

--- a/client/platform/desktop/README.md
+++ b/client/platform/desktop/README.md
@@ -157,38 +157,38 @@ Due to tight OS coupling, some methods will have to be implemented to target a s
 
 Desktop has the capability to import and run pipelines on stereo and multicamera pipelines.  There is a Root folder as well as individual folders for each camera.  To achieve this the folder structure for storage of data is slightly different.
 
-* Root Folder - Base folder which contains the multicamera dataset.  It is tied to a single camera folder which is known as the `defaultDisplay`.  The `defaultDisplay` is the camera that is shown by default when the dataset is loaded.  The Root Folder `meta.json` file will contain a parmeter called `multiCam` and this will point to the multicams in the dataset as well as provide the `defaultDisplay`. 
-* Camera Folders - Individual folders for each camera which behave like their own dataset with their own meta.json and annotations file.  This is achieved by giving them a dataset id of `RootFolder/CameraName`.
+* Root Folder - Base folder which contains the multicamera dataset.  It is tied to a single camera folder which is known as the `defaultDisplay`.  The `defaultDisplay` is the camera that is shown by default when the dataset is loaded.  The Root Folder `config.json` file will contain a parameter called `multiCam` and this will point to the multicams in the dataset as well as provide the `defaultDisplay`. Legacy datasets may still have `meta.json`; DIVE reads that as a fallback and migrates to `config.json` on the next save.
+* Camera Folders - Individual folders for each camera which behave like their own dataset with their own `config.json` and annotations file.  This is achieved by giving them a dataset id of `RootFolder/CameraName`.
 
 ``` text
 DIVE_Projects
 ├── stereodataset_jp7hq88vfv
-│  ├── meta.json
+│  ├── config.json
 │  ├── result_06-01-2021_10-55-38.627.json
 │  ├── left
 |  |  ├── auxiliary
 |  │  │  └── result_06-01-2021_10-52-28.347.json
-│  │  ├── meta.json
+│  │  ├── config.json
 │  │  └── result_06-01-2021_10-55-38.627.json
 │  └── right
 |     ├── auxiliary
 |     │  └── result_06-01-2021_10-52-28.347.json
-│     ├── meta.json
+│     ├── config.json
 │     └── result_06-01-2021_10-55-38.627.json
 └── multicamera_jrgdq760gu
-   ├── meta.json
+   ├── config.json
    ├── result_06-18-2021_22-50-38.435.json
    ├── camera1
    |  ├── auxiliary
-   │  ├── meta.json
+   │  ├── config.json
    │  └── result_06-18-2021_22-50-38.435.json
    ├── camera2
    |  ├── auxiliary
-   │  ├── meta.json
+   │  ├── config.json
    │  └── result_06-18-2021_22-50-38.234.json
    └──── camera3
       ├── auxiliary
-      ├── meta.json
+      ├── config.json
       └── result_06-18-2021_22-50-38.126.json
 ```
 
@@ -198,7 +198,7 @@ When multicamera pipelines are run they will create individual annotation files 
 
 ### MultiCamera Ids and Requests
 
-Internally to reference difference cameras the system creates a datasetId which combines the base datasetId with the cameraName.  So in the example above `stereodataset_jp7hq88vfv` and the `left` camera would be referenced by `stereodataset_jp7hq88vfv/left`.  That is the Id that would be used to loadMetadata, saveMetadata, loadDetections and saveDetections.
+Internally to reference difference cameras the system creates a datasetId which combines the base datasetId with the cameraName.  So in the example above `stereodataset_jp7hq88vfv` and the `left` camera would be referenced by `stereodataset_jp7hq88vfv/left`.  That is the Id that would be used to loadConfig, saveConfig, loadDetections and saveDetections.
 
 ### MultiCamera Display/Loading Process
 

--- a/client/platform/desktop/README.md
+++ b/client/platform/desktop/README.md
@@ -157,38 +157,38 @@ Due to tight OS coupling, some methods will have to be implemented to target a s
 
 Desktop has the capability to import and run pipelines on stereo and multicamera pipelines.  There is a Root folder as well as individual folders for each camera.  To achieve this the folder structure for storage of data is slightly different.
 
-* Root Folder - Base folder which contains the multicamera dataset.  It is tied to a single camera folder which is known as the `defaultDisplay`.  The `defaultDisplay` is the camera that is shown by default when the dataset is loaded.  The Root Folder `config.json` file will contain a parameter called `multiCam` and this will point to the multicams in the dataset as well as provide the `defaultDisplay`. Legacy datasets may still have `meta.json`; DIVE reads that as a fallback and migrates to `config.json` on the next save.
-* Camera Folders - Individual folders for each camera which behave like their own dataset with their own `config.json` and annotations file.  This is achieved by giving them a dataset id of `RootFolder/CameraName`.
+* Root Folder - Base folder which contains the multicamera dataset.  It is tied to a single camera folder which is known as the `defaultDisplay`.  The `defaultDisplay` is the camera that is shown by default when the dataset is loaded.  The Root Folder `dataset.json` file will contain a parameter called `multiCam` and this will point to the multicams in the dataset as well as provide the `defaultDisplay`. Legacy datasets may still have `meta.json`; DIVE reads that as a fallback and migrates to `dataset.json` on the next save.
+* Camera Folders - Individual folders for each camera which behave like their own dataset with their own `dataset.json` and annotations file.  This is achieved by giving them a dataset id of `RootFolder/CameraName`.
 
 ``` text
 DIVE_Projects
 ├── stereodataset_jp7hq88vfv
-│  ├── config.json
+│  ├── dataset.json
 │  ├── result_06-01-2021_10-55-38.627.json
 │  ├── left
 |  |  ├── auxiliary
 |  │  │  └── result_06-01-2021_10-52-28.347.json
-│  │  ├── config.json
+│  │  ├── dataset.json
 │  │  └── result_06-01-2021_10-55-38.627.json
 │  └── right
 |     ├── auxiliary
 |     │  └── result_06-01-2021_10-52-28.347.json
-│     ├── config.json
+│     ├── dataset.json
 │     └── result_06-01-2021_10-55-38.627.json
 └── multicamera_jrgdq760gu
-   ├── config.json
+   ├── dataset.json
    ├── result_06-18-2021_22-50-38.435.json
    ├── camera1
    |  ├── auxiliary
-   │  ├── config.json
+   │  ├── dataset.json
    │  └── result_06-18-2021_22-50-38.435.json
    ├── camera2
    |  ├── auxiliary
-   │  ├── config.json
+   │  ├── dataset.json
    │  └── result_06-18-2021_22-50-38.234.json
    └──── camera3
       ├── auxiliary
-      ├── config.json
+      ├── dataset.json
       └── result_06-18-2021_22-50-38.126.json
 ```
 

--- a/client/platform/desktop/backend/cli.ts
+++ b/client/platform/desktop/backend/cli.ts
@@ -277,7 +277,7 @@ if (argv._.includes('viame2json')) {
     await Promise.all(dsids.map(async (id) => {
       try {
         const proj = await common.getValidatedProjectDir(settings, id);
-        const meta = await common.loadJsonConfig(proj.configFileAbsPath);
+        const meta = await common.loadJsonConfig(proj.datasetFileAbsPath);
         const tracks = await common.loadAnnotationFile(proj.trackFileAbsPath);
         const tracklist = Object.values(tracks);
         const hydrated = tracklist.map((t) => Track.fromJSON(t));

--- a/client/platform/desktop/backend/cli.ts
+++ b/client/platform/desktop/backend/cli.ts
@@ -17,7 +17,7 @@ import fs from 'fs-extra';
 import Track from 'vue-media-annotator/track';
 
 import { DesktopJobUpdate, RunPipeline, RunTraining } from 'platform/desktop/constants';
-import { loadAnnotationFile, loadJsonMetadata } from 'platform/desktop/backend/native/common';
+import { loadAnnotationFile, loadJsonConfig } from 'platform/desktop/backend/native/common';
 import { RectBounds } from 'vue-media-annotator/utils';
 import linux from './native/linux';
 import win32 from './native/windows';
@@ -57,7 +57,7 @@ async function parseViameFile(file: string) {
 async function parseJsonFile(filepath: string, metapath: string) {
   await Promise.all([
     loadAnnotationFile(filepath),
-    loadJsonMetadata(metapath),
+    loadJsonConfig(metapath),
   ]).then(([input, meta]) => serialize(echoStream(), input, meta));
 }
 
@@ -67,7 +67,7 @@ async function parseNistFile(filepath: string, bounds: RectBounds) {
 }
 
 async function convertJSONtoNist(filepath: string, meta: string) {
-  const metaData = await loadJsonMetadata(meta);
+  const metaData = await loadJsonConfig(meta);
   const data = await loadAnnotationFile(filepath);
 
   const videoFile = metaData.originalVideoFile;
@@ -277,7 +277,7 @@ if (argv._.includes('viame2json')) {
     await Promise.all(dsids.map(async (id) => {
       try {
         const proj = await common.getValidatedProjectDir(settings, id);
-        const meta = await common.loadJsonMetadata(proj.metaFileAbsPath);
+        const meta = await common.loadJsonConfig(proj.configFileAbsPath);
         const tracks = await common.loadAnnotationFile(proj.trackFileAbsPath);
         const tracklist = Object.values(tracks);
         const hydrated = tracklist.map((t) => Track.fromJSON(t));

--- a/client/platform/desktop/backend/cliImport.ts
+++ b/client/platform/desktop/backend/cliImport.ts
@@ -272,10 +272,10 @@ export async function runCliImport(
     ? await beginMultiCamImport(buildMultiCamArgs(args))
     : await common.beginMediaImport(args.importPath as string);
   if (args.name) {
-    importPayload.jsonMeta.name = args.name;
+    importPayload.jsonConfig.name = args.name;
   }
   // Single-camera metadata rides on the finalize payload; multicam stashes the
-  // source path on jsonMeta during beginMultiCamImport (same as the wizard).
+  // source path on jsonConfig during beginMultiCamImport (same as the wizard).
   if (args.metadataPath && !args.cameras) {
     importPayload.metadataFileAbsPath = args.metadataPath;
   }

--- a/client/platform/desktop/backend/native/cameraRegistration.ts
+++ b/client/platform/desktop/backend/native/cameraRegistration.ts
@@ -3,7 +3,7 @@
  *
  * Registration transforms are stored as standalone per-camera
  * *_registration.json files in the dataset directory rather than embedded in
- * the Configuration File (config.json / legacy meta.json).
+ * dataset.json (or legacy meta.json).
  */
 
 import npath from 'path';
@@ -290,7 +290,7 @@ export async function exportCameraRegistration(
   camera: string,
 ): Promise<string> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId.split('/')[0]);
-  const meta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const meta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   const calibration = await loadEffectiveRegistration(projectDirInfo.basePath, meta);
   const files = buildPerCameraRegistrationFiles(calibration, referenceCameraName(meta));
   if (!files.length) {
@@ -320,7 +320,7 @@ export async function importCameraRegistration(
 ): Promise<{ cameras: string[]; pairCount: number }> {
   const parentId = datasetId.split('/')[0];
   const projectDirInfo = await getValidatedProjectDir(settings, parentId);
-  const meta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const meta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   let data;
   try {
     data = await fs.readJson(filePath);

--- a/client/platform/desktop/backend/native/cameraRegistration.ts
+++ b/client/platform/desktop/backend/native/cameraRegistration.ts
@@ -3,7 +3,7 @@
  *
  * Registration transforms are stored as standalone per-camera
  * *_registration.json files in the dataset directory rather than embedded in
- * meta.json.
+ * the Configuration File (config.json / legacy meta.json).
  */
 
 import npath from 'path';
@@ -16,24 +16,24 @@ import {
 } from 'vue-media-annotator/alignedView/cameraRegistrationFiles';
 import { readTransformMatrix } from 'vue-media-annotator/alignedView/alignedView';
 import { invert3, Matrix3 } from 'vue-media-annotator/alignedView/homography';
-import { DatasetMetaMutable } from 'dive-common/apispec';
+import { DatasetConfigMutable } from 'dive-common/apispec';
 import { referenceCameraName as multicamReferenceCameraName } from 'dive-common/multicamDisplay';
 import {
   RegistrationFileNamePattern,
   compareRegistrationCandidates,
   qualifiesAsRegistrationFile,
 } from 'dive-common/registrationParentFolder';
-import { JsonMeta, Settings } from 'platform/desktop/constants';
+import { JsonConfig, Settings } from 'platform/desktop/constants';
 
 // eslint-disable-next-line import/no-cycle
 import {
-  getValidatedProjectDir, loadJsonMetadata, saveMetadata,
+  getValidatedProjectDir, loadJsonConfig, saveConfig,
 } from './common';
 
-export type CameraHomographies = NonNullable<DatasetMetaMutable['cameraHomographies']>;
-export type CameraCorrespondences = NonNullable<DatasetMetaMutable['cameraCorrespondences']>;
-export type CameraTransformTypes = NonNullable<DatasetMetaMutable['cameraTransformTypes']>;
-export type RegistrationSource = NonNullable<DatasetMetaMutable['cameraRegistrationSource']>;
+export type CameraHomographies = NonNullable<DatasetConfigMutable['cameraHomographies']>;
+export type CameraCorrespondences = NonNullable<DatasetConfigMutable['cameraCorrespondences']>;
+export type CameraTransformTypes = NonNullable<DatasetConfigMutable['cameraTransformTypes']>;
+export type RegistrationSource = NonNullable<DatasetConfigMutable['cameraRegistrationSource']>;
 
 /**
  * Best-effort read of the calibration file's producer provenance stamp: a
@@ -167,18 +167,18 @@ export async function loadRegistrationFiles(basePath: string): Promise<{
  * Reference Camera choice (stored as defaultDisplay), falling back to the
  * first camera in display order.
  */
-export function referenceCameraName(meta: JsonMeta): string | null {
+export function referenceCameraName(meta: JsonConfig): string | null {
   return meta.multiCam ? multicamReferenceCameraName(meta.multiCam) : null;
 }
 
 /**
  * The calibration a dataset currently resolves to, from the same sources
- * loadMetadata uses: the standalone per-camera files, or the import-time
+ * loadConfig uses: the standalone per-camera files, or the import-time
  * seed in the dataset meta when no files have been written yet.
  */
 export async function loadEffectiveRegistration(
   basePath: string,
-  meta: JsonMeta,
+  meta: JsonConfig,
 ): Promise<CameraRegistrationValues> {
   const onDisk = await loadRegistrationFiles(basePath);
   if (onDisk.found) {
@@ -198,7 +198,7 @@ export async function loadEffectiveRegistration(
  */
 export async function saveRegistrationToDatasetDir(
   basePath: string,
-  args: Pick<DatasetMetaMutable,
+  args: Pick<DatasetConfigMutable,
   'cameraHomographies' | 'cameraCorrespondences' | 'cameraTransformTypes' | 'cameraRegistrationSource'>,
   referenceCamera: string | null,
 ): Promise<void> {
@@ -290,7 +290,7 @@ export async function exportCameraRegistration(
   camera: string,
 ): Promise<string> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId.split('/')[0]);
-  const meta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const meta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   const calibration = await loadEffectiveRegistration(projectDirInfo.basePath, meta);
   const files = buildPerCameraRegistrationFiles(calibration, referenceCameraName(meta));
   if (!files.length) {
@@ -309,7 +309,7 @@ export async function exportCameraRegistration(
  * pairs over the current set: with options.camera, only the file's
  * pairs naming that camera are taken; each imported pair replaces that pair
  * wholly and other pairs are kept, so per-camera files can be imported one
- * at a time. Persists through saveMetadata, which rewrites the standalone
+ * at a time. Persists through saveConfig, which rewrites the standalone
  * per-camera files.
  */
 export async function importCameraRegistration(
@@ -320,7 +320,7 @@ export async function importCameraRegistration(
 ): Promise<{ cameras: string[]; pairCount: number }> {
   const parentId = datasetId.split('/')[0];
   const projectDirInfo = await getValidatedProjectDir(settings, parentId);
-  const meta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const meta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   let data;
   try {
     data = await fs.readJson(filePath);
@@ -353,7 +353,7 @@ export async function importCameraRegistration(
     incoming,
     npath.basename(filePath),
   );
-  await saveMetadata(settings, parentId, {
+  await saveConfig(settings, parentId, {
     cameraHomographies: merged.homographies,
     cameraCorrespondences: merged.correspondences,
     cameraTransformTypes: merged.transformTypes,

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -5,7 +5,7 @@ import { Console } from 'console';
 
 import {
   AnnotationsCurrentVersion, DesktopJob,
-  DesktopJobUpdate, JobType, JsonMeta, ProjectsFolderName, RunTraining, Settings,
+  DesktopJobUpdate, JobType, JsonConfig, ProjectsFolderName, RunTraining, Settings,
 } from 'platform/desktop/constants';
 import { makeEmptyAnnotationFile } from 'platform/desktop/backend/serializers/dive';
 
@@ -336,7 +336,7 @@ beforeEach(() => {
               'foo_20230615_143022.png',
               'bar.png',
             ],
-          } as JsonMeta),
+          } as JsonConfig),
           'result_whatever.json': JSON.stringify({}),
           auxiliary: {},
         },
@@ -348,7 +348,7 @@ beforeEach(() => {
             fps: 5,
             originalVideoFile: 'whatever.mp4',
             transcodedVideoFile: 'whatever-transcoded.mp4',
-          } as JsonMeta),
+          } as JsonConfig),
           'result_whatever.json': JSON.stringify({}),
           auxiliary: {},
         },
@@ -448,7 +448,7 @@ beforeEach(() => {
             fps: 5,
             originalVideoFile: 'whatever.mp4',
             transcodedVideoFile: 'whatever-transcoded.mp4',
-          } as JsonMeta),
+          } as JsonConfig),
           'result_whatever.json': JSON.stringify({}),
           auxiliary: {},
         },
@@ -474,9 +474,23 @@ describe('native.common', () => {
     const basedir = 'DIVE_Projects/projectid1';
     const dir = await common.getValidatedProjectDir(settings, 'projectid1');
     expect(dir.basePath).toBe(npath.join(settings.dataPath, basedir));
-    expect(dir.metaFileAbsPath).toBe(npath.join(settings.dataPath, basedir, 'meta.json'));
+    // Fixtures still use legacy meta.json; resolve falls back until a save migrates.
+    expect(dir.configFileAbsPath).toBe(npath.join(settings.dataPath, basedir, 'meta.json'));
     expect(dir.auxDirAbsPath).toBe(npath.join(settings.dataPath, basedir, 'auxiliary'));
     expect(dir.trackFileAbsPath).toBe(npath.join(settings.dataPath, basedir, 'result_whatever.json'));
+  });
+
+  it('saveProjectConfig migrates legacy meta.json to config.json', async () => {
+    const basedir = npath.join(settings.dataPath, 'DIVE_Projects/projectid1');
+    const legacy = npath.join(basedir, 'meta.json');
+    const preferred = npath.join(basedir, 'config.json');
+    expect(await fs.pathExists(legacy)).toBe(true);
+    const existing = await fs.readJSON(legacy);
+    await common.saveProjectConfig(basedir, existing);
+    expect(await fs.pathExists(preferred)).toBe(true);
+    expect(await fs.pathExists(legacy)).toBe(false);
+    const dir = await common.getValidatedProjectDir(settings, 'projectid1');
+    expect(dir.configFileAbsPath).toBe(preferred);
   });
   it('getValidatedProjectDir loads initial track.json', async () => {
     const basedir = 'DIVE_Projects/projectid4Bad';
@@ -488,11 +502,11 @@ describe('native.common', () => {
     await expect(common.getValidatedProjectDir(settings, 'projectid2Bad'))
       .rejects.toThrow('missing track json file');
     await expect(common.getValidatedProjectDir(settings, 'projectid3Bad'))
-      .rejects.toThrow('missing metadata json file');
+      .rejects.toThrow('missing configuration json file');
   });
 
-  it('loadJsonMetadata loads metadata from file', async () => {
-    const data = await common.loadMetadata(settings, 'projectid1', urlMapper);
+  it('loadJsonConfig loads configuration from file', async () => {
+    const data = await common.loadConfig(settings, 'projectid1', urlMapper);
     expect(data.id).toBe('projectid1');
     expect(data.imageData.map(({ filename }) => filename)).toEqual([
       'foo_20230615_143022.png', 'bar.png',
@@ -501,8 +515,8 @@ describe('native.common', () => {
     expect(data.imageData[1].timestamp).toBeUndefined();
   });
 
-  it('loadJsonMetadata parses per-camera frame timestamps for multicam datasets', async () => {
-    const data = await common.loadMetadata(settings, 'stereoDataset', urlMapper);
+  it('loadJsonConfig parses per-camera frame timestamps for multicam datasets', async () => {
+    const data = await common.loadConfig(settings, 'stereoDataset', urlMapper);
     expect(data.multiCamMedia).not.toBeNull();
     const { cameras } = data.multiCamMedia!;
     expect(cameras.left.imageData.map(({ timestamp }) => timestamp)).toEqual([
@@ -513,21 +527,21 @@ describe('native.common', () => {
     ]);
   });
 
-  it('loadJsonMetadata prefers transcoded media when it exists', async () => {
-    const data = await common.loadMetadata(settings, 'projectid1VideoGood', urlMapper);
+  it('loadJsonConfig prefers transcoded media when it exists', async () => {
+    const data = await common.loadConfig(settings, 'projectid1VideoGood', urlMapper);
     const videoPath = npath.join(settings.dataPath, 'DIVE_Projects', 'projectid1VideoGood', 'whatever-transcoded.mp4');
     expect(data.videoUrl).toBe(`http://localhost:8888/api/media?path=${videoPath}`);
   });
 
-  it('loadJsonMetadata type multi without multiCam', async () => {
-    await expect(common.loadMetadata(settings, 'projectid5missingMultiCam', urlMapper))
+  it('loadJsonConfig type multi without multiCam', async () => {
+    await expect(common.loadConfig(settings, 'projectid5missingMultiCam', urlMapper))
       .rejects.toThrow('Dataset: missingMulti is of type multiCam or stereo but contains no multiCam data');
   });
 
   it('createWorkingDirectory creates pipeline run directories', async () => {
     await expect(createWorkingDirectory(settings, [], 'whatever.pipe'))
-      .rejects.toThrow('At least 1 jsonMeta item');
-    const jsonMeta: JsonMeta = {
+      .rejects.toThrow('At least 1 jsonConfig item');
+    const jsonConfig: JsonConfig = {
       version: 1,
       type: 'image-sequence',
       fps: 100,
@@ -543,7 +557,7 @@ describe('native.common', () => {
       multiCam: null,
       subType: null,
     };
-    const result = await createWorkingDirectory(settings, [jsonMeta], 'mypipeline.pipe');
+    const result = await createWorkingDirectory(settings, [jsonConfig], 'mypipeline.pipe');
     const stat = fs.statSync(result);
     const contents = fs.readdirSync(result);
     expect(stat.isDirectory()).toBe(true);
@@ -553,24 +567,24 @@ describe('native.common', () => {
 
   it('beginMediaImport image sequence success', async () => {
     const payload = await common.beginMediaImport('/home/user/data/imageSuccess');
-    expect(payload.jsonMeta.name).toBe('imageSuccess');
-    expect(payload.jsonMeta.originalImageFiles).toEqual(['bar.png', 'foo.png']);
-    expect(payload.jsonMeta.originalVideoFile).toBe('');
-    expect(payload.jsonMeta.originalBasePath).toBe('/home/user/data/imageSuccess');
+    expect(payload.jsonConfig.name).toBe('imageSuccess');
+    expect(payload.jsonConfig.originalImageFiles).toEqual(['bar.png', 'foo.png']);
+    expect(payload.jsonConfig.originalVideoFile).toBe('');
+    expect(payload.jsonConfig.originalBasePath).toBe('/home/user/data/imageSuccess');
   });
 
   it('beginMediaImport image lists success', async () => {
     const payload = await common.beginMediaImport(
       '/home/user/data/imageLists/success/image_list.txt',
     );
-    expect(payload.jsonMeta.originalBasePath).toBe('');
-    expect(payload.jsonMeta.originalImageFiles).toEqual([
+    expect(payload.jsonConfig.originalBasePath).toBe('');
+    expect(payload.jsonConfig.originalImageFiles).toEqual([
       '/home/user/data/imageLists/success/image3.png',
       '/home/user/data/imageLists/success/image2.png',
       '/home/user/data/imageLists/success/image4.png',
       '/home/user/data/imageLists/success/image1.png',
     ]);
-    expect(payload.jsonMeta.name).toBe('success');
+    expect(payload.jsonConfig.name).toBe('success');
     const res = await common.finalizeMediaImport(settings, payload);
     const final = res.meta;
     expect(final.originalImageFiles.length).toBe(4);
@@ -583,7 +597,7 @@ describe('native.common', () => {
     const payload = await common.beginMediaImport(
       '/home/user/data/imageLists/successGlob/image_list.txt',
     );
-    expect(payload.jsonMeta.originalBasePath).toBe('');
+    expect(payload.jsonConfig.originalBasePath).toBe('');
     payload.globPattern = '2018*';
     const res = await common.finalizeMediaImport(settings, payload);
     const final = res.meta;
@@ -593,7 +607,7 @@ describe('native.common', () => {
     ];
     expect(final.originalImageFiles).toEqual(expectedImageFiles);
     expect(final.originalBasePath).toBe('');
-    const reload = await common.loadMetadata(settings, final.id, urlMapper);
+    const reload = await common.loadConfig(settings, final.id, urlMapper);
     expect(reload.originalImageFiles).toEqual(expectedImageFiles);
     expect(reload.imageListPath).toBe('/home/user/data/imageLists/successGlob/image_list.txt');
   });
@@ -639,11 +653,11 @@ describe('native.common', () => {
     const annotations2 = await common.loadDetections(settings, final.id);
     console.log(annotations2);
     expect(Object.keys(annotations2.tracks)).toHaveLength(0);
-    const meta = await common.loadMetadata(settings, final.id, urlMapper);
+    const meta = await common.loadConfig(settings, final.id, urlMapper);
     expect(meta.fps).toBe(32);
 
     await common.dataFileImport(settings, final.id, '/home/user/data/annotationImport/foreign.meta.json');
-    const meta2 = await common.loadMetadata(settings, final.id, urlMapper);
+    const meta2 = await common.loadConfig(settings, final.id, urlMapper);
     expect(meta2.confidenceFilters).toStrictEqual({ default: 0.8 });
     expect(meta2.type).toBe('image-sequence'); // Ensure meta import cannot change immutable fields.
   });
@@ -657,23 +671,23 @@ describe('native.common', () => {
     const existingDatasetInfo = { cruise: '2403', sta_lat: '26.8195', year: '2024' };
     const importedDatasetInfo = { year: '2025', gfishsite_id: '2024TXN012' };
 
-    await common.saveMetadata(settings, final.id, { datasetInfo: existingDatasetInfo });
+    await common.saveConfig(settings, final.id, { datasetInfo: existingDatasetInfo });
     await common.dataFileImport(
       settings,
       final.id,
       '/home/user/data/annotationImport/dataset-info.config.json',
     );
-    const overwriteMeta = await common.loadMetadata(settings, final.id, urlMapper);
+    const overwriteMeta = await common.loadConfig(settings, final.id, urlMapper);
     expect(overwriteMeta.datasetInfo).toStrictEqual(importedDatasetInfo);
 
-    await common.saveMetadata(settings, final.id, { datasetInfo: existingDatasetInfo });
+    await common.saveConfig(settings, final.id, { datasetInfo: existingDatasetInfo });
     await common.dataFileImport(
       settings,
       final.id,
       '/home/user/data/annotationImport/dataset-info.config.json',
       true,
     );
-    const additiveMeta = await common.loadMetadata(settings, final.id, urlMapper);
+    const additiveMeta = await common.loadConfig(settings, final.id, urlMapper);
     expect(additiveMeta.datasetInfo).toStrictEqual({
       ...existingDatasetInfo,
       ...importedDatasetInfo,
@@ -700,7 +714,7 @@ describe('native.common', () => {
 
     // Seed parent registration so a config import must not clobber it.
     const baseDir = common.getProjectDir(settings, baseId);
-    const seededBase = await common.loadJsonMetadata(baseDir.metaFileAbsPath);
+    const seededBase = await common.loadJsonConfig(baseDir.configFileAbsPath);
     seededBase.cameraHomographies = {
       'left::right': {
         AtoB: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
@@ -712,7 +726,7 @@ describe('native.common', () => {
     };
     seededBase.cameraTransformTypes = { 'left::right': 'similarity' };
     seededBase.cameraRegistrationSource = { model: 'seeded' };
-    await fs.writeJSON(baseDir.metaFileAbsPath, seededBase);
+    await fs.writeJSON(baseDir.configFileAbsPath, seededBase);
 
     await common.dataFileImport(
       settings,
@@ -720,11 +734,11 @@ describe('native.common', () => {
       '/home/user/data/annotationImport/foreign.meta.withExtras.json',
     );
     // The camera's own metadata receives the full imported config,
-    const cameraMeta = await common.loadMetadata(settings, `${baseId}/left`, urlMapper);
+    const cameraMeta = await common.loadConfig(settings, `${baseId}/left`, urlMapper);
     expect(cameraMeta.confidenceFilters).toStrictEqual({ default: 0.8 });
     expect(cameraMeta.imageEnhancements).toStrictEqual({ brightness: 1.1 });
     // Shared keys land on the base metadata the viewer reads,
-    const baseMeta = await common.loadMetadata(settings, baseId, urlMapper);
+    const baseMeta = await common.loadConfig(settings, baseId, urlMapper);
     expect(baseMeta.confidenceFilters).toStrictEqual({ default: 0.8 });
     expect(baseMeta.customTypeStyling).toStrictEqual({ fish: { color: 'green' } });
     // but per-camera enhancements and registration must stay untouched on the parent.
@@ -735,7 +749,7 @@ describe('native.common', () => {
     expect(baseMeta.cameraRegistrationSource).toStrictEqual(seededBase.cameraRegistrationSource);
   });
 
-  it('saveMetadata writes per-camera registration files (pairs + points) and reloads them', async () => {
+  it('saveConfig writes per-camera registration files (pairs + points) and reloads them', async () => {
     const payload = await common.beginMediaImport(
       '/home/user/data/imageLists/success/image_list.txt',
     );
@@ -755,7 +769,7 @@ describe('native.common', () => {
       ],
     };
 
-    await common.saveMetadata(settings, final.id, { cameraHomographies, cameraCorrespondences });
+    await common.saveConfig(settings, final.id, { cameraHomographies, cameraCorrespondences });
 
     // Persisted as a standalone per-camera file, named for the mapping it
     // carries (ir warps onto rgb): pairs labeled left/right, with points
@@ -778,20 +792,23 @@ describe('native.common', () => {
       },
     ]);
 
-    // Not embedded in meta.json.
-    const meta = await fs.readJSON(npath.join(projectDir, 'meta.json'));
+    // Not embedded in the Configuration File.
+    const configPath = npath.join(projectDir, 'config.json');
+    expect(await fs.pathExists(configPath)).toBe(true);
+    expect(await fs.pathExists(npath.join(projectDir, 'meta.json'))).toBe(false);
+    const meta = await fs.readJSON(configPath);
     expect(meta.cameraHomographies).toBeUndefined();
     expect(meta.cameraCorrespondences).toBeUndefined();
     expect(meta.cameraTransformTypes).toBeUndefined();
 
     // Rehydrated on load back into the in-app shapes.
-    const reloaded = await common.loadMetadata(settings, final.id, urlMapper);
+    const reloaded = await common.loadConfig(settings, final.id, urlMapper);
     expect(reloaded.cameraHomographies).toStrictEqual(cameraHomographies);
     expect(reloaded.cameraCorrespondences).toStrictEqual(cameraCorrespondences);
     expect(reloaded.cameraTransformTypes).toStrictEqual({ 'rgb::ir': 'similarity' });
   });
 
-  it('saveMetadata persists a non-default transformType per pair and reloads it', async () => {
+  it('saveConfig persists a non-default transformType per pair and reloads it', async () => {
     const payload = await common.beginMediaImport(
       '/home/user/data/imageLists/success/image_list.txt',
     );
@@ -805,13 +822,13 @@ describe('native.common', () => {
     };
     const cameraTransformTypes = { 'rgb::ir': 'rigid' as const };
 
-    await common.saveMetadata(settings, final.id, { cameraHomographies, cameraTransformTypes });
+    await common.saveConfig(settings, final.id, { cameraHomographies, cameraTransformTypes });
 
     const projectDir = npath.join(settings.dataPath, 'DIVE_Projects', final.id);
     const registration = await fs.readJSON(npath.join(projectDir, 'ir_to_rgb_registration.json'));
     expect(registration.pairs[0].transformType).toBe('rigid');
 
-    const reloaded = await common.loadMetadata(settings, final.id, urlMapper);
+    const reloaded = await common.loadConfig(settings, final.id, urlMapper);
     expect(reloaded.cameraTransformTypes).toStrictEqual(cameraTransformTypes);
   });
 
@@ -880,7 +897,7 @@ describe('native.common', () => {
     expect(correspondences['eo::ir']).toHaveLength(1);
   });
 
-  it('saveMetadata persists the registration source stamp and reloads it', async () => {
+  it('saveConfig persists the registration source stamp and reloads it', async () => {
     const payload = await common.beginMediaImport(
       '/home/user/data/imageLists/success/image_list.txt',
     );
@@ -894,7 +911,7 @@ describe('native.common', () => {
     };
     const source = { model: 'colmap-2026-07-01', swathe: 'fl07_C' };
 
-    await common.saveMetadata(settings, final.id, {
+    await common.saveConfig(settings, final.id, {
       cameraHomographies,
       cameraRegistrationSource: source,
     });
@@ -902,17 +919,17 @@ describe('native.common', () => {
     const projectDir = npath.join(settings.dataPath, 'DIVE_Projects', final.id);
     const registrationPath = npath.join(projectDir, 'ir_to_rgb_registration.json');
     expect((await fs.readJSON(registrationPath)).source).toStrictEqual(source);
-    const reloaded = await common.loadMetadata(settings, final.id, urlMapper);
+    const reloaded = await common.loadConfig(settings, final.id, urlMapper);
     expect(reloaded.cameraRegistrationSource).toStrictEqual(source);
 
     // A save that doesn't mention the stamp leaves it alone.
-    await common.saveMetadata(settings, final.id, {
+    await common.saveConfig(settings, final.id, {
       cameraTransformTypes: { 'rgb::ir': 'rigid' },
     });
     expect((await fs.readJSON(registrationPath)).source).toStrictEqual(source);
 
     // An explicit null clears it.
-    await common.saveMetadata(settings, final.id, {
+    await common.saveConfig(settings, final.id, {
       cameraHomographies,
       cameraRegistrationSource: null,
     });
@@ -942,7 +959,7 @@ describe('native.common', () => {
 
     // Both pairs merge; the disagreeing stamps become a mixed composite so
     // the client can warn about a rig assembled from different generations.
-    const mixed = await common.loadMetadata(settings, final.id, urlMapper);
+    const mixed = await common.loadConfig(settings, final.id, urlMapper);
     expect(Object.keys(mixed.cameraHomographies ?? {}).sort()).toStrictEqual(['rgb::ir', 'rgb::uv']);
     expect(mixed.cameraRegistrationSource).toStrictEqual({
       mixed: true,
@@ -956,7 +973,7 @@ describe('native.common', () => {
     await fs.writeJSON(npath.join(projectDir, 'uv_registration.json'), {
       version: 1, source: { producer: 'kamera', run: 'fl07' }, pairs: [uvPair],
     });
-    const agreeing = await common.loadMetadata(settings, final.id, urlMapper);
+    const agreeing = await common.loadConfig(settings, final.id, urlMapper);
     expect(agreeing.cameraRegistrationSource).toStrictEqual({ producer: 'kamera', run: 'fl07' });
 
     // A save of the mixed set never stamps the per-camera files with the
@@ -964,8 +981,8 @@ describe('native.common', () => {
     await fs.writeJSON(npath.join(projectDir, 'uv_registration.json'), {
       version: 1, source: { producer: 'kamera', run: 'fl09' }, pairs: [uvPair],
     });
-    const beforeSave = await common.loadMetadata(settings, final.id, urlMapper);
-    await common.saveMetadata(settings, final.id, {
+    const beforeSave = await common.loadConfig(settings, final.id, urlMapper);
+    await common.saveConfig(settings, final.id, {
       cameraHomographies: beforeSave.cameraHomographies,
       cameraRegistrationSource: beforeSave.cameraRegistrationSource,
     });
@@ -989,7 +1006,7 @@ describe('native.common', () => {
       },
     };
     const source = { producer: 'kamera', run: 'fl07' };
-    await common.saveMetadata(settings, final.id, {
+    await common.saveConfig(settings, final.id, {
       cameraHomographies,
       cameraRegistrationSource: source,
     });
@@ -1016,7 +1033,7 @@ describe('native.common', () => {
     );
     const res = await common.finalizeMediaImport(settings, payload);
     const final = res.meta;
-    await common.saveMetadata(settings, final.id, {
+    await common.saveConfig(settings, final.id, {
       cameraHomographies: {
         'rgb::ir': {
           AtoB: [[1, 0, 5], [0, 1, -3], [0, 0, 1]],
@@ -1038,7 +1055,7 @@ describe('native.common', () => {
     const result = await common.importCameraRegistration(settings, final.id, '/home/user/output/uv_to_rgb_registration.json');
     expect(result).toStrictEqual({ cameras: ['rgb', 'uv'], pairCount: 1 });
 
-    const reloaded = await common.loadMetadata(settings, final.id, urlMapper);
+    const reloaded = await common.loadConfig(settings, final.id, urlMapper);
     expect(Object.keys(reloaded.cameraHomographies ?? {}).sort()).toStrictEqual(['rgb::ir', 'rgb::uv']);
     // Agreeing stamps stay a single plain stamp, persisted into the files.
     expect(reloaded.cameraRegistrationSource).toStrictEqual({ producer: 'kamera', run: 'fl07' });
@@ -1058,7 +1075,7 @@ describe('native.common', () => {
     );
     const res = await common.finalizeMediaImport(settings, payload);
     const final = res.meta;
-    await common.saveMetadata(settings, final.id, {
+    await common.saveConfig(settings, final.id, {
       cameraHomographies: {
         'rgb::ir': {
           AtoB: [[1, 0, 5], [0, 1, -3], [0, 0, 1]],
@@ -1082,14 +1099,14 @@ describe('native.common', () => {
     });
     const scoped = await common.importCameraRegistration(settings, final.id, '/home/user/output/allpairs.json', { camera: 'uv' });
     expect(scoped).toStrictEqual({ cameras: ['rgb', 'uv'], pairCount: 1 });
-    const merged = await common.loadMetadata(settings, final.id, urlMapper);
+    const merged = await common.loadConfig(settings, final.id, urlMapper);
     expect(Object.keys(merged.cameraHomographies ?? {}).sort()).toStrictEqual(['rgb::ir', 'rgb::uv']);
     // The scoped import left the existing ir pair untouched.
     expect(merged.cameraHomographies?.['rgb::ir'].AtoB).toStrictEqual([[1, 0, 5], [0, 1, -3], [0, 0, 1]]);
 
     // Re-importing scoped to ir replaces that pair while keeping uv.
     await common.importCameraRegistration(settings, final.id, '/home/user/output/allpairs.json', { camera: 'ir' });
-    const replaced = await common.loadMetadata(settings, final.id, urlMapper);
+    const replaced = await common.loadConfig(settings, final.id, urlMapper);
     expect(Object.keys(replaced.cameraHomographies ?? {}).sort()).toStrictEqual(['rgb::ir', 'rgb::uv']);
     expect(replaced.cameraHomographies?.['rgb::ir'].AtoB).toStrictEqual([[2, 0, 0], [0, 2, 0], [0, 0, 1]]);
 
@@ -1105,7 +1122,7 @@ describe('native.common', () => {
     const final = res.meta;
     // A mixed composite stamp describes the assembled set, not any single
     // file; stamping an exported file with it would present a unanimous rig.
-    await common.saveMetadata(settings, final.id, {
+    await common.saveConfig(settings, final.id, {
       cameraHomographies: {
         'rgb::ir': {
           AtoB: [[1, 0, 5], [0, 1, -3], [0, 0, 1]],
@@ -1134,69 +1151,69 @@ describe('native.common', () => {
   it('import with CSV annotations without specifying track file', async () => {
     const payload = await common.beginMediaImport('/home/user/data/imageSuccessWithAnnotations');
     payload.trackFileAbsPath = ''; //It returns null be default but users change it.
-    payload.jsonMeta.fps = 12; // simulate user specify FPS action
+    payload.jsonConfig.fps = 12; // simulate user specify FPS action
     await common.finalizeMediaImport(settings, payload);
-    const meta = await common.loadMetadata(settings, payload.jsonMeta.id, urlMapper);
+    const meta = await common.loadConfig(settings, payload.jsonConfig.id, urlMapper);
     expect(meta.fps).toBe(12);
   });
 
   it('import with CSV annotations with specifying track file', async () => {
     const payload = await common.beginMediaImport('/home/user/data/imageSuccessWithAnnotations');
     payload.trackFileAbsPath = '/home/user/data/imageSuccessWithAnnotations/file1.csv';
-    payload.jsonMeta.fps = 12; // simulate user specify FPS action
+    payload.jsonConfig.fps = 12; // simulate user specify FPS action
     await common.finalizeMediaImport(settings, payload);
-    const meta = await common.loadMetadata(settings, payload.jsonMeta.id, urlMapper);
+    const meta = await common.loadConfig(settings, payload.jsonConfig.id, urlMapper);
     expect(meta.fps).toBe(32);
   });
 
   it('import with user selected FPS > originalFPS', async () => {
     const payload = await common.beginMediaImport('/home/user/data/videoSuccess/video1.mp4');
-    payload.jsonMeta.fps = 50; // above 30
+    payload.jsonConfig.fps = 50; // above 30
     await common.finalizeMediaImport(settings, payload);
-    const meta1 = await common.loadMetadata(settings, payload.jsonMeta.id, urlMapper);
+    const meta1 = await common.loadConfig(settings, payload.jsonConfig.id, urlMapper);
     expect(meta1.fps).toBe(30);
 
-    payload.jsonMeta.fps = -1; // above 30
+    payload.jsonConfig.fps = -1; // above 30
     await common.finalizeMediaImport(settings, payload);
-    const meta2 = await common.loadMetadata(settings, payload.jsonMeta.id, urlMapper);
+    const meta2 = await common.loadConfig(settings, payload.jsonConfig.id, urlMapper);
     expect(meta2.fps).toBe(1);
   });
 
   it('importMedia video success', async () => {
     const payload = await common.beginMediaImport('/home/user/data/videoSuccess/video1.mp4');
-    expect(payload.jsonMeta.name).toBe('video1');
-    expect(payload.jsonMeta.originalImageFiles.length).toBe(0);
-    expect(payload.jsonMeta.originalVideoFile).toBe('video1.mp4');
-    expect(payload.jsonMeta.originalBasePath).toBe('/home/user/data/videoSuccess');
-    expect(payload.jsonMeta.fps).toBe(5); // 5 is still the default
+    expect(payload.jsonConfig.name).toBe('video1');
+    expect(payload.jsonConfig.originalImageFiles.length).toBe(0);
+    expect(payload.jsonConfig.originalVideoFile).toBe('video1.mp4');
+    expect(payload.jsonConfig.originalBasePath).toBe('/home/user/data/videoSuccess');
+    expect(payload.jsonConfig.fps).toBe(5); // 5 is still the default
   });
 
   it('importMedia empty json file success', async () => {
     const payload = await common.beginMediaImport('/home/user/data/annotationEmptySuccess/video1.mp4');
     await common.finalizeMediaImport(settings, payload);
-    const annotations = await common.loadDetections(settings, payload.jsonMeta.id);
+    const annotations = await common.loadDetections(settings, payload.jsonConfig.id);
     expect(annotations).toEqual(makeEmptyAnnotationFile());
   });
 
   it('importMedia include meta.json file ', async () => {
     const payload = await common.beginMediaImport('/home/user/data/metaJsonIncluded/video1.mp4');
-    expect(payload.metaFileAbsPath).toBe('/home/user/data/metaJsonIncluded/meta.json');
+    expect(payload.configFileAbsPath).toBe('/home/user/data/metaJsonIncluded/meta.json');
     await common.finalizeMediaImport(settings, payload);
-    const tracks = await common.loadDetections(settings, payload.jsonMeta.id);
-    const meta = await common.loadMetadata(settings, payload.jsonMeta.id, urlMapper);
+    const tracks = await common.loadDetections(settings, payload.jsonConfig.id);
+    const meta = await common.loadConfig(settings, payload.jsonConfig.id, urlMapper);
     expect(meta?.customTypeStyling?.other.color).toBe('blue');
     expect(tracks).toEqual(makeEmptyAnnotationFile());
   });
 
   it('Export  meta.json file ', async () => {
     const payload = await common.beginMediaImport('/home/user/data/metaJsonIncluded/video1.mp4');
-    expect(payload.metaFileAbsPath).toBe('/home/user/data/metaJsonIncluded/meta.json');
+    expect(payload.configFileAbsPath).toBe('/home/user/data/metaJsonIncluded/meta.json');
     await common.finalizeMediaImport(settings, payload);
-    const tracks = await common.loadDetections(settings, payload.jsonMeta.id);
-    const meta = await common.loadMetadata(settings, payload.jsonMeta.id, urlMapper);
+    const tracks = await common.loadDetections(settings, payload.jsonConfig.id);
+    const meta = await common.loadConfig(settings, payload.jsonConfig.id, urlMapper);
     expect(meta?.customTypeStyling?.other.color).toBe('blue');
     expect(tracks).toEqual(makeEmptyAnnotationFile());
-    await common.exportConfiguration(settings, { id: payload.jsonMeta.id, path: '/home/user/output/test.json' });
+    await common.exportConfiguration(settings, { id: payload.jsonConfig.id, path: '/home/user/output/test.json' });
     const outputMeta = await fs.readJSON('/home/user/output/test.json');
     expect(outputMeta?.customTypeStyling?.other.color).toBe('blue');
   });
@@ -1214,7 +1231,7 @@ describe('native.common', () => {
   it('import first CSV in list', async () => {
     const payload = await common.beginMediaImport('/home/user/data/multiCSV/video1.mp4');
     await common.finalizeMediaImport(settings, payload);
-    const tracks = await common.loadDetections(settings, payload.jsonMeta.id);
+    const tracks = await common.loadDetections(settings, payload.jsonConfig.id);
     expect(tracks).toEqual(makeEmptyAnnotationFile());
   });
 
@@ -1225,13 +1242,13 @@ describe('native.common', () => {
   });
 
   it('check Dastset existence', async () => {
-    await expect(common.checkDataset(settings, 'projectid3Bad')).rejects.toThrow('missing metadata');
+    await expect(common.checkDataset(settings, 'projectid3Bad')).rejects.toThrow('missing configuration');
     await expect(common.checkDataset(settings, 'projectid5Bad')).rejects.toThrow('missing track json file');
-    await expect(common.checkDataset(settings, 'missingFolder')).rejects.toThrow('missing metadata');
+    await expect(common.checkDataset(settings, 'missingFolder')).rejects.toThrow('missing configuration');
   });
 
   it('delete datasets', async () => {
-    await expect(common.deleteDataset(settings, 'missingFolder')).rejects.toThrow('missing metadata');
+    await expect(common.deleteDataset(settings, 'missingFolder')).rejects.toThrow('missing configuration');
     let exists = fs.existsSync('/home/user/viamedata/DIVE_Projects/projectid5Bad');
     expect(exists).toBe(true);
     await expect(common.deleteDataset(settings, 'projectid5Bad')).rejects.toThrow('missing track json file');
@@ -1335,7 +1352,7 @@ describe('native.common', () => {
       const payload = await common.beginMediaImport(
         `/home/user/testPairs/test${num}`,
       );
-      expect(payload.jsonMeta.originalImageFiles).toEqual([
+      expect(payload.jsonConfig.originalImageFiles).toEqual([
         '1.png',
         '2.png',
         '3.png',

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -475,22 +475,22 @@ describe('native.common', () => {
     const dir = await common.getValidatedProjectDir(settings, 'projectid1');
     expect(dir.basePath).toBe(npath.join(settings.dataPath, basedir));
     // Fixtures still use legacy meta.json; resolve falls back until a save migrates.
-    expect(dir.configFileAbsPath).toBe(npath.join(settings.dataPath, basedir, 'meta.json'));
+    expect(dir.datasetFileAbsPath).toBe(npath.join(settings.dataPath, basedir, 'meta.json'));
     expect(dir.auxDirAbsPath).toBe(npath.join(settings.dataPath, basedir, 'auxiliary'));
     expect(dir.trackFileAbsPath).toBe(npath.join(settings.dataPath, basedir, 'result_whatever.json'));
   });
 
-  it('saveProjectConfig migrates legacy meta.json to config.json', async () => {
+  it('saveProjectConfig migrates legacy meta.json to dataset.json', async () => {
     const basedir = npath.join(settings.dataPath, 'DIVE_Projects/projectid1');
     const legacy = npath.join(basedir, 'meta.json');
-    const preferred = npath.join(basedir, 'config.json');
+    const preferred = npath.join(basedir, 'dataset.json');
     expect(await fs.pathExists(legacy)).toBe(true);
     const existing = await fs.readJSON(legacy);
     await common.saveProjectConfig(basedir, existing);
     expect(await fs.pathExists(preferred)).toBe(true);
     expect(await fs.pathExists(legacy)).toBe(false);
     const dir = await common.getValidatedProjectDir(settings, 'projectid1');
-    expect(dir.configFileAbsPath).toBe(preferred);
+    expect(dir.datasetFileAbsPath).toBe(preferred);
   });
   it('getValidatedProjectDir loads initial track.json', async () => {
     const basedir = 'DIVE_Projects/projectid4Bad';
@@ -502,7 +502,7 @@ describe('native.common', () => {
     await expect(common.getValidatedProjectDir(settings, 'projectid2Bad'))
       .rejects.toThrow('missing track json file');
     await expect(common.getValidatedProjectDir(settings, 'projectid3Bad'))
-      .rejects.toThrow('missing configuration json file');
+      .rejects.toThrow('missing dataset json file');
   });
 
   it('loadJsonConfig loads configuration from file', async () => {
@@ -714,7 +714,7 @@ describe('native.common', () => {
 
     // Seed parent registration so a config import must not clobber it.
     const baseDir = common.getProjectDir(settings, baseId);
-    const seededBase = await common.loadJsonConfig(baseDir.configFileAbsPath);
+    const seededBase = await common.loadJsonConfig(baseDir.datasetFileAbsPath);
     seededBase.cameraHomographies = {
       'left::right': {
         AtoB: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
@@ -726,7 +726,7 @@ describe('native.common', () => {
     };
     seededBase.cameraTransformTypes = { 'left::right': 'similarity' };
     seededBase.cameraRegistrationSource = { model: 'seeded' };
-    await fs.writeJSON(baseDir.configFileAbsPath, seededBase);
+    await fs.writeJSON(baseDir.datasetFileAbsPath, seededBase);
 
     await common.dataFileImport(
       settings,
@@ -792,11 +792,11 @@ describe('native.common', () => {
       },
     ]);
 
-    // Not embedded in the Configuration File.
-    const configPath = npath.join(projectDir, 'config.json');
-    expect(await fs.pathExists(configPath)).toBe(true);
+    // Not embedded in dataset.json.
+    const datasetPath = npath.join(projectDir, 'dataset.json');
+    expect(await fs.pathExists(datasetPath)).toBe(true);
     expect(await fs.pathExists(npath.join(projectDir, 'meta.json'))).toBe(false);
-    const meta = await fs.readJSON(configPath);
+    const meta = await fs.readJSON(datasetPath);
     expect(meta.cameraHomographies).toBeUndefined();
     expect(meta.cameraCorrespondences).toBeUndefined();
     expect(meta.cameraTransformTypes).toBeUndefined();
@@ -1242,13 +1242,13 @@ describe('native.common', () => {
   });
 
   it('check Dastset existence', async () => {
-    await expect(common.checkDataset(settings, 'projectid3Bad')).rejects.toThrow('missing configuration');
+    await expect(common.checkDataset(settings, 'projectid3Bad')).rejects.toThrow('missing dataset json');
     await expect(common.checkDataset(settings, 'projectid5Bad')).rejects.toThrow('missing track json file');
-    await expect(common.checkDataset(settings, 'missingFolder')).rejects.toThrow('missing configuration');
+    await expect(common.checkDataset(settings, 'missingFolder')).rejects.toThrow('missing dataset json');
   });
 
   it('delete datasets', async () => {
-    await expect(common.deleteDataset(settings, 'missingFolder')).rejects.toThrow('missing configuration');
+    await expect(common.deleteDataset(settings, 'missingFolder')).rejects.toThrow('missing dataset json');
     let exists = fs.existsSync('/home/user/viamedata/DIVE_Projects/projectid5Bad');
     expect(exists).toBe(true);
     await expect(common.deleteDataset(settings, 'projectid5Bad')).rejects.toThrow('missing track json file');

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -18,9 +18,9 @@ import { TrackData } from 'vue-media-annotator/track';
 import { GroupData } from 'vue-media-annotator/Group';
 import {
   DatasetType, Pipelines, SaveDetectionsArgs,
-  FrameImage, DatasetMetaMutable, TrainingConfig, TrainingConfigs, SaveAttributeArgs,
+  FrameImage, DatasetConfigMutable, TrainingConfig, TrainingConfigs, SaveAttributeArgs,
   MultiCamMedia,
-  DatasetMetaMutableKeys,
+  DatasetConfigMutableKeys,
   MulticamSharedMutableKeys,
   AnnotationSchema,
   SaveAttributeTrackFilterArgs,
@@ -38,10 +38,10 @@ import kpf from 'platform/desktop/backend/serializers/kpf';
 import { checkMedia } from 'platform/desktop/backend/native/mediaJobs';
 import {
   websafeImageTypes, websafeVideoTypes, otherImageTypes, otherVideoTypes, fileVideoTypes,
-  MultiType, JsonMetaRegEx, largeImageDesktopTypes,
+  MultiType, JsonConfigRegEx, largeImageDesktopTypes,
 } from 'dive-common/constants';
 import {
-  JsonMeta, Settings, JsonMetaCurrentVersion, DesktopMetadata,
+  JsonConfig, Settings, JsonConfigCurrentVersion, DesktopConfig,
   RunTraining, ExportDatasetArgs, DesktopMediaImportResponse,
   ExportConfigurationArgs, JobsFolderName, JobsOutputFolderName, ProjectsFolderName,
   PipelinesFolderName, ConversionArgs,
@@ -69,9 +69,29 @@ const AuxFolderName = 'auxiliary';
 
 const JsonTrackFileName = /^result(_.*)?\.json$/i;
 const JsonFileName = /^.*\.json$/i;
-const JsonMetaFileName = 'meta.json';
+/** Canonical on-disk DIVE Configuration File name for new writes. */
+const JsonConfigFileName = 'config.json';
+/** Legacy project config filename; still read, migrated away on save. */
+const JsonConfigFileNameLegacy = 'meta.json';
 const CsvFileName = /^.*\.csv$/i;
 const YAMLFileName = /^.*\.ya?ml$/i;
+
+/**
+ * Resolve the project Configuration File path: prefer config.json, fall back to
+ * meta.json for existing datasets, else the preferred name for new projects.
+ */
+function resolveConfigFileAbsPath(basePath: string): string {
+  const preferred = npath.join(basePath, JsonConfigFileName);
+  const legacy = npath.join(basePath, JsonConfigFileNameLegacy);
+  if (fs.pathExistsSync(preferred)) {
+    return preferred;
+  }
+  if (fs.pathExistsSync(legacy)) {
+    return legacy;
+  }
+  return preferred;
+}
+
 /**
  * Read a text file into a list of lines
  */
@@ -403,10 +423,10 @@ async function _findCSVTrackFiles(searchPath: string) {
  * @returns object containing trackAbsPath and metaPath if it exists
  */
 async function _findJsonAndMetaTrackFile(basePath: string): Promise<
-  {trackFileAbsPath: string; metaFileAbsPath?: string}> {
+  {trackFileAbsPath: string; configFileAbsPath?: string}> {
   const contents = await fs.readdir(basePath);
   const jsonFileCandidates: string[] = [];
-  let metaFileAbsPath: undefined | string;
+  let configFileAbsPath: undefined | string;
   await Promise.all(contents.map(async (name) => {
     const fullPath = npath.join(basePath, name);
     if (JsonTrackFileName.test(name)) {
@@ -414,14 +434,25 @@ async function _findJsonAndMetaTrackFile(basePath: string): Promise<
       if (statResult.isFile()) {
         jsonFileCandidates.push(fullPath);
       }
-    } else if (JsonMetaRegEx.test(name)) {
-      metaFileAbsPath = fullPath;
+    } else if (JsonConfigRegEx.test(name)) {
+      // Prefer exact config.json, then legacy meta.json, then other *.meta/config.json.
+      const lower = name.toLowerCase();
+      const current = configFileAbsPath
+        ? npath.basename(configFileAbsPath).toLowerCase()
+        : '';
+      if (lower === JsonConfigFileName) {
+        configFileAbsPath = fullPath;
+      } else if (lower === JsonConfigFileNameLegacy && current !== JsonConfigFileName) {
+        configFileAbsPath = fullPath;
+      } else if (!configFileAbsPath) {
+        configFileAbsPath = fullPath;
+      }
     }
   }));
   if (jsonFileCandidates.length > 0) {
-    return { trackFileAbsPath: jsonFileCandidates[0], metaFileAbsPath };
+    return { trackFileAbsPath: jsonFileCandidates[0], configFileAbsPath };
   }
-  return { trackFileAbsPath: '', metaFileAbsPath };
+  return { trackFileAbsPath: '', configFileAbsPath };
 }
 
 /**
@@ -430,16 +461,15 @@ async function _findJsonAndMetaTrackFile(basePath: string): Promise<
 function getProjectDir(settings: Settings, datasetId: string) {
   const basePath = npath.join(settings.dataPath, ProjectsFolderName, datasetId);
   const auxDirAbsPath = npath.join(basePath, AuxFolderName);
-  const metaFileAbsPath = npath.join(basePath, JsonMetaFileName);
   return {
     auxDirAbsPath,
     basePath,
-    metaFileAbsPath,
+    configFileAbsPath: resolveConfigFileAbsPath(basePath),
   };
 }
 
 /**
- * REQUIRED members: meta.json, results*.json
+ * REQUIRED members: config.json (or legacy meta.json), results*.json
  * OPTIONAL members: aux/ will be created if none exists
  */
 async function getValidatedProjectDir(settings: Settings, datasetId: string) {
@@ -448,8 +478,8 @@ async function getValidatedProjectDir(settings: Settings, datasetId: string) {
   if (!fs.pathExistsSync(projectInfo.basePath)) {
     throw new Error(`missing project directory ${projectInfo.basePath}`);
   }
-  if (!fs.pathExistsSync(projectInfo.metaFileAbsPath)) {
-    throw new Error(`missing metadata json file ${projectInfo.metaFileAbsPath}`);
+  if (!fs.pathExistsSync(projectInfo.configFileAbsPath)) {
+    throw new Error(`missing configuration json file ${projectInfo.configFileAbsPath}`);
   }
   const { trackFileAbsPath } = await _findJsonAndMetaTrackFile(projectInfo.basePath);
   if (trackFileAbsPath === '') {
@@ -462,14 +492,14 @@ async function getValidatedProjectDir(settings: Settings, datasetId: string) {
 }
 
 /**
- * loadJsonMeta processes dataset information from json
- * @param metaPath a known, existing path
+ * loadJsonConfig processes dataset configuration from JSON
+ * @param configAbsPath a known, existing path
  */
-async function loadJsonMetadata(metaAbsPath: string): Promise<JsonMeta> {
-  const metaJson = await _loadAsJson(metaAbsPath);
+async function loadJsonConfig(configAbsPath: string): Promise<JsonConfig> {
+  const configJson = await _loadAsJson(configAbsPath);
   /* check if this file meets the current schema version */
-  upgrade(metaJson);
-  return metaJson as JsonMeta;
+  upgrade(configJson);
+  return configJson as JsonConfig;
 }
 
 /**
@@ -481,13 +511,13 @@ async function loadAnnotationFile(tracksAbsPath: string): Promise<AnnotationSche
   return dive.migrate(annotationData);
 }
 
-async function loadMetadata(
+async function loadConfig(
   settings: Settings,
   datasetId: string,
   makeMediaUrl: (path: string) => string,
-): Promise<DesktopMetadata> {
+): Promise<DesktopConfig> {
   const projectDirData = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+  const projectMetaData = await loadJsonConfig(projectDirData.configFileAbsPath);
 
   // Load the standalone camera registration (transforms + correspondences)
   // from the per-camera *_registration.json files, if present; the dataset
@@ -588,16 +618,16 @@ async function loadDetections(settings: Settings, datasetId: string) {
  * Look through DIVE project path, find subfolders that
  * look like datasets, and return them.
  */
-async function autodiscoverData(settings: Settings): Promise<JsonMeta[]> {
+async function autodiscoverData(settings: Settings): Promise<JsonConfig[]> {
   const dspath = npath.join(settings.dataPath, ProjectsFolderName);
   const dsids = await fs.readdir(dspath);
-  const metas: JsonMeta[] = [];
+  const metas: JsonConfig[] = [];
   /* eslint-disable no-await-in-loop,no-continue */
   for (let i = 0; i < dsids.length; i += 1) {
     const datasetId = dsids[i];
     try {
       const projectDirData = await getValidatedProjectDir(settings, datasetId);
-      const metadata = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+      const metadata = await loadJsonConfig(projectDirData.configFileAbsPath);
       metas.push(metadata);
     } catch {
       // noop, dataset was invalid
@@ -831,10 +861,28 @@ async function _saveAsJson(absPath: string, data: unknown) {
   await fs.writeFile(absPath, serialized);
 }
 
-async function saveMetadata(settings: Settings, datasetId: string, args: DatasetMetaMutable) {
+/**
+ * Write the project Configuration File as config.json and remove a legacy
+ * meta.json if one was present, so there is only one source of truth.
+ */
+async function saveProjectConfig(basePath: string, data: unknown) {
+  const preferred = npath.join(basePath, JsonConfigFileName);
+  const legacy = npath.join(basePath, JsonConfigFileNameLegacy);
+  await _saveAsJson(preferred, data);
+  if (await fs.pathExists(legacy)) {
+    await fs.remove(legacy);
+  }
+}
+
+async function saveConfig(settings: Settings, datasetId: string, args: DatasetConfigMutable) {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const release = await _acquireLock(projectDirInfo.basePath, projectDirInfo.metaFileAbsPath, 'meta');
-  const existing = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  // Lock against the canonical config path so migrate-on-save stays stable.
+  const release = await _acquireLock(
+    projectDirInfo.basePath,
+    npath.join(projectDirInfo.basePath, JsonConfigFileName),
+    'meta',
+  );
+  const existing = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   if (args.confidenceFilters) {
     existing.confidenceFilters = args.confidenceFilters;
   }
@@ -862,7 +910,7 @@ async function saveMetadata(settings: Settings, datasetId: string, args: Dataset
 
   // The camera registration (transforms + the points behind them) is
   // persisted as standalone <camera>_to_<reference>_registration.json files
-  // in the dataset directory rather than embedded in meta.json, so each
+  // in the dataset directory rather than embedded in the Configuration File, so each
   // camera's registration is easy to find, hand-edit, and consume as a
   // self-contained artifact. There is deliberately never a single all-pairs
   // file.
@@ -875,13 +923,13 @@ async function saveMetadata(settings: Settings, datasetId: string, args: Dataset
     );
   }
 
-  await _saveAsJson(projectDirInfo.metaFileAbsPath, existing);
+  await saveProjectConfig(projectDirInfo.basePath, existing);
   await release();
 }
 
 async function saveAttributes(settings: Settings, datasetId: string, args: SaveAttributeArgs) {
   const projectDirData = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+  const projectMetaData = await loadJsonConfig(projectDirData.configFileAbsPath);
   if (!projectMetaData.attributes) {
     projectMetaData.attributes = {};
   }
@@ -895,7 +943,7 @@ async function saveAttributes(settings: Settings, datasetId: string, args: SaveA
       projectMetaData.attributes[attribute.key] = attribute;
     }
   });
-  await saveMetadata(settings, datasetId, projectMetaData);
+  await saveConfig(settings, datasetId, projectMetaData);
 }
 
 async function saveAttributeTrackFilters(
@@ -904,7 +952,7 @@ async function saveAttributeTrackFilters(
   args: SaveAttributeTrackFilterArgs,
 ) {
   const projectDirData = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+  const projectMetaData = await loadJsonConfig(projectDirData.configFileAbsPath);
   if (!projectMetaData.attributeTrackFilters) {
     projectMetaData.attributeTrackFilters = {};
   }
@@ -918,7 +966,7 @@ async function saveAttributeTrackFilters(
       projectMetaData.attributeTrackFilters[filter.name] = filter;
     }
   });
-  await saveMetadata(settings, datasetId, projectMetaData);
+  await saveConfig(settings, datasetId, projectMetaData);
 }
 
 async function _ingestFilePath(
@@ -928,7 +976,7 @@ async function _ingestFilePath(
   imageMap?: Map<string, number>,
   additive = false,
   additivePrepend = '',
-): Promise<[(DatasetMetaMutable & { fps?: number }), string[]] | null> {
+): Promise<[(DatasetConfigMutable & { fps?: number }), string[]] | null> {
   if (!fs.existsSync(path)) {
     return null;
   }
@@ -942,7 +990,7 @@ async function _ingestFilePath(
   await fs.copy(path, newPath);
   // Attempt to process the file
   let annotations = dive.makeEmptyAnnotationFile();
-  const meta: DatasetMetaMutable & { fps?: number, execTime?: number } = {};
+  const meta: DatasetConfigMutable & { fps?: number, execTime?: number } = {};
   let metadataConfig = false;
   if (JsonFileName.test(path)) {
     const jsonObject = await _loadAsJson(path);
@@ -952,9 +1000,9 @@ async function _ingestFilePath(
       annotations.tracks = data.tracks;
       annotations.groups = data.groups;
       meta.fps = data.fps;
-    } else if (DatasetMetaMutableKeys.some((key) => key in jsonObject)) {
-      // DIVE Json metadata config file
-      merge(meta, pick(jsonObject, DatasetMetaMutableKeys));
+    } else if (DatasetConfigMutableKeys.some((key) => key in jsonObject)) {
+      // DIVE Configuration File (attributes, styles, FPS, …)
+      merge(meta, pick(jsonObject, DatasetConfigMutableKeys));
       metadataConfig = true;
     } else if (coco.isCocoJson(jsonObject)) {
       const [parsedAnnotations, parsedMeta, cocoWarnings] = await coco.parseFile(path);
@@ -1039,7 +1087,7 @@ async function ingestDataFiles(
   additivePrepend = '',
 ): Promise<{
   processedFiles: string[];
-  meta: DatasetMetaMutable & { fps?: number };
+  meta: DatasetConfigMutable & { fps?: number };
   warnings: string[];
 }> {
   const processedFiles = []; // which files were processed to generate the detections
@@ -1121,8 +1169,8 @@ async function _initializeAppDataDir(settings: Settings) {
  * Initialize a new project directory
  * @returns absolute path to new project directory
  */
-async function _initializeProjectDir(settings: Settings, jsonMeta: JsonMeta): Promise<string> {
-  const projectDir = npath.join(settings.dataPath, ProjectsFolderName, jsonMeta.id);
+async function _initializeProjectDir(settings: Settings, jsonConfig: JsonConfig): Promise<string> {
+  const projectDir = npath.join(settings.dataPath, ProjectsFolderName, jsonConfig.id);
   await _initializeAppDataDir(settings);
   await fs.ensureDir(projectDir);
   return projectDir;
@@ -1134,7 +1182,7 @@ async function deleteDataset(
 ): Promise<boolean> {
   // Confirm dataset exists
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const projectMetaData = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   await fs.remove(projectDirInfo.basePath);
   // If the dataset source is inside DIVE_Jobs_Output, delete that output folder
   if (projectMetaData.originalBasePath) {
@@ -1155,7 +1203,7 @@ async function checkDataset(
   datasetId: string,
 ): Promise<boolean> {
   const projectDirData = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+  const projectMetaData = await loadJsonConfig(projectDirData.configFileAbsPath);
   if (projectMetaData.originalBasePath !== '') {
     const exists = await fs.pathExists(projectMetaData.originalBasePath);
     if (!exists) {
@@ -1171,14 +1219,14 @@ async function checkDataset(
 async function findTrackandMetaFileinFolder(path: string) {
   const results = await _findJsonAndMetaTrackFile(path);
   let { trackFileAbsPath } = results;
-  const { metaFileAbsPath } = results;
+  const { configFileAbsPath } = results;
   if (!trackFileAbsPath) {
     const csvFileCandidates = await _findCSVTrackFiles(path);
     if (csvFileCandidates.length) {
       [trackFileAbsPath] = csvFileCandidates;
     }
   }
-  return { trackFileAbsPath, metaFileAbsPath };
+  return { trackFileAbsPath, configFileAbsPath };
 }
 
 /**
@@ -1409,8 +1457,8 @@ async function beginMediaImport(path: string): Promise<DesktopMediaImportRespons
   const dsName = npath.parse(path).name;
 
   const _defaultFps = datasetType === 'video' ? 5 : 1;
-  const jsonMeta: JsonMeta = {
-    version: JsonMetaCurrentVersion,
+  const jsonConfig: JsonConfig = {
+    version: JsonConfigCurrentVersion,
     type: datasetType,
     id: '', // will be assigned on finalize
     fps: _defaultFps, // adjusted below
@@ -1431,23 +1479,23 @@ async function beginMediaImport(path: string): Promise<DesktopMediaImportRespons
 
   if (datasetType === 'video') {
     // get parent folder, since videos reference a file directly
-    jsonMeta.originalBasePath = npath.dirname(path);
+    jsonConfig.originalBasePath = npath.dirname(path);
   }
   if (datasetType === 'large-image') {
-    jsonMeta.originalBasePath = npath.dirname(path);
-    jsonMeta.originalLargeImageFile = npath.basename(path);
+    jsonConfig.originalBasePath = npath.dirname(path);
+    jsonConfig.originalLargeImageFile = npath.basename(path);
   }
 
   /* Path to search for other related data like annotations */
-  let relatedDataSearchPath = jsonMeta.originalBasePath;
+  let relatedDataSearchPath = jsonConfig.originalBasePath;
 
   /* mediaConvertList is a list of absolute paths of media to convert */
   let mediaConvertList: string[] = [];
   /* Extract and validate media from import path */
-  if (jsonMeta.type === 'large-image') {
+  if (jsonConfig.type === 'large-image') {
     // No conversion for large images; tile serving is done on demand via geotiff
-  } else if (jsonMeta.type === 'video') {
-    jsonMeta.originalVideoFile = npath.basename(path);
+  } else if (jsonConfig.type === 'video') {
+    jsonConfig.originalVideoFile = npath.basename(path);
     const mimetype = mime.lookup(path);
     if (mimetype) {
       if (websafeImageTypes.includes(mimetype) || otherImageTypes.includes(mimetype)) {
@@ -1459,10 +1507,10 @@ async function beginMediaImport(path: string): Promise<DesktopMediaImportRespons
         }
         const newAnnotationFps = (
           // Prevent FPS smaller than 1
-          Math.max(1, Math.min(jsonMeta.fps, checkMediaResult.originalFps))
+          Math.max(1, Math.min(jsonConfig.fps, checkMediaResult.originalFps))
         );
-        jsonMeta.originalFps = checkMediaResult.originalFps;
-        jsonMeta.fps = newAnnotationFps;
+        jsonConfig.originalFps = checkMediaResult.originalFps;
+        jsonConfig.fps = newAnnotationFps;
       } else {
         throw new Error(`unsupported MIME type for video ${mimetype}`);
       }
@@ -1475,12 +1523,12 @@ async function beginMediaImport(path: string): Promise<DesktopMediaImportRespons
       throw new Error(`no images found in ${path}`);
     }
     if (found.source === 'directory') {
-      jsonMeta.originalImageFiles = found.imageNames;
+      jsonConfig.originalImageFiles = found.imageNames;
     } else if (found.source === 'image-list') {
-      jsonMeta.originalImageFiles = found.imagePaths;
-      jsonMeta.imageListPath = npath.normalize(path);
-      jsonMeta.originalBasePath = '';
-      jsonMeta.name = npath.basename(npath.dirname(path));
+      jsonConfig.originalImageFiles = found.imagePaths;
+      jsonConfig.imageListPath = npath.normalize(path);
+      jsonConfig.originalBasePath = '';
+      jsonConfig.name = npath.basename(npath.dirname(path));
       relatedDataSearchPath = npath.dirname(path);
     }
     mediaConvertList = found.mediaConvertList;
@@ -1488,23 +1536,23 @@ async function beginMediaImport(path: string): Promise<DesktopMediaImportRespons
     throw new Error('only video, image-sequence, and large-image types are supported');
   }
 
-  const { trackFileAbsPath, metaFileAbsPath } = await
+  const { trackFileAbsPath, configFileAbsPath } = await
   findTrackandMetaFileinFolder(relatedDataSearchPath);
   return {
-    jsonMeta,
+    jsonConfig,
     globPattern: '',
     mediaConvertList,
     trackFileAbsPath,
     forceMediaTranscode: false,
     multiCamTrackFiles: null,
-    metaFileAbsPath,
+    configFileAbsPath,
   };
 }
 
-function validImageNamesMap(jsonMeta: JsonMeta) {
-  if (jsonMeta.originalImageFiles.length > 0) {
+function validImageNamesMap(jsonConfig: JsonConfig) {
+  if (jsonConfig.originalImageFiles.length > 0) {
     const imageMap = new Map<string, number>();
-    jsonMeta.originalImageFiles.forEach((imgPath, i) => {
+    jsonConfig.originalImageFiles.forEach((imgPath, i) => {
       const [imageBaseName] = splitExt(imgPath);
       if (imageMap.get(imageBaseName) !== undefined) {
         throw new Error([
@@ -1522,27 +1570,27 @@ function validImageNamesMap(jsonMeta: JsonMeta) {
 
 async function dataFileImport(settings: Settings, id: string, path: string, additive = false, additivePrepend = '') {
   const projectDirData = await getValidatedProjectDir(settings, id);
-  const jsonMeta = await loadJsonMetadata(projectDirData.metaFileAbsPath);
-  const existingDatasetInfo = jsonMeta.datasetInfo;
+  const jsonConfig = await loadJsonConfig(projectDirData.configFileAbsPath);
+  const existingDatasetInfo = jsonConfig.datasetInfo;
   const result = await ingestDataFiles(
     settings,
     id,
     [path],
     undefined,
-    validImageNamesMap(jsonMeta),
+    validImageNamesMap(jsonConfig),
     additive,
     additivePrepend,
   );
-  merge(jsonMeta, result.meta);
+  merge(jsonConfig, result.meta);
   // Assign datasetInfo explicitly; the deep-merge above would keep keys an Overwrite
   // import meant to drop. Like the server, Overwrite replaces the block wholesale while
   // an additive import merges per-key (imported values win).
   if (result.meta.datasetInfo) {
-    jsonMeta.datasetInfo = additive
+    jsonConfig.datasetInfo = additive
       ? { ...(existingDatasetInfo ?? {}), ...result.meta.datasetInfo }
       : result.meta.datasetInfo;
   }
-  await _saveAsJson(npath.join(projectDirData.basePath, JsonMetaFileName), jsonMeta);
+  await saveProjectConfig(projectDirData.basePath, jsonConfig);
   // Shared mutable config (styling, thresholds, attributes, datasetInfo, ...) is
   // loaded by the viewer from the base dataset's metadata, so an import
   // targeted at one camera of a multicam dataset must update the base too.
@@ -1550,8 +1598,8 @@ async function dataFileImport(settings: Settings, id: string, path: string, addi
   const { parentId, cameraName } = parseCompositeDatasetId(id);
   if (cameraName && MulticamSharedMutableKeys.some((key) => key in result.meta)) {
     const baseProjectDir = getProjectDir(settings, parentId);
-    if (await fs.pathExists(baseProjectDir.metaFileAbsPath)) {
-      const baseMeta = await loadJsonMetadata(baseProjectDir.metaFileAbsPath);
+    if (await fs.pathExists(baseProjectDir.configFileAbsPath)) {
+      const baseMeta = await loadJsonConfig(baseProjectDir.configFileAbsPath);
       const existingBaseDatasetInfo = baseMeta.datasetInfo;
       merge(baseMeta, pick(result.meta, MulticamSharedMutableKeys));
       if (result.meta.datasetInfo) {
@@ -1559,7 +1607,7 @@ async function dataFileImport(settings: Settings, id: string, path: string, addi
           ? { ...(existingBaseDatasetInfo ?? {}), ...result.meta.datasetInfo }
           : result.meta.datasetInfo;
       }
-      await _saveAsJson(baseProjectDir.metaFileAbsPath, baseMeta);
+      await saveProjectConfig(baseProjectDir.basePath, baseMeta);
     }
   }
   return result;
@@ -1569,46 +1617,46 @@ async function _importTrackFile(
   settings: Settings,
   dsId: string,
   projectDirAbsPath: string,
-  jsonMeta: JsonMeta,
+  jsonConfig: JsonConfig,
   userTrackFileAbsPath: string,
 ) {
   /* custom image sort */
-  if (jsonMeta.imageListPath === undefined) {
-    jsonMeta.originalImageFiles.sort(strNumericCompare);
+  if (jsonConfig.imageListPath === undefined) {
+    jsonConfig.originalImageFiles.sort(strNumericCompare);
   }
-  if (jsonMeta.transcodedImageFiles) {
-    jsonMeta.transcodedImageFiles.sort(strNumericCompare);
+  if (jsonConfig.transcodedImageFiles) {
+    jsonConfig.transcodedImageFiles.sort(strNumericCompare);
   }
   if (userTrackFileAbsPath) {
-    const processed = await ingestDataFiles(settings, dsId, [userTrackFileAbsPath], undefined, validImageNamesMap(jsonMeta));
-    merge(jsonMeta, processed.meta);
+    const processed = await ingestDataFiles(settings, dsId, [userTrackFileAbsPath], undefined, validImageNamesMap(jsonConfig));
+    merge(jsonConfig, processed.meta);
     if (processed.processedFiles.length === 0) {
       await _saveSerialized(settings, dsId, dive.makeEmptyAnnotationFile(), true);
     }
   } else {
     await _saveSerialized(settings, dsId, dive.makeEmptyAnnotationFile(), true);
   }
-  await _saveAsJson(npath.join(projectDirAbsPath, JsonMetaFileName), jsonMeta);
-  return jsonMeta;
+  await saveProjectConfig(projectDirAbsPath, jsonConfig);
+  return jsonConfig;
 }
 
 /**
  * After media conversion we need to remove the transcodingKey to signify it is done
  */
-export async function completeConversion(settings: Settings, datasetId: string, transcodingJobKey: string, meta: JsonMeta) {
+export async function completeConversion(settings: Settings, datasetId: string, transcodingJobKey: string, meta: JsonConfig) {
   await getValidatedProjectDir(settings, datasetId);
   if (meta.transcodingJobKey === transcodingJobKey) {
     // eslint-disable-next-line no-param-reassign
     meta.transcodingJobKey = undefined;
-    saveMetadata(settings, datasetId, meta);
+    saveConfig(settings, datasetId, meta);
   }
 }
 
-export async function failConversion(settings: Settings, datasetId: string, meta: JsonMeta, errorMessage: string) {
+export async function failConversion(settings: Settings, datasetId: string, meta: JsonConfig, errorMessage: string) {
   await getValidatedProjectDir(settings, datasetId);
   // eslint-disable-next-line no-param-reassign
   meta.error = errorMessage;
-  saveMetadata(settings, datasetId, meta);
+  saveConfig(settings, datasetId, meta);
 }
 
 /**
@@ -1618,33 +1666,33 @@ async function finalizeMediaImport(
   settings: Settings,
   args: DesktopMediaImportResponse,
 ): Promise<ConversionArgs> {
-  const { jsonMeta, globPattern } = args;
+  const { jsonConfig, globPattern } = args;
   let { mediaConvertList } = args;
-  const { type: datasetType } = jsonMeta;
-  jsonMeta.id = `${cleanString(jsonMeta.name).substr(0, 20)}_${makeid(10)}`;
-  const projectDirAbsPath = await _initializeProjectDir(settings, jsonMeta);
+  const { type: datasetType } = jsonConfig;
+  jsonConfig.id = `${cleanString(jsonConfig.name).substr(0, 20)}_${makeid(10)}`;
+  const projectDirAbsPath = await _initializeProjectDir(settings, jsonConfig);
 
   // Store any stereo calibration / camera file alongside the media and normalize
   // it to the VIAME JSON camera-rig format (keeping the original).
-  if (jsonMeta.multiCam?.calibration) {
-    const calibrationSourcePath = npath.resolve(jsonMeta.multiCam.calibration);
+  if (jsonConfig.multiCam?.calibration) {
+    const calibrationSourcePath = npath.resolve(jsonConfig.multiCam.calibration);
     const preservedOriginalPath = npath.join(
       projectDirAbsPath,
       npath.basename(calibrationSourcePath),
     );
-    jsonMeta.multiCam.calibrationOriginalName = realCalibrationName(calibrationSourcePath);
-    jsonMeta.multiCam.calibration = await prepareDatasetCalibration(
+    jsonConfig.multiCam.calibrationOriginalName = realCalibrationName(calibrationSourcePath);
+    jsonConfig.multiCam.calibration = await prepareDatasetCalibration(
       settings,
       projectDirAbsPath,
       calibrationSourcePath,
     );
-    jsonMeta.multiCam.calibrationSourcePath = preservedOriginalPath;
+    jsonConfig.multiCam.calibrationSourcePath = preservedOriginalPath;
   }
 
   // Store any optional metadata file alongside the media (keeping the original
   // name). Single imports pass it on the response; multicam imports stash the
-  // source path on jsonMeta.metadataFile during beginMultiCamImport.
-  const metadataSourcePath = args.metadataFileAbsPath || jsonMeta.metadataFile;
+  // source path on jsonConfig.metadataFile during beginMultiCamImport.
+  const metadataSourcePath = args.metadataFileAbsPath || jsonConfig.metadataFile;
   if (metadataSourcePath) {
     const resolvedMetadataSource = npath.resolve(metadataSourcePath);
     const metadataDest = npath.join(
@@ -1652,37 +1700,37 @@ async function finalizeMediaImport(
       npath.basename(resolvedMetadataSource),
     );
     await fs.copy(resolvedMetadataSource, metadataDest);
-    jsonMeta.metadataOriginalName = npath.basename(resolvedMetadataSource);
-    jsonMeta.metadataFile = metadataDest;
+    jsonConfig.metadataOriginalName = npath.basename(resolvedMetadataSource);
+    jsonConfig.metadataFile = metadataDest;
   } else {
     // Ensure a stale source path never survives when no file was chosen.
-    jsonMeta.metadataFile = undefined;
-    jsonMeta.metadataOriginalName = undefined;
+    jsonConfig.metadataFile = undefined;
+    jsonConfig.metadataOriginalName = undefined;
   }
 
   // Filter all parts of the input based on glob pattern
-  if (globPattern && jsonMeta.type === 'image-sequence') {
-    const searchPath = jsonMeta.imageListPath || jsonMeta.originalBasePath;
+  if (globPattern && jsonConfig.type === 'image-sequence') {
+    const searchPath = jsonConfig.imageListPath || jsonConfig.originalBasePath;
     const found = await findImagesInFolder(searchPath, globPattern);
     if (found.imageNames.length === 0) {
       throw new Error(`no images in ${searchPath} matched pattern ${globPattern}`);
     }
     if (found.source === 'directory') {
-      jsonMeta.originalImageFiles = found.imageNames;
+      jsonConfig.originalImageFiles = found.imageNames;
     } else if (found.source === 'image-list') {
-      jsonMeta.originalImageFiles = found.imagePaths;
+      jsonConfig.originalImageFiles = found.imagePaths;
     }
     mediaConvertList = found.mediaConvertList;
   }
 
-  if (jsonMeta.type === 'video') {
+  if (jsonConfig.type === 'video') {
     // Verify that the user didn't choose an FPS value higher than originalFPS
     // This shouldn't be possible in the UI, but we should still prevent it here.
-    jsonMeta.fps = (
-      Math.max(1, Math.min(jsonMeta.fps, jsonMeta.originalFps))
+    jsonConfig.fps = (
+      Math.max(1, Math.min(jsonConfig.fps, jsonConfig.originalFps))
     );
     if (args.forceMediaTranscode) {
-      mediaConvertList.push(npath.join(jsonMeta.originalBasePath, jsonMeta.originalVideoFile));
+      mediaConvertList.push(npath.join(jsonConfig.originalBasePath, jsonConfig.originalVideoFile));
     }
   }
 
@@ -1697,16 +1745,16 @@ async function finalizeMediaImport(
       const destLoc = npath.join(projectDirAbsPath, filename);
       //If we have multicam we may need to check more than the base folder
       if (datasetType === MultiType) {
-        destAbsPath = transcodeMultiCam(jsonMeta, absPath, projectDirAbsPath);
+        destAbsPath = transcodeMultiCam(jsonConfig, absPath, projectDirAbsPath);
       } else {
         destAbsPath = destLoc.replace(npath.extname(absPath), extension);
         if (datasetType === 'video') {
-          jsonMeta.transcodedVideoFile = npath.basename(destAbsPath);
+          jsonConfig.transcodedVideoFile = npath.basename(destAbsPath);
         } else if (datasetType === 'image-sequence') {
-          if (!jsonMeta.transcodedImageFiles) {
-            jsonMeta.transcodedImageFiles = [];
+          if (!jsonConfig.transcodedImageFiles) {
+            jsonConfig.transcodedImageFiles = [];
           }
-          jsonMeta.transcodedImageFiles.push(npath.basename(destAbsPath));
+          jsonConfig.transcodedImageFiles.push(npath.basename(destAbsPath));
         }
       }
       srcDstList.push([absPath, destAbsPath]);
@@ -1714,15 +1762,15 @@ async function finalizeMediaImport(
   }
 
   //We need to create datasets for each of the multiCam folders as well
-  if (datasetType === MultiType && jsonMeta.multiCam?.cameras) {
-    const cameraNameAndData = Object.entries(jsonMeta.multiCam.cameras);
+  if (datasetType === MultiType && jsonConfig.multiCam?.cameras) {
+    const cameraNameAndData = Object.entries(jsonConfig.multiCam.cameras);
     for (let i = 0; i < cameraNameAndData.length; i += 1) {
       const cameraName = cameraNameAndData[i][0];
       const cameraData = cameraNameAndData[i][1];
 
-      const jsonClone = { ...cloneDeep(jsonMeta), ...cameraData };
+      const jsonClone = { ...cloneDeep(jsonConfig), ...cameraData };
       jsonClone.multiCam = null;
-      jsonClone.id = `${jsonMeta.id}/${cameraName}`;
+      jsonClone.id = `${jsonConfig.id}/${cameraName}`;
       jsonClone.transcodedVideoFile = cameraData.transcodedVideoFile || '';
       jsonClone.transcodedImageFiles = cameraData.transcodedImageFiles || [];
       jsonClone.subType = null;
@@ -1736,13 +1784,13 @@ async function finalizeMediaImport(
       await _importTrackFile(settings, jsonClone.id, cameraDirAbsPath, jsonClone, multiCamTrackFile);
     }
   }
-  const finalJsonMeta = await _importTrackFile(settings, jsonMeta.id, projectDirAbsPath, jsonMeta, args.trackFileAbsPath);
-  if (args.metaFileAbsPath) {
-    await dataFileImport(settings, jsonMeta.id, args.metaFileAbsPath);
+  const finalJsonConfig = await _importTrackFile(settings, jsonConfig.id, projectDirAbsPath, jsonConfig, args.trackFileAbsPath);
+  if (args.configFileAbsPath) {
+    await dataFileImport(settings, jsonConfig.id, args.configFileAbsPath);
   }
   const conversionJobArgs: ConversionArgs = {
     type: JobType.Conversion,
-    meta: finalJsonMeta,
+    meta: finalJsonConfig,
     mediaList: srcDstList,
   };
   return conversionJobArgs;
@@ -1755,7 +1803,7 @@ async function finalizeMediaImport(
 async function getLargeImagePath(settings: Settings, datasetId: string): Promise<string | null> {
   try {
     const projectDirData = await getValidatedProjectDir(settings, datasetId);
-    const meta = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+    const meta = await loadJsonConfig(projectDirData.configFileAbsPath);
     if (meta.type !== 'large-image' || !meta.originalLargeImageFile) {
       console.warn(
         `[tiles] getLargeImagePath: no path for dataset "${datasetId}" (meta.type=${meta.type}, hasOriginalLargeImageFile=${!!meta.originalLargeImageFile})`,
@@ -1787,7 +1835,7 @@ async function getDisplayImagePath(
 ): Promise<string | null> {
   try {
     const projectDirData = await getValidatedProjectDir(settings, datasetId);
-    const meta = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+    const meta = await loadJsonConfig(projectDirData.configFileAbsPath);
     const originals = meta.originalImageFiles ?? [];
     if (!Number.isInteger(frame) || frame < 0 || frame >= originals.length) {
       console.warn(
@@ -1850,7 +1898,7 @@ async function openPathInFileManager(targetPath: string): Promise<string> {
 
 async function exportDataset(settings: Settings, args: ExportDatasetArgs) {
   const projectDirInfo = await getValidatedProjectDir(settings, args.id);
-  const meta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const meta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   const data = await loadAnnotationFile(projectDirInfo.trackFileAbsPath);
   if (args.type === 'json') {
     return dive.serializeFile(args.path, data, meta, args.typeFilter, {
@@ -1871,11 +1919,11 @@ async function exportDataset(settings: Settings, args: ExportDatasetArgs) {
 
 async function exportConfiguration(settings: Settings, args: ExportConfigurationArgs) {
   const projectDirInfo = await getValidatedProjectDir(settings, args.id);
-  const meta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
-  const output: DatasetMetaMutable & { version: number} = { version: meta.version };
-  if (DatasetMetaMutableKeys.some((key) => key in meta)) {
-    // DIVE Json metadata config file
-    merge(output, pick(meta, DatasetMetaMutableKeys));
+  const meta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const output: DatasetConfigMutable & { version: number} = { version: meta.version };
+  if (DatasetConfigMutableKeys.some((key) => key in meta)) {
+    // DIVE Configuration File fields (attributes, styles, FPS, …)
+    merge(output, pick(meta, DatasetConfigMutableKeys));
   }
   await fs.writeJSON(args.path, output);
   return args.path;
@@ -1900,15 +1948,16 @@ export {
   getValidatedProjectDir,
   getLargeImagePath,
   getDisplayImagePath,
-  loadMetadata,
-  loadJsonMetadata,
+  loadConfig,
+  loadJsonConfig,
   loadAnnotationFile,
   loadDetections,
   openLink,
   openPathInFileManager,
   ingestDataFiles,
   saveDetections,
-  saveMetadata,
+  saveConfig,
+  saveProjectConfig,
   processTrainedPipeline,
   saveAttributes,
   saveAttributeTrackFilters,

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -69,20 +69,27 @@ const AuxFolderName = 'auxiliary';
 
 const JsonTrackFileName = /^result(_.*)?\.json$/i;
 const JsonFileName = /^.*\.json$/i;
-/** Canonical on-disk DIVE Configuration File name for new writes. */
-const JsonConfigFileName = 'config.json';
-/** Legacy project config filename; still read, migrated away on save. */
-const JsonConfigFileNameLegacy = 'meta.json';
+/**
+ * Canonical desktop project dataset file under DIVE_Projects (media paths, id,
+ * type, multicam layout, …). Distinct from the portable Configuration File
+ * (`config.json`) used on import/export.
+ */
+const DatasetFileName = 'dataset.json';
+/** Legacy project filename; still read, migrated away on save. */
+const DatasetFileNameLegacy = 'meta.json';
+/** Portable Configuration File name used on import/export (not the project store). */
+const PortableConfigFileName = 'config.json';
+const PortableConfigFileNameLegacy = 'meta.json';
 const CsvFileName = /^.*\.csv$/i;
 const YAMLFileName = /^.*\.ya?ml$/i;
 
 /**
- * Resolve the project Configuration File path: prefer config.json, fall back to
- * meta.json for existing datasets, else the preferred name for new projects.
+ * Resolve the project dataset.json path: prefer dataset.json, fall back to
+ * legacy meta.json for existing datasets, else the preferred name for new projects.
  */
-function resolveConfigFileAbsPath(basePath: string): string {
-  const preferred = npath.join(basePath, JsonConfigFileName);
-  const legacy = npath.join(basePath, JsonConfigFileNameLegacy);
+function resolveDatasetFileAbsPath(basePath: string): string {
+  const preferred = npath.join(basePath, DatasetFileName);
+  const legacy = npath.join(basePath, DatasetFileNameLegacy);
   if (fs.pathExistsSync(preferred)) {
     return preferred;
   }
@@ -435,14 +442,16 @@ async function _findJsonAndMetaTrackFile(basePath: string): Promise<
         jsonFileCandidates.push(fullPath);
       }
     } else if (JsonConfigRegEx.test(name)) {
-      // Prefer exact config.json, then legacy meta.json, then other *.meta/config.json.
+      // Prefer exact portable config.json, then legacy meta.json, then other
+      // *.meta/config.json. dataset.json is the desktop project store and is
+      // not matched by JsonConfigRegEx.
       const lower = name.toLowerCase();
       const current = configFileAbsPath
         ? npath.basename(configFileAbsPath).toLowerCase()
         : '';
-      if (lower === JsonConfigFileName) {
+      if (lower === PortableConfigFileName) {
         configFileAbsPath = fullPath;
-      } else if (lower === JsonConfigFileNameLegacy && current !== JsonConfigFileName) {
+      } else if (lower === PortableConfigFileNameLegacy && current !== PortableConfigFileName) {
         configFileAbsPath = fullPath;
       } else if (!configFileAbsPath) {
         configFileAbsPath = fullPath;
@@ -464,12 +473,12 @@ function getProjectDir(settings: Settings, datasetId: string) {
   return {
     auxDirAbsPath,
     basePath,
-    configFileAbsPath: resolveConfigFileAbsPath(basePath),
+    datasetFileAbsPath: resolveDatasetFileAbsPath(basePath),
   };
 }
 
 /**
- * REQUIRED members: config.json (or legacy meta.json), results*.json
+ * REQUIRED members: dataset.json (or legacy meta.json), results*.json
  * OPTIONAL members: aux/ will be created if none exists
  */
 async function getValidatedProjectDir(settings: Settings, datasetId: string) {
@@ -478,8 +487,8 @@ async function getValidatedProjectDir(settings: Settings, datasetId: string) {
   if (!fs.pathExistsSync(projectInfo.basePath)) {
     throw new Error(`missing project directory ${projectInfo.basePath}`);
   }
-  if (!fs.pathExistsSync(projectInfo.configFileAbsPath)) {
-    throw new Error(`missing configuration json file ${projectInfo.configFileAbsPath}`);
+  if (!fs.pathExistsSync(projectInfo.datasetFileAbsPath)) {
+    throw new Error(`missing dataset json file ${projectInfo.datasetFileAbsPath}`);
   }
   const { trackFileAbsPath } = await _findJsonAndMetaTrackFile(projectInfo.basePath);
   if (trackFileAbsPath === '') {
@@ -517,7 +526,7 @@ async function loadConfig(
   makeMediaUrl: (path: string) => string,
 ): Promise<DesktopConfig> {
   const projectDirData = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonConfig(projectDirData.configFileAbsPath);
+  const projectMetaData = await loadJsonConfig(projectDirData.datasetFileAbsPath);
 
   // Load the standalone camera registration (transforms + correspondences)
   // from the per-camera *_registration.json files, if present; the dataset
@@ -627,7 +636,7 @@ async function autodiscoverData(settings: Settings): Promise<JsonConfig[]> {
     const datasetId = dsids[i];
     try {
       const projectDirData = await getValidatedProjectDir(settings, datasetId);
-      const metadata = await loadJsonConfig(projectDirData.configFileAbsPath);
+      const metadata = await loadJsonConfig(projectDirData.datasetFileAbsPath);
       metas.push(metadata);
     } catch {
       // noop, dataset was invalid
@@ -862,12 +871,12 @@ async function _saveAsJson(absPath: string, data: unknown) {
 }
 
 /**
- * Write the project Configuration File as config.json and remove a legacy
+ * Write the project dataset file as dataset.json and remove a legacy
  * meta.json if one was present, so there is only one source of truth.
  */
 async function saveProjectConfig(basePath: string, data: unknown) {
-  const preferred = npath.join(basePath, JsonConfigFileName);
-  const legacy = npath.join(basePath, JsonConfigFileNameLegacy);
+  const preferred = npath.join(basePath, DatasetFileName);
+  const legacy = npath.join(basePath, DatasetFileNameLegacy);
   await _saveAsJson(preferred, data);
   if (await fs.pathExists(legacy)) {
     await fs.remove(legacy);
@@ -876,13 +885,13 @@ async function saveProjectConfig(basePath: string, data: unknown) {
 
 async function saveConfig(settings: Settings, datasetId: string, args: DatasetConfigMutable) {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  // Lock against the canonical config path so migrate-on-save stays stable.
+  // Lock against the canonical dataset path so migrate-on-save stays stable.
   const release = await _acquireLock(
     projectDirInfo.basePath,
-    npath.join(projectDirInfo.basePath, JsonConfigFileName),
+    npath.join(projectDirInfo.basePath, DatasetFileName),
     'meta',
   );
-  const existing = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const existing = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   if (args.confidenceFilters) {
     existing.confidenceFilters = args.confidenceFilters;
   }
@@ -910,7 +919,7 @@ async function saveConfig(settings: Settings, datasetId: string, args: DatasetCo
 
   // The camera registration (transforms + the points behind them) is
   // persisted as standalone <camera>_to_<reference>_registration.json files
-  // in the dataset directory rather than embedded in the Configuration File, so each
+  // in the dataset directory rather than embedded in dataset.json, so each
   // camera's registration is easy to find, hand-edit, and consume as a
   // self-contained artifact. There is deliberately never a single all-pairs
   // file.
@@ -929,7 +938,7 @@ async function saveConfig(settings: Settings, datasetId: string, args: DatasetCo
 
 async function saveAttributes(settings: Settings, datasetId: string, args: SaveAttributeArgs) {
   const projectDirData = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonConfig(projectDirData.configFileAbsPath);
+  const projectMetaData = await loadJsonConfig(projectDirData.datasetFileAbsPath);
   if (!projectMetaData.attributes) {
     projectMetaData.attributes = {};
   }
@@ -952,7 +961,7 @@ async function saveAttributeTrackFilters(
   args: SaveAttributeTrackFilterArgs,
 ) {
   const projectDirData = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonConfig(projectDirData.configFileAbsPath);
+  const projectMetaData = await loadJsonConfig(projectDirData.datasetFileAbsPath);
   if (!projectMetaData.attributeTrackFilters) {
     projectMetaData.attributeTrackFilters = {};
   }
@@ -1182,7 +1191,7 @@ async function deleteDataset(
 ): Promise<boolean> {
   // Confirm dataset exists
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const projectMetaData = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   await fs.remove(projectDirInfo.basePath);
   // If the dataset source is inside DIVE_Jobs_Output, delete that output folder
   if (projectMetaData.originalBasePath) {
@@ -1203,7 +1212,7 @@ async function checkDataset(
   datasetId: string,
 ): Promise<boolean> {
   const projectDirData = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonConfig(projectDirData.configFileAbsPath);
+  const projectMetaData = await loadJsonConfig(projectDirData.datasetFileAbsPath);
   if (projectMetaData.originalBasePath !== '') {
     const exists = await fs.pathExists(projectMetaData.originalBasePath);
     if (!exists) {
@@ -1475,7 +1484,7 @@ async function beginMediaImport(path: string): Promise<DesktopMediaImportRespons
     confidenceFilters: { default: DefaultConfidence },
   };
 
-  /* TODO: Look for an EXISTING meta.json file to override the above */
+  /* TODO: Look for an EXISTING portable config.json to override the above */
 
   if (datasetType === 'video') {
     // get parent folder, since videos reference a file directly
@@ -1570,7 +1579,7 @@ function validImageNamesMap(jsonConfig: JsonConfig) {
 
 async function dataFileImport(settings: Settings, id: string, path: string, additive = false, additivePrepend = '') {
   const projectDirData = await getValidatedProjectDir(settings, id);
-  const jsonConfig = await loadJsonConfig(projectDirData.configFileAbsPath);
+  const jsonConfig = await loadJsonConfig(projectDirData.datasetFileAbsPath);
   const existingDatasetInfo = jsonConfig.datasetInfo;
   const result = await ingestDataFiles(
     settings,
@@ -1598,8 +1607,8 @@ async function dataFileImport(settings: Settings, id: string, path: string, addi
   const { parentId, cameraName } = parseCompositeDatasetId(id);
   if (cameraName && MulticamSharedMutableKeys.some((key) => key in result.meta)) {
     const baseProjectDir = getProjectDir(settings, parentId);
-    if (await fs.pathExists(baseProjectDir.configFileAbsPath)) {
-      const baseMeta = await loadJsonConfig(baseProjectDir.configFileAbsPath);
+    if (await fs.pathExists(baseProjectDir.datasetFileAbsPath)) {
+      const baseMeta = await loadJsonConfig(baseProjectDir.datasetFileAbsPath);
       const existingBaseDatasetInfo = baseMeta.datasetInfo;
       merge(baseMeta, pick(result.meta, MulticamSharedMutableKeys));
       if (result.meta.datasetInfo) {
@@ -1803,7 +1812,7 @@ async function finalizeMediaImport(
 async function getLargeImagePath(settings: Settings, datasetId: string): Promise<string | null> {
   try {
     const projectDirData = await getValidatedProjectDir(settings, datasetId);
-    const meta = await loadJsonConfig(projectDirData.configFileAbsPath);
+    const meta = await loadJsonConfig(projectDirData.datasetFileAbsPath);
     if (meta.type !== 'large-image' || !meta.originalLargeImageFile) {
       console.warn(
         `[tiles] getLargeImagePath: no path for dataset "${datasetId}" (meta.type=${meta.type}, hasOriginalLargeImageFile=${!!meta.originalLargeImageFile})`,
@@ -1835,7 +1844,7 @@ async function getDisplayImagePath(
 ): Promise<string | null> {
   try {
     const projectDirData = await getValidatedProjectDir(settings, datasetId);
-    const meta = await loadJsonConfig(projectDirData.configFileAbsPath);
+    const meta = await loadJsonConfig(projectDirData.datasetFileAbsPath);
     const originals = meta.originalImageFiles ?? [];
     if (!Number.isInteger(frame) || frame < 0 || frame >= originals.length) {
       console.warn(
@@ -1898,7 +1907,7 @@ async function openPathInFileManager(targetPath: string): Promise<string> {
 
 async function exportDataset(settings: Settings, args: ExportDatasetArgs) {
   const projectDirInfo = await getValidatedProjectDir(settings, args.id);
-  const meta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const meta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   const data = await loadAnnotationFile(projectDirInfo.trackFileAbsPath);
   if (args.type === 'json') {
     return dive.serializeFile(args.path, data, meta, args.typeFilter, {
@@ -1919,7 +1928,7 @@ async function exportDataset(settings: Settings, args: ExportDatasetArgs) {
 
 async function exportConfiguration(settings: Settings, args: ExportConfigurationArgs) {
   const projectDirInfo = await getValidatedProjectDir(settings, args.id);
-  const meta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const meta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   const output: DatasetConfigMutable & { version: number} = { version: meta.version };
   if (DatasetConfigMutableKeys.some((key) => key in meta)) {
     // DIVE Configuration File fields (attributes, styles, FPS, …)

--- a/client/platform/desktop/backend/native/datasetCalibration.ts
+++ b/client/platform/desktop/backend/native/datasetCalibration.ts
@@ -16,11 +16,9 @@ import { Settings, LastCalibrationBaseName } from 'platform/desktop/constants';
 
 import { prepareDatasetCalibration } from './calibrationConvert';
 // eslint-disable-next-line import/no-cycle
-import { autodiscoverData, getValidatedProjectDir, loadJsonMetadata } from './common';
-
-async function writeJsonFile(absPath: string, data: unknown): Promise<void> {
-  await fs.writeFile(absPath, JSON.stringify(data, null, 2));
-}
+import {
+  autodiscoverData, getValidatedProjectDir, loadJsonConfig, saveProjectConfig,
+} from './common';
 
 /**
  * The user's calibration filename, unless it is DIVE's internal
@@ -115,7 +113,7 @@ export async function applyCalibrationToUncalibratedStereoDatasets(
         // eslint-disable-next-line no-await-in-loop
         const projectDirInfo = await getValidatedProjectDir(settings, meta.id);
         // eslint-disable-next-line no-await-in-loop
-        const fullMeta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+        const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
         if (fullMeta.multiCam) {
           const calibrationSourcePath = npath.resolve(calibrationPath);
           const preservedOriginalPath = npath.join(
@@ -132,7 +130,7 @@ export async function applyCalibrationToUncalibratedStereoDatasets(
           fullMeta.multiCam.calibrationOriginalName = realCalibrationName(originalName)
             ?? realCalibrationName(calibrationSourcePath);
           // eslint-disable-next-line no-await-in-loop
-          await writeJsonFile(projectDirInfo.metaFileAbsPath, fullMeta);
+          await saveProjectConfig(projectDirInfo.basePath, fullMeta);
           updatedIds.push(meta.id);
         }
       } catch (err) {
@@ -152,7 +150,7 @@ export async function datasetHasCalibrationFile(settings: Settings, datasetId: s
   const parentId = datasetId.split('/')[0];
   try {
     const projectDirData = await getValidatedProjectDir(settings, parentId);
-    const meta = await loadJsonMetadata(projectDirData.metaFileAbsPath);
+    const meta = await loadJsonConfig(projectDirData.configFileAbsPath);
     if (meta.multiCam?.calibration && await fs.pathExists(meta.multiCam.calibration)) {
       return true;
     }
@@ -171,7 +169,7 @@ export async function getDatasetCalibrationPath(
   datasetId: string,
 ): Promise<string | null> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const fullMeta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   return fullMeta.multiCam?.calibration ?? null;
 }
 
@@ -183,7 +181,7 @@ export async function getDatasetCalibrationExportPath(
   datasetId: string,
 ): Promise<string | null> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const fullMeta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   const { multiCam } = fullMeta;
   if (!multiCam) {
     return null;
@@ -220,7 +218,7 @@ export async function setDatasetCalibration(
   // per-camera child id (e.g. "<parent>/left").
   const parentId = datasetId.split('/')[0];
   const projectDirInfo = await getValidatedProjectDir(settings, parentId);
-  const fullMeta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   if (!fullMeta.multiCam) {
     throw new Error(`Dataset ${parentId} is not a multi-camera/stereo dataset; cannot set a calibration file.`);
   }
@@ -236,7 +234,7 @@ export async function setDatasetCalibration(
   fullMeta.multiCam.calibration = calibrationPath;
   fullMeta.multiCam.calibrationSourcePath = npath.resolve(preservedOriginalPath);
   fullMeta.multiCam.calibrationOriginalName = realCalibrationName(sourcePath);
-  await writeJsonFile(projectDirInfo.metaFileAbsPath, fullMeta);
+  await saveProjectConfig(projectDirInfo.basePath, fullMeta);
   return calibrationPath;
 }
 
@@ -269,7 +267,7 @@ export async function getDatasetCalibration(
   datasetId: string,
 ): Promise<DatasetCalibrationResult | null> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId.split('/')[0]);
-  const fullMeta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   const calibrationPath = fullMeta.multiCam?.calibration;
   if (!calibrationPath || !(await fs.pathExists(calibrationPath))) {
     return null;
@@ -307,7 +305,7 @@ export async function applyCalibrationToDataset(
   calibrationPath: string,
 ): Promise<string> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const fullMeta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
 
   if (!fullMeta.multiCam) {
     throw new Error(`Dataset ${datasetId} is not a stereo/multicam dataset`);
@@ -327,7 +325,7 @@ export async function applyCalibrationToDataset(
 export async function deleteDatasetCalibration(settings: Settings, datasetId: string): Promise<void> {
   const parentId = datasetId.split('/')[0];
   const projectDirInfo = await getValidatedProjectDir(settings, parentId);
-  const fullMeta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   const calibrationPath = fullMeta.multiCam?.calibration;
   if (calibrationPath && await fs.pathExists(calibrationPath)) {
     await fs.remove(calibrationPath);
@@ -336,6 +334,6 @@ export async function deleteDatasetCalibration(settings: Settings, datasetId: st
     fullMeta.multiCam.calibration = undefined;
     fullMeta.multiCam.calibrationSourcePath = undefined;
     fullMeta.multiCam.calibrationOriginalName = undefined;
-    await writeJsonFile(projectDirInfo.metaFileAbsPath, fullMeta);
+    await saveProjectConfig(projectDirInfo.basePath, fullMeta);
   }
 }

--- a/client/platform/desktop/backend/native/datasetCalibration.ts
+++ b/client/platform/desktop/backend/native/datasetCalibration.ts
@@ -113,7 +113,7 @@ export async function applyCalibrationToUncalibratedStereoDatasets(
         // eslint-disable-next-line no-await-in-loop
         const projectDirInfo = await getValidatedProjectDir(settings, meta.id);
         // eslint-disable-next-line no-await-in-loop
-        const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+        const fullMeta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
         if (fullMeta.multiCam) {
           const calibrationSourcePath = npath.resolve(calibrationPath);
           const preservedOriginalPath = npath.join(
@@ -150,7 +150,7 @@ export async function datasetHasCalibrationFile(settings: Settings, datasetId: s
   const parentId = datasetId.split('/')[0];
   try {
     const projectDirData = await getValidatedProjectDir(settings, parentId);
-    const meta = await loadJsonConfig(projectDirData.configFileAbsPath);
+    const meta = await loadJsonConfig(projectDirData.datasetFileAbsPath);
     if (meta.multiCam?.calibration && await fs.pathExists(meta.multiCam.calibration)) {
       return true;
     }
@@ -169,7 +169,7 @@ export async function getDatasetCalibrationPath(
   datasetId: string,
 ): Promise<string | null> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   return fullMeta.multiCam?.calibration ?? null;
 }
 
@@ -181,7 +181,7 @@ export async function getDatasetCalibrationExportPath(
   datasetId: string,
 ): Promise<string | null> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   const { multiCam } = fullMeta;
   if (!multiCam) {
     return null;
@@ -218,7 +218,7 @@ export async function setDatasetCalibration(
   // per-camera child id (e.g. "<parent>/left").
   const parentId = datasetId.split('/')[0];
   const projectDirInfo = await getValidatedProjectDir(settings, parentId);
-  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   if (!fullMeta.multiCam) {
     throw new Error(`Dataset ${parentId} is not a multi-camera/stereo dataset; cannot set a calibration file.`);
   }
@@ -267,7 +267,7 @@ export async function getDatasetCalibration(
   datasetId: string,
 ): Promise<DatasetCalibrationResult | null> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId.split('/')[0]);
-  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   const calibrationPath = fullMeta.multiCam?.calibration;
   if (!calibrationPath || !(await fs.pathExists(calibrationPath))) {
     return null;
@@ -305,7 +305,7 @@ export async function applyCalibrationToDataset(
   calibrationPath: string,
 ): Promise<string> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
 
   if (!fullMeta.multiCam) {
     throw new Error(`Dataset ${datasetId} is not a stereo/multicam dataset`);
@@ -325,7 +325,7 @@ export async function applyCalibrationToDataset(
 export async function deleteDatasetCalibration(settings: Settings, datasetId: string): Promise<void> {
   const parentId = datasetId.split('/')[0];
   const projectDirInfo = await getValidatedProjectDir(settings, parentId);
-  const fullMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const fullMeta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   const calibrationPath = fullMeta.multiCam?.calibration;
   if (calibrationPath && await fs.pathExists(calibrationPath)) {
     await fs.remove(calibrationPath);

--- a/client/platform/desktop/backend/native/mediaJobs.ts
+++ b/client/platform/desktop/backend/native/mediaJobs.ts
@@ -7,7 +7,7 @@ import {
   ConversionArgs,
   DesktopJobUpdater,
   FFProbeFrameResults,
-  JsonMeta,
+  JsonConfig,
 } from 'platform/desktop/constants';
 import { observeChild } from 'platform/desktop/backend/native/processManager';
 
@@ -193,8 +193,8 @@ async function convertMedia(
   settings: Settings,
   args: ConversionArgs,
   updater: DesktopJobUpdater,
-  onComplete?: (jobKey: string, meta: JsonMeta) => void,
-  onFail?: (jobKey: string, meta: JsonMeta, errorMessage: string) => void,
+  onComplete?: (jobKey: string, meta: JsonConfig) => void,
+  onFail?: (jobKey: string, meta: JsonConfig, errorMessage: string) => void,
   setTranscodingKey = false,
   mediaIndex = 0,
   key = '',

--- a/client/platform/desktop/backend/native/migrations.ts
+++ b/client/platform/desktop/backend/native/migrations.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-param-reassign */
-import { JsonMeta, JsonMetaCurrentVersion } from 'platform/desktop/constants';
+import { JsonConfig, JsonConfigCurrentVersion } from 'platform/desktop/constants';
 
-function upgrade(meta: JsonMeta) {
-  if (meta.version === JsonMetaCurrentVersion) {
+function upgrade(meta: JsonConfig) {
+  if (meta.version === JsonConfigCurrentVersion) {
     /* Perform soft upgrades of backward-compatible properties */
     if (meta.originalFps === undefined) {
       // This will be an incorrect value.
@@ -14,14 +14,14 @@ function upgrade(meta: JsonMeta) {
     if (meta.subType === undefined) {
       meta.subType = null;
     }
-  } else if (meta.version < JsonMetaCurrentVersion) {
+  } else if (meta.version < JsonConfigCurrentVersion) {
     /* Perform major version upgrade */
     console.error('Impossible schema', meta);
     throw new Error('Impossible schema revision detected.  This is not a valid DIVE project metadata file.  Check the console for details.');
-  } else if (meta.version > JsonMetaCurrentVersion) {
+  } else if (meta.version > JsonConfigCurrentVersion) {
     throw new Error('You are trying to open a newer version of the project schema.  Please upgrade DIVE to the latest version');
   }
-  meta.version = JsonMetaCurrentVersion;
+  meta.version = JsonConfigCurrentVersion;
 }
 
 // eslint-disable-next-line import/prefer-default-export

--- a/client/platform/desktop/backend/native/multiCam.spec.ts
+++ b/client/platform/desktop/backend/native/multiCam.spec.ts
@@ -97,7 +97,7 @@ describe('native.multiCamImport', () => {
       },
       type: 'image-sequence',
     });
-    expect(output.jsonMeta.name).toBe('my_stereo_scene');
+    expect(output.jsonConfig.name).toBe('my_stereo_scene');
   });
 
   if (multiCamSetup.folderTests) {
@@ -105,7 +105,7 @@ describe('native.multiCamImport', () => {
     Object.entries(folderTests).forEach(([key, val]) => {
       it(`Test Folder Import: ${key}`, async () => {
         const output = await beginMultiCamImport(val.input);
-        expect(output.jsonMeta.multiCam).toEqual(val.output.multiCam);
+        expect(output.jsonConfig.multiCam).toEqual(val.output.multiCam);
         expect(output.mediaConvertList).toEqual(val.output.mediaConvertList);
       });
     });
@@ -115,7 +115,7 @@ describe('native.multiCamImport', () => {
     Object.entries(keywordTests).forEach(([key, val]) => {
       it(`Test Keyword Import: ${key}`, async () => {
         const output = await beginMultiCamImport(val.input);
-        expect(output.jsonMeta.multiCam).toEqual(val.output.multiCam);
+        expect(output.jsonConfig.multiCam).toEqual(val.output.multiCam);
         expect(output.mediaConvertList).toEqual(val.output.mediaConvertList);
       });
     });

--- a/client/platform/desktop/backend/native/multiCamImport.ts
+++ b/client/platform/desktop/backend/native/multiCamImport.ts
@@ -12,7 +12,7 @@ import {
 } from 'dive-common/constants';
 import { preferEoIrSubfolderOrder } from 'dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout';
 import {
-  JsonMeta, JsonMetaCurrentVersion,
+  JsonConfig, JsonConfigCurrentVersion,
   DesktopMediaImportResponse,
   Camera,
 } from 'platform/desktop/constants';
@@ -122,7 +122,7 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
 
   // Per-camera transform/registration files seed the dataset's saved camera
   // registration -- the same single registration the in-app panel edits and
-  // the aligned view consumes (loadMetadata falls back to these meta fields
+  // the aligned view consumes (loadConfig falls back to these meta fields
   // until a save writes the standalone per-camera files).
   const seedHomographies: CameraHomographies = {};
   const seedCorrespondences: CameraCorrespondences = {};
@@ -178,8 +178,8 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
     });
   }
 
-  const jsonMeta: JsonMeta = {
-    version: JsonMetaCurrentVersion,
+  const jsonConfig: JsonConfig = {
+    version: JsonConfigCurrentVersion,
     type: datasetType,
     id: '', // will be assigned on finalize
     fps: 5,
@@ -205,12 +205,12 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
     subType: null,
   };
   if (Object.keys(seedHomographies).length || Object.keys(seedCorrespondences).length) {
-    jsonMeta.cameraHomographies = seedHomographies;
-    jsonMeta.cameraCorrespondences = seedCorrespondences;
-    jsonMeta.cameraTransformTypes = seedTransformTypes;
+    jsonConfig.cameraHomographies = seedHomographies;
+    jsonConfig.cameraCorrespondences = seedCorrespondences;
+    jsonConfig.cameraTransformTypes = seedTransformTypes;
     const seedRegistrationSource = mergeRegistrationSources(seedSourceStamps);
     if (seedRegistrationSource) {
-      jsonMeta.cameraRegistrationSource = seedRegistrationSource;
+      jsonConfig.cameraRegistrationSource = seedRegistrationSource;
     }
   }
 
@@ -229,7 +229,7 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
           const video = item.sourcePath;
           const mimetype = mime.lookup(video);
           if (cameraName === args.defaultDisplay) {
-            jsonMeta.originalVideoFile = npath.basename(video);
+            jsonConfig.originalVideoFile = npath.basename(video);
           }
           if (mimetype) {
             if (websafeImageTypes.includes(mimetype) || otherImageTypes.includes(mimetype)) {
@@ -239,17 +239,17 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
               if (!checkMediaResult.websafe || otherVideoTypes.includes(mimetype)) {
                 mediaConvertList.push(video);
               }
-              if (jsonMeta.multiCam && jsonMeta.multiCam.cameras[cameraName] !== undefined) {
-                jsonMeta.multiCam.cameras[cameraName].originalVideoFile = npath.basename(video);
+              if (jsonConfig.multiCam && jsonConfig.multiCam.cameras[cameraName] !== undefined) {
+                jsonConfig.multiCam.cameras[cameraName].originalVideoFile = npath.basename(video);
               }
               const newAnnotationFps = Math.floor(
-                Math.min(jsonMeta.fps, checkMediaResult.originalFps),
+                Math.min(jsonConfig.fps, checkMediaResult.originalFps),
               );
               if (newAnnotationFps <= 0) {
                 throw new Error('fps < 1 unsupported');
               }
-              jsonMeta.originalFps = checkMediaResult.originalFps;
-              jsonMeta.fps = newAnnotationFps;
+              jsonConfig.originalFps = checkMediaResult.originalFps;
+              jsonConfig.fps = newAnnotationFps;
             } else {
               throw new Error(`unsupported MIME type for video ${mimetype}`);
             }
@@ -279,13 +279,13 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
             cameras[cameraName].originalImageFiles = found.imageNames;
           } else if (found.source === 'image-list') {
             cameras[cameraName].originalImageFiles = found.imagePaths;
-            cameras[cameraName].imageListPath = jsonMeta.originalBasePath;
+            cameras[cameraName].imageListPath = jsonConfig.originalBasePath;
             cameras[cameraName].originalBasePath = '';
           }
         },
       );
     } else if (isKeywordArgs(args)) {
-      jsonMeta.originalBasePath = args.sourcePath;
+      jsonConfig.originalBasePath = args.sourcePath;
       await asyncForEach(
         Object.entries(args.globList),
         async ([cameraName, item]) => {
@@ -295,7 +295,7 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
             cameras[cameraName].originalImageFiles = found.imageNames;
           } else if (found.source === 'image-list') {
             cameras[cameraName].originalImageFiles = found.imagePaths;
-            cameras[cameraName].imageListPath = jsonMeta.originalBasePath;
+            cameras[cameraName].imageListPath = jsonConfig.originalBasePath;
             cameras[cameraName].originalBasePath = '';
           }
         },
@@ -305,11 +305,11 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
     throw new Error('only video and image-sequence types are supported');
   }
 
-  if (jsonMeta.multiCam?.cameras && jsonMeta.multiCam.cameras.left
-    && jsonMeta.multiCam.cameras.right) {
-    jsonMeta.subType = 'stereo';
-  } else if (jsonMeta.multiCam) {
-    jsonMeta.subType = 'multicam';
+  if (jsonConfig.multiCam?.cameras && jsonConfig.multiCam.cameras.left
+    && jsonConfig.multiCam.cameras.right) {
+    jsonConfig.subType = 'stereo';
+  } else if (jsonConfig.multiCam) {
+    jsonConfig.subType = 'multicam';
   }
 
   if (mediaConvertList.length && Object.values(cameras).some((cam) => cam.imageListPath)) {
@@ -317,7 +317,7 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
   }
 
   return {
-    jsonMeta,
+    jsonConfig,
     globPattern: '',
     mediaConvertList,
     trackFileAbsPath: '',

--- a/client/platform/desktop/backend/native/multiCamTransformImport.spec.ts
+++ b/client/platform/desktop/backend/native/multiCamTransformImport.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Wire-through tests for per-camera transform/registration files in multicam
  * import: they seed the dataset's saved camera registration
- * (jsonMeta.cameraHomographies et al.) from a DIVE registration .json.
+ * (jsonConfig.cameraHomographies et al.) from a DIVE registration .json.
  */
 import os from 'os';
 import npath from 'path';
@@ -73,13 +73,13 @@ describe('multiCamImport transform wire-through', () => {
       sourceList: sourceListWith(registrationJsonPath),
       type: 'image-sequence',
     });
-    expect(output.jsonMeta.cameraHomographies?.['eo::ir'].AtoB).toEqual(
+    expect(output.jsonConfig.cameraHomographies?.['eo::ir'].AtoB).toEqual(
       [[1, 0, 5], [0, 1, -3], [0, 0, 1]],
     );
-    expect(output.jsonMeta.cameraCorrespondences?.['eo::ir']).toHaveLength(2);
-    expect(output.jsonMeta.cameraTransformTypes?.['eo::ir']).toBe('translation');
+    expect(output.jsonConfig.cameraCorrespondences?.['eo::ir']).toHaveLength(2);
+    expect(output.jsonConfig.cameraTransformTypes?.['eo::ir']).toBe('translation');
     // The producer provenance stamp travels with the seed.
-    expect(output.jsonMeta.cameraRegistrationSource).toEqual(
+    expect(output.jsonConfig.cameraRegistrationSource).toEqual(
       { model: 'colmap-2026-07-01', swathe: 'fl07_C' },
     );
   });
@@ -115,7 +115,7 @@ describe('multiCamImport transform wire-through', () => {
       type: 'image-sequence',
     });
     // The seed still imports: pair bodies are authoritative.
-    expect(output.jsonMeta.cameraHomographies?.['uv::rgb']).toBeDefined();
+    expect(output.jsonConfig.cameraHomographies?.['uv::rgb']).toBeDefined();
     expect(output.importWarnings).toHaveLength(1);
     expect(output.importWarnings?.[0]).toContain('uv_to_rgb_registration.json');
     expect(output.importWarnings?.[0]).toContain('rgb, uv');
@@ -128,8 +128,8 @@ describe('multiCamImport transform wire-through', () => {
       sourceList: sourceListWith(),
       type: 'image-sequence',
     });
-    expect(output.jsonMeta.cameraHomographies).toBeUndefined();
-    expect(output.jsonMeta.cameraCorrespondences).toBeUndefined();
+    expect(output.jsonConfig.cameraHomographies).toBeUndefined();
+    expect(output.jsonConfig.cameraCorrespondences).toBeUndefined();
   });
 
   it('fails the import for a .json without a pairs list', async () => {

--- a/client/platform/desktop/backend/native/multiCamUtils.ts
+++ b/client/platform/desktop/backend/native/multiCamUtils.ts
@@ -6,9 +6,9 @@ import {
   MultiCamMedia,
 } from 'dive-common/apispec';
 
-import { JsonMeta, Settings } from 'platform/desktop/constants';
+import { JsonConfig, Settings } from 'platform/desktop/constants';
 // eslint-disable-next-line import/no-cycle
-import { loadAnnotationFile, loadJsonMetadata, getValidatedProjectDir } from 'platform/desktop/backend/native/common';
+import { loadAnnotationFile, loadJsonConfig, getValidatedProjectDir } from 'platform/desktop/backend/native/common';
 import { serialize } from 'platform/desktop/backend/serializers/viame';
 import { parseFrameTimestamp } from 'dive-common/frameTimestamp';
 
@@ -16,13 +16,13 @@ import { parseFrameTimestamp } from 'dive-common/frameTimestamp';
  * Figure out the destination location
  */
 function transcodeMultiCam(
-  jsonMeta: JsonMeta,
+  jsonConfig: JsonConfig,
   item: string,
   projectDirAbsPath: string,
 ) {
   let destLoc = '';
-  if (jsonMeta.multiCam) {
-    const entries = Object.entries(jsonMeta.multiCam.cameras);
+  if (jsonConfig.multiCam) {
+    const entries = Object.entries(jsonConfig.multiCam.cameras);
     for (let i = 0; i < entries.length; i += 1) {
       const [cameraName, cameraData] = entries[i];
       if (cameraData.imageListPath) {
@@ -56,12 +56,12 @@ function transcodeMultiCam(
   return destLoc;
 }
 
-function getTranscodedMultiCamType(imageListFile: string, jsonMeta: JsonMeta) {
+function getTranscodedMultiCamType(imageListFile: string, jsonConfig: JsonConfig) {
   // Look through cameras trying to find the match for the key/name and type to return back the type
-  if (jsonMeta.multiCam) {
+  if (jsonConfig.multiCam) {
     const base = npath.basename(imageListFile).replace(npath.extname(imageListFile), '');
     let type;
-    Object.values(jsonMeta.multiCam.cameras).forEach((val) => {
+    Object.values(jsonConfig.multiCam.cameras).forEach((val) => {
       if (val.originalImageFiles.map((item) => item.replace(npath.extname(item), '')).includes(base)) {
         type = val.type;
       }
@@ -76,7 +76,7 @@ function getTranscodedMultiCamType(imageListFile: string, jsonMeta: JsonMeta) {
   throw new Error(`No associate type for ${imageListFile} in multiCam data`);
 }
 
-async function writeMultiCamStereoPipelineArgs(jobWorkDir: string, meta: JsonMeta, settings: Settings, utility = false, forceTranscoded = false) {
+async function writeMultiCamStereoPipelineArgs(jobWorkDir: string, meta: JsonConfig, settings: Settings, utility = false, forceTranscoded = false) {
   const argFilePair: Record<string, string> = {};
   const outFiles: Record<string, string> = {};
   if (meta.multiCam && meta.multiCam.cameras) {
@@ -129,7 +129,7 @@ async function writeMultiCamStereoPipelineArgs(jobWorkDir: string, meta: JsonMet
           argFilePair['detection_reader:file_name'] = groundTruthFileName;
           argFilePair['track_reader:file_name'] = groundTruthFileName;
         }
-        const subMeta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+        const subMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
         const inputData = await loadAnnotationFile(projectDirInfo.trackFileAbsPath);
         await serialize(groundTruthFileStream, inputData, subMeta);
         groundTruthFileStream.end();
@@ -140,7 +140,7 @@ async function writeMultiCamStereoPipelineArgs(jobWorkDir: string, meta: JsonMet
 }
 
 function getMultiCamUrls(
-  projectMetaData: JsonMeta,
+  projectMetaData: JsonConfig,
   projectBasePath: string,
   makeMediaUrl: (path: string) => string,
 ) {
@@ -196,7 +196,7 @@ function getMultiCamUrls(
   throw new Error('There is no multiCam data associated with this');
 }
 
-function getMultiCamVideoPath(meta: JsonMeta, forceTranscodedVideo?: boolean) {
+function getMultiCamVideoPath(meta: JsonConfig, forceTranscodedVideo?: boolean) {
   if (meta.multiCam && meta.multiCam.defaultDisplay) {
     if (meta.multiCam.cameras[meta.multiCam.defaultDisplay]) {
       const display = meta.multiCam.cameras[meta.multiCam.defaultDisplay];
@@ -210,7 +210,7 @@ function getMultiCamVideoPath(meta: JsonMeta, forceTranscodedVideo?: boolean) {
   throw new Error(`${meta.id} does not contain multiCam data`);
 }
 
-function getMultiCamImageFiles(meta: JsonMeta) {
+function getMultiCamImageFiles(meta: JsonConfig) {
   if (meta.multiCam && meta.multiCam.defaultDisplay) {
     if (meta.multiCam.cameras[meta.multiCam.defaultDisplay]) {
       const display = meta.multiCam.cameras[meta.multiCam.defaultDisplay];

--- a/client/platform/desktop/backend/native/multiCamUtils.ts
+++ b/client/platform/desktop/backend/native/multiCamUtils.ts
@@ -129,7 +129,7 @@ async function writeMultiCamStereoPipelineArgs(jobWorkDir: string, meta: JsonCon
           argFilePair['detection_reader:file_name'] = groundTruthFileName;
           argFilePair['track_reader:file_name'] = groundTruthFileName;
         }
-        const subMeta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+        const subMeta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
         const inputData = await loadAnnotationFile(projectDirInfo.trackFileAbsPath);
         await serialize(groundTruthFileStream, inputData, subMeta);
         groundTruthFileStream.end();

--- a/client/platform/desktop/backend/native/multiCollectImport.spec.ts
+++ b/client/platform/desktop/backend/native/multiCollectImport.spec.ts
@@ -283,7 +283,7 @@ describe('native.multiCollectImport', () => {
       throw new Error('expected fl01 importArgs');
     }
     const imported = await beginMultiCamImport(fl01.importArgs);
-    expect(imported.jsonMeta.cameraHomographies?.['EO::IR'].AtoB).toEqual(
+    expect(imported.jsonConfig.cameraHomographies?.['EO::IR'].AtoB).toEqual(
       [[1, 0, 5], [0, 1, -3], [0, 0, 1]],
     );
     expect(imported.importWarnings).toBeUndefined();
@@ -326,11 +326,11 @@ describe('native.multiCollectImport', () => {
       return;
     }
     const imported = await beginMultiCamImport(importArgs);
-    expect(imported.jsonMeta.name).toBe('fl09_center_view');
-    expect(imported.jsonMeta.subType).toBe('multicam');
-    expect(Object.keys(imported.jsonMeta.multiCam?.cameras ?? {})).toEqual(['rgb', 'ir']);
-    const rgb = imported.jsonMeta.multiCam?.cameras.rgb;
-    const ir = imported.jsonMeta.multiCam?.cameras.ir;
+    expect(imported.jsonConfig.name).toBe('fl09_center_view');
+    expect(imported.jsonConfig.subType).toBe('multicam');
+    expect(Object.keys(imported.jsonConfig.multiCam?.cameras ?? {})).toEqual(['rgb', 'ir']);
+    const rgb = imported.jsonConfig.multiCam?.cameras.rgb;
+    const ir = imported.jsonConfig.multiCam?.cameras.ir;
     expect(rgb?.originalBasePath).toBe('/data/fl09/center_view');
     expect(rgb?.originalImageFiles).toHaveLength(2);
     expect(rgb?.originalImageFiles.every((name) => name.endsWith('_rgb.jpg'))).toBe(true);
@@ -351,11 +351,11 @@ describe('native.multiCollectImport', () => {
       return;
     }
     const imported = await beginMultiCamImport(importArgs);
-    expect(imported.jsonMeta.name).toBe('fl01');
-    expect(imported.jsonMeta.subType).toBe('multicam');
-    expect(imported.jsonMeta.multiCam?.defaultDisplay).toBe('EO');
-    expect(Object.keys(imported.jsonMeta.multiCam?.cameras ?? {})).toEqual(['EO', 'IR']);
-    expect(imported.jsonMeta.multiCam?.cameras.EO.originalBasePath).toBe('/survey/fl01/EO');
-    expect(imported.jsonMeta.multiCam?.cameras.EO.originalImageFiles).toHaveLength(2);
+    expect(imported.jsonConfig.name).toBe('fl01');
+    expect(imported.jsonConfig.subType).toBe('multicam');
+    expect(imported.jsonConfig.multiCam?.defaultDisplay).toBe('EO');
+    expect(Object.keys(imported.jsonConfig.multiCam?.cameras ?? {})).toEqual(['EO', 'IR']);
+    expect(imported.jsonConfig.multiCam?.cameras.EO.originalBasePath).toBe('/survey/fl01/EO');
+    expect(imported.jsonConfig.multiCam?.cameras.EO.originalImageFiles).toHaveLength(2);
   });
 });

--- a/client/platform/desktop/backend/native/multicamExport.ts
+++ b/client/platform/desktop/backend/native/multicamExport.ts
@@ -53,7 +53,7 @@ async function writeDatasetExportContents(
   typeFilter: Set<string>,
 ): Promise<void> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const meta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
+  const meta = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
   const data = await loadAnnotationFile(projectDirInfo.trackFileAbsPath);
   const serializeOptions = {
     excludeBelowThreshold,
@@ -98,7 +98,7 @@ export async function exportMulticamEverything(
 ): Promise<string> {
   const parentId = args.id.split('/')[0];
   const parentDirInfo = await getValidatedProjectDir(settings, parentId);
-  const parentMeta = await loadJsonConfig(parentDirInfo.configFileAbsPath);
+  const parentMeta = await loadJsonConfig(parentDirInfo.datasetFileAbsPath);
   if (parentMeta.type !== MultiType || !parentMeta.multiCam) {
     throw new Error('Everything export is only available for multi-camera datasets.');
   }

--- a/client/platform/desktop/backend/native/multicamExport.ts
+++ b/client/platform/desktop/backend/native/multicamExport.ts
@@ -16,7 +16,7 @@ import * as viameSerializers from 'platform/desktop/backend/serializers/viame';
 import * as dive from 'platform/desktop/backend/serializers/dive';
 
 // eslint-disable-next-line import/no-cycle
-import { getValidatedProjectDir, loadAnnotationFile, loadJsonMetadata } from './common';
+import { getValidatedProjectDir, loadAnnotationFile, loadJsonConfig } from './common';
 import {
   findParentFolderCalibrationFile,
   getDatasetCalibrationExportPath,
@@ -29,7 +29,7 @@ async function writeJsonFile(absPath: string, data: unknown): Promise<void> {
   await fs.writeFile(absPath, JSON.stringify(data, null, 2));
 }
 
-function buildExportMetaJson(meta: JsonMeta): Record<string, unknown> {
+function buildExportMetaJson(meta: JsonConfig): Record<string, unknown> {
   const output: Record<string, unknown> = { ...meta };
   if (meta.type === 'image-sequence') {
     const files = meta.transcodedImageFiles?.length
@@ -53,7 +53,7 @@ async function writeDatasetExportContents(
   typeFilter: Set<string>,
 ): Promise<void> {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const meta = await loadJsonMetadata(projectDirInfo.metaFileAbsPath);
+  const meta = await loadJsonConfig(projectDirInfo.configFileAbsPath);
   const data = await loadAnnotationFile(projectDirInfo.trackFileAbsPath);
   const serializeOptions = {
     excludeBelowThreshold,
@@ -61,7 +61,7 @@ async function writeDatasetExportContents(
   };
 
   await fs.ensureDir(destDir);
-  await fs.writeJSON(npath.join(destDir, 'meta.json'), buildExportMetaJson(meta), { spaces: 2 });
+  await fs.writeJSON(npath.join(destDir, 'config.json'), buildExportMetaJson(meta), { spaces: 2 });
   await dive.serializeFile(
     npath.join(destDir, 'annotations.dive.json'),
     data,
@@ -98,7 +98,7 @@ export async function exportMulticamEverything(
 ): Promise<string> {
   const parentId = args.id.split('/')[0];
   const parentDirInfo = await getValidatedProjectDir(settings, parentId);
-  const parentMeta = await loadJsonMetadata(parentDirInfo.metaFileAbsPath);
+  const parentMeta = await loadJsonConfig(parentDirInfo.configFileAbsPath);
   if (parentMeta.type !== MultiType || !parentMeta.multiCam) {
     throw new Error('Everything export is only available for multi-camera datasets.');
   }

--- a/client/platform/desktop/backend/native/utils.ts
+++ b/client/platform/desktop/backend/native/utils.ts
@@ -6,7 +6,7 @@ import os from 'os';
 
 import { observeChild } from 'platform/desktop/backend/native/processManager';
 import {
-  DesktopJob, DesktopJobUpdater, JsonMeta, Settings, JobsFolderName,
+  DesktopJob, DesktopJobUpdater, JsonConfig, Settings, JobsFolderName,
 } from 'platform/desktop/constants';
 
 const processChunk = (chunk: Buffer) => chunk
@@ -91,14 +91,14 @@ Promise<{ output: null | string; exitCode: number | null; error: string}> {
 /**
  * Create job run working directory
  */
-async function createWorkingDirectory(settings: Settings, jsonMetaList: JsonMeta[], pipeline: string) {
-  if (jsonMetaList.length === 0) {
-    throw new Error('At least 1 jsonMeta item must be provided');
+async function createWorkingDirectory(settings: Settings, jsonConfigList: JsonConfig[], pipeline: string) {
+  if (jsonConfigList.length === 0) {
+    throw new Error('At least 1 jsonConfig item must be provided');
   }
   const jobFolderPath = path.join(settings.dataPath, JobsFolderName);
   // eslint won't recognize \. as valid escape
   // eslint-disable-next-line no-useless-escape
-  const safeDatasetName = jsonMetaList[0].id.replace(/[\.\s/]+/g, '_');
+  const safeDatasetName = jsonConfigList[0].id.replace(/[\.\s/]+/g, '_');
   const runFolderName = moment().format(`[${safeDatasetName}_${pipeline}]_MM-DD-yy_hh-mm-ss.SSS`);
   const runFolderPath = path.join(jobFolderPath, runFolderName);
   if (!fs.existsSync(jobFolderPath)) {

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -6,7 +6,7 @@ import {
   Settings, DesktopJob, RunPipeline, RunTraining,
   DesktopJobUpdater,
   ExportTrainedPipeline,
-  JsonMeta,
+  JsonConfig,
   JobsOutputFolderName,
 } from 'platform/desktop/constants';
 import { cleanString } from 'platform/desktop/sharedUtils';
@@ -130,7 +130,7 @@ async function importNewMedia(
     return;
   }
   const importPayload = await common.beginMediaImport(sourceName);
-  importPayload.jsonMeta.name = datasetName;
+  importPayload.jsonConfig.name = datasetName;
   const conversionJobArgs = await common.finalizeMediaImport(settings, importPayload);
   if (conversionJobArgs.mediaList.length > 0) {
     // Convert the media, directly in this job
@@ -144,7 +144,7 @@ async function importNewMedia(
       settings,
       conversionJobArgs,
       updater,
-      (_key: string, meta: JsonMeta) => sendToRenderer('filter-complete', meta),
+      (_key: string, meta: JsonConfig) => sendToRenderer('filter-complete', meta),
       undefined,
       false,
       0,
@@ -189,7 +189,7 @@ async function runPipeline(
     pipelinePath = pipeline.pipe;
   }
   const projectInfo = await common.getValidatedProjectDir(settings, datasetId);
-  const meta = await common.loadJsonMetadata(projectInfo.metaFileAbsPath);
+  const meta = await common.loadJsonConfig(projectInfo.configFileAbsPath);
   const jobWorkDir = await createWorkingDirectory(settings, [meta], pipeline.name);
 
   const { parentId, cameraName } = parseCompositeDatasetId(datasetId);
@@ -197,7 +197,7 @@ async function runPipeline(
   if (cameraName) {
     try {
       const parentInfo = await common.getValidatedProjectDir(settings, parentId);
-      const parentMeta = await common.loadJsonMetadata(parentInfo.metaFileAbsPath);
+      const parentMeta = await common.loadJsonConfig(parentInfo.configFileAbsPath);
       const defaultDisplay = parentMeta.multiCam?.defaultDisplay;
       if (cameraName !== defaultDisplay) {
         cameraLogLine = `Running pipeline on camera: ${cameraName}`;
@@ -474,7 +474,7 @@ async function runPipeline(
           const { meta: newMeta } = await common.ingestDataFiles(settings, datasetId, [finalDetectorOutput, finalTrackOutput], multiOutFiles);
           if (newMeta) {
             meta.attributes = newMeta.attributes;
-            await common.saveMetadata(settings, datasetId, meta);
+            await common.saveConfig(settings, datasetId, meta);
           }
         }
 
@@ -695,14 +695,14 @@ async function train(
   const infoAndMeta = await Promise.all(
     runTrainingArgs.datasetIds.map(async (id) => {
       const projectInfo = await common.getValidatedProjectDir(settings, id);
-      const meta = await common.loadJsonMetadata(projectInfo.metaFileAbsPath);
+      const meta = await common.loadJsonConfig(projectInfo.configFileAbsPath);
       return { projectInfo, meta };
     }),
   );
-  const jsonMetaList = infoAndMeta.map(({ meta }) => meta);
+  const jsonConfigList = infoAndMeta.map(({ meta }) => meta);
 
   // Working dir for training
-  const jobWorkDir = await createWorkingDirectory(settings, jsonMetaList, runTrainingArgs.pipelineName);
+  const jobWorkDir = await createWorkingDirectory(settings, jsonConfigList, runTrainingArgs.pipelineName);
 
   // Argument files for training
   const inputFolderFileList = npath.join(jobWorkDir, 'input_folder_list.txt');

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -189,7 +189,7 @@ async function runPipeline(
     pipelinePath = pipeline.pipe;
   }
   const projectInfo = await common.getValidatedProjectDir(settings, datasetId);
-  const meta = await common.loadJsonConfig(projectInfo.configFileAbsPath);
+  const meta = await common.loadJsonConfig(projectInfo.datasetFileAbsPath);
   const jobWorkDir = await createWorkingDirectory(settings, [meta], pipeline.name);
 
   const { parentId, cameraName } = parseCompositeDatasetId(datasetId);
@@ -197,7 +197,7 @@ async function runPipeline(
   if (cameraName) {
     try {
       const parentInfo = await common.getValidatedProjectDir(settings, parentId);
-      const parentMeta = await common.loadJsonConfig(parentInfo.configFileAbsPath);
+      const parentMeta = await common.loadJsonConfig(parentInfo.datasetFileAbsPath);
       const defaultDisplay = parentMeta.multiCam?.defaultDisplay;
       if (cameraName !== defaultDisplay) {
         cameraLogLine = `Running pipeline on camera: ${cameraName}`;
@@ -695,7 +695,7 @@ async function train(
   const infoAndMeta = await Promise.all(
     runTrainingArgs.datasetIds.map(async (id) => {
       const projectInfo = await common.getValidatedProjectDir(settings, id);
-      const meta = await common.loadJsonConfig(projectInfo.configFileAbsPath);
+      const meta = await common.loadJsonConfig(projectInfo.datasetFileAbsPath);
       return { projectInfo, meta };
     }),
   );

--- a/client/platform/desktop/backend/serializers/coco.spec.ts
+++ b/client/platform/desktop/backend/serializers/coco.spec.ts
@@ -2,7 +2,7 @@
 import fs from 'fs-extra';
 import mockfs from 'mock-fs';
 import { AnnotationSchema } from 'dive-common/apispec';
-import { AnnotationsCurrentVersion, JsonMeta } from 'platform/desktop/constants';
+import { AnnotationsCurrentVersion, JsonConfig } from 'platform/desktop/constants';
 import { isCocoJson, parseFile, serializeFile } from 'platform/desktop/backend/serializers/coco';
 
 const cocoInput = {
@@ -66,7 +66,7 @@ const imageMeta = {
   confidenceFilters: { default: 0.1 },
   multiCam: null,
   subType: null,
-} as JsonMeta;
+} as JsonConfig;
 
 beforeEach(() => {
   mockfs({

--- a/client/platform/desktop/backend/serializers/coco.ts
+++ b/client/platform/desktop/backend/serializers/coco.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import { isEmpty } from 'lodash';
 import { AnnotationSchema } from 'dive-common/apispec';
-import { JsonMeta } from 'platform/desktop/constants';
+import { JsonConfig } from 'platform/desktop/constants';
 import processTrackAttributes from 'platform/desktop/backend/native/attributeProcessor';
 import { TrackSupportedFeature } from 'vue-media-annotator/track';
 
@@ -309,7 +309,7 @@ async function parseFile(path: string): Promise<[AnnotationSchema, Record<string
   return [annotations, meta, warnings];
 }
 
-function frameNameForExport(frame: number, meta: JsonMeta): string {
+function frameNameForExport(frame: number, meta: JsonConfig): string {
   if (meta.type === 'image-sequence') {
     return meta.originalImageFiles[frame] || `frame_${frame.toString().padStart(6, '0')}.jpg`;
   }
@@ -319,7 +319,7 @@ function frameNameForExport(frame: number, meta: JsonMeta): string {
 async function serializeFile(
   path: string,
   data: AnnotationSchema,
-  meta: JsonMeta,
+  meta: JsonConfig,
   typeFilter = new Set<string>(),
   options = {
     excludeBelowThreshold: false,

--- a/client/platform/desktop/backend/serializers/dive.ts
+++ b/client/platform/desktop/backend/serializers/dive.ts
@@ -1,6 +1,6 @@
 import { AnnotationSchema, MultiTrackRecord } from 'dive-common/apispec';
 import { has } from 'lodash';
-import { AnnotationsCurrentVersion, JsonMeta } from 'platform/desktop/constants';
+import { AnnotationsCurrentVersion, JsonConfig } from 'platform/desktop/constants';
 import Track, { TrackData, TrackId } from 'vue-media-annotator/track';
 import fs from 'fs-extra';
 
@@ -43,7 +43,7 @@ function migrate(jsonData: any): AnnotationSchema {
 
 function filterTracks(
   data: AnnotationSchema,
-  meta: JsonMeta,
+  meta: JsonConfig,
   typeFilter = new Set<string>(),
   options = {
     excludeBelowThreshold: false,
@@ -75,7 +75,7 @@ function filterTracks(
 async function serializeFile(
   path: string,
   data: AnnotationSchema,
-  meta: JsonMeta,
+  meta: JsonConfig,
   typeFilter = new Set<string>(),
   options = {
     excludeBelowThreshold: false,

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -4,7 +4,7 @@ import parseSync from 'csv-parse/lib/sync';
 import fs from 'fs-extra';
 import mockfs from 'mock-fs';
 import { Readable } from 'stream';
-import { AnnotationsCurrentVersion, JsonMeta } from 'platform/desktop/constants';
+import { AnnotationsCurrentVersion, JsonConfig } from 'platform/desktop/constants';
 import { serialize, parse, parseFile } from 'platform/desktop/backend/serializers/viame';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import processTrackAttributes from 'platform/desktop/backend/native/attributeProcessor';
@@ -179,7 +179,7 @@ const meta = {
   },
   multiCam: null,
   subType: null,
-} as JsonMeta;
+} as JsonConfig;
 const testFiles: Record<string, string> = { };
 testData.forEach((item, index) => {
   // eslint-disable-next-line prefer-destructuring
@@ -347,7 +347,7 @@ describe('VIAME datasetInfo passthrough', () => {
   it('writes a populated datasetInfo as one nested JSON entry on the # metadata line', async () => {
     const path = '/home/test.json';
     const stream = fs.createWriteStream(path);
-    await serialize(stream, data, { ...meta, datasetInfo } as JsonMeta, new Set<string>(), {
+    await serialize(stream, data, { ...meta, datasetInfo } as JsonConfig, new Set<string>(), {
       excludeBelowThreshold: false,
       header: true,
     });
@@ -363,7 +363,7 @@ describe('VIAME datasetInfo passthrough', () => {
   it('omits the datasetInfo entry entirely when datasetInfo is empty', async () => {
     const path = '/home/test.json';
     const stream = fs.createWriteStream(path);
-    await serialize(stream, data, { ...meta, datasetInfo: {} } as JsonMeta, new Set<string>(), {
+    await serialize(stream, data, { ...meta, datasetInfo: {} } as JsonConfig, new Set<string>(), {
       excludeBelowThreshold: false,
       header: true,
     });
@@ -376,7 +376,7 @@ describe('VIAME datasetInfo passthrough', () => {
   it('restores datasetInfo from the # metadata line on parse', async () => {
     const path = '/home/test.json';
     const stream = fs.createWriteStream(path);
-    await serialize(stream, data, { ...meta, datasetInfo } as JsonMeta, new Set<string>(), {
+    await serialize(stream, data, { ...meta, datasetInfo } as JsonConfig, new Set<string>(), {
       excludeBelowThreshold: false,
       header: true,
     });

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -12,7 +12,7 @@ import { cloneDeep, flattenDeep, isEmpty } from 'lodash';
 import { pipeline, Readable, Writable } from 'stream';
 
 import { AnnotationSchema, MultiGroupRecord, MultiTrackRecord } from 'dive-common/apispec';
-import { JsonMeta } from 'platform/desktop/constants';
+import { JsonConfig } from 'platform/desktop/constants';
 import { splitExt } from 'platform/desktop/backend/native/utils';
 // Imports that involve actual code require relative imports because ts-node barely works
 // https://github.com/TypeStrong/ts-node/issues/422
@@ -645,7 +645,7 @@ async function parseFile(path: string, imageMap?: Map<string, number>):
   return parse(stream, imageMap);
 }
 
-async function writeHeader(writer: Writable, meta: JsonMeta) {
+async function writeHeader(writer: Writable, meta: JsonConfig) {
   writer.write([
     '# 1: Detection or Track-id',
     '2: Video or Image Identifier',
@@ -683,7 +683,7 @@ async function writeHeader(writer: Writable, meta: JsonMeta) {
 async function serialize(
   stream: Writable,
   data: AnnotationSchema,
-  meta: JsonMeta,
+  meta: JsonConfig,
   typeFilter = new Set<string>(),
   options = {
     excludeBelowThreshold: false,
@@ -809,7 +809,7 @@ async function serialize(
 async function serializeFile(
   path: string,
   data: AnnotationSchema,
-  meta: JsonMeta,
+  meta: JsonConfig,
   typeFilter = new Set<string>(),
   options = {
     excludeBelowThreshold: false,

--- a/client/platform/desktop/backend/server.ts
+++ b/client/platform/desktop/backend/server.ts
@@ -53,14 +53,14 @@ function makeMediaUrl(filepath: string): string {
   return `http://${formatHostForUrl(addr.address)}:${addr.port}/api/media?path=${encodeURIComponent(filepath)}`;
 }
 
-/* LOAD metadata */
+/* LOAD dataset config */
 apirouter.get('/dataset/:id/:camera?/meta', async (req, res, next) => {
   try {
     let { id } = req.params;
     if (req.params.camera) {
       id = `${req.params.id}/${req.params.camera}`;
     }
-    const ds = await common.loadMetadata(settings.get(), id, makeMediaUrl);
+    const ds = await common.loadConfig(settings.get(), id, makeMediaUrl);
     res.json(ds);
   } catch (err) {
     err.status = 500;
@@ -68,14 +68,14 @@ apirouter.get('/dataset/:id/:camera?/meta', async (req, res, next) => {
   }
 });
 
-/* SAVE metadata */
+/* SAVE dataset config */
 apirouter.post('/dataset/:id/:camera?/meta', async (req, res, next) => {
   try {
     let { id } = req.params;
     if (req.params.camera) {
       id = `${req.params.id}/${req.params.camera}`;
     }
-    await common.saveMetadata(settings.get(), id, req.body);
+    await common.saveConfig(settings.get(), id, req.body);
     res.status(200).send('done');
   } catch (err) {
     err.status = 500;

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -1,12 +1,12 @@
 import type {
-  DatasetMeta, DatasetMetaMutable, DatasetType,
+  DatasetConfig, DatasetConfigMutable, DatasetType,
   Pipe, SubType, MediaImportResponse, PipelineParams,
 } from 'dive-common/apispec';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import { AttributeTrackFilter } from 'vue-media-annotator/AttributeTrackFilterControls';
 import { ImageEnhancements } from 'vue-media-annotator/use/useImageEnhancements';
 
-export const JsonMetaCurrentVersion = 1;
+export const JsonConfigCurrentVersion = 1;
 export const SettingsCurrentVersion = 1;
 export const AnnotationsCurrentVersion = 2;
 export const ProjectsFolderName = 'DIVE_Projects';
@@ -66,11 +66,11 @@ export interface MultiCamDesktop {
 }
 
 /**
- * JsonMeta is a SUBSET of DatasetMeta contained within
- * the JsonFileSchema.  The remaining parts of DatasetMeta must
+ * JsonConfig is a SUBSET of DatasetConfig contained within
+ * the JsonFileSchema.  The remaining parts of DatasetConfig must
  * be generated at load time.
  */
-export interface JsonMeta extends DatasetMetaMutable {
+export interface JsonConfig extends DatasetConfigMutable {
   // version used to manage schema migrations
   version: number;
 
@@ -127,10 +127,10 @@ export interface JsonMeta extends DatasetMetaMutable {
 
   error?: string;
 
-  // attributes are not datasetMetaMutable and are stored separate
+  // attributes are not DatasetConfigMutable and are stored separate
   attributes?: Record<string, Attribute>;
 
-  // attributes are not datasetMetaMutable and are stored separate
+  // attributes are not DatasetConfigMutable and are stored separate
   attributeTrackFilters?: Record<string, AttributeTrackFilter>;
 
   // confidence filter threshold for exporting
@@ -156,7 +156,7 @@ export interface JsonMeta extends DatasetMetaMutable {
   execTime?: number
 }
 
-export type DesktopMetadata = DatasetMeta & JsonMeta;
+export type DesktopConfig = DatasetConfig & JsonConfig;
 
 interface NvidiaSmiTextRecord {
   _text: string;
@@ -227,7 +227,7 @@ export interface RunTraining extends JobArgs {
 
 export interface ConversionArgs extends JobArgs {
   type: JobType.Conversion;
-  meta: JsonMeta;
+  meta: JsonConfig;
   mediaList: [string, string][];
 }
 
@@ -268,12 +268,13 @@ export interface DesktopJob {
 }
 
 export interface DesktopMediaImportResponse extends MediaImportResponse {
-  jsonMeta: JsonMeta;
+  jsonConfig: JsonConfig;
   trackFileAbsPath: string;
   multiCamTrackFiles: null | Record<string, string>;
   forceMediaTranscode: boolean;
-  metaFileAbsPath?: string;
-  // Absolute path of an optional metadata file chosen in the import dialog.
+  /** Absolute path of an optional DIVE Configuration File (JSON) chosen at import. */
+  configFileAbsPath?: string;
+  /** Absolute path of an optional Metadata File (pipeline sidecar) chosen at import. */
   metadataFileAbsPath?: string;
   // Non-fatal problems found while preparing the import (e.g. a registration
   // file naming cameras this dataset doesn't have), shown in the import dialog.

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
 
 import type {
-  DatasetMetaMutable, DatasetType, MultiCamImportArgs,
+  DatasetConfigMutable, DatasetType, MultiCamImportArgs,
   Pipe, Pipelines, PipelineParams, SaveAttributeArgs,
   SaveAttributeTrackFilterArgs, SaveDetectionsArgs, TrainingConfigs,
   DatasetCalibrationResult,
@@ -17,7 +17,7 @@ import {
   metadataFileTypes,
 } from 'dive-common/constants';
 import {
-  DesktopMetadata, NvidiaSmiReply,
+  DesktopConfig, NvidiaSmiReply,
   RunPipeline, RunTraining, ExportTrainedPipeline, ExportDatasetArgs, ExportConfigurationArgs,
   ExportMulticamEverythingArgs,
   DesktopMediaImportResponse, ConversionArgs, JobType,
@@ -48,7 +48,7 @@ function joinPath(dir: string, filename: string) {
  * Native functions that run entirely in the renderer
  */
 
-async function openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 'annotation' | 'text' | 'transform' | 'metadata', directory = false) {
+async function openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 'annotation' | 'config' | 'text' | 'transform' | 'metadata', directory = false) {
   let filters: FileFilter[] = [];
   const allFiles = { name: 'All Files', extensions: ['*'] };
   if (datasetType === 'video') {
@@ -71,6 +71,12 @@ async function openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 
   if (datasetType === 'annotation') {
     filters = [
       { name: 'annotation', extensions: inputAnnotationFileTypes },
+      allFiles,
+    ];
+  }
+  if (datasetType === 'config') {
+    filters = [
+      { name: 'configuration', extensions: ['json'] },
       allFiles,
     ];
   }
@@ -103,6 +109,11 @@ async function openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 
       (item) => allowed.has(getExtension(item)),
     )) {
       throw Error('File Types did not match JSON or CSV');
+    }
+  }
+  if (datasetType === 'config') {
+    if (!results.filePaths.every((item) => getExtension(item) === 'json')) {
+      throw Error('Configuration File must be JSON');
     }
   }
   if (datasetType === 'large-image') {
@@ -251,7 +262,7 @@ function importAnnotationFile(id: string, path: string, _htmlFile = undefined, a
 }
 
 function finalizeImport(args: DesktopMediaImportResponse): Promise<ConversionArgs> {
-  // Have this return JsonMeta as well as everything needed to start a job?
+  // Have this return JsonConfig as well as everything needed to start a job?
   return window.diveDesktop.invoke('finalize-import', args);
 }
 
@@ -616,9 +627,9 @@ function getTileURL(itemId: string, x: number, y: number, level: number, query: 
   return `${_baseURL}/dataset/${itemId}/tiles/${level}/${x}/${y}${suffix}`;
 }
 
-async function loadMetadata(id: string) {
+async function loadConfig(id: string) {
   const client = await getClient();
-  const { data } = await client.get<DesktopMetadata>(`dataset/${id}/meta`);
+  const { data } = await client.get<DesktopConfig>(`dataset/${id}/meta`);
   return { ...data, calibration: data.multiCam?.calibration ?? null };
 }
 
@@ -632,7 +643,7 @@ async function loadDetections(datasetId: string) {
   };
 }
 
-async function saveMetadata(id: string, args: DatasetMetaMutable) {
+async function saveConfig(id: string, args: DatasetConfigMutable) {
   const client = await getClient();
   return client.post(`dataset/${id}/meta`, args);
 }
@@ -709,7 +720,7 @@ function deleteCalibration(datasetId: string): Promise<void> {
 
 export {
   /* Standard Specification APIs */
-  loadMetadata,
+  loadConfig,
   loadDetections,
   getPipelineList,
   deleteTrainedPipeline,
@@ -717,7 +728,7 @@ export {
   exportTrainedPipeline,
   getTrainingConfigurations,
   runTraining,
-  saveMetadata,
+  saveConfig,
   saveDetections,
   saveAttributes,
   saveAttributeTrackFilters,

--- a/client/platform/desktop/frontend/components/BulkImportDialog.vue
+++ b/client/platform/desktop/frontend/components/BulkImportDialog.vue
@@ -24,7 +24,7 @@ const headers = [
     text: 'Dataset Type',
     align: 'start',
     sortable: false,
-    value: 'jsonMeta.type',
+    value: 'jsonConfig.type',
     width: '150',
   },
   {
@@ -50,7 +50,7 @@ export default defineComponent({
     // Map imports to include generated "id" field, used in rendering.
     const imports = ref(props.importData.map((im) => {
       const cloned = cloneDeep(im);
-      cloned.jsonMeta.id = (Math.random() + 1).toString(36).substring(2);
+      cloned.jsonConfig.id = (Math.random() + 1).toString(36).substring(2);
 
       return cloned;
     }));
@@ -67,7 +67,7 @@ export default defineComponent({
 
     function stripId(item: DesktopMediaImportResponse) {
       const cloned = cloneDeep(item);
-      cloned.jsonMeta.id = '';
+      cloned.jsonConfig.id = '';
       return item;
     }
 
@@ -89,10 +89,10 @@ export default defineComponent({
     }
 
     function formatPath(item: DesktopMediaImportResponse) {
-      let path = item.jsonMeta.originalBasePath;
+      let path = item.jsonConfig.originalBasePath;
 
-      if (item.jsonMeta.originalVideoFile !== '') {
-        path = `${path}/${item.jsonMeta.originalVideoFile}`;
+      if (item.jsonConfig.originalVideoFile !== '') {
+        path = `${path}/${item.jsonConfig.originalVideoFile}`;
       }
 
       return path;
@@ -131,7 +131,7 @@ export default defineComponent({
     <v-data-table
       :value="selectedImports"
       :items="imports"
-      item-key="jsonMeta.id"
+      item-key="jsonConfig.id"
       :headers="headers"
       show-select
       disable-sort
@@ -139,7 +139,7 @@ export default defineComponent({
     >
       <template #item.name="{ item }">
         <div class="text-wrap" style="word-break: break-word;">
-          {{ item.jsonMeta.name }}
+          {{ item.jsonConfig.name }}
         </div>
       </template>
 

--- a/client/platform/desktop/frontend/components/DatasetSourceInfo.vue
+++ b/client/platform/desktop/frontend/components/DatasetSourceInfo.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { defineComponent, ref } from 'vue';
 
-import { loadMetadata } from '../api';
+import { loadConfig } from '../api';
 import { settings, initializedSettings } from '../store/settings';
 import { buildDatasetSourceInfo } from '../utils/datasetSourcePaths';
 import type { DatasetSourceInfo as SourceInfo } from '../utils/datasetSourcePaths';
@@ -27,7 +27,7 @@ export default defineComponent({
       try {
         await initializedSettings;
         const parentId = props.datasetId.split('/')[0];
-        const meta = await loadMetadata(parentId);
+        const meta = await loadConfig(parentId);
         info.value = buildDatasetSourceInfo(meta, settings.value);
       } catch (err) {
         error.value = String(err);

--- a/client/platform/desktop/frontend/components/Export.vue
+++ b/client/platform/desktop/frontend/components/Export.vue
@@ -11,10 +11,10 @@ import { MultiType } from 'dive-common/constants';
 import { referenceCameraName } from 'dive-common/multicamDisplay';
 import { buildPerCameraRegistrationFiles } from 'vue-media-annotator/alignedView/cameraRegistrationFiles';
 import {
-  loadMetadata, exportDataset, exportConfiguration, exportCalibrationFile,
+  loadConfig, exportDataset, exportConfiguration, exportCalibrationFile,
   exportCameraRegistration, exportMulticamEverything,
 } from 'platform/desktop/frontend/api';
-import type { JsonMeta } from 'platform/desktop/constants';
+import type { JsonConfig } from 'platform/desktop/constants';
 
 type ExportType = 'dataset' | 'configuration' | 'trackJSON' | 'coco' | 'everything';
 
@@ -45,7 +45,7 @@ export default defineComponent({
       excludeUncheckedTypes: false,
       activator: 0,
       err: null as unknown,
-      meta: null as JsonMeta | null,
+      meta: null as JsonConfig | null,
       outPath: '',
     });
     const savePrompt = ref(false);
@@ -60,7 +60,7 @@ export default defineComponent({
 
     watch(toRef(data, 'menuOpen'), async (newval) => {
       if (newval) {
-        data.meta = await loadMetadata(parentId.value);
+        data.meta = await loadConfig(parentId.value);
       } else {
         data.err = null;
         data.outPath = '';

--- a/client/platform/desktop/frontend/components/ImportDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportDialog.vue
@@ -30,33 +30,33 @@ export default defineComponent({
   },
   setup(props) {
     const argCopy = ref(cloneDeep(props.importData));
-    const duplicates = ref(locateDuplicates(props.importData.jsonMeta));
+    const duplicates = ref(locateDuplicates(props.importData.jsonConfig));
     const showAdvanced = ref(false);
 
     // Set default FPS to stored value or video frame rate if it exceeds current frame rate
     if (clientSettings.annotationFPS === -1
-      || clientSettings.annotationFPS > argCopy.value.jsonMeta.originalFps) {
-      argCopy.value.jsonMeta.fps = argCopy.value.jsonMeta.originalFps;
+      || clientSettings.annotationFPS > argCopy.value.jsonConfig.originalFps) {
+      argCopy.value.jsonConfig.fps = argCopy.value.jsonConfig.originalFps;
     } else {
-      argCopy.value.jsonMeta.fps = clientSettings.annotationFPS;
+      argCopy.value.jsonConfig.fps = clientSettings.annotationFPS;
     }
 
     watch(toRef(props, 'importData'), (val) => {
-      duplicates.value = locateDuplicates(val.jsonMeta);
+      duplicates.value = locateDuplicates(val.jsonConfig);
       argCopy.value = cloneDeep(val);
     });
 
     const filteredImages = computed(() => filterByGlob(
       argCopy.value.globPattern,
-      argCopy.value.jsonMeta.originalImageFiles,
+      argCopy.value.jsonConfig.originalImageFiles,
     ));
 
     const sortedFpsOptions = computed(() => {
       const filteredOptions = FPSOptions
-        .filter((v) => v.value < argCopy.value.jsonMeta.originalFps);
+        .filter((v) => v.value < argCopy.value.jsonConfig.originalFps);
       filteredOptions.splice(-1, 1, {
-        text: `${argCopy.value.jsonMeta.originalFps} (Video FPS)`,
-        value: argCopy.value.jsonMeta.originalFps,
+        text: `${argCopy.value.jsonConfig.originalFps} (Video FPS)`,
+        value: argCopy.value.jsonConfig.originalFps,
       });
       return filteredOptions;
     });
@@ -69,18 +69,15 @@ export default defineComponent({
     });
 
     const { openFromDisk } = useApi();
-    const openUpload = async (type: 'annotation' | 'meta' | 'metadata') => {
+    // 'config' is the DIVE JSON configuration file; 'metadata' is the optional
+    // pipeline sidecar — keep these names distinct from each other.
+    const openUpload = async (type: 'annotation' | 'config' | 'metadata') => {
       const argMap = {
         annotation: 'trackFileAbsPath',
-        meta: 'metaFileAbsPath',
+        config: 'configFileAbsPath',
         metadata: 'metadataFileAbsPath',
       } as const;
-      const openTypeMap = {
-        annotation: 'annotation',
-        meta: 'annotation',
-        metadata: 'metadata',
-      } as const;
-      const ret = await openFromDisk(openTypeMap[type]);
+      const ret = await openFromDisk(type);
       if (!ret.canceled) {
         if (ret.filePaths?.length) {
           const path = ret.filePaths[0];
@@ -90,7 +87,7 @@ export default defineComponent({
     };
 
     const updateClientSettingFPS = (val: number) => {
-      if (val !== argCopy.value.jsonMeta.originalFps) {
+      if (val !== argCopy.value.jsonConfig.originalFps) {
         clientSettings.annotationFPS = val;
       } else {
         clientSettings.annotationFPS = -1;
@@ -119,7 +116,7 @@ export default defineComponent({
     style="overflow-x: hidden;"
   >
     <v-card-title class="text-h5">
-      Import new {{ MediaTypes[argCopy.jsonMeta.type] }}
+      Import new {{ MediaTypes[argCopy.jsonConfig.type] }}
     </v-card-title>
     <v-card-text>
       <v-alert
@@ -178,7 +175,7 @@ export default defineComponent({
       <v-row class="d-flex my-2 mt-7">
         <v-col cols="9">
           <v-text-field
-            v-model="argCopy.jsonMeta.name"
+            v-model="argCopy.jsonConfig.name"
             label="Name"
             placeholder="Name for this dataset"
             hint="Changing the name does not modify the data source directory."
@@ -189,7 +186,7 @@ export default defineComponent({
         </v-col>
         <v-col cols="3">
           <v-select
-            v-model="argCopy.jsonMeta.fps"
+            v-model="argCopy.jsonConfig.fps"
             :items="sortedFpsOptions"
             type="number"
             required
@@ -204,7 +201,7 @@ export default defineComponent({
         </v-col>
       </v-row>
       <v-row
-        v-if="!argCopy.jsonMeta.multiCam"
+        v-if="!argCopy.jsonConfig.multiCam"
         class="d-flex my-2 mt-2"
       >
         <v-col>
@@ -250,7 +247,7 @@ export default defineComponent({
       </p>
       <div v-if="showAdvanced">
         <v-text-field
-          :value="argCopy.metaFileAbsPath"
+          :value="argCopy.configFileAbsPath"
           outlined
           clearable
           dense
@@ -258,10 +255,10 @@ export default defineComponent({
           label="Configuration File (Optional)"
           hint="Optional. Supports DIVE JSON configuration file."
           persistent-hint
-          @input="argCopy.metaFileAbsPath = $event"
-          @click="openUpload('meta')"
-          @click:prepend-inner="openUpload('meta')"
-          @click:clear="argCopy.metaFileAbsPath = ''"
+          @input="argCopy.configFileAbsPath = $event"
+          @click="openUpload('config')"
+          @click:prepend-inner="openUpload('config')"
+          @click:clear="argCopy.configFileAbsPath = ''"
         />
         <v-text-field
           :value="argCopy.metadataFileAbsPath"
@@ -280,7 +277,7 @@ export default defineComponent({
           @click:clear="argCopy.metadataFileAbsPath = ''"
         />
         <v-text-field
-          v-if="argCopy.jsonMeta.type === 'image-sequence'"
+          v-if="argCopy.jsonConfig.type === 'image-sequence'"
           v-model="argCopy.globPattern"
           label="Glob Filter Pattern"
           placeholder="Leave blank to use all images. example: *.png"
@@ -299,10 +296,10 @@ export default defineComponent({
           class="ml-3"
         >
           "{{ argCopy.globPattern }}" matches {{ filteredImages.length }}
-          out of {{ argCopy.jsonMeta.originalImageFiles.length }} images
+          out of {{ argCopy.jsonConfig.originalImageFiles.length }} images
         </v-chip>
         <v-switch
-          v-if="argCopy.jsonMeta.type === 'video'"
+          v-if="argCopy.jsonConfig.type === 'video'"
           v-model="argCopy.forceMediaTranscode"
           :disabled="importData.mediaConvertList.length !== 0"
           label="Force Media Transcoding"
@@ -316,37 +313,37 @@ export default defineComponent({
         <table
           class="key-value-table"
         >
-          <tr v-if="argCopy.jsonMeta.type == 'video'">
+          <tr v-if="argCopy.jsonConfig.type == 'video'">
             <td>Video</td>
-            <td>{{ argCopy.jsonMeta.originalVideoFile }}</td>
+            <td>{{ argCopy.jsonConfig.originalVideoFile }}</td>
           </tr>
           <tr>
             <td>Source</td>
             <td>
-              <pre>{{ argCopy.jsonMeta.imageListPath || argCopy.jsonMeta.originalBasePath }}</pre>
+              <pre>{{ argCopy.jsonConfig.imageListPath || argCopy.jsonConfig.originalBasePath }}</pre>
             </td>
           </tr>
           <tr>
             <td>Annotation FPS</td>
             <td>
-              {{ argCopy.jsonMeta.fps }}
+              {{ argCopy.jsonConfig.fps }}
               <span
-                v-if="argCopy.jsonMeta.type === 'video'"
+                v-if="argCopy.jsonConfig.type === 'video'"
                 class="pl-2"
               >
                 <b>Note</b> video downsampled annotation framerate is different than raw video FPS
               </span>
             </td>
           </tr>
-          <tr v-if="argCopy.jsonMeta.type == 'video'">
+          <tr v-if="argCopy.jsonConfig.type == 'video'">
             <td>Raw FPS</td>
             <td>
-              {{ argCopy.jsonMeta.originalFps }}
+              {{ argCopy.jsonConfig.originalFps }}
             </td>
           </tr>
-          <tr v-if="argCopy.jsonMeta.type == 'image-sequence'">
+          <tr v-if="argCopy.jsonConfig.type == 'image-sequence'">
             <td>Image Count</td>
-            <td>{{ argCopy.jsonMeta.originalImageFiles.length }}</td>
+            <td>{{ argCopy.jsonConfig.originalImageFiles.length }}</td>
           </tr>
         </table>
       </div>

--- a/client/platform/desktop/frontend/components/ImportMultiCamBatchDialog.vue
+++ b/client/platform/desktop/frontend/components/ImportMultiCamBatchDialog.vue
@@ -30,7 +30,7 @@ export default defineComponent({
       if (conversionArgs.mediaList.length > 0) {
         await api.convert(conversionArgs);
       }
-      const recentsMeta = await api.loadMetadata(conversionArgs.meta.id);
+      const recentsMeta = await api.loadConfig(conversionArgs.meta.id);
       setRecents(recentsMeta);
       // Batch imports skip the confirmation dialog that normally shows these.
       return importPayload.importWarnings;

--- a/client/platform/desktop/frontend/components/MultiPipeline.vue
+++ b/client/platform/desktop/frontend/components/MultiPipeline.vue
@@ -25,7 +25,7 @@ import {
 import PipelineCalibrationWarningIcon from 'dive-common/components/PipelineCalibrationWarningIcon.vue';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { clientSettings } from 'dive-common/store/settings';
-import { datasets, JsonMetaCache } from '../store/dataset';
+import { datasets, JsonConfigCache } from '../store/dataset';
 
 const { getPipelineList, runPipeline, hasCalibrationFile } = useApi();
 const { prompt } = usePrompt();
@@ -99,27 +99,27 @@ const createNewDatasetHeaders: DataTableHeader[] = headersTmpl.concat([
     width: 80,
   },
 ]);
-function computeOutputDatasetName(item: JsonMetaCache) {
+function computeOutputDatasetName(item: JsonConfigCache) {
   const timeStamp = (new Date()).toISOString().replace(/[:.]/g, '-');
   return `${selectedPipeline.value?.name}_${item.name}_${timeStamp}`;
 }
-function getAvailableItems(): JsonMetaCache[] {
+function getAvailableItems(): JsonConfigCache[] {
   if (!selectedPipelineType.value || !selectedPipeline.value) {
     return [];
   }
   if (selectedPipelineType.value === stereoPipelineMarker) {
     // Only allow stereo datasets to be included for bulk pipeline
     // operations if the selected pipeline type is a measurement.
-    return Object.values(datasets.value).filter((dataset: JsonMetaCache) => (
+    return Object.values(datasets.value).filter((dataset: JsonConfigCache) => (
       dataset.type === MultiType && dataset.cameraNumber === 2
     ));
   }
   return Object.values(datasets.value);
 }
-const availableItems: Ref<JsonMetaCache[]> = ref([]);
+const availableItems: Ref<JsonConfigCache[]> = ref([]);
 const availableDatasetSearch = ref('');
 const stagedDatasetIds: Ref<string[]> = ref([]);
-const stagedDatasets = computed(() => availableItems.value.filter((item: JsonMetaCache) => stagedDatasetIds.value.includes(item.id)));
+const stagedDatasets = computed(() => availableItems.value.filter((item: JsonConfigCache) => stagedDatasetIds.value.includes(item.id)));
 const calibrationAvailableByDatasetId = ref<Record<string, boolean>>({});
 
 async function refreshCalibrationForDatasets(datasetIds: string[]) {
@@ -163,7 +163,7 @@ function isPipelineItemDisabledForCalibration(pipe: Pipe) {
 watch(selectedPipeline, () => {
   availableItems.value = getAvailableItems();
 });
-function toggleStaged(item: JsonMetaCache) {
+function toggleStaged(item: JsonConfigCache) {
   if (stagedDatasetIds.value.includes(item.id)) {
     stagedDatasetIds.value = stagedDatasetIds.value.filter((id: string) => id !== item.id);
   } else {
@@ -176,7 +176,7 @@ async function runPipelineForDatasets() {
     const results = await Promise.allSettled(
       stagedDatasetIds.value.map((datasetId: string) => {
         if (pipelineCreatesNewDataset(selectedPipeline.value)) {
-          const datasetMeta = availableItems.value.find((item: JsonMetaCache) => item.id === datasetId);
+          const datasetMeta = availableItems.value.find((item: JsonConfigCache) => item.id === datasetId);
           if (!datasetMeta) {
             throw new Error(`Attempted to run pipeline on nonexistant dataset ${datasetId}`);
           }

--- a/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
+++ b/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
@@ -12,7 +12,7 @@ import {
   watch,
 } from 'vue';
 import {
-  DatasetMeta, Pipelines, TrainingConfigs, useApi, Pipe,
+  DatasetConfig, Pipelines, TrainingConfigs, useApi, Pipe,
 } from 'dive-common/apispec';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { itemsPerPageOptions, simplifyTrainingName } from 'dive-common/constants';
@@ -75,7 +75,7 @@ export default defineComponent({
     ];
 
     const data = reactive({
-      stagedItems: {} as Record<string, DatasetMeta>,
+      stagedItems: {} as Record<string, DatasetConfig>,
       trainingOutputName: '',
       selectedTrainingConfig: 'foo.whatever',
       fineTuneTraining: false,
@@ -133,7 +133,7 @@ export default defineComponent({
       return [];
     });
 
-    function toggleStaged(meta: DatasetMeta) {
+    function toggleStaged(meta: DatasetConfig) {
       if (data.stagedItems[meta.id]) {
         del(data.stagedItems, meta.id);
       } else {

--- a/client/platform/desktop/frontend/components/Recent.vue
+++ b/client/platform/desktop/frontend/components/Recent.vue
@@ -20,7 +20,7 @@ import { DataTableHeader } from 'vuetify';
 import { useRouter } from 'vue-router/composables';
 import * as api from '../api';
 import {
-  JsonMetaCache, recents, removeRecents, setRecents,
+  JsonConfigCache, recents, removeRecents, setRecents,
 } from '../store/dataset';
 import {
   upgradedVersion, downgradedVersion, acknowledgeVersion, knownVersion,
@@ -97,7 +97,7 @@ export default defineComponent({
         if (conversionArgs.mediaList.length > 0) {
           await api.convert(conversionArgs);
         }
-        const recentsMeta = await api.loadMetadata(conversionArgs.meta.id);
+        const recentsMeta = await api.loadConfig(conversionArgs.meta.id);
         setRecents(recentsMeta);
       });
 
@@ -119,7 +119,7 @@ export default defineComponent({
           // Queue conversion job
           await api.convert(conversionArgs);
           // Display new data and await transcoding to complete
-          const recentsMeta = await api.loadMetadata(conversionArgs.meta.id);
+          const recentsMeta = await api.loadConfig(conversionArgs.meta.id);
           setRecents(recentsMeta);
         }
       });
@@ -167,7 +167,7 @@ export default defineComponent({
 
     const filteredRecents = computed(() => recents.value
       .filter((v) => v.name.toLowerCase().indexOf((searchText.value || '').toLowerCase()) >= 0));
-    function getTypeIcon(recent: JsonMetaCache) {
+    function getTypeIcon(recent: JsonConfigCache) {
       if (recent.subType) {
         if (recent.subType === 'stereo') {
           return 'mdi-binoculars';
@@ -187,12 +187,12 @@ export default defineComponent({
       return 'mdi-image-multiple';
     }
 
-    async function preloadCheck(recent: JsonMetaCache) {
+    async function preloadCheck(recent: JsonConfigCache) {
       //Attempts to preload the data to see if there are any isues
       try {
         await api.checkDataset(recent.id);
       } catch (e) {
-        const recentsMeta = await api.loadMetadata(recent.id);
+        const recentsMeta = await api.loadConfig(recent.id);
         setRecents(recentsMeta);
         await prompt({
           title: 'Error Loading Data',

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -11,7 +11,7 @@ import context from 'dive-common/store/context';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { SegmentationPredictRequest } from 'dive-common/apispec';
 import { clientSettings } from 'dive-common/store/settings';
-import { isStereoscopicDatasetMeta } from 'dive-common/multicamDisplay';
+import { isStereoscopicDatasetConfig } from 'dive-common/multicamDisplay';
 import type {
   StereoAnnotationCompleteParams,
   StereoAnnotationResetParams,
@@ -27,7 +27,7 @@ import {
   segmentationPredict, segmentationStereoSegment, segmentationInitialize, segmentationIsReady,
   segmentationEnsureStarted,
   segmentationSam3Installed,
-  loadMetadata, textQuery,
+  loadConfig, textQuery,
   runTextQueryPipeline,
   stereoEnable, stereoDisable, stereoSetFrame, stereoTransferLine, stereoTransferPoints,
   stereoMeasureLine, stereoAggregateLengths,
@@ -233,7 +233,7 @@ export default defineComponent({
 
       try {
         // Load metadata to get image paths
-        const meta = await loadMetadata(props.id);
+        const meta = await loadConfig(props.id);
 
         let getImagePath: (frameNum: number) => string;
         let getFrameTime: ((frameNum: number) => number | undefined) | undefined;
@@ -246,7 +246,7 @@ export default defineComponent({
           for (let i = 0; i < cameraNames.length; i += 1) {
             const cam = cameraNames[i];
             // eslint-disable-next-line no-await-in-loop
-            const camMeta = await loadMetadata(`${props.id}/${cam}`);
+            const camMeta = await loadConfig(`${props.id}/${cam}`);
             stereoImagePathGetters.value[cam] = buildImagePathGetter(camMeta);
             if (camMeta.fps) stereoCameraFps.value[cam] = camMeta.fps;
             if (camMeta.type === 'video') multiCamIsVideo = true;
@@ -381,7 +381,7 @@ export default defineComponent({
       // Ensure metadata is loaded
       if (!cachedMeta) {
         try {
-          const meta = await loadMetadata(props.id);
+          const meta = await loadConfig(props.id);
           cachedMeta = {
             originalBasePath: meta.originalBasePath,
             originalImageFiles: meta.originalImageFiles,
@@ -643,10 +643,10 @@ export default defineComponent({
      */
     async function loadStereoMetadata(): Promise<boolean> {
       try {
-        const meta = await loadMetadata(props.id);
+        const meta = await loadConfig(props.id);
         // Plain multicam and single-camera datasets have no stereo pair: report
         // no stereo so the caller does not load the stereo service.
-        if (!meta.multiCamMedia || !isStereoscopicDatasetMeta(meta)) return false;
+        if (!meta.multiCamMedia || !isStereoscopicDatasetConfig(meta)) return false;
 
         // Extract calibration file path from multiCam metadata
         stereoCalibrationFile = meta.multiCam?.calibration || undefined;
@@ -663,7 +663,7 @@ export default defineComponent({
           const cam = cameraNames[i];
           const cameraId = `${props.id}/${cam}`;
           // eslint-disable-next-line no-await-in-loop
-          const camMeta = await loadMetadata(cameraId);
+          const camMeta = await loadConfig(cameraId);
           const {
             originalBasePath, originalImageFiles, type, originalVideoFile,
           } = camMeta;

--- a/client/platform/desktop/frontend/store/dataset.ts
+++ b/client/platform/desktop/frontend/store/dataset.ts
@@ -1,16 +1,16 @@
 import Vue, { ref, computed } from 'vue';
-import { JsonMeta } from 'platform/desktop/constants';
+import { JsonConfig } from 'platform/desktop/constants';
 import { DatasetType, SubType } from 'dive-common/apispec';
 import { initializedSettings } from './settings';
 
 const RecentsKey = 'desktop.recent';
 
 /**
- * JsonMetaCache is a subset of JsonMeta
+ * JsonConfigCache is a subset of JsonConfig
  * cached in localStorage for quickly listing
  * known datasets
  */
-export interface JsonMetaCache {
+export interface JsonConfigCache {
   version: number;
   type: DatasetType | 'multi';
   id: string;
@@ -29,10 +29,10 @@ export interface JsonMetaCache {
 }
 
 /**
- * Handle migration for changes in JsonMetaCache schema
+ * Handle migration for changes in JsonConfigCache schema
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function hydrateJsonMetaCacheValue(input: any): JsonMetaCache {
+function hydrateJsonConfigCacheValue(input: any): JsonConfigCache {
   return {
     originalVideoFile: '',
     transcodedVideoFile: '',
@@ -43,11 +43,11 @@ function hydrateJsonMetaCacheValue(input: any): JsonMetaCache {
   };
 }
 
-const datasets = ref({} as Record<string, JsonMetaCache>);
+const datasets = ref({} as Record<string, JsonConfigCache>);
 
 const recents = computed(() => (Object.values(datasets.value)));
 
-function setRecents(meta: JsonMeta, accessTime?: string) {
+function setRecents(meta: JsonConfig, accessTime?: string) {
   Vue.set(datasets.value, meta.id, {
     version: meta.version,
     type: meta.type,
@@ -64,7 +64,7 @@ function setRecents(meta: JsonMeta, accessTime?: string) {
     error: meta.error,
     cameraNumber: Object.keys(meta.multiCam?.cameras || {}).length,
     calibration: meta.multiCam?.calibration ?? null,
-  } as JsonMetaCache);
+  } as JsonConfigCache);
   const values = Object.values(datasets.value);
   window.localStorage.setItem(RecentsKey, JSON.stringify(values));
 }
@@ -79,7 +79,7 @@ async function autoDiscover() {
   /* Make sure settings are ready on backend */
   await initializedSettings;
   /* Nothing came from localStorage, try to populate from autodiscovery */
-  const discovered: JsonMeta[] = await window.diveDesktop.invoke('autodiscover-data');
+  const discovered: JsonConfig[] = await window.diveDesktop.invoke('autodiscover-data');
   discovered.forEach((d) => setRecents(d));
 }
 
@@ -87,8 +87,8 @@ async function autoDiscover() {
  * Load recent datasets from localstorage.
  *
  * Note that the localStorage copy is just a cache and not a source of truth.
- * The real dataset JsonMeta must be loaded from disk through the
- * loadMetadata() backend method.
+ * The real dataset JsonConfig must be loaded from disk through the
+ * loadConfig() backend method.
  */
 async function load() {
   let loaded = [];
@@ -97,8 +97,8 @@ async function load() {
     if (arr) {
       const maybeArr = JSON.parse(arr);
       if (maybeArr.length) { // verify maybeArr is an array
-        maybeArr.forEach((meta: JsonMetaCache) => (
-          Vue.set(datasets.value, meta.id, hydrateJsonMetaCacheValue(meta))
+        maybeArr.forEach((meta: JsonConfigCache) => (
+          Vue.set(datasets.value, meta.id, hydrateJsonConfigCacheValue(meta))
         ));
         loaded = maybeArr;
       }
@@ -111,7 +111,7 @@ async function load() {
   }
 }
 
-function locateDuplicates(meta: JsonMeta) {
+function locateDuplicates(meta: JsonConfig) {
   return recents.value.filter((candidate) => (
     candidate.originalBasePath === meta.originalBasePath
     && (

--- a/client/platform/desktop/frontend/store/index.ts
+++ b/client/platform/desktop/frontend/store/index.ts
@@ -13,8 +13,8 @@ export async function migrate() {
  * Wrap API with hooks to use the store
  */
 export default function wrap(): Api {
-  async function loadMetadata(datasetId: string) {
-    const meta = await api.loadMetadata(datasetId);
+  async function loadConfig(datasetId: string) {
+    const meta = await api.loadConfig(datasetId);
     if (!datasetId.includes('/')) { // Only update if not multiCam
       setRecents(meta, (new Date()).toString());
     }
@@ -28,6 +28,6 @@ export default function wrap(): Api {
   return {
     ...api,
     loadDetections,
-    loadMetadata,
+    loadConfig,
   };
 }

--- a/client/platform/desktop/frontend/store/jobs.ts
+++ b/client/platform/desktop/frontend/store/jobs.ts
@@ -14,7 +14,7 @@ import {
   JobType,
   RunPipeline,
   RunTraining,
-  JsonMeta,
+  JsonConfig,
 } from 'platform/desktop/constants';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import AsyncGpuJobQueue from './queues/asyncGpuJobQueue';
@@ -180,7 +180,7 @@ function init() {
       ...args, body: ['Job cancelled by user'], exitCode: cancelledJobExitCode, endTime: new Date(), cancelledJob: true,
     });
   });
-  window.diveDesktop.on('filter-complete', (args: JsonMeta) => {
+  window.diveDesktop.on('filter-complete', (args: JsonConfig) => {
     setRecents(args);
   });
 }

--- a/client/platform/desktop/frontend/utils/datasetSourcePaths.ts
+++ b/client/platform/desktop/frontend/utils/datasetSourcePaths.ts
@@ -1,5 +1,5 @@
 import {
-  Camera, DesktopMetadata, JsonMeta, ProjectsFolderName, Settings,
+  Camera, DesktopConfig, JsonConfig, ProjectsFolderName, Settings,
 } from 'platform/desktop/constants';
 
 export interface LabeledPath {
@@ -62,7 +62,7 @@ function getCameraSourceFolder(camera: Camera): string {
   return camera.originalBasePath;
 }
 
-function getSingleCameraPaths(meta: JsonMeta): { mediaSource: string; sourceFolder: string } {
+function getSingleCameraPaths(meta: JsonConfig): { mediaSource: string; sourceFolder: string } {
   if (meta.type === 'video') {
     return {
       mediaSource: joinPath(meta.originalBasePath, meta.originalVideoFile),
@@ -101,7 +101,7 @@ function getSingleCameraPaths(meta: JsonMeta): { mediaSource: string; sourceFold
  * Resolve the user's original calibration file path. New datasets store
  * `calibrationSourcePath`; older datasets only stored the basename.
  */
-function resolveCalibrationSourcePath(meta: JsonMeta): string | null {
+function resolveCalibrationSourcePath(meta: JsonConfig): string | null {
   const { multiCam } = meta;
   if (!multiCam?.calibration && !multiCam?.calibrationOriginalName) {
     return null;
@@ -124,7 +124,7 @@ function resolveCalibrationSourcePath(meta: JsonMeta): string | null {
 }
 
 export function buildDatasetSourceInfo(
-  meta: DesktopMetadata,
+  meta: DesktopConfig,
   appSettings: Settings | null,
 ): DatasetSourceInfo {
   const projectDirectory = getProjectDirectory(meta.id, appSettings);

--- a/client/platform/desktop/main.ts
+++ b/client/platform/desktop/main.ts
@@ -30,7 +30,7 @@ migrate().then(() => {
   window.diveDesktop.on('desktop:open-dataset', async (id) => {
     const datasetId = String(id);
     try {
-      setRecents(await api.loadMetadata(datasetId));
+      setRecents(await api.loadConfig(datasetId));
     } catch {
       // A dataset that cannot be summarized can still be opened; recents is
       // only a convenience listing.
@@ -46,7 +46,7 @@ migrate().then(() => {
   window.diveDesktop.on('desktop:cli-transcoding', async (payload) => {
     const notice = payload as CliTranscodingNotice;
     try {
-      setRecents(await api.loadMetadata(notice.datasetId));
+      setRecents(await api.loadConfig(notice.datasetId));
     } catch {
       // Still show the dialog even if recents cannot be updated yet.
     }

--- a/client/platform/web-girder/App.vue
+++ b/client/platform/web-girder/App.vue
@@ -10,7 +10,7 @@ import { provideApi } from 'dive-common/apispec';
 import { useRoute } from 'vue-router/composables';
 import { useDataset } from 'platform/web-girder/store/useDataset';
 import { useLocation } from 'platform/web-girder/store/useLocation';
-import type { GirderMetadata } from './constants';
+import type { GirderConfig } from './constants';
 import {
   getPipelineList,
   deleteTrainedPipeline,
@@ -19,7 +19,7 @@ import {
   getDatasetCalibration,
   getTrainingConfigurations,
   runTraining,
-  saveMetadata,
+  saveConfig,
   saveAttributes,
   saveAttributeTrackFilters,
   importAnnotationFile,
@@ -51,7 +51,7 @@ export default defineComponent({
     const route = useRoute();
     const { loadDataset } = useDataset();
     const { setLocationFromRoute } = useLocation();
-    async function loadMetadata(datasetId: string): Promise<GirderMetadata> {
+    async function loadConfig(datasetId: string): Promise<GirderConfig> {
       return loadDataset(datasetId);
     }
 
@@ -71,10 +71,10 @@ export default defineComponent({
       runTraining: unwrap(runTraining),
       loadDetections,
       saveDetections: unwrap(saveDetections),
-      saveMetadata: unwrap(saveMetadata),
+      saveConfig: unwrap(saveConfig),
       saveAttributes: unwrap(saveAttributes),
       saveAttributeTrackFilters: unwrap(saveAttributeTrackFilters),
-      loadMetadata,
+      loadConfig,
       hasCalibrationFile,
       openFromDisk: openFromDiskWithRegistry,
       getLastCalibration,

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -353,7 +353,7 @@ async function uploadCalibrationItem(parentFolderId: string, file: File): Promis
  * Upload an optional per-dataset metadata file as a marked Girder item in the
  * dataset (parent) folder and return its item id.
  */
-async function uploadConfigFileItem(parentFolderId: string, file: File): Promise<string> {
+async function uploadMetadataFileItem(parentFolderId: string, file: File): Promise<string> {
   const metadataMeta = { [metadataFileMarker]: 'true' };
   const itemResp = await girderRest.post<GirderModel>('/item', null, {
     params: {
@@ -385,7 +385,7 @@ async function uploadConfigFileItem(parentFolderId: string, file: File): Promise
 }
 
 /** Mark an already-uploaded metadata item as the dataset's metadata file. */
-function setDatasetConfigdataFile(folderId: string, itemId: string) {
+function setDatasetMetadataFile(folderId: string, itemId: string) {
   return girderRest.post(`dive_dataset/${folderId}/metadata_file`, null, {
     params: { itemId },
   });
@@ -462,7 +462,7 @@ export {
   saveAttributeTrackFilters,
   saveConfig,
   uploadCalibrationItem,
-  uploadConfigFileItem,
-  setDatasetConfigdataFile,
+  uploadMetadataFileItem,
+  setDatasetMetadataFile,
   validateUploadGroup,
 };

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -5,7 +5,7 @@ import {
   registrationValuesSummary, filterRegistrationValues, mergeRegistrationValues,
 } from 'vue-media-annotator/alignedView/cameraRegistrationFiles';
 import {
-  DatasetMetaMutable, FrameImage, SaveAttributeArgs, SaveAttributeTrackFilterArgs,
+  DatasetMetaMutable, DatasetType, FrameImage, SaveAttributeArgs, SaveAttributeTrackFilterArgs,
 } from 'dive-common/apispec';
 import { calibrationFileMarker, jsonCalibrationFileMarker, metadataFileMarker } from 'dive-common/constants';
 import { attachFrameTimestamps } from 'dive-common/frameTimestamp';
@@ -247,13 +247,32 @@ async function importCameraRegistration(
   return summary;
 }
 
-interface ValidationResponse {
-  ok: boolean;
-  type: 'video' | 'image-sequence' | 'large-image';
-  media: string[];
-  annotations: string[];
-  message: string;
+export type UploadRole = 'media' | 'annotations' | 'datasetConfig' | 'ignored';
+
+/** Every validated filename under exactly one role. `ignored` is the files not accepted. */
+export type ValidatedUploadRoleMap = Record<UploadRole, string[]>;
+
+/** A filename with the reason it is not uploaded. Display shape; the wire carries `reasons`. */
+export interface IgnoredUploadFile {
+  name: string;
+  reason: string;
 }
+
+interface ValidationBase {
+  message: string;
+  roles: ValidatedUploadRoleMap;
+  /** Why a file landed in its role, keyed by filename. Populated for the `ignored` role. */
+  reasons: Record<string, string>;
+}
+
+/**
+ * Server classification of one upload selection. `roles` is authoritative for what each file
+ * is for, so the set to upload is the selection minus `roles.ignored`. Only an accepted
+ * selection has a media type, so `ok` narrows `type` to a real DatasetType.
+ */
+export type ValidationResponse =
+  | (ValidationBase & { ok: true; type: DatasetType })
+  | (ValidationBase & { ok: false; type?: undefined });
 
 function validateUploadGroup(names: string[]) {
   return girderRest.post<ValidationResponse>('dive_dataset/validate_files', names);

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -5,13 +5,13 @@ import {
   registrationValuesSummary, filterRegistrationValues, mergeRegistrationValues,
 } from 'vue-media-annotator/alignedView/cameraRegistrationFiles';
 import {
-  DatasetMetaMutable, DatasetType, FrameImage, SaveAttributeArgs, SaveAttributeTrackFilterArgs,
+  DatasetConfigMutable, DatasetType, FrameImage, SaveAttributeArgs, SaveAttributeTrackFilterArgs,
 } from 'dive-common/apispec';
 import { calibrationFileMarker, jsonCalibrationFileMarker, metadataFileMarker } from 'dive-common/constants';
 import { attachFrameTimestamps } from 'dive-common/frameTimestamp';
 import { parentDatasetId } from 'dive-common/compositeDatasetId';
 import { isStereoCalibrationFileName } from 'dive-common/stereoParentFolder';
-import { GirderMetadataStatic } from 'platform/web-girder/constants';
+import { GirderConfigStatic } from 'platform/web-girder/constants';
 import girderRest from 'platform/web-girder/plugins/girder';
 import { resolveDatasetFolderId } from './multicamResolve';
 import { postProcess } from './rpc.service';
@@ -22,7 +22,7 @@ interface HTMLFile extends File {
 
 async function getDataset(datasetId: string) {
   const { folderId, compositeId } = await resolveDatasetFolderId(datasetId);
-  const response = await girderRest.get<GirderMetadataStatic>(`dive_dataset/${folderId}`);
+  const response = await girderRest.get<GirderConfigStatic>(`dive_dataset/${folderId}`);
   if (compositeId) {
     response.data.id = compositeId;
   }
@@ -186,9 +186,9 @@ async function saveAttributeTrackFilters(
   return girderRest.patch(`/dive_dataset/${folderId}/attribute_track_filters`, args);
 }
 
-async function saveMetadata(datasetId: string, metadata: DatasetMetaMutable) {
+async function saveConfig(datasetId: string, config: DatasetConfigMutable) {
   const { folderId } = await resolveDatasetFolderId(datasetId);
-  return girderRest.patch(`/dive_dataset/${folderId}`, metadata);
+  return girderRest.patch(`/dive_dataset/${folderId}`, config);
 }
 
 /**
@@ -238,7 +238,7 @@ async function importCameraRegistration(
     incoming,
     file.name,
   );
-  await saveMetadata(parentId, {
+  await saveConfig(parentId, {
     cameraHomographies: merged.homographies,
     cameraCorrespondences: merged.correspondences,
     cameraTransformTypes: merged.transformTypes,
@@ -353,7 +353,7 @@ async function uploadCalibrationItem(parentFolderId: string, file: File): Promis
  * Upload an optional per-dataset metadata file as a marked Girder item in the
  * dataset (parent) folder and return its item id.
  */
-async function uploadMetadataFileItem(parentFolderId: string, file: File): Promise<string> {
+async function uploadConfigFileItem(parentFolderId: string, file: File): Promise<string> {
   const metadataMeta = { [metadataFileMarker]: 'true' };
   const itemResp = await girderRest.post<GirderModel>('/item', null, {
     params: {
@@ -385,7 +385,7 @@ async function uploadMetadataFileItem(parentFolderId: string, file: File): Promi
 }
 
 /** Mark an already-uploaded metadata item as the dataset's metadata file. */
-function setDatasetMetadataFile(folderId: string, itemId: string) {
+function setDatasetConfigdataFile(folderId: string, itemId: string) {
   return girderRest.post(`dive_dataset/${folderId}/metadata_file`, null, {
     params: { itemId },
   });
@@ -460,9 +460,9 @@ export {
   makeViameFolder,
   saveAttributes,
   saveAttributeTrackFilters,
-  saveMetadata,
+  saveConfig,
   uploadCalibrationItem,
-  uploadMetadataFileItem,
-  setDatasetMetadataFile,
+  uploadConfigFileItem,
+  setDatasetConfigdataFile,
   validateUploadGroup,
 };

--- a/client/platform/web-girder/constants.ts
+++ b/client/platform/web-girder/constants.ts
@@ -1,14 +1,14 @@
 import {
-  DatasetMeta, DatasetMetaMutable, DatasetType, MultiCamMedia, SubType,
+  DatasetConfig, DatasetConfigMutable, DatasetType, MultiCamMedia, SubType,
 } from 'dive-common/apispec';
 
 /**
  * Static properties loaded from the girder folder data/metadata
  */
-interface GirderMetadataStatic extends DatasetMetaMutable {
+interface GirderConfigStatic extends DatasetConfigMutable {
   /**
    * Required fields
-   * Everything copied from DatasetMeta except imageData and videoUrl
+   * Everything copied from DatasetConfig except imageData and videoUrl
    */
   id: Readonly<string>;
   name: Readonly<string>;
@@ -32,12 +32,12 @@ interface GirderMetadataStatic extends DatasetMetaMutable {
 /**
  * Full metadata including dynamic properties (image list, video url)
  */
-type GirderMetadata = DatasetMeta & GirderMetadataStatic;
+type GirderConfig = DatasetConfig & GirderConfigStatic;
 
 const fileSuffixRegex = /\.[^.]*$/;
 
 export {
   fileSuffixRegex,
-  GirderMetadataStatic,
-  GirderMetadata,
+  GirderConfigStatic,
+  GirderConfig,
 };

--- a/client/platform/web-girder/multicamFileRegistry.spec.ts
+++ b/client/platform/web-girder/multicamFileRegistry.spec.ts
@@ -6,10 +6,24 @@ import {
 import {
   clearMulticamFileRegistry,
   getCalibrationFile,
+  getCameraPackageFiles,
   getLastCalibration,
+  mediaFileNamesForImport,
   saveCalibration,
+  stashAnnotationFile,
   stashCalibrationFile,
 } from './multicamFileRegistry';
+
+/** Fixed lastModified so "did the user pick this very file?" is deterministic in tests. */
+function file(name: string, content = name): File {
+  return new File([content], name, { type: 'application/octet-stream', lastModified: 0 });
+}
+
+function fileWithPath(name: string, relPath: string, content = name): File {
+  const f = file(name, content);
+  Object.defineProperty(f, 'webkitRelativePath', { value: relPath, configurable: true });
+  return f;
+}
 
 describe('multicamFileRegistry calibration', () => {
   const storage = new Map<string, string>();
@@ -30,10 +44,10 @@ describe('multicamFileRegistry calibration', () => {
   });
 
   it('resolves calibration by basename when stashed with a path-like key', () => {
-    const file = new File(['{}'], 'stereo-cal.json', { type: 'application/json' });
-    stashCalibrationFile('folder/stereo-cal.json', file);
-    expect(getCalibrationFile('stereo-cal.json')).toBe(file);
-    expect(getCalibrationFile('folder/stereo-cal.json')).toBe(file);
+    const cal = new File(['{}'], 'stereo-cal.json', { type: 'application/json' });
+    stashCalibrationFile('folder/stereo-cal.json', cal);
+    expect(getCalibrationFile('stereo-cal.json')).toBe(cal);
+    expect(getCalibrationFile('folder/stereo-cal.json')).toBe(cal);
   });
 
   it('does not restore last calibration from localStorage without a session File', async () => {
@@ -43,9 +57,94 @@ describe('multicamFileRegistry calibration', () => {
   });
 
   it('restores last calibration when the File is still in the registry', async () => {
-    const file = new File(['{}'], 'cal.json', { type: 'application/json' });
-    stashCalibrationFile('cal.json', file);
+    const cal = new File(['{}'], 'cal.json', { type: 'application/json' });
+    stashCalibrationFile('cal.json', cal);
     await saveCalibration('cal.json');
     await expect(getLastCalibration()).resolves.toBe('cal.json');
+  });
+});
+
+describe('multicam camera package construction', () => {
+  beforeEach(() => {
+    clearMulticamFileRegistry();
+  });
+
+  it('flattens folder files before validation so names match uploaded names', () => {
+    const folderFiles = [
+      fileWithPath('img001.png', 'cam1/img001.png'),
+      fileWithPath('img002.png', 'cam1/img002.png'),
+    ];
+    const { files: cameraFiles } = getCameraPackageFiles(folderFiles);
+    // The server validates and Girder uploads flat basenames, not folder paths.
+    expect(cameraFiles.map((f) => f.name)).toEqual(['img001.png', 'img002.png']);
+    expect(
+      cameraFiles.every((f) => !f.webkitRelativePath || f.webkitRelativePath === f.name),
+    ).toBe(true);
+  });
+
+  it('reports only media filenames for multicam pre-import validation', () => {
+    const files = [
+      fileWithPath('img001.png', 'cam1/img001.png'),
+      fileWithPath('nav.csv', 'cam1/nav.csv'),
+      fileWithPath('tracks.csv', 'cam1/tracks.csv'),
+    ];
+    expect(mediaFileNamesForImport(files, 'image-sequence')).toEqual(['img001.png']);
+  });
+
+  it('reports TIFF camera files as media so Begin Import stays enabled', () => {
+    // Subfolder discovery registers a camera folder of .tif images (the SealTK IR layout) and
+    // imports it as large-image; reporting zero files here disables Begin Import permanently.
+    const files = [
+      fileWithPath('ir_0001.tif', 'ir/ir_0001.tif'),
+      fileWithPath('ir_0002.TIFF', 'ir/ir_0002.TIFF'),
+      fileWithPath('scan.nitf', 'ir/scan.nitf'),
+      fileWithPath('notes.txt', 'ir/notes.txt'),
+    ];
+    expect(mediaFileNamesForImport(files, 'image-sequence')).toEqual([
+      'ir_0001.tif', 'ir_0002.TIFF', 'scan.nitf',
+    ]);
+  });
+
+  it('appends the explicit track file to the validation input', () => {
+    const folderFiles = [file('img001.png')];
+    const track = file('tracks.csv');
+    stashAnnotationFile('cam1/tracks.csv', track);
+    const { files: cameraFiles, replaced } = getCameraPackageFiles(folderFiles, 'cam1/tracks.csv');
+    expect(cameraFiles.map((f) => f.name)).toEqual(['img001.png', 'tracks.csv']);
+    expect(cameraFiles).toContain(track);
+    expect(replaced).toEqual([]);
+  });
+
+  it('deduplicates the explicit track file by name', () => {
+    const track = file('tracks.csv');
+    stashAnnotationFile('cam1/tracks.csv', track);
+    // The same File object is also part of the camera folder selection.
+    const folderFiles = [file('img001.png'), track];
+    const { files: cameraFiles, replaced } = getCameraPackageFiles(folderFiles, 'cam1/tracks.csv');
+    expect(cameraFiles.map((f) => f.name)).toEqual(['img001.png', 'tracks.csv']);
+    expect(cameraFiles.filter((f) => f.name === 'tracks.csv')).toHaveLength(1);
+    // Re-picking the folder's own file is not a file leaving the upload.
+    expect(replaced).toEqual([]);
+  });
+
+  it('uploads the explicitly picked track file, and reports the folder copy it displaced', () => {
+    const explicitTrack = file('tracks.csv', 'chosen elsewhere');
+    stashAnnotationFile('cam1/tracks.csv', explicitTrack);
+    const folderTrack = file('tracks.csv', 'the camera folder copy');
+    const folderFiles = [file('img001.png'), folderTrack];
+    const { files: cameraFiles, replaced } = getCameraPackageFiles(folderFiles, 'cam1/tracks.csv');
+    expect(cameraFiles.map((f) => f.name)).toEqual(['img001.png', 'tracks.csv']);
+    expect(cameraFiles).toContain(explicitTrack);
+    expect(cameraFiles).not.toContain(folderTrack);
+    expect(replaced).toEqual([folderTrack]);
+  });
+
+  it('keeps camera-folder annotations and config in the package, not just media', () => {
+    // tracks.csv and config.json are auto-detected in the camera folder, and both belong to
+    // the camera: the package is everything the server validates, not only the media.
+    const folderFiles = [file('img001.png'), file('tracks.csv'), file('config.json')];
+    expect(getCameraPackageFiles(folderFiles).files.map((f) => f.name)).toEqual([
+      'img001.png', 'tracks.csv', 'config.json',
+    ]);
   });
 });

--- a/client/platform/web-girder/multicamFileRegistry.ts
+++ b/client/platform/web-girder/multicamFileRegistry.ts
@@ -2,6 +2,13 @@
 
 import { Location } from '@girder/components/src';
 import { parentDatasetId } from 'dive-common/compositeDatasetId';
+import {
+  ImageSequenceType,
+  VideoType,
+  fileVideoTypes,
+  largeImageFileExtensions,
+} from 'dive-common/constants';
+import { fileImageTypes } from 'dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout';
 import { openFromDisk, GirderUploadManager } from './utils';
 
 const LAST_CALIBRATION_STORAGE_KEY = 'dive_web_last_calibration';
@@ -89,8 +96,26 @@ export function flattenUploadFiles(files: File[]): File[] {
   });
 }
 
-export function mediaFileNamesForImport(files: File[]): string[] {
-  return flattenUploadFiles(files).map((file) => file.name);
+function fileExtension(fileName: string): string {
+  return fileName.split('.').pop()?.toLowerCase() ?? '';
+}
+
+/**
+ * Extensions a camera folder can contribute as importable images: the set multicam subfolder
+ * discovery accepts, plus the large-image formats an all-TIFF camera folder imports as. A
+ * camera that discovery registered must never report zero media files here, or Begin Import
+ * is disabled with no way to correct it.
+ */
+const importableImageExtensions = [...fileImageTypes, ...largeImageFileExtensions];
+
+export function mediaFileNamesForImport(
+  files: File[],
+  mediaType: typeof ImageSequenceType | typeof VideoType = ImageSequenceType,
+): string[] {
+  const allowedExtensions = mediaType === VideoType ? fileVideoTypes : importableImageExtensions;
+  return files
+    .map((file) => file.name)
+    .filter((name) => allowedExtensions.includes(fileExtension(name)));
 }
 
 export function stashAnnotationFile(key: string, file: File): void {
@@ -99,6 +124,52 @@ export function stashAnnotationFile(key: string, file: File): void {
 
 export function getAnnotationFile(key: string): File | undefined {
   return annotationFilesByKey.get(key);
+}
+
+export interface CameraPackage {
+  /** Files to validate and upload with the camera. */
+  files: File[];
+  /**
+   * Camera-folder files left out only because an explicit pick claimed their name. They are
+   * a different file than the one the user chose, so the caller must report them.
+   */
+  replaced: File[];
+}
+
+/** Two selections of the same file on disk are distinct File objects; treat them as one. */
+function isSameSelection(a: File, b: File): boolean {
+  return a === b
+    || (a.name === b.name && a.size === b.size && a.lastModified === b.lastModified);
+}
+
+/**
+ * Assemble the complete file package for one multicam camera: the camera folder's files plus
+ * the annotation file explicitly chosen for that camera.
+ *
+ * An explicit pick always wins over a folder file of the same name — the folder copy is
+ * dropped, so the user uploads the file they chose and Girder never sees a duplicate name.
+ *
+ * A dropped folder copy that is not the picked file is a real file leaving the upload, so it
+ * is returned in `replaced` rather than vanishing.
+ *
+ * `flattenUploadFiles` is applied here, before validation, so the names sent to
+ * the server for validation match the names uploaded to Girder.
+ */
+export function getCameraPackageFiles(
+  folderFiles: File[],
+  annotationKey?: string,
+): CameraPackage {
+  const annotationFile = annotationKey ? getAnnotationFile(annotationKey) : undefined;
+  const explicitFiles = annotationFile ? [annotationFile] : [];
+  const explicitNames = new Set(explicitFiles.map((file) => file.name));
+  const folderPackage = flattenUploadFiles(
+    folderFiles.filter((file) => !explicitNames.has(file.name)),
+  );
+  return {
+    files: annotationFile ? [...folderPackage, annotationFile] : folderPackage,
+    replaced: folderFiles.filter((file) => explicitNames.has(file.name)
+      && !explicitFiles.some((pick) => isSameSelection(pick, file))),
+  };
 }
 
 function calibrationLookupKeys(key: string): string[] {

--- a/client/platform/web-girder/store/types.ts
+++ b/client/platform/web-girder/store/types.ts
@@ -1,6 +1,6 @@
 import type { GirderModel, GirderModelType } from '@girder/components/src';
 import type { BrandData } from 'platform/web-girder/api';
-import type { GirderMetadata } from 'platform/web-girder/constants';
+import type { GirderConfig } from 'platform/web-girder/constants';
 
 /**
  * Location can be either
@@ -17,7 +17,7 @@ export interface LocationState {
 }
 
 export interface DatasetState {
-  meta: GirderMetadata | null;
+  meta: GirderConfig | null;
 }
 
 export interface BrandState {

--- a/client/platform/web-girder/store/useDataset.ts
+++ b/client/platform/web-girder/store/useDataset.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export -- singleton composable store */
-import type { GirderMetadata } from 'platform/web-girder/constants';
+import type { GirderConfig } from 'platform/web-girder/constants';
 import { ref } from 'vue';
 import {
   getDataset, getDatasetMedia, getFolder, resolveDatasetFolderId,
@@ -9,25 +9,25 @@ import { MultiType } from 'dive-common/constants';
 
 import { useLocation } from './useLocation';
 
-const meta = ref<GirderMetadata | null>(null);
+const meta = ref<GirderConfig | null>(null);
 
 export function useDataset() {
-  function getMeta(): GirderMetadata | null {
+  function getMeta(): GirderConfig | null {
     return meta.value;
   }
 
-  function setMeta(dataset: GirderMetadata | null): void {
+  function setMeta(dataset: GirderConfig | null): void {
     meta.value = dataset;
   }
 
-  async function loadDataset(datasetId: string): Promise<GirderMetadata> {
+  async function loadDataset(datasetId: string): Promise<GirderConfig> {
     const { folderId, compositeId } = await resolveDatasetFolderId(datasetId);
     const [folder, metaStatic, media] = await Promise.all([
       getFolder(folderId),
       getDataset(datasetId),
       getDatasetMedia(datasetId),
     ]);
-    const dsMeta: GirderMetadata = {
+    const dsMeta: GirderConfig = {
       ...metaStatic.data,
       ...media.data,
       id: compositeId ?? metaStatic.data.id,

--- a/client/platform/web-girder/uploadSlots.spec.ts
+++ b/client/platform/web-girder/uploadSlots.spec.ts
@@ -1,0 +1,72 @@
+// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
+import { describe, expect, it } from 'vitest';
+
+import suggestUploadSlots from './uploadSlots';
+
+function file(name: string): File {
+  return new File([name], name, { type: 'application/octet-stream' });
+}
+
+function accountedNames(slots: ReturnType<typeof suggestUploadSlots>): string[] {
+  return [
+    ...slots.mediaList.map((f) => f.name),
+    ...(slots.annotationFile ? [slots.annotationFile.name] : []),
+    ...(slots.configFile ? [slots.configFile.name] : []),
+    ...slots.unslotted.map((entry) => entry.name),
+  ].sort();
+}
+
+describe('suggestUploadSlots', () => {
+  it('suggests a single annotation CSV and keeps it out of the media slot', () => {
+    const slots = suggestUploadSlots([file('img001.png'), file('tracks.csv')]);
+    expect(slots.mediaList.map((f) => f.name)).toEqual(['img001.png']);
+    expect(slots.annotationFile?.name).toBe('tracks.csv');
+  });
+
+  it('detects a config JSON alongside an annotation CSV', () => {
+    const slots = suggestUploadSlots([file('img001.png'), file('tracks.csv'), file('dataset.meta.json')]);
+    expect(slots.configFile?.name).toBe('dataset.meta.json');
+    expect(slots.annotationFile?.name).toBe('tracks.csv');
+    expect(slots.mediaList.map((f) => f.name)).toEqual(['img001.png']);
+  });
+
+  it('leaves a second CSV unslotted rather than in the media slot the server rejects', () => {
+    // A second CSV in the media slot makes server validation fail outright ("Can only upload a
+    // single CSV Annotation per import"), which blocks the whole selection. Report it instead.
+    const slots = suggestUploadSlots([file('img001.png'), file('tracks.csv'), file('nav_2024.csv')]);
+    expect(slots.mediaList.map((f) => f.name)).toEqual(['img001.png']);
+    expect(slots.annotationFile?.name).toBe('tracks.csv');
+    expect(slots.unslotted).toEqual([
+      { name: 'nav_2024.csv', reason: 'Only one annotation file can be uploaded per dataset' },
+    ]);
+  });
+
+  it('reports a second configuration JSON rather than sending both to validation', () => {
+    const slots = suggestUploadSlots([
+      file('img001.png'), file('a.meta.json'), file('b.config.json'),
+    ]);
+    expect(slots.configFile?.name).toBe('a.meta.json');
+    expect(slots.annotationFile).toBeNull();
+    expect(slots.mediaList.map((f) => f.name)).toEqual(['img001.png']);
+    expect(slots.unslotted).toEqual([
+      { name: 'b.config.json', reason: 'Only one configuration file can be uploaded per dataset' },
+    ]);
+  });
+
+  it('slots a lone YAML annotation instead of leaving it to look like media', () => {
+    const slots = suggestUploadSlots([file('video.mp4'), file('tracks.yml')]);
+    expect(slots.mediaList.map((f) => f.name)).toEqual(['video.mp4']);
+    expect(slots.annotationFile?.name).toBe('tracks.yml');
+  });
+
+  it('never silently drops any picked file (every input is slotted or reported)', () => {
+    const picked = [
+      file('img001.png'), file('img002.png'),
+      file('tracks.csv'), file('extra.csv'),
+      file('dataset.meta.json'), file('other.json'),
+      file('nav.unknown'),
+    ];
+    const slots = suggestUploadSlots(picked);
+    expect(accountedNames(slots)).toEqual(picked.map((f) => f.name).sort());
+  });
+});

--- a/client/platform/web-girder/uploadSlots.ts
+++ b/client/platform/web-girder/uploadSlots.ts
@@ -1,4 +1,4 @@
-import { JsonMetaRegEx } from 'dive-common/constants';
+import { JsonConfigRegEx } from 'dive-common/constants';
 import type { IgnoredUploadFile } from './api/dataset.service';
 
 export interface SuggestedUploadSlots {
@@ -35,7 +35,7 @@ function annotationCandidates(files: File[], configFiles: File[]): File[] {
  * in exactly one slot or in `unslotted`, so nothing the user picked is ever silently dropped.
  */
 export default function suggestUploadSlots(fileList: File[]): SuggestedUploadSlots {
-  const configFiles = fileList.filter((f) => JsonMetaRegEx.test(f.name));
+  const configFiles = fileList.filter((f) => JsonConfigRegEx.test(f.name));
   const [configFile = null, ...extraConfigs] = configFiles;
   const [annotationFile = null, ...extraAnnotations] = annotationCandidates(fileList, configFiles);
   const claimed = new Set<File>([

--- a/client/platform/web-girder/uploadSlots.ts
+++ b/client/platform/web-girder/uploadSlots.ts
@@ -1,0 +1,55 @@
+import { JsonMetaRegEx } from 'dive-common/constants';
+import type { IgnoredUploadFile } from './api/dataset.service';
+
+export interface SuggestedUploadSlots {
+  mediaList: File[];
+  annotationFile: File | null;
+  configFile: File | null;
+  /**
+   * Picked files no slot can hold, each with the reason. A dataset takes at most one
+   * annotation source, so the extras are reported to the user instead of being placed in a
+   * slot that would make the whole selection fail validation.
+   */
+  unslotted: IgnoredUploadFile[];
+}
+
+const ONE_ANNOTATION_REASON = 'Only one annotation file can be uploaded per dataset';
+const ONE_CONFIG_REASON = 'Only one configuration file can be uploaded per dataset';
+
+/** Files the server classifies as annotation sources, in the order this split prefers them. */
+function annotationCandidates(files: File[], configFiles: File[]): File[] {
+  const matching = (test: (name: string) => boolean) => files.filter(
+    (file) => !configFiles.includes(file) && test(file.name),
+  );
+  return [
+    ...matching((name) => name.includes('.csv')),
+    ...matching((name) => name.includes('.yml') || name.includes('.yaml')),
+    ...matching((name) => name.includes('.json')),
+  ];
+}
+
+/**
+ * Auto-suggest a picked selection into the per-role upload slots.
+ *
+ * Placement is a convenience split the server re-validates at upload. Every input file lands
+ * in exactly one slot or in `unslotted`, so nothing the user picked is ever silently dropped.
+ */
+export default function suggestUploadSlots(fileList: File[]): SuggestedUploadSlots {
+  const configFiles = fileList.filter((f) => JsonMetaRegEx.test(f.name));
+  const [configFile = null, ...extraConfigs] = configFiles;
+  const [annotationFile = null, ...extraAnnotations] = annotationCandidates(fileList, configFiles);
+  const claimed = new Set<File>([
+    ...configFiles,
+    ...(annotationFile ? [annotationFile] : []),
+    ...extraAnnotations,
+  ]);
+  return {
+    mediaList: fileList.filter((f) => !claimed.has(f)),
+    annotationFile,
+    configFile,
+    unslotted: [
+      ...extraAnnotations.map((f) => ({ name: f.name, reason: ONE_ANNOTATION_REASON })),
+      ...extraConfigs.map((f) => ({ name: f.name, reason: ONE_CONFIG_REASON })),
+    ],
+  };
+}

--- a/client/platform/web-girder/utils.ts
+++ b/client/platform/web-girder/utils.ts
@@ -1,9 +1,9 @@
 import { UploadManager, Location } from '@girder/components/src';
 import {
   calibrationFileTypes, metadataFileTypes, inputAnnotationFileTypes, inputAnnotationTypes,
-  getLargeImageAllowedExtensions, getLargeImageFileAccept,
-  otherImageTypes, otherVideoTypes, transformFileTypes,
-  websafeImageTypes, websafeVideoTypes, zipFileTypes,
+  getImageSequenceFileAccept, getLargeImageAllowedExtensions, getLargeImageFileAccept,
+  otherVideoTypes, transformFileTypes,
+  websafeVideoTypes, zipFileTypes,
 } from 'dive-common/constants';
 import { DatasetType } from 'dive-common/apispec';
 import type { LocationType, RootlessLocationType } from 'platform/web-girder/store/types';
@@ -51,14 +51,17 @@ async function openFromDisk(
   if (!['calibration', 'annotation', 'config', 'zip', 'metadata'].includes(datasetType)) {
     input.multiple = true;
   }
-  if (directory && (datasetType === 'image-sequence' || datasetType === 'video')) {
+  if (
+    directory
+    && (datasetType === 'image-sequence' || datasetType === 'video' || datasetType === 'large-image')
+  ) {
+    // Empty accept so multi-dot names (e.g. a.b.c.png) are not hidden by MIME/extension filters.
     input.setAttribute('webkitdirectory', '');
     input.multiple = true;
-  }
-  if (datasetType === 'image-sequence' && !directory) {
-    input.accept = baseTypes.concat(websafeImageTypes).concat(otherImageTypes).join(',');
-  } else if (directory && (datasetType === 'image-sequence' || datasetType === 'video')) {
     input.accept = '';
+  } else if (datasetType === 'image-sequence') {
+    // Extensions + MIME: some Linux pickers miss multi-dot PNGs when only MIME is listed.
+    input.accept = [...baseTypes, getImageSequenceFileAccept()].join(',');
   } else if (datasetType === 'video') {
     input.accept = baseTypes.concat(websafeVideoTypes).concat(otherVideoTypes).join(',');
   } else if (datasetType === 'large-image') {

--- a/client/platform/web-girder/utils.ts
+++ b/client/platform/web-girder/utils.ts
@@ -39,7 +39,7 @@ function getRouteFromLocation(location: LocationType): string {
 }
 
 async function openFromDisk(
-  datasetType: DatasetType | 'calibration' | 'annotation' | 'text' | 'zip' | 'transform' | 'metadata',
+  datasetType: DatasetType | 'calibration' | 'annotation' | 'config' | 'text' | 'zip' | 'transform' | 'metadata',
   directory = false,
 ): Promise<{ canceled: boolean; filePaths: string[]; fileList?: File[]; root?: string }> {
   const input: HTMLInputElement = document.createElement('input');
@@ -48,7 +48,7 @@ async function openFromDisk(
   // Filtering one out here would settle its fate before the server ever classified it.
   const baseTypes: string[] = [...new Set([...inputAnnotationFileTypes, ...metadataFileTypes])]
     .map((item) => `.${item}`);
-  if (!['calibration', 'annotation', 'zip', 'metadata'].includes(datasetType)) {
+  if (!['calibration', 'annotation', 'config', 'zip', 'metadata'].includes(datasetType)) {
     input.multiple = true;
   }
   if (directory && (datasetType === 'image-sequence' || datasetType === 'video')) {
@@ -68,6 +68,9 @@ async function openFromDisk(
   } else if (datasetType === 'annotation') {
     input.accept = inputAnnotationTypes
       .concat(inputAnnotationFileTypes.map((item) => `.${item}`)).join(',');
+  } else if (datasetType === 'config') {
+    input.accept = '.json';
+    input.multiple = false;
   } else if (datasetType === 'zip') {
     input.accept = zipFileTypes.map((item) => `.${item}`).join(',');
   } else if (datasetType === 'transform') {

--- a/client/platform/web-girder/utils.ts
+++ b/client/platform/web-girder/utils.ts
@@ -44,7 +44,10 @@ async function openFromDisk(
 ): Promise<{ canceled: boolean; filePaths: string[]; fileList?: File[]; root?: string }> {
   const input: HTMLInputElement = document.createElement('input');
   input.type = 'file';
-  const baseTypes: string[] = inputAnnotationFileTypes.map((item) => `.${item}`);
+  // Side files a media selection may carry: an annotation source or a metadata attachment.
+  // Filtering one out here would settle its fate before the server ever classified it.
+  const baseTypes: string[] = [...new Set([...inputAnnotationFileTypes, ...metadataFileTypes])]
+    .map((item) => `.${item}`);
   if (!['calibration', 'annotation', 'zip', 'metadata'].includes(datasetType)) {
     input.multiple = true;
   }

--- a/client/platform/web-girder/views/Clone.vue
+++ b/client/platform/web-girder/views/Clone.vue
@@ -5,7 +5,7 @@ import {
 import { GirderFileManager, GirderModelType } from '@girder/components/src';
 import useRequest from 'dive-common/use/useRequest';
 import { RootlessLocationType } from 'platform/web-girder/store/types';
-import { GirderMetadataStatic } from 'platform/web-girder/constants';
+import { GirderConfigStatic } from 'platform/web-girder/constants';
 import { useGirderRest } from 'platform/web-girder/plugins/girder';
 import { clone, getDataset } from 'platform/web-girder/api';
 import { useRouter } from 'vue-router/composables';
@@ -36,7 +36,7 @@ export default defineComponent({
   setup(props) {
     const girderRest = useGirderRest();
     const router = useRouter();
-    const source = ref(null as GirderMetadataStatic | null);
+    const source = ref(null as GirderConfigStatic | null);
     const open = ref(false);
     const location: Ref<RootlessLocationType> = ref({
       _modelType: ('user' as GirderModelType),

--- a/client/platform/web-girder/views/Export.vue
+++ b/client/platform/web-girder/views/Export.vue
@@ -14,7 +14,7 @@ import {
   DatasetSourceMedia, getDataset, getDatasetMedia, getUri,
   hasCalibrationFile, downloadCalibration,
 } from 'platform/web-girder/api';
-import { GirderMetadataStatic } from 'platform/web-girder/constants';
+import { GirderConfigStatic } from 'platform/web-girder/constants';
 import {
   ImageSequenceType, LargeImageType, MultiType, VideoType,
 } from 'dive-common/constants';
@@ -98,10 +98,10 @@ export default defineComponent({
     const cameraFileSupported = ref(false);
 
     const singleDataSetId: Ref<string|null> = ref(null);
-    const dataset = shallowRef(null as GirderMetadataStatic | null);
+    const dataset = shallowRef(null as GirderConfigStatic | null);
     const datasetMedia = shallowRef(null as DatasetSourceMedia | null);
     const { request, error } = useRequest();
-    const loadDatasetMeta = () => request(async () => {
+    const loadDatasetConfig = () => request(async () => {
       if (props.datasetIds.length > 1) {
         singleDataSetId.value = null;
         dataset.value = null;
@@ -119,7 +119,7 @@ export default defineComponent({
         cameraFileSupported.value = false;
       }
     });
-    watch([toRef(props, 'datasetIds'), menuOpen], loadDatasetMeta);
+    watch([toRef(props, 'datasetIds'), menuOpen], loadDatasetConfig);
 
     const exportUrls = computed(() => {
       const params = {

--- a/client/platform/web-girder/views/Upload.spec.ts
+++ b/client/platform/web-girder/views/Upload.spec.ts
@@ -1,0 +1,247 @@
+// @vitest-environment jsdom
+/* eslint-disable import/no-extraneous-dependencies */
+import { mount } from '@vue/test-utils';
+import Vue, { CreateElement, nextTick } from 'vue';
+
+import {
+  beforeEach, describe, expect, it, vi,
+} from 'vitest';
+
+import type { ValidatedUploadRoleMap, ValidationResponse } from 'platform/web-girder/api';
+import type { DatasetType } from 'dive-common/apispec';
+import { openFromDisk } from 'platform/web-girder/utils';
+import { validateUploadGroup } from 'platform/web-girder/api';
+import Upload from './Upload.vue';
+
+Vue.config.ignoredElements = [/^v-/];
+
+vi.mock('platform/web-girder/api', () => ({
+  createGirderFolder: vi.fn(),
+  createMulticamDataset: vi.fn(),
+  deleteResources: vi.fn(),
+  saveMetadata: vi.fn(),
+  uploadCalibrationItem: vi.fn(),
+  uploadMetadataFileItem: vi.fn(),
+  validateUploadGroup: vi.fn(),
+  waitForFolderDatasetReady: vi.fn(),
+}));
+
+vi.mock('platform/web-girder/utils', () => ({
+  openFromDisk: vi.fn(),
+  GirderUploadManager: class {},
+}));
+
+vi.mock('vue-router/composables', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('dive-common/vue-utilities/prompt-service', () => ({
+  usePrompt: () => ({ prompt: vi.fn() }),
+}));
+
+const Stub = {
+  render(this: Vue, h: CreateElement) {
+    return h('div');
+  },
+};
+
+/** Renders the row slot the way UploadGirder does, with a spy for the upload action. */
+function uploadGirderStub(upload: () => Promise<void>) {
+  return {
+    name: 'UploadGirder',
+    render(this: Vue, h: CreateElement) {
+      return h('div', this.$scopedSlots.default?.({ upload }));
+    },
+  };
+}
+
+function file(name: string): File {
+  return new File([name], name, { type: 'application/octet-stream' });
+}
+
+const emptyRoles: ValidatedUploadRoleMap = {
+  media: [], annotations: [], datasetConfig: [], ignored: [],
+};
+
+/** A passing validation response; unnamed roles default to empty. */
+function validation(overrides: {
+  type?: DatasetType;
+  roles?: Partial<ValidatedUploadRoleMap>;
+  reasons?: Record<string, string>;
+} = {}): ValidationResponse {
+  const { roles, type = 'video', reasons = {} } = overrides;
+  return {
+    ok: true, type, message: '', reasons, roles: { ...emptyRoles, ...roles },
+  };
+}
+
+/** A rejected selection: a blocking message, and no media type at all. */
+function rejection(message: string): ValidationResponse {
+  return {
+    ok: false, message, roles: { ...emptyRoles }, reasons: {},
+  };
+}
+
+function mountUpload(upload: () => Promise<void> = () => Promise.resolve()) {
+  return mount(Upload, {
+    propsData: { location: { _id: 'folder-id', _modelType: 'folder' } },
+    stubs: {
+      ImportButton: Stub,
+      ImportMultiCamDialog: Stub,
+      ImportMultiCamBatchDialog: Stub,
+      UploadGirder: uploadGirderStub(upload),
+    },
+  });
+}
+
+function pick(files: File[]) {
+  vi.mocked(openFromDisk).mockResolvedValue({
+    canceled: false,
+    filePaths: files.map((f) => f.name),
+    fileList: files,
+  });
+}
+
+describe('Upload pending rows', () => {
+  beforeEach(() => {
+    vi.mocked(openFromDisk).mockReset();
+    vi.mocked(validateUploadGroup).mockReset();
+  });
+
+  it('derives fan-out from the server media role, not the client slot guess', async () => {
+    // camera.npz cannot be classified, so it stays in the media slot; only the server knows
+    // it is not media. Counting the slot instead would fan one video out into subfolders.
+    pick([file('dive.mp4'), file('camera.npz')]);
+    vi.mocked(validateUploadGroup).mockResolvedValue({
+      data: validation({
+        roles: { media: ['dive.mp4'], ignored: ['camera.npz'] },
+        reasons: { 'camera.npz': 'Unsupported side file' },
+      }),
+    } as never);
+
+    const wrapper = mountUpload();
+    await wrapper.vm.openImport('video');
+
+    const [row] = wrapper.vm.pendingUploads;
+    expect(row.createSubFolders).toBe(false);
+    expect(row.name).toBe('dive.mp4');
+    expect(row.uploadFiles.map((f: File) => f.name)).toEqual(['dive.mp4']);
+    expect(row.ignored).toEqual([{ name: 'camera.npz', reason: 'Unsupported side file' }]);
+  });
+
+  it('creates a row in an error state when validation rejects the selection', async () => {
+    pick([file('img001.png'), file('tracks.csv')]);
+    vi.mocked(validateUploadGroup).mockResolvedValue({
+      data: rejection('Can only upload a single CSV Annotation per import'),
+    } as never);
+
+    const wrapper = mountUpload();
+    await wrapper.vm.openImport('image-sequence');
+    await nextTick();
+
+    expect(wrapper.vm.pendingUploads).toHaveLength(1);
+    const [row] = wrapper.vm.pendingUploads;
+    expect(row.error).toBe('Can only upload a single CSV Annotation per import');
+    expect(row.uploadFiles).toEqual([]);
+    // The slot editor stays usable so the user can correct the selection in place.
+    expect(row.createSubFolders).toBe(false);
+    expect(row.mediaList.map((f: File) => f.name)).toEqual(['img001.png']);
+    expect(wrapper.text()).toContain('Can only upload a single CSV Annotation per import');
+  });
+
+  it('leaves the media slot unfiltered while a row is in an error state', async () => {
+    // Until the server accepts a selection the row's type is only the menu the user opened.
+    // A TIFF folder picked from Import > Image Sequence validates as large-image, but a
+    // rejected one keeps the image-sequence guess, whose accept filter excludes TIFF -- so
+    // filtering by the guess would refuse the very files the user must re-pick.
+    pick([file('a.tif'), file('tracks.csv'), file('nav.csv')]);
+    vi.mocked(validateUploadGroup).mockResolvedValue({
+      data: rejection('Can only upload a single CSV Annotation per import'),
+    } as never);
+
+    const wrapper = mountUpload();
+    await wrapper.vm.openImport('image-sequence');
+    await nextTick();
+
+    const [row] = wrapper.vm.pendingUploads;
+    expect(wrapper.vm.mediaSlotAccept(row)).toBeUndefined();
+    row.error = null;
+    expect(wrapper.vm.mediaSlotAccept(row)).toEqual(wrapper.vm.filterFileUpload(row.type));
+  });
+
+  it('names a corrected row when Start upload finally validates it', async () => {
+    // The row exists only so the slot editor can fix the selection; until it validates the
+    // server has named no media, so the row has no folder name to upload into.
+    pick([file('a.mp4'), file('img.png')]);
+    vi.mocked(validateUploadGroup).mockResolvedValueOnce({
+      data: rejection('Do not upload images and videos in the same batch.'),
+    } as never);
+    const upload = vi.fn().mockResolvedValue(undefined);
+
+    const wrapper = mountUpload(upload);
+    await wrapper.vm.openImport('video');
+
+    const [row] = wrapper.vm.pendingUploads;
+    expect(row.name).toBe('');
+
+    // The user drops the stray image in the slot editor, then starts the upload.
+    row.mediaList = [file('a.mp4')];
+    vi.mocked(validateUploadGroup).mockResolvedValue({
+      data: validation({ roles: { media: ['a.mp4'] } }),
+    } as never);
+    await wrapper.vm.prepAndUpload(upload);
+
+    expect(row.error).toBeNull();
+    expect(row.name).toBe('a.mp4');
+    expect(upload).toHaveBeenCalledTimes(1);
+  });
+
+  it('lists every ignored file, including two that share a basename', async () => {
+    // A selection spanning subfolders repeats basenames, and both copies are dropped, so the
+    // notice has to name both — the list is keyed by position for that reason.
+    pick([file('dive.mp4'), file('tracks.csv'), file('notes.csv'), file('notes.csv')]);
+    vi.mocked(validateUploadGroup).mockResolvedValue({
+      data: validation({ roles: { media: ['dive.mp4'], annotations: ['tracks.csv'] } }),
+    } as never);
+
+    const wrapper = mountUpload();
+    await wrapper.vm.openImport('video');
+    await nextTick();
+
+    const [row] = wrapper.vm.pendingUploads;
+    expect(row.ignored.map((entry: { name: string }) => entry.name)).toEqual(['notes.csv', 'notes.csv']);
+    expect(wrapper.text().match(/notes\.csv/g)).toHaveLength(2);
+  });
+
+  it('retires the row the child names, not whichever row is last in the queue', async () => {
+    vi.mocked(validateUploadGroup).mockImplementation(async (names: string[]) => ({
+      data: validation({ roles: { media: names } }),
+    }) as never);
+
+    const wrapper = mountUpload();
+    pick([file('a.mp4')]);
+    await wrapper.vm.openImport('video');
+    pick([file('b.mp4')]);
+    await wrapper.vm.openImport('video');
+
+    wrapper.findComponent({ name: 'UploadGirder' }).vm.$emit('remove-upload', wrapper.vm.pendingUploads[0]);
+
+    expect(wrapper.vm.pendingUploads.map((row: { name: string }) => row.name)).toEqual(['b.mp4']);
+  });
+
+  it('starts only one upload when Start upload is clicked twice', async () => {
+    pick([file('dive.mp4')]);
+    vi.mocked(validateUploadGroup).mockResolvedValue({
+      data: validation({ roles: { media: ['dive.mp4'] } }),
+    } as never);
+    const upload = vi.fn().mockResolvedValue(undefined);
+
+    const wrapper = mountUpload(upload);
+    await wrapper.vm.openImport('video');
+
+    // Both clicks land before the awaited validation round-trip resolves.
+    await Promise.all([wrapper.vm.prepAndUpload(upload), wrapper.vm.prepAndUpload(upload)]);
+
+    expect(upload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/platform/web-girder/views/Upload.spec.ts
+++ b/client/platform/web-girder/views/Upload.spec.ts
@@ -21,7 +21,7 @@ vi.mock('platform/web-girder/api', () => ({
   deleteResources: vi.fn(),
   saveConfig: vi.fn(),
   uploadCalibrationItem: vi.fn(),
-  uploadConfigFileItem: vi.fn(),
+  uploadMetadataFileItem: vi.fn(),
   validateUploadGroup: vi.fn(),
   waitForFolderDatasetReady: vi.fn(),
 }));

--- a/client/platform/web-girder/views/Upload.spec.ts
+++ b/client/platform/web-girder/views/Upload.spec.ts
@@ -19,9 +19,9 @@ vi.mock('platform/web-girder/api', () => ({
   createGirderFolder: vi.fn(),
   createMulticamDataset: vi.fn(),
   deleteResources: vi.fn(),
-  saveMetadata: vi.fn(),
+  saveConfig: vi.fn(),
   uploadCalibrationItem: vi.fn(),
-  uploadMetadataFileItem: vi.fn(),
+  uploadConfigFileItem: vi.fn(),
   validateUploadGroup: vi.fn(),
   waitForFolderDatasetReady: vi.fn(),
 }));

--- a/client/platform/web-girder/views/Upload.spec.ts
+++ b/client/platform/web-girder/views/Upload.spec.ts
@@ -94,23 +94,12 @@ function mountUpload(upload: () => Promise<void> = () => Promise.resolve()) {
   });
 }
 
-function pick(files: File[], options: { directory?: boolean } = {}) {
-  const fileList = options.directory
-    ? files.map((f) => {
-      // Simulate webkitdirectory: root folder + basename path.
-      const clone = new File([f], f.name, { type: f.type });
-      Object.defineProperty(clone, 'webkitRelativePath', {
-        value: `Ehu/${f.name}`,
-        configurable: true,
-      });
-      return clone;
-    })
-    : files;
+function pick(files: File[]) {
+  const fileList = files;
   vi.mocked(openFromDisk).mockResolvedValue({
     canceled: false,
-    filePaths: fileList.map((f) => (f as File & { webkitRelativePath?: string }).webkitRelativePath || f.name),
+    filePaths: fileList.map((f) => f.name),
     fileList,
-    root: options.directory ? 'Ehu' : undefined,
   });
 }
 
@@ -270,8 +259,8 @@ describe('Upload pending rows', () => {
     expect(wrapper.vm.pendingUploads.map((row: { name: string }) => row.name)).toEqual(['b.mp4']);
   });
 
-  it('opens image-sequence as a directory and names the row from the folder', async () => {
-    pick([file('20171027.214830.208.029135.png'), file('meta.json')], { directory: true });
+  it('opens image-sequence as a multi-file picker and keeps multi-dot frame names', async () => {
+    pick([file('20171027.214830.208.029135.png'), file('meta.json')]);
     vi.mocked(validateUploadGroup).mockResolvedValue({
       data: validation({
         type: 'image-sequence',
@@ -285,42 +274,14 @@ describe('Upload pending rows', () => {
     const wrapper = mountUpload();
     await wrapper.vm.openImport('image-sequence');
 
-    expect(openFromDisk).toHaveBeenCalledWith('image-sequence', true);
+    expect(openFromDisk).toHaveBeenCalledWith('image-sequence');
     const [row] = wrapper.vm.pendingUploads;
-    expect(row.name).toBe('Ehu');
+    expect(row.name).toBe('20171027.214830.208.029135.png');
     expect(row.type).toBe('image-sequence');
     expect(row.uploadFiles.map((f: File) => f.name)).toEqual([
       '20171027.214830.208.029135.png',
       'meta.json',
     ]);
-  });
-
-  it('drops nested directory files from a single image-sequence import', async () => {
-    const top = file('top.png');
-    Object.defineProperty(top, 'webkitRelativePath', { value: 'Ehu/top.png', configurable: true });
-    const nested = file('nested.png');
-    Object.defineProperty(nested, 'webkitRelativePath', {
-      value: 'Ehu/midRange/nested.png',
-      configurable: true,
-    });
-    vi.mocked(openFromDisk).mockResolvedValue({
-      canceled: false,
-      filePaths: [top.webkitRelativePath, nested.webkitRelativePath],
-      fileList: [top, nested],
-      root: 'Ehu',
-    });
-    vi.mocked(validateUploadGroup).mockResolvedValue({
-      data: validation({
-        type: 'image-sequence',
-        roles: { media: ['top.png'] },
-      }),
-    } as never);
-
-    const wrapper = mountUpload();
-    await wrapper.vm.openImport('image-sequence');
-
-    expect(validateUploadGroup).toHaveBeenCalledWith(['top.png']);
-    expect(wrapper.vm.pendingUploads[0].name).toBe('Ehu');
   });
 
   it('starts only one upload when Start upload is clicked twice', async () => {

--- a/client/platform/web-girder/views/Upload.spec.ts
+++ b/client/platform/web-girder/views/Upload.spec.ts
@@ -196,6 +196,35 @@ describe('Upload pending rows', () => {
     expect(upload).toHaveBeenCalledTimes(1);
   });
 
+  it('updates type from the server when Start upload validates a corrected error row', async () => {
+    // Error rows leave the media slot unfiltered, so the user can replace a mixed
+    // video pick with images. The folder must be created as image-sequence, not video.
+    pick([file('a.mp4'), file('img.png')]);
+    vi.mocked(validateUploadGroup).mockResolvedValueOnce({
+      data: rejection('Do not upload images and videos in the same batch.'),
+    } as never);
+    const upload = vi.fn().mockResolvedValue(undefined);
+
+    const wrapper = mountUpload(upload);
+    await wrapper.vm.openImport('video');
+
+    const [row] = wrapper.vm.pendingUploads;
+    expect(row.type).toBe('video');
+
+    row.mediaList = [file('img.png')];
+    vi.mocked(validateUploadGroup).mockResolvedValue({
+      data: validation({
+        type: 'image-sequence',
+        roles: { media: ['img.png'] },
+      }),
+    } as never);
+    await wrapper.vm.prepAndUpload(upload);
+
+    expect(row.error).toBeNull();
+    expect(row.type).toBe('image-sequence');
+    expect(upload).toHaveBeenCalledTimes(1);
+  });
+
   it('lists every ignored file, including two that share a basename', async () => {
     // A selection spanning subfolders repeats basenames, and both copies are dropped, so the
     // notice has to name both — the list is keyed by position for that reason.

--- a/client/platform/web-girder/views/Upload.spec.ts
+++ b/client/platform/web-girder/views/Upload.spec.ts
@@ -94,11 +94,23 @@ function mountUpload(upload: () => Promise<void> = () => Promise.resolve()) {
   });
 }
 
-function pick(files: File[]) {
+function pick(files: File[], options: { directory?: boolean } = {}) {
+  const fileList = options.directory
+    ? files.map((f) => {
+      // Simulate webkitdirectory: root folder + basename path.
+      const clone = new File([f], f.name, { type: f.type });
+      Object.defineProperty(clone, 'webkitRelativePath', {
+        value: `Ehu/${f.name}`,
+        configurable: true,
+      });
+      return clone;
+    })
+    : files;
   vi.mocked(openFromDisk).mockResolvedValue({
     canceled: false,
-    filePaths: files.map((f) => f.name),
-    fileList: files,
+    filePaths: fileList.map((f) => (f as File & { webkitRelativePath?: string }).webkitRelativePath || f.name),
+    fileList,
+    root: options.directory ? 'Ehu' : undefined,
   });
 }
 
@@ -256,6 +268,59 @@ describe('Upload pending rows', () => {
     wrapper.findComponent({ name: 'UploadGirder' }).vm.$emit('remove-upload', wrapper.vm.pendingUploads[0]);
 
     expect(wrapper.vm.pendingUploads.map((row: { name: string }) => row.name)).toEqual(['b.mp4']);
+  });
+
+  it('opens image-sequence as a directory and names the row from the folder', async () => {
+    pick([file('20171027.214830.208.029135.png'), file('meta.json')], { directory: true });
+    vi.mocked(validateUploadGroup).mockResolvedValue({
+      data: validation({
+        type: 'image-sequence',
+        roles: {
+          media: ['20171027.214830.208.029135.png'],
+          datasetConfig: ['meta.json'],
+        },
+      }),
+    } as never);
+
+    const wrapper = mountUpload();
+    await wrapper.vm.openImport('image-sequence');
+
+    expect(openFromDisk).toHaveBeenCalledWith('image-sequence', true);
+    const [row] = wrapper.vm.pendingUploads;
+    expect(row.name).toBe('Ehu');
+    expect(row.type).toBe('image-sequence');
+    expect(row.uploadFiles.map((f: File) => f.name)).toEqual([
+      '20171027.214830.208.029135.png',
+      'meta.json',
+    ]);
+  });
+
+  it('drops nested directory files from a single image-sequence import', async () => {
+    const top = file('top.png');
+    Object.defineProperty(top, 'webkitRelativePath', { value: 'Ehu/top.png', configurable: true });
+    const nested = file('nested.png');
+    Object.defineProperty(nested, 'webkitRelativePath', {
+      value: 'Ehu/midRange/nested.png',
+      configurable: true,
+    });
+    vi.mocked(openFromDisk).mockResolvedValue({
+      canceled: false,
+      filePaths: [top.webkitRelativePath, nested.webkitRelativePath],
+      fileList: [top, nested],
+      root: 'Ehu',
+    });
+    vi.mocked(validateUploadGroup).mockResolvedValue({
+      data: validation({
+        type: 'image-sequence',
+        roles: { media: ['top.png'] },
+      }),
+    } as never);
+
+    const wrapper = mountUpload();
+    await wrapper.vm.openImport('image-sequence');
+
+    expect(validateUploadGroup).toHaveBeenCalledWith(['top.png']);
+    expect(wrapper.vm.pendingUploads[0].name).toBe('Ehu');
   });
 
   it('starts only one upload when Start upload is clicked twice', async () => {

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -1109,7 +1109,7 @@ export default defineComponent({
               dense
               outlined
               type="error"
-              class="mt-2 mb-0 text-body-2"
+              class="mt-4 mb-0 text-body-2"
             >
               {{ pendingUpload.error }}
             </v-alert>
@@ -1213,7 +1213,7 @@ export default defineComponent({
             -->
             <div
               v-if="pendingUpload.ignored.length"
-              class="mx-4 mt-3"
+              class="mx-4 mt-6"
             >
               <div class="text-caption warning--text">
                 Ignored (not uploaded):

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -812,6 +812,14 @@ export default defineComponent({
             if (!pendingUpload.name) {
               pendingUpload.name = defaultRowName(validation);
             }
+            // Server confirms the media type here too: an error row's type was only the
+            // import menu until now, and the (unfiltered) slot editor may have changed
+            // media kinds. Preserve the large-image menu preference when the server
+            // still classifies the files as an image sequence, matching addPendingUpload.
+            pendingUpload.type = pendingUpload.type === LargeImageType
+              && validation.type === ImageSequenceType
+              ? LargeImageType
+              : validation.type;
             pendingUpload.createSubFolders = fansOutToSubFolders(validation);
             pendingUpload.uploadFiles = acceptedUploadFiles(slotFiles, validation);
             pendingUpload.ignored = rowIgnoredFiles(pendingUpload, validation);

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -27,9 +27,9 @@ import {
   createGirderFolder,
   createMulticamDataset,
   deleteResources,
-  saveMetadata,
+  saveConfig,
   uploadCalibrationItem,
-  uploadMetadataFileItem,
+  uploadConfigFileItem,
   validateUploadGroup,
   waitForFolderDatasetReady,
 } from 'platform/web-girder/api';
@@ -86,8 +86,9 @@ export interface PendingUpload {
    */
   mediaList: File[];
   annotationFile: File | null;
+  /** Optional DIVE Configuration File (JSON attributes, styles, FPS, …). */
   configFile: File | null;
-  /** Optional dataset-level file handed to pipelines that request it. */
+  /** Optional Metadata File handed to pipelines that declare `# Metadata File:`. */
   metadataFile: File | null;
   /** Media/annotation/config package the server validated for upload (rebuilt at start). */
   uploadFiles: File[];
@@ -275,8 +276,10 @@ export default defineComponent({
     };
 
     // Accept filters per slot, mirroring the file dialog's own filters.
-    const filterFileUpload = (type: DatasetType | 'meta' | 'annotation' | 'metadata') => {
-      if (type === 'meta') {
+    // 'config' is the DIVE JSON configuration file; 'metadata' is the optional
+    // pipeline sidecar — keep these names distinct from each other.
+    const filterFileUpload = (type: DatasetType | 'config' | 'annotation' | 'metadata') => {
+      if (type === 'config') {
         return '.json';
       }
       if (type === 'annotation') {
@@ -384,7 +387,7 @@ export default defineComponent({
       const files = getFilesForSourceKey(sourcePath) ?? [];
       const mediaType = multiCamOpenType.value === VideoType ? VideoType : ImageSequenceType;
       return {
-        jsonMeta: {
+        jsonConfig: {
           originalImageFiles: mediaFileNamesForImport(files, mediaType),
         },
         globPattern: '',
@@ -594,7 +597,7 @@ export default defineComponent({
               'Metadata file was not found. Use "Choose metadata" in the import dialog to select the file again.',
             );
           }
-          metadataFileId = await uploadMetadataFileItem(datasetFolder._id, metadataFile);
+          metadataFileId = await uploadConfigFileItem(datasetFolder._id, metadataFile);
         }
 
         const subType = stereo.value ? 'stereo' : 'multicam';
@@ -618,7 +621,7 @@ export default defineComponent({
           // registration the in-app panel edits and the Align button
           // applies); the camera* fields are allowlisted in the meta PATCH.
           setMulticamImportProgress(98, `${labelPrefix}Saving camera registration…`);
-          await saveMetadata(parentFolder._id, {
+          await saveConfig(parentFolder._id, {
             cameraHomographies: registrationSeed.values.homographies,
             cameraCorrespondences: registrationSeed.values.correspondences,
             cameraTransformTypes: registrationSeed.values.transformTypes,
@@ -1124,7 +1127,7 @@ export default defineComponent({
                     label="Configuration File (Optional)"
                     hint="Optional"
                     :disabled="pendingUpload.uploading"
-                    :accept="filterFileUpload('meta')"
+                    :accept="filterFileUpload('config')"
                   />
                 </v-row>
                 <v-row>

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -7,7 +7,7 @@ import { useRouter } from 'vue-router/composables';
 import {
   ImageSequenceType, VideoType, DefaultVideoFPS, FPSOptions, LargeImageType,
   inputAnnotationFileTypes, websafeVideoTypes, otherVideoTypes,
-  websafeImageTypes, otherImageTypes, getLargeImageFileAccept,
+  getImageSequenceFileAccept, getLargeImageFileAccept,
   metadataFileTypes,
 } from 'dive-common/constants';
 import suggestUploadSlots from 'platform/web-girder/uploadSlots';
@@ -168,11 +168,37 @@ function fansOutToSubFolders(validation: ValidationResponse): boolean {
  * several media files — the first one with its suffix stripped. Derived from the server's
  * media role, so a row that was rejected on pick still gets a name once it validates.
  */
-function defaultRowName(validation: ValidationResponse): string {
+function defaultRowName(validation: ValidationResponse, folderHint?: string): string {
+  if (folderHint) {
+    return folderHint;
+  }
   const [firstMedia = ''] = validation.roles.media;
   return validation.roles.media.length > 1
     ? firstMedia.replace(fileSuffixRegex, '')
     : firstMedia;
+}
+
+/**
+ * webkitdirectory includes nested files; single-camera import only uses the selected folder's
+ * immediate children (desktop readdir parity). Nested collects belong to MultiCam Batch.
+ */
+function topLevelDirectoryFiles(files: File[]): File[] {
+  const withRelative = files.filter((file) => file.webkitRelativePath);
+  if (!withRelative.length) {
+    return files;
+  }
+  return files.filter((file) => {
+    const parts = (file.webkitRelativePath || file.name).replace(/\\/g, '/').split('/').filter(Boolean);
+    return parts.length === 2;
+  });
+}
+
+function directoryFolderName(files: File[]): string | undefined {
+  const relative = files.find((file) => file.webkitRelativePath)?.webkitRelativePath;
+  if (!relative) {
+    return undefined;
+  }
+  return relative.replace(/\\/g, '/').split('/').filter(Boolean)[0];
 }
 
 /**
@@ -289,12 +315,12 @@ export default defineComponent({
         return metadataFileTypes.map((item) => `.${item}`).join(',');
       }
       if (type === 'video') {
-        return websafeVideoTypes.concat(otherVideoTypes);
+        return websafeVideoTypes.concat(otherVideoTypes).join(',');
       }
       if (type === 'large-image') {
         return getLargeImageFileAccept();
       }
-      return websafeImageTypes.concat(otherImageTypes);
+      return getImageSequenceFileAccept();
     };
 
     /**
@@ -318,6 +344,7 @@ export default defineComponent({
       allFiles: File[],
       suggestedFps?: number, // suggested FPS for large/images
       expectedType?: DatasetType,
+      folderHint?: string,
     ) => {
       const slots = suggestUploadSlots(allFiles);
       // Validate the slotted selection so the media type is server-determined.
@@ -349,7 +376,7 @@ export default defineComponent({
       }
       // Server validation is authoritative for the media/annotation/config roles.
       row.createSubFolders = fansOutToSubFolders(validation);
-      row.name = defaultRowName(validation);
+      row.name = defaultRowName(validation, folderHint);
       row.uploadFiles = acceptedUploadFiles(slotFiles, validation);
       row.ignored = rowIgnoredFiles(row, validation);
       row.type = expectedType === LargeImageType ? LargeImageType : validation.type;
@@ -360,11 +387,18 @@ export default defineComponent({
      * validation, which is what classifies the files.
      */
     const openImport = async (dstype: DatasetType | 'zip') => {
-      const ret = await openFromDisk(dstype);
+      // Image-sequence / large-image match desktop: open a directory, not a multi-file picker.
+      // Directory mode also clears accept so multi-dot frame names are not filtered out.
+      const useDirectory = dstype === ImageSequenceType || dstype === LargeImageType;
+      const ret = await openFromDisk(dstype, useDirectory);
       if (ret.canceled || !ret.fileList || ret.fileList.length === 0) {
         return;
       }
-      const allFiles = ret.fileList;
+      const allFiles = useDirectory ? topLevelDirectoryFiles(ret.fileList) : ret.fileList;
+      if (!allFiles.length) {
+        preUploadErrorMessage.value = 'No files found in the selected folder.';
+        return;
+      }
       preUploadErrorMessage.value = null;
       try {
         if (dstype === 'zip') {
@@ -372,7 +406,12 @@ export default defineComponent({
           addPendingZipUpload(name, allFiles);
         } else {
           const suggestedFps = dstype === 'image-sequence' || dstype === 'large-image' ? 1 : undefined;
-          await addPendingUpload(allFiles, suggestedFps, dstype);
+          await addPendingUpload(
+            allFiles,
+            suggestedFps,
+            dstype,
+            useDirectory ? directoryFolderName(allFiles) : undefined,
+          );
         }
       } catch (err) {
         preUploadErrorMessage.value = err.response?.data?.message || err;

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -5,11 +5,12 @@ import {
 import { useRouter } from 'vue-router/composables';
 
 import {
-  ImageSequenceType, VideoType, DefaultVideoFPS, FPSOptions,
+  ImageSequenceType, VideoType, DefaultVideoFPS, FPSOptions, LargeImageType,
   inputAnnotationFileTypes, websafeVideoTypes, otherVideoTypes,
-  websafeImageTypes, otherImageTypes, JsonMetaRegEx, getLargeImageFileAccept, LargeImageType,
+  websafeImageTypes, otherImageTypes, getLargeImageFileAccept,
   metadataFileTypes,
 } from 'dive-common/constants';
+import suggestUploadSlots from 'platform/web-girder/uploadSlots';
 
 import {
   fileSuffixRegex,
@@ -32,14 +33,18 @@ import {
   validateUploadGroup,
   waitForFolderDatasetReady,
 } from 'platform/web-girder/api';
+import type {
+  IgnoredUploadFile,
+  ValidationResponse,
+} from 'platform/web-girder/api';
 import {
   clearMulticamFileRegistry,
-  getAnnotationFile,
   getCalibrationFile,
   getMetadataFile,
+  getCameraPackageFiles,
   getFilesForSourceKey,
   getTransformFile,
-  flattenUploadFiles,
+  mediaFileNamesForImport,
   removeCameraFolderFiles,
   renameCameraFolderFiles,
   stashCameraFolderFiles,
@@ -75,10 +80,22 @@ export interface PendingUpload {
   createSubFolders: boolean;
   name: string;
   files: InteralFiles[];
-  meta: null | File;
-  metadataFile: null | File;
-  annotationFile: null | File;
+  /**
+   * Per-role upload slots. The user declares each file's role by which slot it goes in;
+   * placement is a suggestion the server re-validates at upload.
+   */
   mediaList: File[];
+  annotationFile: File | null;
+  configFile: File | null;
+  /** Optional dataset-level file handed to pipelines that request it. */
+  metadataFile: File | null;
+  /** Media/annotation/config package the server validated for upload (rebuilt at start). */
+  uploadFiles: File[];
+  /** Picked files that have no slot on this row, each with the reason it is not uploaded. */
+  unslotted: IgnoredUploadFile[];
+  ignored: IgnoredUploadFile[];
+  /** Blocking validation message for this row; the slots stay editable until it clears. */
+  error: string | null;
   type: DatasetType | 'zip';
   fps: number;
   uploading: boolean;
@@ -94,10 +111,9 @@ interface GirderUpload {
     name: string;
     fps: number;
     type: DatasetType;
-    mediaList: File[];
-    meta?: File | null;
-    annotationFile?: File | null;
+    uploadFiles: File[];
     skipTranscoding?: boolean;
+    parentFolderId?: string;
   }) => Promise<{ folder: { _id: string }; jobIds: string[] }>;
 }
 
@@ -124,6 +140,54 @@ function multicamCameraSlotPercent(
   return MULTICAM_PROGRESS_START + (cameraIndex * span) + (subFraction * span);
 }
 
+/**
+ * The server names every file it did not accept, so what to upload is the validated
+ * selection minus those names.
+ */
+function acceptedUploadFiles(files: File[], validation: ValidationResponse): File[] {
+  const ignoredNames = new Set(validation.roles.ignored);
+  return files.filter((file) => !ignoredNames.has(file.name));
+}
+
+/** The server's ignored role, each name paired with the reason it reported for it. */
+function validationIgnoredFiles(validation: ValidationResponse): IgnoredUploadFile[] {
+  return validation.roles.ignored.map((name) => ({
+    name,
+    reason: validation.reasons[name] ?? 'Not accepted for upload',
+  }));
+}
+
+/** Only a multi-video upload fans out into per-video subfolders. */
+function fansOutToSubFolders(validation: ValidationResponse): boolean {
+  return validation.type === VideoType && validation.roles.media.length > 1;
+}
+
+/**
+ * The folder name a row starts with: the single media file's name, or — when the row holds
+ * several media files — the first one with its suffix stripped. Derived from the server's
+ * media role, so a row that was rejected on pick still gets a name once it validates.
+ */
+function defaultRowName(validation: ValidationResponse): string {
+  const [firstMedia = ''] = validation.roles.media;
+  return validation.roles.media.length > 1
+    ? firstMedia.replace(fileSuffixRegex, '')
+    : firstMedia;
+}
+
+/**
+ * Every picked file this row will not upload, with the reason: what the server ignored, and
+ * what had no slot to go in.
+ */
+function rowIgnoredFiles(
+  row: Pick<PendingUpload, 'unslotted'>,
+  validation: ValidationResponse,
+): IgnoredUploadFile[] {
+  return [
+    ...validationIgnoredFiles(validation),
+    ...row.unslotted,
+  ];
+}
+
 export default defineComponent({
   components: {
     ImportButton,
@@ -140,6 +204,8 @@ export default defineComponent({
   setup(props, { emit }) {
     const preUploadErrorMessage: Ref<string | null> = ref(null);
     const pendingUploads: Ref<PendingUpload[]> = ref([]);
+    /** True from the moment Start upload is clicked until its upload settles. */
+    const preparing = ref(false);
     const stereo = ref(false);
     const multiCamOpenType = ref('image-sequence');
     const importMultiCamDialog = ref(false);
@@ -194,150 +260,119 @@ export default defineComponent({
         createSubFolders: false,
         name: defaultFilename,
         files: [], //Will be set in the GirderUpload Component
-        meta: null,
-        metadataFile: null,
-        annotationFile: null,
         mediaList: allFiles,
+        annotationFile: null,
+        configFile: null,
+        metadataFile: null,
+        uploadFiles: allFiles,
+        unslotted: [],
+        ignored: [],
+        error: null,
         type: 'zip',
         fps,
         uploading: false,
       });
     };
 
+    // Accept filters per slot, mirroring the file dialog's own filters.
+    const filterFileUpload = (type: DatasetType | 'meta' | 'annotation' | 'metadata') => {
+      if (type === 'meta') {
+        return '.json';
+      }
+      if (type === 'annotation') {
+        return inputAnnotationFileTypes.map((item) => `.${item}`).join(',');
+      }
+      if (type === 'metadata') {
+        return metadataFileTypes.map((item) => `.${item}`).join(',');
+      }
+      if (type === 'video') {
+        return websafeVideoTypes.concat(otherVideoTypes);
+      }
+      if (type === 'large-image') {
+        return getLargeImageFileAccept();
+      }
+      return websafeImageTypes.concat(otherImageTypes);
+    };
+
+    /**
+     * Until a row validates, its type is only the import menu the user opened, which the
+     * server may yet contradict (an image-sequence pick of TIFFs validates as large-image).
+     * An error row is therefore left unfiltered: filtering by the guess would hide the very
+     * files the user has to re-pick to clear the error.
+     */
+    const mediaSlotAccept = (pendingUpload: PendingUpload) => (
+      pendingUpload.error ? undefined : filterFileUpload(pendingUpload.type)
+    );
+
+    // Every slot file the server validates, in a single list.
+    const slotFileList = (pendingUpload: PendingUpload): File[] => [
+      ...pendingUpload.mediaList,
+      ...(pendingUpload.annotationFile ? [pendingUpload.annotationFile] : []),
+      ...(pendingUpload.configFile ? [pendingUpload.configFile] : []),
+    ];
+
     const addPendingUpload = async (
-      name: string,
       allFiles: File[],
-      meta: File | null,
-      annotationFile: File | null,
-      mediaList: File[],
       suggestedFps?: number, // suggested FPS for large/images
       expectedType?: DatasetType,
     ) => {
-      const resp = (await validateUploadGroup(allFiles.map((f) => f.name))).data;
-      if (!resp.ok) {
-        if (resp.message) {
-          preUploadErrorMessage.value = resp.message;
-        }
-        throw new Error(resp.message);
-      }
-      const uploadType = expectedType === LargeImageType ? LargeImageType : resp.type;
-      const fps = suggestedFps || clientSettings.annotationFPS || DefaultVideoFPS;
-      const defaultFilename = resp.media[0];
-      const validFiles = resp.media.concat(resp.annotations);
-      // mapping needs to be done for the mixin upload functions
-      const internalFiles = allFiles
-        .filter((f) => validFiles.includes(f.name));
-      let createSubFolders = false;
-      if (resp.type === 'video') {
-        if (resp.media.length > 1) {
-          createSubFolders = true;
-        }
-      }
-      pendingUploads.value.push({
-        createSubFolders,
-        name:
-          internalFiles.length > 1
-            ? defaultFilename.replace(fileSuffixRegex, '')
-            : defaultFilename,
+      const slots = suggestUploadSlots(allFiles);
+      // Validate the slotted selection so the media type is server-determined.
+      const row: PendingUpload = {
+        createSubFolders: false,
+        name: '',
         files: [], //Will be set in the GirderUpload Component
-        meta,
+        mediaList: slots.mediaList,
+        annotationFile: slots.annotationFile,
+        configFile: slots.configFile,
         metadataFile: null,
-        annotationFile,
-        mediaList,
-        type: uploadType,
-        fps,
+        uploadFiles: [],
+        unslotted: slots.unslotted,
+        ignored: [...slots.unslotted],
+        error: null,
+        type: expectedType ?? ImageSequenceType,
+        fps: suggestedFps || clientSettings.annotationFPS || DefaultVideoFPS,
         uploading: false,
         skipTranscoding: true,
-      });
-    };
-    /**
-     * Processes the imported media files to distinguish between
-     * Media Files - Default files that aren't the Annotation or Meta
-     * Annotation File - CSV or JSON file, or more in the future
-     * Meta File - Right now a json file which has 'meta' or 'config in the name
-     */
-    const processImport = (files: {
-      canceled: boolean; filePaths: string[]; fileList?: File[];
-    }) => {
-      //Check for auto files for meta and annotations
-      const output: {
-        annotationFile: null | File;
-        metaFile: null | File;
-        mediaList: File[];
-        fullList: File[];
-      } = {
-        annotationFile: null,
-        metaFile: null,
-        mediaList: [],
-        fullList: [],
       };
-      const jsonFiles: [string, number][] = [];
-      const csvFiles: [string, number][] = [];
-      if (files.fileList) {
-        files.filePaths.forEach((item, index) => {
-          if (item.indexOf('.json') !== -1) {
-            jsonFiles.push([item, index]);
-          } else if (item.indexOf('.csv') !== -1) {
-            csvFiles.push([item, index]);
-          }
-        });
-        output.mediaList = files.fileList.filter((item) => (
-          item.name.indexOf('.json') === -1 && item.name.indexOf('.csv') === -1));
-        const metaIndex = jsonFiles.findIndex((item) => (JsonMetaRegEx.test(item[0])));
-        if (metaIndex !== -1) {
-          output.metaFile = files.fileList[jsonFiles[metaIndex][1]];
-          jsonFiles.splice(metaIndex, 1); //remove chosen meta from list
-        }
-        if (jsonFiles.length === 1 && csvFiles.length === 0) { // only remaining json file
-          output.annotationFile = files.fileList[jsonFiles[0][1]];
-        } else if (csvFiles.length) { // Prefer First CSV if both found
-          output.annotationFile = files.fileList[csvFiles[0][1]];
-        } else if (jsonFiles.length > 1) { //multiple jsons, filter out additional meta/configs
-          const filtered = jsonFiles.filter((item) => (!JsonMetaRegEx.test(item[0]) && (item[0].indexOf('.json') !== -1)));
-          if (filtered.length) { // take first filtered JSON file
-            output.annotationFile = files.fileList[filtered[0][1]];
-          }
-        }
-        output.fullList = [...output.mediaList];
-        if (output.annotationFile) {
-          output.fullList.push(output.annotationFile);
-        }
-        if (output.metaFile) {
-          output.fullList.push(output.metaFile);
-        }
+      const slotFiles = slotFileList(row);
+      const validation = (await validateUploadGroup(slotFiles.map((f) => f.name))).data;
+      // A rejected selection still gets a row: its slot editor is the only place the user
+      // can correct the problem without reopening the OS file picker.
+      if (!validation.ok) {
+        row.error = validation.message || 'Upload validation failed';
+        pendingUploads.value.push(row);
+        return;
       }
-      return output;
+      // Server validation is authoritative for the media/annotation/config roles.
+      row.createSubFolders = fansOutToSubFolders(validation);
+      row.name = defaultRowName(validation);
+      row.uploadFiles = acceptedUploadFiles(slotFiles, validation);
+      row.ignored = rowIgnoredFiles(row, validation);
+      row.type = expectedType === LargeImageType ? LargeImageType : validation.type;
+      pendingUploads.value.push(row);
     };
     /**
-     * Initial opening of file dialog
+     * Initial opening of file dialog. The complete selection is sent to server
+     * validation, which is what classifies the files.
      */
     const openImport = async (dstype: DatasetType | 'zip') => {
       const ret = await openFromDisk(dstype);
-      if (!ret.canceled && ret.fileList) {
-        const processed = processImport(ret);
-        if (processed?.fullList?.length === 0) return;
-        if (processed && processed.fullList) {
-          const name = processed.fullList.length === 1 ? processed.fullList[0].name : '';
-          preUploadErrorMessage.value = null;
-          try {
-            if (dstype !== 'zip') {
-              const suggestedFps = dstype === 'image-sequence' || dstype === 'large-image' ? 1 : undefined;
-              await addPendingUpload(
-                name,
-                processed.fullList,
-                processed.metaFile,
-                processed.annotationFile,
-                processed.mediaList,
-                suggestedFps,
-                dstype,
-              );
-            } else {
-              addPendingZipUpload(name, processed.fullList);
-            }
-          } catch (err) {
-            preUploadErrorMessage.value = err.response?.data?.message || err;
-          }
+      if (ret.canceled || !ret.fileList || ret.fileList.length === 0) {
+        return;
+      }
+      const allFiles = ret.fileList;
+      preUploadErrorMessage.value = null;
+      try {
+        if (dstype === 'zip') {
+          const name = allFiles.length === 1 ? allFiles[0].name : '';
+          addPendingZipUpload(name, allFiles);
+        } else {
+          const suggestedFps = dstype === 'image-sequence' || dstype === 'large-image' ? 1 : undefined;
+          await addPendingUpload(allFiles, suggestedFps, dstype);
         }
+      } catch (err) {
+        preUploadErrorMessage.value = err.response?.data?.message || err;
       }
     };
     const openMultiCamDialog = (args: { stereo: boolean; openType: 'image-sequence' | 'video' }) => {
@@ -345,26 +380,12 @@ export default defineComponent({
       multiCamOpenType.value = args.openType;
       importMultiCamDialog.value = true;
     };
-    const filterFileUpload = (type: DatasetType | 'meta' | 'annotation' | 'metadata') => {
-      if (type === 'meta') {
-        return '.json';
-      } if (type === 'metadata') {
-        return metadataFileTypes.map((item) => `.${item}`).join(',');
-      } if (type === 'annotation') {
-        return inputAnnotationFileTypes.map((item) => `.${item}`).join(',');
-      } if (type === 'video') {
-        return websafeVideoTypes.concat(otherVideoTypes);
-      } if (type === 'large-image') {
-        return getLargeImageFileAccept();
-      }
-      return websafeImageTypes.concat(otherImageTypes);
-    };
-
     const multiCamImportCheck = (sourcePath: string): MediaImportResponse => {
       const files = getFilesForSourceKey(sourcePath) ?? [];
+      const mediaType = multiCamOpenType.value === VideoType ? VideoType : ImageSequenceType;
       return {
         jsonMeta: {
-          originalImageFiles: files.map((file) => file.name),
+          originalImageFiles: mediaFileNamesForImport(files, mediaType),
         },
         globPattern: '',
         mediaConvertList: [],
@@ -463,19 +484,28 @@ export default defineComponent({
           .filter((name) => args.sourceList[name])
           .map((name) => [name, args.sourceList[name]] as const);
         const totalCameras = cameraEntries.length;
+        // Collect files the server accepted-but-ignored per camera so they can be
+        // surfaced before navigation — no selected file is silently dropped.
+        const ignoredAcrossCameras: { camera: string; name: string; reason: string }[] = [];
 
         for (let i = 0; i < cameraEntries.length; i += 1) {
           const [cameraName, source] = cameraEntries[i];
-          let files = flattenUploadFiles(getFilesForSourceKey(source.sourcePath) ?? []);
+          let folderFiles = getFilesForSourceKey(source.sourcePath) ?? [];
           if (source.glob) {
             // Cameras sharing one folder (per-modality suffixes) upload only their glob's files
-            files = files.filter((file) => filterByGlob(source.glob as string, [file.name]).length === 1);
+            folderFiles = folderFiles.filter((file) => filterByGlob(source.glob as string, [file.name]).length === 1);
           }
-          if (!files?.length) {
+          if (!folderFiles.length) {
             throw new Error(`No media files found for camera "${cameraName}"`);
           }
+          // Flatten before validation so the names the server validates match the
+          // names uploaded to Girder.
+          const { files: cameraFiles, replaced } = getCameraPackageFiles(
+            folderFiles,
+            source.trackFile,
+          );
           // eslint-disable-next-line no-await-in-loop -- validate then upload each camera sequentially
-          const validation = (await validateUploadGroup(files.map((f) => f.name))).data;
+          const validation = (await validateUploadGroup(cameraFiles.map((f) => f.name))).data;
           if (!validation.ok) {
             throw new Error(validation.message || `Invalid files for camera "${cameraName}"`);
           }
@@ -485,18 +515,25 @@ export default defineComponent({
           if (!compatibleTypes.has(uploadType)) {
             throw new Error(`Camera "${cameraName}" must use ${cameraType} media`);
           }
-          const mediaList = files.filter((file) => validation.media.includes(file.name));
-          const annotationFile = source.trackFile
-            ? getAnnotationFile(source.trackFile)
-            : undefined;
+          // Server validation is the authority: upload exactly what it accepted,
+          // which includes validated camera-folder sidecars and annotation/config
+          // files, not just validation.roles.media.
+          const uploadFiles = acceptedUploadFiles(cameraFiles, validation);
+          validationIgnoredFiles(validation).forEach((entry) => ignoredAcrossCameras.push({
+            camera: cameraName, name: entry.name, reason: entry.reason,
+          }));
+          replaced.forEach((entry) => ignoredAcrossCameras.push({
+            camera: cameraName,
+            name: entry.name,
+            reason: 'a different file you chose for this camera has the same name',
+          }));
           trackMulticamCameraUploadProgress(i, totalCameras, cameraName);
           // eslint-disable-next-line no-await-in-loop
           const { folder, jobIds } = await uploadComponent.uploadCameraDataset({
             name: cameraName,
             fps,
             type: uploadType,
-            mediaList,
-            annotationFile: annotationFile ?? null,
+            uploadFiles,
             skipTranscoding: true,
             parentFolderId: datasetFolder._id,
           });
@@ -594,6 +631,19 @@ export default defineComponent({
           await prompt({
             title: 'Registration Warnings',
             text: registrationSeed.warnings,
+            positiveButton: 'OK',
+          });
+        }
+
+        if (ignoredAcrossCameras.length) {
+          await prompt({
+            title: 'Some files were not uploaded',
+            text: [
+              'These selected files were not needed for the dataset and were left out:',
+              ...ignoredAcrossCameras.map(
+                (entry) => `${entry.camera}: ${entry.name} — ${entry.reason}`,
+              ),
+            ],
             positiveButton: 'OK',
           });
         }
@@ -732,9 +782,51 @@ export default defineComponent({
     const getFilenameInputValue = (pendingUpload: PendingUpload) => (
       pendingUpload.createSubFolders && pendingUpload.type !== 'zip' ? 'default' : pendingUpload.name
     );
+    /**
+     * Rebuild every non-zip row's validated media/annotation/config package from its
+     * (possibly edited) slots, then start the shared Girder upload. The server stays the
+     * authority for those roles; the metadata attachment is uploaded separately.
+     */
+    const prepAndUpload = async (uploadFn: () => Promise<void>) => {
+      // Validation is an awaited round-trip, so without this gate a second click starts the
+      // whole upload again before the first one has set any row's `uploading` flag.
+      if (preparing.value || uploading.value) {
+        return;
+      }
+      preparing.value = true;
+      preUploadErrorMessage.value = null;
+      try {
+        for (let i = 0; i < pendingUploads.value.length; i += 1) {
+          const pendingUpload = pendingUploads.value[i];
+          if (pendingUpload.type !== 'zip') {
+            const slotFiles = slotFileList(pendingUpload);
+            // eslint-disable-next-line no-await-in-loop -- validate each row before upload
+            const validation = (await validateUploadGroup(slotFiles.map((f) => f.name))).data;
+            if (!validation.ok) {
+              pendingUpload.error = validation.message || 'Upload validation failed';
+              return;
+            }
+            pendingUpload.error = null;
+            // A row rejected on pick has no name yet; name it now that the user's
+            // correction validates, so it never uploads into an unnamed folder.
+            if (!pendingUpload.name) {
+              pendingUpload.name = defaultRowName(validation);
+            }
+            pendingUpload.createSubFolders = fansOutToSubFolders(validation);
+            pendingUpload.uploadFiles = acceptedUploadFiles(slotFiles, validation);
+            pendingUpload.ignored = rowIgnoredFiles(pendingUpload, validation);
+          }
+        }
+        await uploadFn();
+      } catch (err) {
+        preUploadErrorMessage.value = err.response?.data?.message || err.message || String(err);
+      } finally {
+        preparing.value = false;
+      }
+    };
     const remove = (pendingUpload: PendingUpload) => {
-      const index = pendingUploads.value.indexOf(pendingUpload);
-      pendingUploads.value.splice(index, 1);
+      // Identity, not index: a row retired twice must never take a different row with it.
+      pendingUploads.value = pendingUploads.value.filter((row) => row !== pendingUpload);
     };
     function close() {
       emit('close');
@@ -788,15 +880,14 @@ export default defineComponent({
       girderUpload,
       multicamImporting,
       multicamImportProgress,
+      preparing,
       uploading,
       clientSettings,
       //methods
       close,
       closeMultiCamBatchDialog,
       openImport,
-      processImport,
       openMultiCamDialog,
-      filterFileUpload,
       multiCamImportCheck,
       multiCamImport,
       chooseAndScanBatch,
@@ -809,7 +900,9 @@ export default defineComponent({
       getFilenameInputValue,
       getFilenameInputStateDisabled,
       getFilenameInputStateHint,
-      addPendingUpload,
+      filterFileUpload,
+      mediaSlotAccept,
+      prepAndUpload,
       remove,
       abort,
       errorHandler,
@@ -961,7 +1054,24 @@ export default defineComponent({
                 </v-btn>
               </v-col>
             </v-row>
-            <v-row v-if="!pendingUpload.createSubFolders && pendingUpload.type !== 'zip'">
+            <v-alert
+              v-if="pendingUpload.error"
+              dense
+              outlined
+              type="error"
+              class="mt-2 mb-0 text-body-2"
+            >
+              {{ pendingUpload.error }}
+            </v-alert>
+            <!--
+              mt-3 states the gap outright instead of relying on Vuetify's `.row + .row` rule: the
+              error alert and the ignored-file list sit between these rows, and when either renders
+              the row falls back to the base -12px and rides up over it.
+            -->
+            <v-row
+              v-if="!pendingUpload.createSubFolders && pendingUpload.type !== 'zip'"
+              class="mt-3"
+            >
               <v-col class="py-0 mx-2">
                 <v-row>
                   <v-file-input
@@ -983,7 +1093,7 @@ export default defineComponent({
                           : 'Tiled Image files'
                     "
                     :rules="[val => (val || '').length > 0 || 'Media Files are required']"
-                    :accept="filterFileUpload(pendingUpload.type)"
+                    :accept="mediaSlotAccept(pendingUpload)"
                   />
                 </v-row>
                 <v-row>
@@ -1000,7 +1110,7 @@ export default defineComponent({
                 </v-row>
                 <v-row>
                   <v-file-input
-                    v-model="pendingUpload.meta"
+                    v-model="pendingUpload.configFile"
                     show-size
                     counter
                     label="Configuration File (Optional)"
@@ -1047,9 +1157,38 @@ export default defineComponent({
                   If skipping fails it will fallback to transcoding.</span>
               </v-tooltip>
             </v-row>
-            <span v-if="uploading">
+            <!--
+              Below the slots, where it reads as the remainder of the selection the slot counts
+              above do not account for. mt-3 clears the negative bottom margin the row above ends on.
+            -->
+            <div
+              v-if="pendingUpload.ignored.length"
+              class="mx-4 mt-3"
+            >
+              <div class="text-caption warning--text">
+                Ignored (not uploaded):
+              </div>
+              <div
+                v-for="(ignoredFile, ignoredIndex) in pendingUpload.ignored"
+                :key="`${ignoredIndex}-${ignoredFile.name}`"
+                class="text-caption grey--text"
+              >
+                {{ ignoredFile.name }} ({{ ignoredFile.reason }})
+              </div>
+            </div>
+            <!-- mt-3 clears the negative bottom margin the row above ends on. -->
+            <div
+              v-if="uploading"
+              class="mx-4 mt-3 text-body-2 d-flex align-center"
+            >
+              <v-progress-circular
+                indeterminate
+                size="16"
+                width="2"
+                class="mr-2"
+              />
               {{ computeUploadProgress(pendingUpload) }}
-            </span>
+            </div>
           </v-card>
           <div>
             <v-list>
@@ -1119,12 +1258,12 @@ export default defineComponent({
           </div>
           <v-btn
             v-if="pendingUploads.length"
-            :disabled="uploading"
+            :disabled="uploading || preparing"
             block
             large
             color="primary"
             class="my-6"
-            @click="upload"
+            @click="prepAndUpload(upload)"
           >
             <v-icon class="pr-3">
               mdi-upload

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -29,7 +29,7 @@ import {
   deleteResources,
   saveConfig,
   uploadCalibrationItem,
-  uploadConfigFileItem,
+  uploadMetadataFileItem,
   validateUploadGroup,
   waitForFolderDatasetReady,
 } from 'platform/web-girder/api';
@@ -636,7 +636,7 @@ export default defineComponent({
               'Metadata file was not found. Use "Choose metadata" in the import dialog to select the file again.',
             );
           }
-          metadataFileId = await uploadConfigFileItem(datasetFolder._id, metadataFile);
+          metadataFileId = await uploadMetadataFileItem(datasetFolder._id, metadataFile);
         }
 
         const subType = stereo.value ? 'stereo' : 'multicam';

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -179,29 +179,6 @@ function defaultRowName(validation: ValidationResponse, folderHint?: string): st
 }
 
 /**
- * webkitdirectory includes nested files; single-camera import only uses the selected folder's
- * immediate children (desktop readdir parity). Nested collects belong to MultiCam Batch.
- */
-function topLevelDirectoryFiles(files: File[]): File[] {
-  const withRelative = files.filter((file) => file.webkitRelativePath);
-  if (!withRelative.length) {
-    return files;
-  }
-  return files.filter((file) => {
-    const parts = (file.webkitRelativePath || file.name).replace(/\\/g, '/').split('/').filter(Boolean);
-    return parts.length === 2;
-  });
-}
-
-function directoryFolderName(files: File[]): string | undefined {
-  const relative = files.find((file) => file.webkitRelativePath)?.webkitRelativePath;
-  if (!relative) {
-    return undefined;
-  }
-  return relative.replace(/\\/g, '/').split('/').filter(Boolean)[0];
-}
-
-/**
  * Every picked file this row will not upload, with the reason: what the server ignored, and
  * what had no slot to go in.
  */
@@ -387,31 +364,20 @@ export default defineComponent({
      * validation, which is what classifies the files.
      */
     const openImport = async (dstype: DatasetType | 'zip') => {
-      // Image-sequence / large-image match desktop: open a directory, not a multi-file picker.
-      // Directory mode also clears accept so multi-dot frame names are not filtered out.
-      const useDirectory = dstype === ImageSequenceType || dstype === LargeImageType;
-      const ret = await openFromDisk(dstype, useDirectory);
+      // Multi-file picker (not directory): web uploads an explicit selection. Multi-dot frame
+      // names are kept selectable via getImageSequenceFileAccept() in openFromDisk.
+      const ret = await openFromDisk(dstype);
       if (ret.canceled || !ret.fileList || ret.fileList.length === 0) {
-        return;
-      }
-      const allFiles = useDirectory ? topLevelDirectoryFiles(ret.fileList) : ret.fileList;
-      if (!allFiles.length) {
-        preUploadErrorMessage.value = 'No files found in the selected folder.';
         return;
       }
       preUploadErrorMessage.value = null;
       try {
         if (dstype === 'zip') {
-          const name = allFiles.length === 1 ? allFiles[0].name : '';
-          addPendingZipUpload(name, allFiles);
+          const name = ret.fileList.length === 1 ? ret.fileList[0].name : '';
+          addPendingZipUpload(name, ret.fileList);
         } else {
           const suggestedFps = dstype === 'image-sequence' || dstype === 'large-image' ? 1 : undefined;
-          await addPendingUpload(
-            allFiles,
-            suggestedFps,
-            dstype,
-            useDirectory ? directoryFolderName(allFiles) : undefined,
-          );
+          await addPendingUpload(ret.fileList, suggestedFps, dstype);
         }
       } catch (err) {
         preUploadErrorMessage.value = err.response?.data?.message || err;

--- a/client/platform/web-girder/views/UploadGirder.spec.ts
+++ b/client/platform/web-girder/views/UploadGirder.spec.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+/* eslint-disable import/no-extraneous-dependencies */
+import { mount } from '@vue/test-utils';
+import Vue from 'vue';
+
+import { describe, expect, it } from 'vitest';
+
+import UploadGirder from './UploadGirder.vue';
+
+Vue.config.ignoredElements = [/^v-/];
+
+describe('UploadGirder row retirement', () => {
+  it('names the row to remove so the parent never retires a different one', () => {
+    const rows = [{ name: 'first' }, { name: 'second' }];
+    const wrapper = mount(UploadGirder, {
+      propsData: {
+        location: { _id: 'folder-id', _modelType: 'folder' },
+        pendingUploads: rows,
+      },
+      provide: { girderRest: {} },
+    });
+
+    wrapper.vm.remove(rows[0]);
+
+    // An index payload would land on the parent's `remove(pendingUpload)` as a number,
+    // whose indexOf is -1, retiring the last queued row instead.
+    expect(wrapper.emitted('remove-upload')).toEqual([[rows[0]]]);
+  });
+});

--- a/client/platform/web-girder/views/UploadGirder.vue
+++ b/client/platform/web-girder/views/UploadGirder.vue
@@ -8,7 +8,7 @@ import {
 } from 'platform/web-girder/constants';
 
 import {
-  makeViameFolder, postProcess, uploadConfigFileItem, setDatasetConfigdataFile,
+  makeViameFolder, postProcess, uploadMetadataFileItem, setDatasetMetadataFile,
 } from 'platform/web-girder/api';
 import { GirderUploadManager } from 'platform/web-girder/utils';
 
@@ -117,8 +117,8 @@ export default Vue.extend({
         if (folder) {
           await this.uploadFiles(pendingUpload.name, folder, files, uploaded, skipTranscoding);
           if (metadataFile) {
-            const itemId = await uploadConfigFileItem(folder._id, metadataFile);
-            await setDatasetConfigdataFile(folder._id, itemId);
+            const itemId = await uploadMetadataFileItem(folder._id, metadataFile);
+            await setDatasetMetadataFile(folder._id, itemId);
           }
           this.remove(pendingUpload);
         }

--- a/client/platform/web-girder/views/UploadGirder.vue
+++ b/client/platform/web-girder/views/UploadGirder.vue
@@ -8,7 +8,7 @@ import {
 } from 'platform/web-girder/constants';
 
 import {
-  makeViameFolder, postProcess, uploadMetadataFileItem, setDatasetMetadataFile,
+  makeViameFolder, postProcess, uploadConfigFileItem, setDatasetConfigdataFile,
 } from 'platform/web-girder/api';
 import { GirderUploadManager } from 'platform/web-girder/utils';
 
@@ -117,8 +117,8 @@ export default Vue.extend({
         if (folder) {
           await this.uploadFiles(pendingUpload.name, folder, files, uploaded, skipTranscoding);
           if (metadataFile) {
-            const itemId = await uploadMetadataFileItem(folder._id, metadataFile);
-            await setDatasetMetadataFile(folder._id, itemId);
+            const itemId = await uploadConfigFileItem(folder._id, metadataFile);
+            await setDatasetConfigdataFile(folder._id, itemId);
           }
           this.remove(pendingUpload);
         }

--- a/client/platform/web-girder/views/UploadGirder.vue
+++ b/client/platform/web-girder/views/UploadGirder.vue
@@ -46,8 +46,7 @@ export default Vue.extend({
       this.$emit('abort');
     },
     remove(pendingUpload) {
-      const index = this.pendingUploads.indexOf(pendingUpload);
-      this.$emit('remove-upload', index);
+      this.$emit('remove-upload', pendingUpload);
     },
     async upload() {
       if (this.location._modelType !== 'folder') {
@@ -70,9 +69,15 @@ export default Vue.extend({
           break;
         }
       }
-      if (!error) {
-        this.$emit('update:uploading', false);
+      if (error) {
+        // Reset failed/interrupted rows so the dialog recovers: the progress
+        // spinner stops and each row's controls (remove, FPS) re-enable.
+        pendingUplodsCopy.forEach((pendingUpload) => {
+          // eslint-disable-next-line no-param-reassign
+          pendingUpload.uploading = false;
+        });
       }
+      this.$emit('update:uploading', false);
     },
     convertFileToInternal(file) {
       if (file === null) {
@@ -92,14 +97,12 @@ export default Vue.extend({
     },
     async uploadPending(pendingUpload, uploaded) {
       const {
-        name, createSubFolders, meta, annotationFile, mediaList, metadataFile,
+        name, createSubFolders, uploadFiles, metadataFile,
       } = pendingUpload;
-      //Combine the files for uploading. The optional metadata file is uploaded
-      //separately (as a marked item) so postprocess does not classify it.
-      let files = mediaList.map((item) => this.convertFileToInternal(item));
-      files.push(this.convertFileToInternal(meta));
-      files.push(this.convertFileToInternal(annotationFile));
-      files = files.filter((item) => item !== null);
+      // The validated package is the only source of files to upload.
+      const files = uploadFiles
+        .map(this.convertFileToInternal)
+        .filter((item) => item !== null);
       // eslint-disable-next-line no-param-reassign
       pendingUpload.files = files;
       const fps = parseInt(pendingUpload.fps, 10);
@@ -180,13 +183,12 @@ export default Vue.extend({
      * Upload a single camera dataset folder (used by multicam import).
      */
     async uploadCameraDataset({
-      name, fps, type, mediaList, meta = null, annotationFile = null, skipTranscoding = true,
-      parentFolderId = null,
+      name, fps, type, uploadFiles, skipTranscoding = true, parentFolderId = null,
     }) {
-      let files = mediaList.map((item) => this.convertFileToInternal(item));
-      files.push(this.convertFileToInternal(meta));
-      files.push(this.convertFileToInternal(annotationFile));
-      files = files.filter((item) => item !== null);
+      // The validated package is the only source of files to upload for the camera.
+      const files = uploadFiles
+        .map(this.convertFileToInternal)
+        .filter((item) => item !== null);
       const folder = await this.createUploadFolder(name, parseInt(fps, 10), type, parentFolderId);
       if (!folder) {
         throw new Error(`Failed to create folder for camera ${name}`);

--- a/client/src/components/controls/Controls.vue
+++ b/client/src/components/controls/Controls.vue
@@ -73,7 +73,7 @@ export default defineComponent({
     const { frameRate } = useTime();
     const { visible } = usePrompt();
     const trackFilters = useTrackFilters();
-    const { saveMetadata } = useApi();
+    const { saveConfig } = useApi();
     const datasetId = useDatasetId();
     const activeLockedCamera = ref(false);
     const activeTimeFilter = ref(false);
@@ -131,7 +131,7 @@ export default defineComponent({
     const timeFilterMax = computed(() => trackFilters.timeFilters.value?.[1] ?? mediaController.maxFrame.value);
 
     function saveTimeFilter() {
-      saveMetadata(datasetId.value, { timeFilters: trackFilters.timeFilters.value });
+      saveConfig(datasetId.value, { timeFilters: trackFilters.timeFilters.value });
     }
 
     function handleTimeFilterClick() {

--- a/client/src/components/controls/Timeline.vue
+++ b/client/src/components/controls/Timeline.vue
@@ -38,7 +38,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const trackFilters = useTrackFilters();
     const { frameRate } = useTime();
-    const { saveMetadata } = useApi();
+    const { saveConfig } = useApi();
     const datasetId = useDatasetId();
 
     const init = ref(!!props.maxFrame || 1);
@@ -324,7 +324,7 @@ export default defineComponent({
         draggingTimeFilter.value = null;
         dragTooltipFrame.value = null;
         dragTooltipPosition.value = null;
-        saveMetadata(datasetId.value, { timeFilters: trackFilters.timeFilters.value });
+        saveConfig(datasetId.value, { timeFilters: trackFilters.timeFilters.value });
         return;
       }
       if (dragging.value) {
@@ -393,7 +393,7 @@ export default defineComponent({
         draggingTimeFilter.value = null;
         dragTooltipFrame.value = null;
         dragTooltipPosition.value = null;
-        saveMetadata(datasetId.value, { timeFilters: trackFilters.timeFilters.value });
+        saveConfig(datasetId.value, { timeFilters: trackFilters.timeFilters.value });
       }
     }
 

--- a/docs/Dive-Desktop.md
+++ b/docs/Dive-Desktop.md
@@ -59,9 +59,9 @@ Click either ==Open Image Sequence :material-folder-open:== or ==Open Video :mat
 * ==:material-camera-burst: Multi-Cam== will prompt you to describe the multi-cam configuration by naming several cameras and picking the source media for each.
 * ==:material-folder-multiple-image: MultiCam Batch== will prompt you to choose a root folder of **collect** subfolders and import one multicam image-sequence dataset per collect. See [Batch multicam import](Multicamera-data.md#batch-multicam-import) for the expected folder layout.
 
-The import routine will look for `.csv` and `.json` files in the same directory as the source media, and you will be prompted to manually select an annotation file and a **Configuration File** (DIVE JSON). Neither is required.
+The import routine will look for `.csv` and `.json` files in the same directory as the source media, and you will be prompted to manually select an annotation file and a **Configuration File** (DIVE JSON, sometimes named `*.meta.json` or `*.config.json`). Neither is required.
 
-Advanced options also include an optional **Metadata File** (`.json`, `.txt`, or `.csv`) — a pipeline sidecar such as a flight log. This is **not** the same as the Configuration File: DIVE does not parse it, and only pipelines that declare `# Metadata File:` receive it at run time. Metadata can be attached on single-camera, stereo, and multicam imports. See [Pipe file headers](Pipeline-Import-Export.md#pipe-file-headers).
+Advanced options also include an optional **Metadata File** (`.json`, `.txt`, or `.csv`) — a pipeline sidecar such as a flight log. This is **not** the same as the Configuration File: DIVE does not parse it, and only pipelines that declare `# Metadata File:` receive it at run time. Metadata can be attached on single-camera, stereo, and multicam imports. See [Metadata File vs Configuration File](Pipeline-Import-Export.md#metadata-file-vs-configuration-file).
 
 ### Launching from the command line
 
@@ -185,15 +185,16 @@ VIAME_DATA
    ├── fish_training_data_c_jp7hq88vfv
    │  ├── auxiliary
    │  │  └── result_06-01-2021_10-55-38.627.json
-   │  ├── meta.json
+   │  ├── config.json
    │  └── result_06-01-2021_04-53-38.050.json
    └── scallop_2_jrgdq760gu
       ├── auxiliary
       │  └── result_06-01-2021_10-54-56.034.json
-      ├── meta.json
+      ├── config.json
       └── result_06-01-2021_11-02-35.857.json
 ```
 
+Existing datasets that still have `meta.json` are read normally; the next save migrates them to `config.json` and removes the legacy file.
 ### Configuration with env
 
 DIVE Desktop looks for the these environment variables on launch.

--- a/docs/Dive-Desktop.md
+++ b/docs/Dive-Desktop.md
@@ -185,16 +185,18 @@ VIAME_DATA
    ├── fish_training_data_c_jp7hq88vfv
    │  ├── auxiliary
    │  │  └── result_06-01-2021_10-55-38.627.json
-   │  ├── config.json
+   │  ├── dataset.json
    │  └── result_06-01-2021_04-53-38.050.json
    └── scallop_2_jrgdq760gu
       ├── auxiliary
       │  └── result_06-01-2021_10-54-56.034.json
-      ├── config.json
+      ├── dataset.json
       └── result_06-01-2021_11-02-35.857.json
 ```
 
-Existing datasets that still have `meta.json` are read normally; the next save migrates them to `config.json` and removes the legacy file.
+Each project folder stores a `dataset.json` with desktop-specific dataset state (media paths, ids, transcodes, multicam layout, …). This is separate from the portable **Configuration File** (`config.json`) used on import/export for attributes, styles, FPS, and related settings.
+
+Existing datasets that still have `meta.json` in the project folder are read normally; the next save migrates them to `dataset.json` and removes the legacy file.
 ### Configuration with env
 
 DIVE Desktop looks for the these environment variables on launch.

--- a/docs/Multicamera-data.md
+++ b/docs/Multicamera-data.md
@@ -35,7 +35,7 @@ Multicam import is available from the standard upload dialog on [viame.kitware.c
     * ==:material-folder-multiple-image: MultiCam Batch== — import many multicam datasets at once from a folder of **collect** subfolders (image sequences only). See [Batch multicam import](#batch-multicam-import).
 6. In the import dialog, assign a source folder or video file to each camera. All cameras must use the same media type (all image sequences or all videos). By default, every camera must have the same number of frames (or matching video duration). For **image-sequence** imports with capture timestamps in filenames, enable **Infer frame index from filename** to allow unequal per-camera counts — see [Infer frame index from filename](#infer-frame-index-from-filename).
 7. Optionally attach a per-camera annotation file during import.
-8. Optionally attach a **Metadata File** (`.json`, `.txt`, or `.csv`) — for example a flight log used by registration pipelines. This is **not** stereo-only and is independent of the calibration file. See [Pipe file headers](Pipeline-Import-Export.md#pipe-file-headers).
+8. Optionally attach a **Metadata File** (`.json`, `.txt`, or `.csv`) — for example a flight log used by registration pipelines. This is **not** stereo-only and is independent of the calibration file. See [Metadata File vs Configuration File](Pipeline-Import-Export.md#metadata-file-vs-configuration-file).
 9. Enter a dataset name, choose the default display camera, and click ==Begin Import==.
 10. When upload finishes, DIVE opens the new multicam dataset in the annotator.
 

--- a/docs/Pipeline-Import-Export.md
+++ b/docs/Pipeline-Import-Export.md
@@ -82,8 +82,8 @@ These are different files with different jobs:
 
 | Import field | What it is | Consumed by |
 | ------------ | ---------- | ----------- |
-| **Configuration File** | DIVE JSON (`meta` / attributes, styles, FPS, …) | DIVE itself |
-| **Metadata File** | Opaque sidecar (`.json`, `.txt`, or `.csv`), e.g. a UAV flight log | Only pipelines that declare `# Metadata File:` |
+| **Configuration File** (`config`) | DIVE JSON (`config.json`, or legacy `meta.json` / `*.meta.json` / `*.config.json`: attributes, styles, FPS, …) | DIVE itself |
+| **Metadata File** (`metadata`) | Opaque sidecar (`.json`, `.txt`, or `.csv`), e.g. a UAV flight log | Only pipelines that declare `# Metadata File:` |
 
 DIVE does **not** auto-discover a flight log in the media folder — the user must pick it at import (UI or CLI `--metadata`). The file format is opaque to DIVE; the KWIVER process behind the pipe owns the schema. Metadata is available on **single-camera and multicamera** imports alike; it is not stereo-gated (unlike calibration).
 

--- a/docs/Pipeline-Import-Export.md
+++ b/docs/Pipeline-Import-Export.md
@@ -85,6 +85,10 @@ These are different files with different jobs:
 | **Configuration File** (`config`) | DIVE JSON (`config.json`, or legacy `meta.json` / `*.meta.json` / `*.config.json`: attributes, styles, FPS, …) | DIVE itself |
 | **Metadata File** (`metadata`) | Opaque sidecar (`.json`, `.txt`, or `.csv`), e.g. a UAV flight log | Only pipelines that declare `# Metadata File:` |
 
+!!! note "Desktop project store vs Configuration File"
+
+    On DIVE Desktop, each imported dataset also has a `dataset.json` under `DIVE_Projects/` that records media paths and other local project state. That file is not portable and is not the Configuration File described here.
+
 DIVE does **not** auto-discover a flight log in the media folder — the user must pick it at import (UI or CLI `--metadata`). The file format is opaque to DIVE; the KWIVER process behind the pipe owns the schema. Metadata is available on **single-camera and multicamera** imports alike; it is not stereo-gated (unlike calibration).
 
 !!! note

--- a/docs/Web-Version.md
+++ b/docs/Web-Version.md
@@ -27,7 +27,7 @@ A user account is required to store data and run pipelines on viame.kitware.com.
 * Select a video or multi-select a group of image frames.
     * Use ++ctrl++ or ++shift++ to click every file you want to upload.
     * If you already have `annotations.csv` or an annotation or configuration JSON select that too.
-    * Optionally select a **Metadata File** (`.json`, `.txt`, or `.csv`) such as a flight log. This is separate from the DIVE configuration JSON; only pipelines that declare `# Metadata File:` use it. See [Pipe file headers](Pipeline-Import-Export.md#pipe-file-headers).
+    * Optionally select a **Metadata File** (`.json`, `.txt`, or `.csv`) such as a flight log. This is separate from the DIVE **Configuration File** JSON; only pipelines that declare `# Metadata File:` use it. See [Metadata File vs Configuration File](Pipeline-Import-Export.md#metadata-file-vs-configuration-file).
     * Uploads that contain only `.tif` / `.tiff` files are classified as [large-image](Large-Image-Support.md) datasets rather than image sequences.
 * Choose a name for the dataset and enter the optional playback frame rate or select other optional files.
 * Press ==Start Upload==

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -1447,57 +1447,100 @@ def create_multicam(
     return parent_folder_doc
 
 
+UNSUPPORTED_SIDE_FILE_REASON = "Unsupported side file"
+
+
 def validate_files(files: List[str]):
     """
-    Given a collection of filenames, guess based on regular expressions
-    if the collection represents a valid dataset, and if so, which files
-    represent which type of data
+    Given a collection of filenames, classify each into a semantic upload role.
+
+    Every filename appears under exactly one key of ``roles``; files that are not needed get
+    the ``ignored`` role, and ``reasons`` maps a filename to why it landed there. Only the
+    interactive browser upload honours the per-file drop, uploading the selection minus
+    ``roles['ignored']`` so nothing is discarded without a reason the user can see. The
+    girder-worker zip path (``dive_tasks.utils.upload_zipped_flat_media_files``) uses this as a
+    whole-archive gate and then uploads every extracted file.
+
+    ``type`` is present only when ``ok``: a rejected selection has no single media type.
     """
-    ok = True
-    message = ""
-    mediatype = ""
     videos = [f for f in files if constants.videoRegex.search(f)]
-    csvs = [f for f in files if constants.csvRegex.search(f)]
     images = [f for f in files if constants.imageRegex.search(f)]
     large_images = [f for f in files if constants.largeImageRegEx.search(f)]
-    ymls = [f for f in files if constants.ymlRegex.search(f)]
-    jsons = [f for f in files if constants.jsonRegex.search(f)]
+    media = images + videos + large_images
+
+    # Dataset config JSON follows the same meta/config filename contract as the client's
+    # JsonMetaRegEx; annotation JSON is every other .json.
+    dataset_config = [
+        f for f in files if constants.jsonRegex.search(f) and constants.metaRegex.search(f)
+    ]
+    dataset_config_set = set(dataset_config)
+
+    annotation_csvs = [f for f in files if constants.csvRegex.search(f)]
+    annotation_ymls = [f for f in files if constants.ymlRegex.search(f)]
+    annotation_jsons = [
+        f for f in files if constants.jsonRegex.search(f) and f not in dataset_config_set
+    ]
+    annotations = annotation_csvs + annotation_ymls + annotation_jsons
+
+    if len(videos):
+        mediatype = constants.VideoType
+    elif len(images):
+        mediatype = constants.ImageSequenceType
+    elif len(large_images):
+        mediatype = constants.LargeImageType
+    else:
+        mediatype = ""
+
+    ok = True
+    message = ""
     if len(videos) and (len(images) or len(large_images)):
         ok = False
         message = "Do not upload images and videos in the same batch."
     elif len(large_images) and len(images):
         ok = False
         message = "Do not upload images and tile images in the same batch."
-    elif len(csvs) > 1:
+    elif len(annotation_csvs) > 1:
         ok = False
         message = "Can only upload a single CSV Annotation per import"
-    elif len(jsons) > 2:
+    elif len(dataset_config) > 1:
         ok = False
-        message = (
-            "Can only upload a single JSON Annotation and single configuration JSON per import"
-        )
-    elif len(csvs) == 1 and len(ymls):
+        message = "Can only upload a single configuration JSON per import"
+    elif len(annotation_jsons) > 1:
+        ok = False
+        message = "Can only upload a single annotation JSON per import"
+    elif len(annotation_csvs) and len(annotation_ymls):
         ok = False
         message = "Cannot mix annotation import types"
-    elif len(videos) > 1 and (len(csvs) or len(ymls) or len(jsons)):
+    elif len(annotation_ymls) > 1:
+        ok = False
+        message = "Can only upload a single YAML Annotation per import"
+    elif len(annotation_csvs) + len(annotation_ymls) + len(annotation_jsons) > 1:
+        # Multiple annotation sources across formats (e.g. CSV + JSON) would silently
+        # overwrite each other at import, so only one annotation source is allowed.
+        ok = False
+        message = "Cannot mix annotation import types"
+    elif len(videos) > 1 and (len(annotations) or len(dataset_config)):
         ok = False
         message = "Annotation upload is not supported when multiple videos are uploaded"
-    elif (not len(videos)) and (not len(images)) and (not len(large_images)):
+    elif not (len(videos) or len(images) or len(large_images)):
         ok = False
         message = "No supported media-type files found"
-    elif len(videos):
-        mediatype = constants.VideoType
-    elif len(images):
-        mediatype = constants.ImageSequenceType
-    elif len(large_images):
-        mediatype = constants.LargeImageType
+
+    accepted = set(media) | set(annotations) | set(dataset_config)
+    ignored = [f for f in files if f not in accepted]
 
     return {
         "ok": ok,
+        # Only an accepted selection has a media type.
+        **({"type": mediatype} if ok else {}),
         "message": message,
-        "type": mediatype,
-        "media": images + videos + large_images,
-        "annotations": csvs + ymls + jsons,
+        "roles": {
+            "media": media,
+            "annotations": annotations,
+            "datasetConfig": dataset_config,
+            "ignored": ignored,
+        },
+        "reasons": {f: UNSUPPORTED_SIDE_FILE_REASON for f in ignored},
     }
 
 

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -727,7 +727,7 @@ def _yield_single_dataset_export(
         annotations['tracks'] = updated_tracks
         yield json.dumps(annotations)
 
-    for data in z.addFile(makeMetajson, Path(f'{zip_path}meta.json')):
+    for data in z.addFile(makeMetajson, Path(f'{zip_path}{constants.ConfigFileName}')):
         yield data
 
     for data in z.addFile(makeDiveJson, Path(f'{zip_path}annotations.dive.json')):

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -350,8 +350,8 @@ def upload_zipped_flat_media_files(
     root_folderId = folderId
     default_fps = gc.getFolder(root_folderId).get(f"meta.{constants.FPSMarker}", -1)
     if validation.get('ok', False):
-        manager.write(f"Annotations: {validation['annotations']}\n")
-        manager.write(f"Media: {validation['media']}\n")
+        manager.write(f"Annotations: {validation['roles']['annotations']}\n")
+        manager.write(f"Media: {validation['roles']['media']}\n")
         dataset_type = validation['type']
         manager.write(f"Type: {dataset_type}\n")
         if create_subfolder != '':

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -439,11 +439,15 @@ def _load_exported_dataset_meta(working_directory: Path) -> dict:
     potential_meta_files = list(filter(constants.metaRegex.match, list_of_names))
     if len(potential_meta_files) == 0:
         raise ValueError('Could not find meta.json or config.json in exported dataset folder')
-    meta = {}
-    for meta_name in potential_meta_files:
-        with open(working_directory / meta_name) as f:
-            meta = json.load(f)
-    return meta
+    # Prefer config.json, then legacy meta.json, then any other *.meta/config.json match.
+    by_lower = {name.lower(): name for name in potential_meta_files}
+    chosen = (
+        by_lower.get(constants.ConfigFileName)
+        or by_lower.get(constants.LegacyConfigFileName)
+        or potential_meta_files[0]
+    )
+    with open(working_directory / chosen) as f:
+        return json.load(f)
 
 
 def _import_exported_dataset_directory(
@@ -622,7 +626,7 @@ def upload_exported_multicam_zipped_dataset(
     sub_type = parent_meta.get(constants.SubTypeMarker)
     if sub_type not in ('stereo', 'multicam'):
         raise Exception(
-            'Exported multicam dataset is missing subType "stereo" or "multicam" in meta.json'
+            'Exported multicam dataset is missing subType "stereo" or "multicam" in config.json'
         )
 
     parent_folder_id = folderId

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -152,8 +152,9 @@ TrainingOutputFolderName = "VIAME Training Results"
 SourceFolderName = "source"
 # The name of the auxiliary folder
 AuxiliaryFolderName = "auxiliary"
-# the name of the meta file
-MetaFileName = "meta.json"
+# the name of the configuration file (legacy meta.json is still accepted on read)
+ConfigFileName = "config.json"
+LegacyConfigFileName = "meta.json"
 # Exported multicam datasets include this file at the dataset root (see crud_dataset export).
 MultiCamJsonFileName = "multiCam.json"
 

--- a/server/scripts/commands_main.py
+++ b/server/scripts/commands_main.py
@@ -80,7 +80,7 @@ def convert_viame_csv(input: TextIO, output: TextIO, output_attrs: TextIO):
     '--meta',
     type=click.File('rt'),
     default=None,
-    help="Populate image list and fps from meta.json",
+    help="Populate image list and fps from config.json",
 )
 @click.option('--output', type=click.File('wt'), default='annotatiosn.viame.csv')
 @click.option(

--- a/server/tests/test_multicam_export_clone.py
+++ b/server/tests/test_multicam_export_clone.py
@@ -298,9 +298,9 @@ def test_export_multicam_integration_zip_paths(
         list(stream())
 
     assert 'stereo-dataset/multiCam.json' in zip_entries
-    assert 'stereo-dataset/meta.json' in zip_entries
-    assert 'stereo-dataset/left/meta.json' in zip_entries
-    assert 'stereo-dataset/right/meta.json' in zip_entries
+    assert 'stereo-dataset/config.json' in zip_entries
+    assert 'stereo-dataset/left/config.json' in zip_entries
+    assert 'stereo-dataset/right/config.json' in zip_entries
     multi_cam = json.loads(zip_entries['stereo-dataset/multiCam.json'].decode())
     assert multi_cam['defaultDisplay'] == 'left'
 

--- a/server/tests/test_validate_files.py
+++ b/server/tests/test_validate_files.py
@@ -1,5 +1,133 @@
-from dive_server import crud_dataset
+from dive_server.crud_dataset import UNSUPPORTED_SIDE_FILE_REASON, validate_files
 from dive_utils import constants
+
+
+def test_response_shape():
+    # `roles` is the single owner of what each file is for, ignored included, and the client
+    # uploads the selection minus that role.
+    result = validate_files(['image_0001.jpg', 'tracks.csv'])
+
+    assert set(result) == {"ok", "message", "type", "roles", "reasons"}
+    assert set(result["roles"]) == {"media", "annotations", "datasetConfig", "ignored"}
+
+
+def test_image_sequence_with_yaml_annotation():
+    result = validate_files(['image_0001.jpg', 'annotations.yml'])
+
+    assert result['ok'] is True
+    assert result['type'] == constants.ImageSequenceType
+    assert 'annotations.yml' in result['roles']['annotations']
+
+
+def test_image_sequence_with_plain_txt_is_ignored():
+    result = validate_files(['image_0001.jpg', 'notes.txt'])
+
+    assert result['ok'] is True
+    assert result['type'] == constants.ImageSequenceType
+    assert 'notes.txt' in result['roles']['ignored']
+    assert result['reasons']['notes.txt'] == UNSUPPORTED_SIDE_FILE_REASON
+    # The rest of the package is unaffected.
+    assert result['roles']['media'] == ['image_0001.jpg']
+
+
+def test_image_sequence_with_unsupported_extension_is_ignored():
+    result = validate_files(['image_0001.jpg', 'weird.xyz'])
+
+    assert result['ok'] is True
+    assert 'weird.xyz' in result['roles']['ignored']
+    assert result['reasons']['weird.xyz'] == UNSUPPORTED_SIDE_FILE_REASON
+
+
+def test_two_plain_annotation_csvs_are_rejected():
+    result = validate_files(['image_0001.jpg', 'a.csv', 'b.csv'])
+
+    assert result['ok'] is False
+    assert result['message'] == "Can only upload a single CSV Annotation per import"
+
+
+def test_image_sequence_with_config_json_is_dataset_config():
+    result = validate_files(['image_0001.jpg', 'meta.json'])
+
+    assert result['ok'] is True
+    assert 'meta.json' in result['roles']['datasetConfig']
+    assert 'meta.json' not in result['roles']['annotations']
+    assert 'meta.json' not in result['roles']['ignored']
+
+
+def test_annotation_json_and_config_json_are_distinguished():
+    result = validate_files(['image_0001.jpg', 'tracks.json', 'config.json'])
+
+    assert result['ok'] is True
+    assert 'config.json' in result['roles']['datasetConfig']
+    assert 'tracks.json' in result['roles']['annotations']
+    assert 'config.json' not in result['roles']['annotations']
+
+
+def test_every_role_is_populated_for_a_full_selection():
+    result = validate_files(['image_0001.jpg', 'tracks.csv', 'meta.json'])
+
+    assert result['ok'] is True
+    assert result['roles'] == {
+        'media': ['image_0001.jpg'],
+        'annotations': ['tracks.csv'],
+        'datasetConfig': ['meta.json'],
+        'ignored': [],
+    }
+    assert result['reasons'] == {}
+
+
+def test_images_and_videos_mixed_is_rejected():
+    result = validate_files(['image_0001.jpg', 'movie.mp4'])
+
+    assert result['ok'] is False
+    # A rejected selection carries no media type.
+    assert 'type' not in result
+    assert result['message'] == "Do not upload images and videos in the same batch."
+
+
+def test_csv_and_yaml_mixed_is_rejected():
+    result = validate_files(['image_0001.jpg', 'tracks.csv', 'config.yml'])
+
+    assert result['ok'] is False
+    assert result['message'] == "Cannot mix annotation import types"
+
+
+def test_csv_and_annotation_json_mixed_is_rejected():
+    # Two annotation sources of different formats would silently overwrite at import.
+    result = validate_files(['image_0001.jpg', 'tracks.csv', 'tracks.json'])
+
+    assert result['ok'] is False
+    assert result['message'] == "Cannot mix annotation import types"
+
+
+def test_yaml_and_annotation_json_mixed_is_rejected():
+    result = validate_files(['image_0001.jpg', 'tracks.yml', 'tracks.json'])
+
+    assert result['ok'] is False
+    assert result['message'] == "Cannot mix annotation import types"
+
+
+def test_multiple_videos_with_config_json_is_rejected():
+    # A single dataset-config JSON cannot apply to a multi-video (subfolder) upload.
+    result = validate_files(['a.mp4', 'b.mp4', 'config.json'])
+
+    assert result['ok'] is False
+    assert result['message'] == "Annotation upload is not supported when multiple videos are uploaded"
+
+
+def test_multiple_videos_without_annotations_is_allowed():
+    result = validate_files(['a.mp4', 'b.mp4'])
+
+    assert result['ok'] is True
+    assert result['type'] == constants.VideoType
+    assert result['roles']['media'] == ['a.mp4', 'b.mp4']
+
+
+def test_no_media_is_rejected():
+    result = validate_files(['tracks.csv'])
+
+    assert result['ok'] is False
+    assert result['message'] == "No supported media-type files found"
 
 
 def test_validate_files_tiff_as_large_image():
@@ -7,23 +135,43 @@ def test_validate_files_tiff_as_large_image():
         'kamera_2021_test_fl01_C_20210814_003347.198347_ir.tif',
         'kamera_2021_test_fl01_C_20210814_003353.208198_ir.tif',
     ]
-    result = crud_dataset.validate_files(files)
+    result = validate_files(files)
     assert result['ok'] is True
     assert result['type'] == constants.LargeImageType
-    assert result['media'] == files
+    assert result['roles']['media'] == files
 
 
 def test_validate_files_jpg_as_image_sequence():
     files = ['frame.jpg', 'frame2.jpg']
-    result = crud_dataset.validate_files(files)
+    result = validate_files(files)
     assert result['ok'] is True
     assert result['type'] == constants.ImageSequenceType
-    assert result['media'] == files
+    assert result['roles']['media'] == files
 
 
 def test_validate_files_nitf_remains_large_image():
     files = ['scene.nitf']
-    result = crud_dataset.validate_files(files)
+    result = validate_files(files)
     assert result['ok'] is True
     assert result['type'] == constants.LargeImageType
-    assert result['media'] == files
+    assert result['roles']['media'] == files
+
+
+def test_ignored_is_the_exact_complement_of_the_accepted_roles():
+    # The web client uploads the selection minus `ignored`, so a file that is neither given a
+    # role nor listed as ignored would silently not upload. Pin the partition over a selection
+    # that reaches every branch: media, annotations, dataset config, and two side files.
+    files = [
+        'image_0001.jpg',
+        'image_0002.jpg',
+        'tracks.csv',
+        'config.json',
+        'notes.md',
+        'thumbnail.png.bak',
+    ]
+
+    result = validate_files(files)
+
+    classified = [name for role in result['roles'].values() for name in role]
+    assert sorted(classified) == sorted(files)
+    assert set(result['reasons']) == set(result['roles']['ignored'])


### PR DESCRIPTION
First of a four-PR stack. Foundation only: no attachment semantics or frame metadata yet.

### Summary

Make server validation authoritative for the browser upload package.

<img width="655" height="816" alt="image" src="https://github.com/user-attachments/assets/5a4ef67b-8949-4d3d-9807-fef6ce6f3fb0" />

Upload validated one interpretation of the selected files, then rebuilt the package in the browser
with separate rules. The two could disagree: an accepted file could be dropped, an ignored file
could still upload, and ordinary and multicamera imports kept different side files.

`validate_files` now returns semantic `roles` (media, annotations, dataset configuration) plus
`ignored` with a per-file reason. The browser uploads the selection minus the ignored names — one
derivation, no second classifier, same contract for ordinary and multicamera camera-folder uploads.
Files that upload today still upload; a skipped file is now listed with its reason instead of
vanishing.

The per-role slots stay; their contents and meaning change. `processImport` is deleted and
`suggestUploadSlots` replaces it as a convenience split that is never trusted — slots are
re-validated at Start upload, and the server decides media type, folder name, fan-out, and what
uploads. A rejected selection now yields a row in an error state rather than a discarded pick,
since the slot editor is the only place to fix it without reopening the OS picker.

Four intentional behavior changes ride along:

- **The media file dialog offers every side file a slot can hold.** Its filter was built from the
  annotation extensions alone, so `.yml`, `.yaml`, `.json`, and `.csv` were selectable but `.txt`
  was not — the browser silently withheld a file the server would have classified, which is the
  drift this PR exists to remove. The filter is now the union of the annotation and metadata
  attachment extensions.
- **Response shape.** The flat `media`/`annotations` lists are replaced by `roles` + `ignored`. Both
  in-tree consumers (browser upload, girder-worker zip path) are updated here; external callers of
  this endpoint must adopt the new shape.
- **Stricter annotation multiplicity.** Five selections `main` accepted and then mishandled via
  silent last-write-wins or an ambiguous config pick are now rejected explicitly: two annotation
  JSONs, CSV + JSON, YAML + JSON, more than one YAML, two config JSONs. Everything else validates as
  before.
- **Row retirement.** `UploadGirder` emitted a row index while `Upload` expected the row object, so
  `splice(-1, 1)` retired the last queued row instead of the finished one. A pre-existing `main`
  bug, fixed here because per-row error state makes retiring the wrong row destructive.

The zip path is unchanged: validation gates the whole archive and every extracted file uploads. Only
interactive upload drops `ignored` files — the same files `main` already dropped, silently.

### Reviewer focus

- Server and browser classification cannot drift after validation, and the file dialog no longer
  pre-empts it by withholding a selectable side file.
- Ignored files stay visible below the pickers and never enter the upload request.
- Accepted packages behave as on `main`; the five new rejections are the intended change.
- Multicamera flattening preserves every server-approved file, including the annotation and config
  side files `main`'s media-only path dropped.
- When a camera-folder file and a separately picked file share a name, the picked file uploads and
  the displaced folder copy is reported as ignored. Re-picking the folder's own file displaces
  nothing.
- An edited slot changes what uploads: the package is rebuilt and re-validated at Start upload.
- An error row stays correctable — slots editable, media slot unfiltered (the row's type is only the
  import menu opened until the server confirms it), never uploads into an unnamed folder.

### Manual test

Uses `okeanos-upload-authority-ignore` from `okeanos-frame-metadata-fixtures.zip`, attached to this
PR — CC0 NOAA Okeanos Explorer media with synthetic metadata and annotations. Select all files in
the directory.

[okeanos-frame-metadata-fixtures.zip](https://github.com/user-attachments/files/30395261/okeanos-frame-metadata-fixtures.zip)


1. Select all 17 files; confirm the 16 JPEGs validate as image-sequence media.
2. Confirm `notes.txt` is listed under "Ignored (not uploaded)", below the pickers, with the
   unsupported-side-file reason.
3. Create and open the dataset: 16 frames, and `notes.txt` uploaded as neither media, annotation,
   nor dataset config.
4. Repeat through the folder/multicamera surface — identical ignored result and media set.
