### PR TITLE
Order the export buttons VIAME CSV, COCO JSON, DIVE JSON

### DIFF
--- a/client/platform/desktop/frontend/components/Export.vue
+++ b/client/platform/desktop/frontend/components/Export.vue
@@ -351,17 +351,17 @@ export default defineComponent({
                 depressed
                 block
                 class="my-1"
-                @click="doExport({ type: 'trackJSON' })"
+                @click="doExport({ type: 'coco' })"
               >
-                <span>TRACK JSON</span>
+                <span>COCO JSON</span>
               </v-btn>
               <v-btn
                 depressed
                 block
                 class="my-1"
-                @click="doExport({ type: 'coco' })"
+                @click="doExport({ type: 'trackJSON' })"
               >
-                <span>COCO JSON</span>
+                <span>DIVE JSON</span>
               </v-btn>
             </v-col>
           </v-row>

--- a/client/platform/web-girder/views/Export.vue
+++ b/client/platform/web-girder/views/Export.vue
@@ -463,12 +463,12 @@ export default defineComponent({
                   :disabled="!exportUrls.exportDetectionsUrl"
                   @click="doExport({
                     url: exportUrls
-                      && exportUrls.exportDetectionsUrlTrackJSON,
+                      && exportUrls.exportDetectionsUrlCocoJSON,
                   })"
                 >
                   <span
                     v-if="exportUrls.exportDetectionsUrl"
-                  >DIVE TrackJSON</span>
+                  >COCO JSON</span>
                   <span
                     v-else
                   >detections unavailable</span>
@@ -480,12 +480,12 @@ export default defineComponent({
                   :disabled="!exportUrls.exportDetectionsUrl"
                   @click="doExport({
                     url: exportUrls
-                      && exportUrls.exportDetectionsUrlCocoJSON,
+                      && exportUrls.exportDetectionsUrlTrackJSON,
                   })"
                 >
                   <span
                     v-if="exportUrls.exportDetectionsUrl"
-                  >COCO JSON</span>
+                  >DIVE JSON</span>
                   <span
                     v-else
                   >detections unavailable</span>
@@ -591,7 +591,7 @@ export default defineComponent({
             </v-btn>
           </v-card-actions>
           <v-card-text class="pb-0">
-            Export All selected Dataset Detections in VIAME CSV and TrackJSON
+            Export All selected Dataset Detections in VIAME CSV and DIVE JSON
           </v-card-text>
           <v-checkbox
             v-model="excludeBelowThreshold"


### PR DESCRIPTION
- Swap COCO JSON above the DIVE JSON button in both the web and desktop export dialogs.
- Rename `DIVE TrackJSON` / `TRACK JSON` to `DIVE JSON`, and the matching "Everything" blurb on web.

Labels and ordering only; no change to what each button exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)