### PR TITLE
Let a pipe declare which config keys receive the calibration file

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -70,6 +70,14 @@ interface PipeMetadata {
    * it gets the first camera's list. Parsed from a `# Image List Keys:` header.
    */
   imageListKeys?: string[];
+  /**
+   * KWIVER config keys (e.g. "depth_map:computer:ocv_stereo_disparity:calibration_file")
+   * that the dataset's stereo calibration file is bound to at run time. Parsed from a
+   * `# Calibration Keys: <k> [k...]` header. Pipes whose calibration consumer is not the
+   * conventional `measurer`/`calibration_reader` declare their own keys here; when unset
+   * the two conventional keys are used.
+   */
+  calibrationKeys?: string[];
 }
 
 interface PipelineRuntimeParams {

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -230,7 +230,7 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
       }
 
       if (inDescription) {
-        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File|Image\s+List\s+Keys?):/i.test(line) || !line.startsWith('#')) {
+        if (/^#\s*$/.test(line) || /^#\s*=/.test(line) || /^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File|Image\s+List\s+Keys?|Calibration\s+Keys?):/i.test(line) || !line.startsWith('#')) {
           inDescription = false;
         } else {
           fullDescription += ` ${line.replace(/^#\s*/, '').trim()}`;
@@ -271,6 +271,19 @@ async function extractPipeMetadata(filePath: string): Promise<PipeMetadata> {
         const keys = imageListMatch[1].trim().split(/[\s,]+/).filter((k) => k);
         if (keys.length) {
           metadata.imageListKeys = keys;
+        }
+      }
+
+      // `# Calibration Keys: <k> [k...]` binds the dataset's stereo calibration
+      // file to each listed KWIVER key. Needed because `$CONFIG{global:...}`
+      // indirection cannot receive `-s` overrides (macros expand at parse time,
+      // `-s` blocks are appended last), so a pipe must name the consuming process
+      // key directly.
+      const calibrationKeysMatch = line.match(/^#\s*Calibration\s+Keys?:\s*(.+)/i);
+      if (calibrationKeysMatch) {
+        const keys = calibrationKeysMatch[1].trim().split(/[\s,]+/).filter((k) => k);
+        if (keys.length) {
+          metadata.calibrationKeys = keys;
         }
       }
     });

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -35,6 +35,12 @@ import {
 const PipelineRelativeDir = 'configs/pipelines';
 const DiveJobManifestName = 'dive_job_manifest.json';
 
+// Calibration consumers every stereo pipe is assumed to have unless it declares
+// its own via a `# Calibration Keys:` header.
+// Keep in sync with server/dive_tasks/multicam_pipeline.py DEFAULT_CALIBRATION_KEYS.
+const DEFAULT_CALIBRATION_KEYS = ['measurer:calibration_file', 'calibration_reader:file'] as const;
+
+
 /**
  * Filter an image list to only include images within frame range.
  * @param imageList List of image file paths
@@ -359,7 +365,7 @@ async function runPipeline(
       // `measurer`/`calibration_reader` names its own keys via `# Calibration Keys:`.
       const calibrationKeys = runPipelineArgs.pipeline.metadata?.calibrationKeys?.length
         ? runPipelineArgs.pipeline.metadata.calibrationKeys
-        : ['measurer:calibration_file', 'calibration_reader:file'];
+        : DEFAULT_CALIBRATION_KEYS;
       calibrationKeys.forEach((key) => {
         command.push(`-s ${key}="${meta.multiCam?.calibration}"`);
       });
@@ -811,4 +817,5 @@ export {
   runPipeline,
   exportTrainedPipeline,
   train,
+  DEFAULT_CALIBRATION_KEYS,
 };

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -355,8 +355,14 @@ async function runPipeline(
     trackOutput = npath.join(jobWorkDir, outFiles[meta.multiCam.defaultDisplay]);
 
     if (meta.multiCam.calibration) {
-      command.push(`-s measurer:calibration_file="${meta.multiCam.calibration}"`);
-      command.push(`-s calibration_reader:file="${meta.multiCam.calibration}"`);
+      // A pipe whose calibration consumer is not the conventional
+      // `measurer`/`calibration_reader` names its own keys via `# Calibration Keys:`.
+      const calibrationKeys = runPipelineArgs.pipeline.metadata?.calibrationKeys?.length
+        ? runPipelineArgs.pipeline.metadata.calibrationKeys
+        : ['measurer:calibration_file', 'calibration_reader:file'];
+      calibrationKeys.forEach((key) => {
+        command.push(`-s ${key}="${meta.multiCam?.calibration}"`);
+      });
     }
   } else if (pipeline.type === stereoPipelineMarker) {
     throw new Error('Attempting to run a multicam pipeline on non multicam data');

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -40,7 +40,6 @@ const DiveJobManifestName = 'dive_job_manifest.json';
 // Keep in sync with server/dive_tasks/multicam_pipeline.py DEFAULT_CALIBRATION_KEYS.
 const DEFAULT_CALIBRATION_KEYS = ['measurer:calibration_file', 'calibration_reader:file'] as const;
 
-
 /**
  * Filter an image list to only include images within frame range.
  * @param imageList List of image file paths

--- a/docs/Pipeline-Import-Export.md
+++ b/docs/Pipeline-Import-Export.md
@@ -72,6 +72,7 @@ Example:
 | `# Description:` | Human-readable summary shown in the Run Pipeline UI. May continue on following `#` comment lines until the next named header. |
 | `# Input:` / `# Output:` | Declared media/annotation kinds for the pipe (used when discovering and categorizing static pipelines). |
 | `# Requires Calibration: True` | Restricts the pipe to stereo datasets that have a calibration file attached. Values `true`, `yes`, and `1` are accepted. |
+| `# Calibration Keys: <k> [k…]` | Opt-in: binds the dataset's stereo calibration file to each listed KWIVER config key at run time (one `-s <k>=<cal-path>` per key). Keys may be space- or comma-separated. Use this when the pipe's calibration consumer is not the conventional `measurer:calibration_file` / `calibration_reader:file` pair (those are used when the header is unset). Needed because `$CONFIG{global:…}` indirection cannot receive `-s` overrides (macros expand at parse time; `-s` blocks are appended last). |
 | `# Metadata File: <block>:<key>` | Opt-in: when the dataset has an attached **Metadata File**, DIVE appends a KWIVER override `-s <block>:<key>=<path>` at run time. Without this header, no metadata file is injected. |
 | `# Image List Keys: <k> [k…]` | Opt-in: binds the run's per-camera input image list(s) to each listed KWIVER key. Keys may be space- or comma-separated. A key containing `{cam}` is expanded once per camera (1-based), e.g. `stabilizer:image_list{cam}` → `image_list1`, `image_list2`, …. A key without `{cam}` receives camera 1's list only. |
 

--- a/server/dive_tasks/multicam_pipeline.py
+++ b/server/dive_tasks/multicam_pipeline.py
@@ -45,14 +45,32 @@ def find_downloaded_calibration_file(directory: Path) -> Optional[Path]:
     return sorted(matches, key=lambda p: (len(p.parts), str(p)))[0]
 
 
+# Calibration consumers every stereo pipe is assumed to have unless it declares
+# its own via a `# Calibration Keys:` header.
+DEFAULT_CALIBRATION_KEYS = ('measurer:calibration_file', 'calibration_reader:file')
+
+
+def stereo_calibration_keys(pipeline: Optional[PipelineDescription]) -> Tuple[str, ...]:
+    """
+    KWIVER keys the dataset's calibration file binds to for this pipe.
+
+    A pipe opts out of the `measurer`/`calibration_reader` convention with a
+    `# Calibration Keys: <k> [k...]` header, naming the consuming process keys
+    directly (e.g. `depth_map:computer:ocv_stereo_disparity:calibration_file`).
+    """
+    declared = ((pipeline or {}).get('metadata') or {}).get('calibrationKeys')
+    return tuple(declared) if declared else DEFAULT_CALIBRATION_KEYS
+
+
 def append_stereo_calibration_kwiver_settings(
     command: List[str],
     calibration_path: Path,
+    pipeline: Optional[PipelineDescription] = None,
 ) -> None:
     """Append KWIVER settings used by desktop for stereoscopic calibration input."""
     cal_path = shlex.quote(str(calibration_path))
-    command.append(f'-s measurer:calibration_file={cal_path}')
-    command.append(f'-s calibration_reader:file={cal_path}')
+    for key in stereo_calibration_keys(pipeline):
+        command.append(f'-s {shlex.quote(key)}={cal_path}')
 
 
 def append_metadata_file_kwiver_settings(

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -206,7 +206,7 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                         or re.match(r'^#\s*=', line_raw)
                         or re.match(
                             r'^#\s*(Input|Output|Requires\s+Calibration|Metadata\s+File'
-                            r'|Image\s+List\s+Keys?):',
+                            r'|Image\s+List\s+Keys?|Calibration\s+Keys?):',
                             line_raw,
                             re.IGNORECASE,
                         )
@@ -260,6 +260,23 @@ def extract_pipe_metadata(file_path: Path) -> PipeMetadata:
                     keys = [k for k in re.split(r'[\s,]+', image_list_match.group(1).strip()) if k]
                     if keys:
                         metadata["imageListKeys"] = keys
+
+                # `# Calibration Keys: <k> [k...]` binds the dataset's stereo
+                # calibration file to each listed KWIVER key. Needed because
+                # `$CONFIG{global:...}` indirection cannot receive `-s` overrides
+                # (macros expand at parse time, `-s` blocks are appended last), so a
+                # pipe must name the consuming process key directly.
+                calibration_keys_match = re.match(
+                    r'^#\s*Calibration\s+Keys?:\s*(.+)', line_raw, re.IGNORECASE
+                )
+                if calibration_keys_match:
+                    keys = [
+                        k
+                        for k in re.split(r'[\s,]+', calibration_keys_match.group(1).strip())
+                        if k
+                    ]
+                    if keys:
+                        metadata["calibrationKeys"] = keys
 
         if full_description_parts:
             metadata["description"] = " ".join(full_description_parts)

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -498,7 +498,7 @@ def run_pipeline(self: Task, params: PipelineJob):
                 )
                 cal_path = find_downloaded_calibration_file(cal_dir)
                 if cal_path is not None:
-                    append_stereo_calibration_kwiver_settings(command, cal_path)
+                    append_stereo_calibration_kwiver_settings(command, cal_path, pipeline)
                 else:
                     manager.write(
                         f'Warning: calibration item {calibration_item_id} '

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -87,6 +87,11 @@ class PipeMetadata(TypedDict):
     # (one single-file list per camera). A `{cam}` placeholder is expanded per
     # camera (1-based); a key without it gets the first camera's list.
     imageListKeys: NotRequired[Optional[list[str]]]
+    # KWIVER config keys the dataset's stereo calibration file is bound to, parsed
+    # from `# Calibration Keys: <k> [k...]`. Pipes whose calibration consumer is
+    # not the conventional `measurer`/`calibration_reader` declare their own keys
+    # here; when unset the two conventional keys are used.
+    calibrationKeys: NotRequired[Optional[list[str]]]
 
 
 class PipelineDescription(TypedDict):

--- a/server/tests/test_multicam_pipeline.py
+++ b/server/tests/test_multicam_pipeline.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 
 from dive_tasks.multicam_pipeline import (
+    DEFAULT_CALIBRATION_KEYS,
     append_stereo_calibration_kwiver_settings,
     build_multicam_kwiver_settings,
     find_downloaded_calibration_file,
     is_stereo_measurement_pipeline,
     is_stereo_or_multicam_pipeline,
     pipeline_requires_input,
+    stereo_calibration_keys,
 )
 from dive_utils import constants
 
@@ -52,6 +54,34 @@ def test_append_stereo_calibration_kwiver_settings():
         '-s measurer:calibration_file=/work/stereo-cal.json',
         '-s calibration_reader:file=/work/stereo-cal.json',
     ]
+
+
+def test_append_stereo_calibration_kwiver_settings_declared_keys():
+    """A pipe's `# Calibration Keys:` header replaces the default keys."""
+    pipeline = {
+        'name': 'disparity',
+        'type': constants.StereoPipelineMarker,
+        'pipe': 'measurement_compute_rectified_disparity.pipe',
+        'metadata': {
+            'calibrationKeys': [
+                'depth_map:computer:ocv_stereo_disparity:calibration_file',
+                'stereo_pairing:cameras_directory',
+            ]
+        },
+    }
+    command: list = []
+    append_stereo_calibration_kwiver_settings(command, Path('/work/cal.npz'), pipeline)
+    assert command == [
+        '-s depth_map:computer:ocv_stereo_disparity:calibration_file=/work/cal.npz',
+        '-s stereo_pairing:cameras_directory=/work/cal.npz',
+    ]
+
+
+def test_stereo_calibration_keys_defaults():
+    assert stereo_calibration_keys(None) == DEFAULT_CALIBRATION_KEYS
+    assert stereo_calibration_keys({'metadata': None}) == DEFAULT_CALIBRATION_KEYS
+    assert stereo_calibration_keys({'metadata': {'calibrationKeys': []}}) == DEFAULT_CALIBRATION_KEYS
+    assert stereo_calibration_keys({'metadata': {'calibrationKeys': ['a:b']}}) == ('a:b',)
 
 
 def test_build_multicam_kwiver_settings_image_sequence(tmp_path: Path):

--- a/server/tests/test_pipeline_discovery.py
+++ b/server/tests/test_pipeline_discovery.py
@@ -94,3 +94,27 @@ def test_extract_pipe_metadata_requires_calibration(tmp_path: Path):
     assert metadata['description'] == 'stereo measurement'
     assert metadata['inputType'] == 'TRACK'
     assert metadata['outputType'] == 'TRACK'
+    assert metadata.get('calibrationKeys') is None
+
+
+def test_extract_pipe_metadata_calibration_keys(tmp_path: Path):
+    pipe = tmp_path / 'measurement_disparity.pipe'
+    pipe.write_text(
+        '\n'.join(
+            [
+                '# Description: rectified disparity',
+                '# Requires Calibration: True',
+                '# Calibration Keys: depth_map:computer:ocv_stereo_disparity:calibration_file'
+                ' stereo_pairing:cameras_directory',
+            ]
+        )
+    )
+
+    metadata = extract_pipe_metadata(pipe)
+
+    assert metadata['calibrationKeys'] == [
+        'depth_map:computer:ocv_stereo_disparity:calibration_file',
+        'stereo_pairing:cameras_directory',
+    ]
+    # The header must not bleed into the multi-line description.
+    assert metadata['description'] == 'rectified disparity'


### PR DESCRIPTION
Stereo calibration was bound to two hardcoded keys, `measurer:calibration_file` and `calibration_reader:file`. Pipes whose calibration consumer is neither of those had no way to receive it.

Routing it through a `$CONFIG{global:...}` indirection does not work: kwiver expands macros at parse time with backward references only (`bakery_base.cxx:189-211`), while `-s` blocks are appended last (`pipeline_builder.cxx:131-173`), so the override never reaches the process.

- New `# Calibration Keys: <k> [k...]` header naming the consuming process keys directly, parsed on both server (`pipeline_discovery.py`) and desktop (`common.ts`)
- `append_stereo_calibration_kwiver_settings` emits one `-s` per declared key; unset keeps the two conventional keys, so existing pipes are unaffected
- Header added to the description stop-condition on both parsers so it doesn't bleed into descriptions

Paired with VIAME/VIAME#dev/measurement-calibration-passdown, which declares the header on the measurement and ifremer stereo pipes.

Tests added for declared-keys emission, default fallback, and header parsing.