### PR TITLE
fix timeline scrubber for video playback

### DIFF
--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -202,6 +202,8 @@ export default defineComponent({
         data.frame = Math.floor(newFrame);
         data.flick = Math.round(video.currentTime * Flick);
         data.syncedFrame = data.frame;
+        // Keep shared time.frame in sync so Timeline playhead tracks playback
+        props.updateTime(data);
         geoViewer.value.scheduleAnimationFrame(syncWithVideo);
       }
       data.currentTime = video.currentTime;

--- a/client/src/components/controls/LineChart.vue
+++ b/client/src/components/controls/LineChart.vue
@@ -197,6 +197,7 @@ export default Vue.extend({
 
   .axis-y {
     font-size: 12px;
+    user-select: none;
 
     g:first-of-type,
     g:last-of-type {


### PR DESCRIPTION
SealTK integration had modified the time sync so the scrubbers in the timeline view (vertical blue-ish line) wasn't moving with the video frame advancing.  This fixes that and prevents users from selecting the text in the detection count y-axis when dragging the scrubber.