### PR TITLE
Remove exposed Redis Port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,6 @@ services:
   redis:
     image: redis:latest
     command: ["redis-server", "--maxmemory", "8192MB", "--maxmemory-policy", "volatile-lru"]
-    ports:
-      - "6379:6379"
     volumes:
       - redis_data:/data
 


### PR DESCRIPTION
Oversight to have the redis port exposed.  This is not needed by any remote workers, redis is being used as a cache for large image and as a tool for websocket notifications both are done through the api so remote workers don't need exposed access to redis.