### PR TITLE
Allow deleting corrupt or incomplete datasets

### DIFF
--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -1244,15 +1244,17 @@ describe('native.common', () => {
   it('check Dastset existence', async () => {
     await expect(common.checkDataset(settings, 'projectid3Bad')).rejects.toThrow('missing dataset json');
     await expect(common.checkDataset(settings, 'projectid5Bad')).rejects.toThrow('missing track json file');
-    await expect(common.checkDataset(settings, 'missingFolder')).rejects.toThrow('missing dataset json');
+    await expect(common.checkDataset(settings, 'missingFolder')).rejects.toThrow('missing project directory');
+  });
+
+  it('checkDataset does not create directories for missing datasets', async () => {
+    await expect(common.checkDataset(settings, 'missingFolder')).rejects.toThrow();
+    expect(fs.existsSync('/home/user/viamedata/DIVE_Projects/missingFolder')).toBe(false);
   });
 
   it('delete datasets', async () => {
-    await expect(common.deleteDataset(settings, 'missingFolder')).rejects.toThrow('missing dataset json');
+    await expect(common.deleteDataset(settings, 'missingFolder')).resolves.toBe(true);
     let exists = fs.existsSync('/home/user/viamedata/DIVE_Projects/projectid5Bad');
-    expect(exists).toBe(true);
-    await expect(common.deleteDataset(settings, 'projectid5Bad')).rejects.toThrow('missing track json file');
-    exists = fs.existsSync('/home/user/viamedata/DIVE_Projects/projectid5Bad');
     expect(exists).toBe(true);
     exists = fs.existsSync('/home/user/viamedata/DIVE_Projects/projectid6Delete');
     expect(exists).toBe(true);
@@ -1260,6 +1262,18 @@ describe('native.common', () => {
     expect(deleted).toBe(true);
     exists = fs.existsSync('/home/user/viamedata/DIVE_Projects/projectid6Delete');
     expect(exists).toBe(false);
+  });
+
+  it('delete incomplete datasets', async () => {
+    await expect(common.deleteDataset(settings, 'projectid3Bad')).resolves.toBe(true);
+    expect(fs.existsSync('/home/user/viamedata/DIVE_Projects/projectid3Bad')).toBe(false);
+    await expect(common.deleteDataset(settings, 'projectid5Bad')).resolves.toBe(true);
+    expect(fs.existsSync('/home/user/viamedata/DIVE_Projects/projectid5Bad')).toBe(false);
+  });
+
+  it('delete rejects paths outside the projects folder', async () => {
+    await expect(common.deleteDataset(settings, '../DIVE_Jobs')).rejects.toThrow('not a dataset directory');
+    expect(fs.existsSync('/home/user/viamedata/DIVE_Jobs')).toBe(true);
   });
 
   it('delete stereo dataset', async () => {

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -483,10 +483,10 @@ function getProjectDir(settings: Settings, datasetId: string) {
  */
 async function getValidatedProjectDir(settings: Settings, datasetId: string) {
   const projectInfo = getProjectDir(settings, datasetId);
-  fs.ensureDirSync(projectInfo.auxDirAbsPath);
   if (!fs.pathExistsSync(projectInfo.basePath)) {
     throw new Error(`missing project directory ${projectInfo.basePath}`);
   }
+  fs.ensureDirSync(projectInfo.auxDirAbsPath);
   if (!fs.pathExistsSync(projectInfo.datasetFileAbsPath)) {
     throw new Error(`missing dataset json file ${projectInfo.datasetFileAbsPath}`);
   }
@@ -1189,12 +1189,26 @@ async function deleteDataset(
   settings: Settings,
   datasetId: string,
 ): Promise<boolean> {
-  // Confirm dataset exists
-  const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  const projectMetaData = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
-  await fs.remove(projectDirInfo.basePath);
+  /* Incomplete or corrupt projects must still be removable, so this
+   * deliberately skips getValidatedProjectDir() */
+  const projectDirInfo = getProjectDir(settings, datasetId);
+  const projectsDir = npath.resolve(settings.dataPath, ProjectsFolderName);
+  const basePath = npath.resolve(projectDirInfo.basePath);
+  if (!basePath.startsWith(projectsDir + npath.sep)) {
+    throw new Error(`${datasetId} is not a dataset directory`);
+  }
+  if (!await fs.pathExists(basePath)) {
+    return true;
+  }
+  let projectMetaData: JsonConfig | undefined;
+  try {
+    projectMetaData = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
+  } catch {
+    // unreadable dataset json, delete the project directory anyway
+  }
+  await fs.remove(basePath);
   // If the dataset source is inside DIVE_Jobs_Output, delete that output folder
-  if (projectMetaData.originalBasePath) {
+  if (projectMetaData?.originalBasePath) {
     const jobsOutputPath = npath.resolve(settings.dataPath, JobsOutputFolderName);
     const originalBasePath = npath.resolve(projectMetaData.originalBasePath);
     const isInsideJobsOutput = originalBasePath !== jobsOutputPath


### PR DESCRIPTION
A dataset whose import died before `dataset.json` was written can never be deleted from the Recents list — `delete-dataset` fails with `missing metadata json file <path>`.

- `deleteDataset()` no longer runs `getValidatedProjectDir()`; it removes the project directory whatever state it's in, loads the dataset json only opportunistically for the DIVE_Jobs_Output cleanup, returns true when the directory is already gone, and rejects ids resolving outside DIVE_Projects.
- `getValidatedProjectDir()` checks the base path before `ensureDirSync(aux)`, so failed lookups stop creating stub `<id>/auxiliary/` dirs — which is what made the ghost entries reappear after manual cleanup.

Tests updated for the new behavior, 3 added.