### PR TITLE
Desktop: resume interrupted training runs

### DIFF
--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -331,6 +331,10 @@ export default function register() {
     };
     return currentPlatform.train(settings.get(), args, updater);
   });
+  ipcMain.handle('list-resumable-training', async () => common.findResumableTrainingJobs(settings.get()));
+  ipcMain.handle('discard-resumable-training', async (_event, workingDir: string) => {
+    await common.discardResumableTraining(settings.get(), workingDir);
+  });
 
   /**
    * Interactive Segmentation Service

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -1379,6 +1379,106 @@ describe('native.common', () => {
   });
 });
 
+describe('resumable training jobs', () => {
+  const jobsDir = '/home/user/viamedata/DIVE_Jobs';
+  const baseManifest = {
+    key: 'key',
+    command: 'viame train',
+    jobType: 'training',
+    title: 'fish detector',
+    args: {
+      type: JobType.RunTraining,
+      datasetIds: ['datasetId'],
+      pipelineName: 'fish detector',
+      trainingConfig: 'train.conf',
+      annotatedFramesOnly: false,
+    },
+    datasetIds: ['datasetId'],
+    pid: 999999999,
+    exitCode: null,
+    startTime: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  /* mock-fs cannot intercept writeFileSync on newer node, so job directories
+   * are seeded through the mockfs() config instead of written at runtime */
+  function jobDirConfig(
+    name: string,
+    manifestOverrides: Record<string, unknown>,
+    files = ['deep_training', 'input_folder_list.txt', 'input_truth_list.txt'],
+  ) {
+    const entries: Record<string, string | Record<string, never>> = {};
+    files.forEach((f) => {
+      entries[f] = f.includes('.') ? '' : {};
+    });
+    entries['dive_job_manifest.json'] = JSON.stringify({
+      ...baseManifest,
+      workingDir: npath.join(jobsDir, name),
+      ...manifestOverrides,
+    });
+    return entries;
+  }
+
+  function mockJobsFolder(jobs: Record<string, Record<string, string | Record<string, never>>>) {
+    mockfs({
+      '/home/user/viamedata': {
+        DIVE_Jobs: jobs,
+        DIVE_Projects: {},
+      },
+    });
+  }
+
+  it('finds interrupted runs with intermediate files, newest first', async () => {
+    mockJobsFolder({
+      crashed: jobDirConfig('crashed', { endTime: new Date('2026-01-01T01:00:00Z'), exitCode: 139 }),
+      cancelled: jobDirConfig('cancelled', {
+        startTime: new Date('2026-01-02T00:00:00Z'),
+        endTime: new Date('2026-01-02T01:00:00Z'),
+        exitCode: -1,
+      }),
+    });
+    const found = await common.findResumableTrainingJobs(settings);
+    expect(found.map((j) => j.workingDir)).toEqual([
+      npath.join(jobsDir, 'cancelled'),
+      npath.join(jobsDir, 'crashed'),
+    ]);
+  });
+
+  it('excludes successful, still running, and stateless runs', async () => {
+    mockJobsFolder({
+      succeeded: jobDirConfig('succeeded', { endTime: new Date(), exitCode: 0 }),
+      running: jobDirConfig('running', { pid: process.pid }),
+      noTrainerState: jobDirConfig('noTrainerState', { endTime: new Date(), exitCode: 1 }, ['input_folder_list.txt', 'input_truth_list.txt']),
+      interrupted: jobDirConfig('interrupted', { endTime: new Date(), exitCode: 1 }),
+    });
+    const found = await common.findResumableTrainingJobs(settings);
+    expect(found.map((j) => j.workingDir)).toEqual([npath.join(jobsDir, 'interrupted')]);
+  });
+
+  it('excludes legacy successful runs with an emptied category_models', async () => {
+    mockJobsFolder({
+      legacySuccess: jobDirConfig(
+        'legacySuccess',
+        {},
+        ['deep_training', 'category_models', 'input_folder_list.txt', 'input_truth_list.txt'],
+      ),
+      legacyInterrupted: jobDirConfig('legacyInterrupted', {}),
+    });
+    const found = await common.findResumableTrainingJobs(settings);
+    expect(found.map((j) => j.workingDir)).toEqual([npath.join(jobsDir, 'legacyInterrupted')]);
+  });
+
+  it('discard removes only job working directories', async () => {
+    mockJobsFolder({
+      discardMe: jobDirConfig('discardMe', { endTime: new Date(), exitCode: 1 }),
+    });
+    const dir = npath.join(jobsDir, 'discardMe');
+    await common.discardResumableTraining(settings, dir);
+    expect(fs.existsSync(dir)).toBe(false);
+    await expect(common.discardResumableTraining(settings, '/home/user/viamedata/DIVE_Projects'))
+      .rejects.toThrow('not a job working directory');
+  });
+});
+
 afterEach(() => {
   mockfs.restore();
 });

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -12,7 +12,7 @@ import { makeEmptyAnnotationFile } from 'platform/desktop/backend/serializers/di
 import { MultiTrackRecord } from 'dive-common/apispec';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import * as common from './common';
-import { createWorkingDirectory } from './utils';
+import { createWorkingDirectory, buildTrainingExitManifest } from './utils';
 
 vi.mock('fs-extra', async () => {
   const actual = await vi.importActual<typeof import('fs-extra')>('fs-extra');
@@ -1476,6 +1476,47 @@ describe('resumable training jobs', () => {
     expect(fs.existsSync(dir)).toBe(false);
     await expect(common.discardResumableTraining(settings, '/home/user/viamedata/DIVE_Projects'))
       .rejects.toThrow('not a job working directory');
+  });
+});
+
+describe('buildTrainingExitManifest', () => {
+  const jobBase: DesktopJob = {
+    key: 'key',
+    command: 'viame train',
+    jobType: 'training',
+    title: 'fish detector',
+    args: {
+      type: JobType.RunTraining,
+      datasetIds: ['datasetId'],
+      pipelineName: 'fish detector',
+      trainingConfig: 'train.conf',
+      annotatedFramesOnly: false,
+    },
+    datasetIds: ['datasetId'],
+    pid: 1234,
+    workingDir: '/jobs/run',
+    exitCode: null,
+    startTime: new Date('2026-01-01T00:00:00Z'),
+  };
+  const endTime = new Date('2026-01-01T02:00:00Z');
+
+  it('preserves cancel status over a null/signal process exit code', () => {
+    const cancelTime = new Date('2026-01-01T01:30:00Z');
+    const result = buildTrainingExitManifest(jobBase, null, endTime, {
+      cancelledJob: true,
+      exitCode: -1,
+      endTime: cancelTime,
+    });
+    expect(result.cancelledJob).toBe(true);
+    expect(result.exitCode).toBe(-1);
+    expect(result.endTime).toEqual(cancelTime);
+  });
+
+  it('records the process exit code when the job was not cancelled', () => {
+    const result = buildTrainingExitManifest(jobBase, 1, endTime, { exitCode: null });
+    expect(result.cancelledJob).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.endTime).toEqual(endTime);
   });
 });
 

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -45,7 +45,7 @@ import {
   RunTraining, ExportDatasetArgs, DesktopMediaImportResponse,
   ExportConfigurationArgs, JobsFolderName, JobsOutputFolderName, ProjectsFolderName,
   PipelinesFolderName, ConversionArgs,
-  JobType,
+  JobType, DesktopJob,
 } from 'platform/desktop/constants';
 import {
   cleanString, filterByGlob, makeid, strNumericCompare,
@@ -79,6 +79,7 @@ const DatasetFileName = 'dataset.json';
 const DatasetFileNameLegacy = 'meta.json';
 /** Portable Configuration File name used on import/export (not the project store). */
 const PortableConfigFileName = 'config.json';
+const DiveJobManifestName = 'dive_job_manifest.json';
 const PortableConfigFileNameLegacy = 'meta.json';
 const CsvFileName = /^.*\.csv$/i;
 const YAMLFileName = /^.*\.ya?ml$/i;
@@ -1168,6 +1169,66 @@ async function processTrainedPipeline(settings: Settings, args: RunTraining, wor
   return folderContents;
 }
 
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find prior training runs whose intermediate files are still on disk and can
+ * be continued with `viame train --continue`: runs that were interrupted by a
+ * crash, a cancellation, or the app shutting down, or that exited early
+ * without producing a model.
+ */
+async function findResumableTrainingJobs(settings: Settings): Promise<DesktopJob[]> {
+  const jobsDir = npath.join(settings.dataPath, JobsFolderName);
+  if (!fs.existsSync(jobsDir)) {
+    return [];
+  }
+  const results: DesktopJob[] = [];
+  const entries = await fs.readdir(jobsDir);
+  await Promise.all(entries.map(async (entry) => {
+    const workingDir = npath.join(jobsDir, entry);
+    try {
+      const manifest = await fs.readJson(
+        npath.join(workingDir, DiveJobManifestName),
+      ) as DesktopJob;
+      if (manifest.jobType !== 'training') return;
+      if (manifest.exitCode === 0) return;
+      if (manifest.endTime === undefined && processIsRunning(manifest.pid)) return;
+      // The trainer's intermediate state and the original input lists must survive
+      const required = ['deep_training', 'input_folder_list.txt', 'input_truth_list.txt'];
+      if (!required.every((f) => fs.existsSync(npath.join(workingDir, f)))) return;
+      // Manifests predating final-status recording never carry an end time; a
+      // successful run's models were moved out of category_models, leaving it empty
+      if (manifest.endTime === undefined) {
+        const modelsDir = npath.join(workingDir, 'category_models');
+        if (fs.existsSync(modelsDir) && (await fs.readdir(modelsDir)).length === 0) return;
+      }
+      // The jobs folder may have been relocated since the manifest was written
+      results.push({ ...manifest, workingDir });
+    } catch {
+      // not a job directory or unreadable manifest
+    }
+  }));
+  return results.sort(
+    (a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime(),
+  );
+}
+
+async function discardResumableTraining(settings: Settings, workingDir: string): Promise<void> {
+  const jobsDir = npath.resolve(settings.dataPath, JobsFolderName);
+  const resolved = npath.resolve(workingDir);
+  if (npath.dirname(resolved) !== jobsDir) {
+    throw new Error(`${workingDir} is not a job working directory`);
+  }
+  await fs.remove(resolved);
+}
+
 async function _initializeAppDataDir(settings: Settings) {
   await fs.ensureDir(settings.dataPath);
   await fs.ensureDir(npath.join(settings.dataPath, ProjectsFolderName));
@@ -1968,6 +2029,8 @@ export {
   saveConfig,
   saveProjectConfig,
   processTrainedPipeline,
+  findResumableTrainingJobs,
+  discardResumableTraining,
   saveAttributes,
   saveAttributeTrackFilters,
   findImagesInFolder,

--- a/client/platform/desktop/backend/native/utils.ts
+++ b/client/platform/desktop/backend/native/utils.ts
@@ -164,6 +164,32 @@ async function updateJobFilesOnCancel(workingDir: string): Promise<void> {
   ]);
 }
 
+/**
+ * Build the final training job manifest after process exit. Cancel writes
+ * cancelledJob to disk before killing the child; the exit handler must not
+ * overwrite that with the raw process code (signal kills often report null).
+ */
+function buildTrainingExitManifest(
+  jobBase: DesktopJob,
+  processExitCode: number | null,
+  endTime: Date,
+  existing: Partial<DesktopJob> | null | undefined,
+): DesktopJob {
+  if (existing?.cancelledJob) {
+    return {
+      ...jobBase,
+      cancelledJob: true,
+      exitCode: existing.exitCode ?? -1,
+      endTime: existing.endTime ? new Date(existing.endTime) : endTime,
+    };
+  }
+  return {
+    ...jobBase,
+    exitCode: processExitCode,
+    endTime,
+  };
+}
+
 export {
   getBinaryPath,
   jobFileEchoMiddleware,
@@ -172,4 +198,5 @@ export {
   spawnResult,
   splitExt,
   updateJobFilesOnCancel,
+  buildTrainingExitManifest,
 };

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -28,7 +28,10 @@ import {
   pipelineCreatesNewDataset,
 } from 'dive-common/pipelineCreatesDataset';
 import * as common from './common';
-import { jobFileEchoMiddleware, createWorkingDirectory, createCustomWorkingDirectory } from './utils';
+import {
+  jobFileEchoMiddleware, createWorkingDirectory, createCustomWorkingDirectory,
+  buildTrainingExitManifest,
+} from './utils';
 import {
   getMultiCamImageFiles, getMultiCamVideoPath,
   writeMultiCamStereoPipelineArgs,
@@ -827,9 +830,21 @@ async function train(
   job.stdout.on('data', jobFileEchoMiddleware(jobBase, updater, joblog));
   job.stderr.on('data', jobFileEchoMiddleware(jobBase, updater, joblog));
   job.on('exit', async (code) => {
+    const manifestPath = npath.join(jobWorkDir, DiveJobManifestName);
+    // Cancel updates the manifest before killing the child; read that first so
+    // we do not clobber cancelledJob with a null/signal exit code.
+    let existingManifest: DesktopJob | undefined;
+    try {
+      if (await fs.pathExists(manifestPath)) {
+        existingManifest = await fs.readJson(manifestPath) as DesktopJob;
+      }
+    } catch {
+      // fall through and record process exit status
+    }
+
     let exitCode = code;
     const bodyText = [''];
-    if (code === 0) {
+    if (!existingManifest?.cancelledJob && code === 0) {
       try {
         await common.processTrainedPipeline(settings, runTrainingArgs, jobWorkDir);
       } catch (err) {
@@ -842,16 +857,12 @@ async function train(
       }
     }
     const endTime = new Date();
+    const finalJob = buildTrainingExitManifest(jobBase, exitCode, endTime, existingManifest);
     // Record the final status so interrupted runs can be detected as resumable
-    fs.writeFile(
-      npath.join(jobWorkDir, DiveJobManifestName),
-      JSON.stringify({ ...jobBase, exitCode, endTime }, null, 2),
-    );
+    fs.writeFile(manifestPath, JSON.stringify(finalJob, null, 2));
     updater({
-      ...jobBase,
+      ...finalJob,
       body: bodyText,
-      exitCode,
-      endTime,
     });
   });
   return jobBase;

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -691,59 +691,73 @@ async function train(
     throw new Error(isValid);
   }
 
-  /* Zip together project info and meta */
-  const infoAndMeta = await Promise.all(
-    runTrainingArgs.datasetIds.map(async (id) => {
-      const projectInfo = await common.getValidatedProjectDir(settings, id);
-      const meta = await common.loadJsonConfig(projectInfo.datasetFileAbsPath);
-      return { projectInfo, meta };
-    }),
-  );
-  const jsonConfigList = infoAndMeta.map(({ meta }) => meta);
+  const resumeDir = runTrainingArgs.resumeWorkingDir;
+  let jobWorkDir: string;
+  if (resumeDir) {
+    /* Continue an interrupted run: its input lists, groundtruth files, and
+     * intermediate trainer state are already in the working directory. */
+    if (!fs.existsSync(npath.join(resumeDir, DiveJobManifestName))) {
+      throw new Error(`Cannot resume training: no job manifest found in ${resumeDir}`);
+    }
+    jobWorkDir = resumeDir;
+  } else {
+    /* Zip together project info and meta */
+    const infoAndMeta = await Promise.all(
+      runTrainingArgs.datasetIds.map(async (id) => {
+        const projectInfo = await common.getValidatedProjectDir(settings, id);
+        const meta = await common.loadJsonConfig(projectInfo.datasetFileAbsPath);
+        return { projectInfo, meta };
+      }),
+    );
+    const jsonConfigList = infoAndMeta.map(({ meta }) => meta);
 
-  // Working dir for training
-  const jobWorkDir = await createWorkingDirectory(settings, jsonConfigList, runTrainingArgs.pipelineName);
+    // Working dir for training
+    jobWorkDir = await createWorkingDirectory(settings, jsonConfigList, runTrainingArgs.pipelineName);
+
+    const groundtruthFilenames = await Promise.all(
+      infoAndMeta.map(async ({ meta, projectInfo }) => {
+        // Organize data for training
+        const groundTruthFileName = `groundtruth_${meta.id}.csv`;
+        const groundTruthFileStream = fs.createWriteStream(
+          npath.join(jobWorkDir, groundTruthFileName),
+        );
+        const inputData = await common.loadAnnotationFile(projectInfo.trackFileAbsPath);
+        await serialize(groundTruthFileStream, inputData, meta);
+        groundTruthFileStream.end();
+        return groundTruthFileName;
+      }),
+    );
+
+    // Write groundtruth filenames to list
+    const groundtruthFile = fs.createWriteStream(npath.join(jobWorkDir, 'input_truth_list.txt'));
+    groundtruthFilenames.forEach((name) => groundtruthFile.write(`${name}\n`));
+    groundtruthFile.end();
+
+    // Write input folder paths to list
+    const inputFile = fs.createWriteStream(npath.join(jobWorkDir, 'input_folder_list.txt'));
+    infoAndMeta.forEach(({ projectInfo, meta }) => {
+      if (meta.type === 'video') {
+        let videopath = '';
+        /* If the video has been transcoded, use that video */
+        if ((meta.transcodedVideoFile && forceTranscoding) || meta.transcodedMisalign) {
+          videopath = npath.join(projectInfo.basePath, meta.transcodedVideoFile);
+        } else {
+          videopath = npath.join(meta.originalBasePath, meta.originalVideoFile);
+        }
+        inputFile.write(`${videopath}\n`);
+      } else if (meta.type === 'image-sequence') {
+        inputFile.write(`${npath.join(meta.originalBasePath)}\n`);
+      }
+    });
+    inputFile.end();
+  }
 
   // Argument files for training
   const inputFolderFileList = npath.join(jobWorkDir, 'input_folder_list.txt');
   const groundTruthFileList = npath.join(jobWorkDir, 'input_truth_list.txt');
-
-  const groundtruthFilenames = await Promise.all(
-    infoAndMeta.map(async ({ meta, projectInfo }) => {
-      // Organize data for training
-      const groundTruthFileName = `groundtruth_${meta.id}.csv`;
-      const groundTruthFileStream = fs.createWriteStream(
-        npath.join(jobWorkDir, groundTruthFileName),
-      );
-      const inputData = await common.loadAnnotationFile(projectInfo.trackFileAbsPath);
-      await serialize(groundTruthFileStream, inputData, meta);
-      groundTruthFileStream.end();
-      return groundTruthFileName;
-    }),
-  );
-
-  // Write groundtruth filenames to list
-  const groundtruthFile = fs.createWriteStream(groundTruthFileList);
-  groundtruthFilenames.forEach((name) => groundtruthFile.write(`${name}\n`));
-  groundtruthFile.end();
-
-  // Write input folder paths to list
-  const inputFile = fs.createWriteStream(inputFolderFileList);
-  infoAndMeta.forEach(({ projectInfo, meta }) => {
-    if (meta.type === 'video') {
-      let videopath = '';
-      /* If the video has been transcoded, use that video */
-      if ((meta.transcodedVideoFile && forceTranscoding) || meta.transcodedMisalign) {
-        videopath = npath.join(projectInfo.basePath, meta.transcodedVideoFile);
-      } else {
-        videopath = npath.join(meta.originalBasePath, meta.originalVideoFile);
-      }
-      inputFile.write(`${videopath}\n`);
-    } else if (meta.type === 'image-sequence') {
-      inputFile.write(`${npath.join(meta.originalBasePath)}\n`);
-    }
-  });
-  inputFile.end();
+  if (resumeDir && !(fs.existsSync(inputFolderFileList) && fs.existsSync(groundTruthFileList))) {
+    throw new Error(`Cannot resume training: input lists are missing from ${resumeDir}`);
+  }
 
   const joblog = npath.join(jobWorkDir, 'runlog.txt');
   const configFilePath = npath.join(settings.viamePath, PipelineRelativeDir, runTrainingArgs.trainingConfig);
@@ -759,18 +773,26 @@ async function train(
     '--no-embedded-pipe',
   ];
 
+  if (resumeDir) {
+    command.push('--continue');
+  }
+
   if (runTrainingArgs.annotatedFramesOnly) {
     command.push('--gt-frames-only');
   }
 
-  if (runTrainingArgs.fineTuneModel && runTrainingArgs.fineTuneModel.path) {
+  // On resume, --continue restores the run's own checkpoint; re-seeding with
+  // the fine-tune weights would override it
+  if (!resumeDir && runTrainingArgs.fineTuneModel && runTrainingArgs.fineTuneModel.path) {
     command.push('--init-weights');
     command.push(runTrainingArgs.fineTuneModel.path);
   }
 
   if (runTrainingArgs.labelText) {
     const labelsPath = `${jobWorkDir}/labels.txt`;
-    fs.writeFileSync(labelsPath, runTrainingArgs.labelText);
+    if (!resumeDir) {
+      fs.writeFileSync(labelsPath, runTrainingArgs.labelText);
+    }
     command.push('--labels');
     command.push(labelsPath);
   }
@@ -819,11 +841,17 @@ async function train(
         });
       }
     }
+    const endTime = new Date();
+    // Record the final status so interrupted runs can be detected as resumable
+    fs.writeFile(
+      npath.join(jobWorkDir, DiveJobManifestName),
+      JSON.stringify({ ...jobBase, exitCode, endTime }, null, 2),
+    );
     updater({
       ...jobBase,
       body: bodyText,
       exitCode,
-      endTime: new Date(),
+      endTime,
     });
   });
   return jobBase;

--- a/client/platform/desktop/constants.ts
+++ b/client/platform/desktop/constants.ts
@@ -223,6 +223,8 @@ export interface RunTraining extends JobArgs {
     path?: string;
     folderId?: string;
   };
+  // working directory of a prior interrupted run to continue from
+  resumeWorkingDir?: string;
 }
 
 export interface ConversionArgs extends JobArgs {

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -196,6 +196,22 @@ async function deleteTrainedPipeline(pipeline: Pipe): Promise<void> {
   return window.diveDesktop.invoke('delete-trained-pipeline', pipeline);
 }
 
+async function listResumableTrainingJobs(): Promise<DesktopJob[]> {
+  return window.diveDesktop.invoke('list-resumable-training');
+}
+
+async function resumeTraining(job: DesktopJob): Promise<void> {
+  const args: RunTraining = {
+    ...(job.args as RunTraining),
+    resumeWorkingDir: job.workingDir,
+  };
+  gpuJobQueue.enqueue(args);
+}
+
+async function discardResumableTraining(job: DesktopJob): Promise<void> {
+  return window.diveDesktop.invoke('discard-resumable-training', job.workingDir);
+}
+
 function importMedia(path: string): Promise<DesktopMediaImportResponse> {
   return window.diveDesktop.invoke('import-media', { path });
 }
@@ -728,6 +744,9 @@ export {
   exportTrainedPipeline,
   getTrainingConfigurations,
   runTraining,
+  listResumableTrainingJobs,
+  resumeTraining,
+  discardResumableTraining,
   saveConfig,
   saveDetections,
   saveAttributes,

--- a/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
+++ b/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
@@ -19,6 +19,10 @@ import { itemsPerPageOptions, simplifyTrainingName } from 'dive-common/constants
 import { clientSettings } from 'dive-common/store/settings';
 
 import { useRouter } from 'vue-router/composables';
+import { DesktopJob, RunTraining } from 'platform/desktop/constants';
+import {
+  listResumableTrainingJobs, resumeTraining, discardResumableTraining,
+} from '../api';
 import { datasets } from '../store/dataset';
 
 function joinPath(dir: string, filename: string) {
@@ -55,6 +59,41 @@ export default defineComponent({
     onBeforeMount(async () => {
       unsortedPipelines.value = await getPipelineList();
     });
+
+    const resumableJobs = ref([] as DesktopJob[]);
+
+    async function refreshResumable() {
+      resumableJobs.value = await listResumableTrainingJobs();
+    }
+    onBeforeMount(refreshResumable);
+
+    const resumableItems = computed(() => resumableJobs.value.map((job) => ({
+      job,
+      title: job.title,
+      config: (job.args as RunTraining).trainingConfig,
+      datasetCount: job.datasetIds.length,
+      started: job.startTime ? new Date(job.startTime).toLocaleString() : '',
+    })));
+
+    async function resumeJob(job: DesktopJob) {
+      await resumeTraining(job);
+      router.push({ name: 'jobs' });
+    }
+
+    async function discardJob(job: DesktopJob) {
+      const confirmDiscard = await prompt({
+        title: `Discard "${job.title}" training run`,
+        text: 'Delete this run\'s intermediate training files? This cannot be undone.',
+        positiveButton: 'Delete',
+        negativeButton: 'Cancel',
+        confirm: true,
+      });
+      if (!confirmDiscard) {
+        return;
+      }
+      await discardResumableTraining(job);
+      await refreshResumable();
+    }
 
     const trainedPipelines = computed(() => {
       if (unsortedPipelines.value.trained) {
@@ -241,6 +280,43 @@ export default defineComponent({
       }
     }
 
+    const resumableHeaders: DataTableHeader[] = [
+      {
+        text: 'Name',
+        value: 'title',
+        sortable: true,
+      },
+      {
+        text: 'Configuration',
+        value: 'config',
+        sortable: true,
+      },
+      {
+        text: 'Datasets',
+        value: 'datasetCount',
+        sortable: false,
+        width: 100,
+      },
+      {
+        text: 'Started',
+        value: 'started',
+        sortable: true,
+        width: 200,
+      },
+      {
+        text: 'Resume',
+        value: 'resume',
+        sortable: false,
+        width: 90,
+      },
+      {
+        text: 'Discard',
+        value: 'discard',
+        sortable: false,
+        width: 90,
+      },
+    ];
+
     return {
       data,
       labelFile,
@@ -251,10 +327,16 @@ export default defineComponent({
       simplifyTrainingName,
       isReadyToTrain,
       runTrainingOnFolder,
+      resumeJob,
+      discardJob,
       nameRules,
       itemsPerPageOptions,
       clientSettings,
       modelNames,
+      resumable: {
+        items: resumableItems,
+        headers: resumableHeaders,
+      },
       models: {
         items: trainedModels,
         headers: trainedHeadersTmpl.concat({
@@ -430,6 +512,47 @@ export default defineComponent({
         />
       </div>
     </div>
+    <div v-if="resumable.items.value.length">
+      <v-card-title class="text-h4">
+        Interrupted training runs
+      </v-card-title>
+      <v-card-text>
+        These runs did not finish, but their intermediate files are still on disk.
+        Resuming continues from the last saved training state.
+      </v-card-text>
+      <v-data-table
+        dense
+        v-bind="{ headers: resumable.headers, items: resumable.items.value }"
+        hide-default-footer
+      >
+        <template #[`item.config`]="{ item }">
+          {{ simplifyTrainingName(item.config || '') }}
+        </template>
+        <template #[`item.resume`]="{ item }">
+          <v-btn
+            color="primary"
+            x-small
+            @click="resumeJob(item.job)"
+          >
+            <v-icon small>
+              mdi-play
+            </v-icon>
+          </v-btn>
+        </template>
+        <template #[`item.discard`]="{ item }">
+          <v-btn
+            color="error"
+            x-small
+            @click="discardJob(item.job)"
+          >
+            <v-icon small>
+              mdi-trash-can
+            </v-icon>
+          </v-btn>
+        </template>
+      </v-data-table>
+    </div>
+
     <div>
       <v-card-title class="text-h4">
         Available for training

--- a/client/platform/desktop/frontend/store/queues/asyncGpuJobQueue.ts
+++ b/client/platform/desktop/frontend/store/queues/asyncGpuJobQueue.ts
@@ -20,6 +20,7 @@ function runTrainingsAreEquivalent(a: RunTraining, b: RunTraining) {
     && a.annotatedFramesOnly === b.annotatedFramesOnly
     && a.labelText === b.labelText
     && a.fineTuneModel?.name === b.fineTuneModel?.name
+    && a.resumeWorkingDir === b.resumeWorkingDir
   );
 }
 


### PR DESCRIPTION
- Desktop training jobs that were interrupted (crash, cancel, closing DIVE) or exited early can now be continued if their intermediate files are still in `DIVE_Jobs`
- The Training page gains an "Interrupted training runs" section with Resume and Discard actions; resume re-launches `viame train` in the original working directory with `--continue`, discard deletes the run's working directory
- Training jobs now record their final exit status into `dive_job_manifest.json` so interrupted runs are detected across app restarts; legacy successful runs are excluded via their emptied `category_models` folder
- Requires a VIAME build whose train tool supports `--continue`; on older builds the resumed command fails with an unknown-option error in the job log

🤖 Generated with [Claude Code](https://claude.com/claude-code)