### PR TITLE
allow downloading addons from google drive

### DIFF
--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -11,6 +11,8 @@ from urllib import request
 from urllib.parse import urlparse
 import zipfile
 
+import gdown
+from gdown.parse_url import is_google_drive_url, parse_url
 from GPUtil import getGPUs
 from girder_client import GirderClient, HttpError
 from girder_worker.app import app
@@ -196,13 +198,42 @@ class Config:
         return pipeline_path
 
 
+def _normalize_google_drive_url(url: str) -> str:
+    """Strip a leading www. so gdown recognizes common pasted Drive links."""
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    if host.startswith('www.'):
+        return parsed._replace(netloc=host[4:]).geturl()
+    return url
+
+
+def is_google_drive_addon_url(url: str) -> bool:
+    """Return True if url is a Google Drive link (after normalizing www.)."""
+    return is_google_drive_url(_normalize_google_drive_url(url))
+
+
+def download_google_drive_zip(url: str, dest: Path) -> None:
+    """Download a publicly shared Google Drive zip to dest via gdown."""
+    gdown.download(url=_normalize_google_drive_url(url), output=str(dest), quiet=True)
+
+
+def _addon_zip_path_for_url(addon_url: str, addon_zip_dir: Path) -> Path:
+    normalized = _normalize_google_drive_url(addon_url)
+    if is_google_drive_url(normalized):
+        file_id, _ = parse_url(normalized)
+        if file_id:
+            return addon_zip_dir / f'gdrive_{file_id}.zip'
+    download_name = urlparse(addon_url).path.replace(os.path.sep, '_')
+    return addon_zip_dir / f'{download_name}.zip'
+
+
 @app.task(bind=True, acks_late=True, ignore_result=True)
 def upgrade_pipelines(
     self: Task,
     urls: List[str] = UPGRADE_JOB_DEFAULT_URLS,
     force: bool = False,
 ):
-    """Install addons from zip files over HTTP"""
+    """Install addons from zip files over HTTP (including Google Drive share links)"""
     conf = Config()
     context: dict = {}
     manager: JobManager = patch_manager(self.job_manager)
@@ -215,13 +246,15 @@ def upgrade_pipelines(
     addons_to_update_update: List[Path] = []
 
     for addon in urls:
-        download_name = urlparse(addon).path.replace(os.path.sep, '_')
-        zipfile_path = conf.addon_zip_path / f'{download_name}.zip'
+        zipfile_path = _addon_zip_path_for_url(addon, conf.addon_zip_path)
         had_existing_zip = zipfile_path.exists()
         try:
             if not had_existing_zip or force:
                 manager.write(f'Downloading {addon} to {zipfile_path}\n')
-                request.urlretrieve(addon, filename=zipfile_path)
+                if is_google_drive_addon_url(addon):
+                    download_google_drive_zip(addon, zipfile_path)
+                else:
+                    request.urlretrieve(addon, filename=zipfile_path)
             else:
                 manager.write(f'Skipping download of {zipfile_path}\n')
             addons_to_update_update.append(zipfile_path)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
   "girder-large-image==1.34.3a186",
   "cherrypy>=18.9.0",
   "numpy==1.24.4",
+  "gdown>=6.1.0",
 ]
 
 [dependency-groups]

--- a/server/tests/test_google_drive_download.py
+++ b/server/tests/test_google_drive_download.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dive_tasks.tasks import (
+    _addon_zip_path_for_url,
+    download_google_drive_zip,
+    is_google_drive_addon_url,
+)
+
+
+@pytest.mark.parametrize(
+    'url,expected',
+    [
+        ('https://drive.google.com/file/d/abc123XYZ/view?usp=sharing', True),
+        ('https://www.drive.google.com/open?id=abc123', True),
+        ('https://drive.google.com/uc?id=abc123&export=download', True),
+        ('https://docs.google.com/uc?id=abc123&export=download', True),
+        ('https://viame.kitware.com/api/v1/item/627b145487bad2e19a4c4697/download', False),
+        ('https://example.com/addon.zip', False),
+    ],
+)
+def test_is_google_drive_addon_url(url: str, expected: bool):
+    assert is_google_drive_addon_url(url) is expected
+
+
+def test_addon_zip_path_uses_gdrive_file_id(tmp_path: Path):
+    url = 'https://drive.google.com/file/d/abc123XYZ/view?usp=sharing'
+    assert _addon_zip_path_for_url(url, tmp_path) == tmp_path / 'gdrive_abc123XYZ.zip'
+
+
+def test_addon_zip_path_normalizes_www(tmp_path: Path):
+    url = 'https://www.drive.google.com/open?id=abc123XYZ'
+    assert _addon_zip_path_for_url(url, tmp_path) == tmp_path / 'gdrive_abc123XYZ.zip'
+
+
+def test_addon_zip_path_keeps_http_path_naming(tmp_path: Path):
+    url = 'https://viame.kitware.com/api/v1/item/627b145487bad2e19a4c4697/download'
+    expected = tmp_path / '_api_v1_item_627b145487bad2e19a4c4697_download.zip'
+    assert _addon_zip_path_for_url(url, tmp_path) == expected
+
+
+def test_download_google_drive_zip_uses_gdown(tmp_path: Path):
+    dest = tmp_path / 'addon.zip'
+    url = 'https://www.drive.google.com/file/d/abc123XYZ/view?usp=sharing'
+    with patch('dive_tasks.tasks.gdown.download') as mock_download:
+        download_google_drive_zip(url, dest)
+    mock_download.assert_called_once_with(
+        url='https://drive.google.com/file/d/abc123XYZ/view?usp=sharing',
+        output=str(dest),
+        quiet=True,
+    )

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.12"
 resolution-markers = [
     "python_full_version >= '3.11' and sys_platform == 'darwin'",
@@ -134,6 +134,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
     { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
     { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
@@ -491,6 +504,7 @@ dependencies = [
     { name = "bitarray" },
     { name = "cherrypy" },
     { name = "click" },
+    { name = "gdown" },
     { name = "girder" },
     { name = "girder-client" },
     { name = "girder-jobs" },
@@ -539,6 +553,7 @@ requires-dist = [
     { name = "cherrypy", specifier = ">=18.9.0" },
     { name = "click", specifier = ">=8.1.3" },
     { name = "gdal", marker = "extra == 'large-image'", index = "https://girder.github.io/large_image_wheels/" },
+    { name = "gdown", specifier = ">=6.1.0" },
     { name = "girder", specifier = "==5.0.10" },
     { name = "girder-client", specifier = "==5.0.10" },
     { name = "girder-jobs", specifier = "==5.0.10" },
@@ -644,6 +659,22 @@ wheels = [
     { url = "https://github.com/girder/large_image_wheels/raw/wheelhouse/GDAL-3.12.4.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:4493a6997bd8382975e96b7a64272c82f24b34618d2011928f5ed18168ed9b0f" },
     { url = "https://github.com/girder/large_image_wheels/raw/wheelhouse/GDAL-3.12.4.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:b0eaaa025fa15b09851d8c5502d750b49b087bc7c1bdda7bf349ef397a5339ec" },
     { url = "https://github.com/girder/large_image_wheels/raw/wheelhouse/GDAL-3.12.4.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b574494b5c5b5aa301f1706250cef46418363ad6d9af6b44fa3fdee5029c45ee" },
+]
+
+[[package]]
+name = "gdown"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "filelock" },
+    { name = "requests", extra = ["socks"] },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/b5/a45f62f20664031bf74a6aeb6f8d8cd5910e411bf90d756bd6b09bdc6c35/gdown-6.1.0.tar.gz", hash = "sha256:361c6e04c6ca335df50b9d71f40bcfe9ab70fb26a1b0e890a427267781389553", size = 269670, upload-time = "2026-05-30T11:56:21.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/56/a99f0f159cce5b26d267317d436afee184f45fc7911938757d7cbbd2d10c/gdown-6.1.0-py3-none-any.whl", hash = "sha256:38a36a94275b8272f684db469bbd73b4d1f64cbbc1751bcb993a1b2be8f013c8", size = 19216, upload-time = "2026-05-30T11:56:20.016Z" },
 ]
 
 [[package]]
@@ -1657,6 +1688,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1789,6 +1829,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
 ]
 
 [[package]]
@@ -1943,6 +1988,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2060,6 +2114,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0a/cb/168dc1ccf24e4065a9a0a33df55709ed2b5eb73bd2b13ddd53187e5dffb8/tox_uv_bare-1.35.2.tar.gz", hash = "sha256:49e28a804c97f23ea17e25859960c0fa78f35bccb7e14344cfd840e89a9aade9", size = 32333, upload-time = "2026-05-05T01:34:18.916Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/53/4a33dc81da39db7b31e5622333df361e8fe055b7ec636bd5fea762c9182d/tox_uv_bare-1.35.2-py3-none-any.whl", hash = "sha256:c0d590a41d1054a1ad0874e9e5943ff52402786e3d4599d8f8d37a65b566ef53", size = 22307, upload-time = "2026-05-05T01:34:17.681Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
adds `gdown` python package to make it easier to download addons from google drive

@mattdawkins once I can confirm this works locally, I'll merg it in.