### PR TITLE
solve an issue with the metadat/dataset rename in electron

### DIFF
--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -492,6 +492,27 @@ describe('native.common', () => {
     const dir = await common.getValidatedProjectDir(settings, 'projectid1');
     expect(dir.datasetFileAbsPath).toBe(preferred);
   });
+
+  it('saveConfig works on legacy meta.json-only projects and migrates', async () => {
+    // Regression: locking dataset.json before it exists caused ENOENT 500s on
+    // POST /dataset/:id/meta for projects still on meta.json.
+    const basedir = npath.join(settings.dataPath, 'DIVE_Projects/projectid1VideoGood');
+    const legacy = npath.join(basedir, 'meta.json');
+    const preferred = npath.join(basedir, 'dataset.json');
+    expect(await fs.pathExists(legacy)).toBe(true);
+    expect(await fs.pathExists(preferred)).toBe(false);
+
+    await common.saveConfig(settings, 'projectid1VideoGood', {
+      imageEnhancements: {
+        brightness: 1.2, contrast: 1, saturation: 1, sharpen: 0,
+      },
+    });
+
+    expect(await fs.pathExists(preferred)).toBe(true);
+    expect(await fs.pathExists(legacy)).toBe(false);
+    const saved = await fs.readJSON(preferred);
+    expect(saved.imageEnhancements.brightness).toBe(1.2);
+  });
   it('getValidatedProjectDir loads initial track.json', async () => {
     const basedir = 'DIVE_Projects/projectid4Bad';
     const dir = await common.getValidatedProjectDir(settings, 'projectid4Bad');

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -885,13 +885,18 @@ async function saveProjectConfig(basePath: string, data: unknown) {
 
 async function saveConfig(settings: Settings, datasetId: string, args: DatasetConfigMutable) {
   const projectDirInfo = await getValidatedProjectDir(settings, datasetId);
-  // Lock against the canonical dataset path so migrate-on-save stays stable.
+  // Lock the project directory (same pattern as tracks). Locking dataset.json
+  // directly fails with ENOENT on legacy projects that still only have
+  // meta.json, and migrate-on-save below may remove the legacy file while the
+  // lock is held.
   const release = await _acquireLock(
     projectDirInfo.basePath,
-    npath.join(projectDirInfo.basePath, DatasetFileName),
+    projectDirInfo.basePath,
     'meta',
   );
-  const existing = await loadJsonConfig(projectDirInfo.datasetFileAbsPath);
+  const existing = await loadJsonConfig(
+    resolveDatasetFileAbsPath(projectDirInfo.basePath),
+  );
   if (args.confidenceFilters) {
     existing.confidenceFilters = args.confidenceFilters;
   }


### PR DESCRIPTION
old datasets still have 'meta' for their information where it should be 'dataset', this resolves the issue.