### PR TITLE
Admin setting to disable job running

### DIFF
--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -88,6 +88,15 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    /* When true, gray out the Run button and show jobsDisabledMessage as tooltip */
+    jobsDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    jobsDisabledMessage: {
+      type: String,
+      default: '',
+    },
     /* Time filter range from the viewer - [startFrame, endFrame] or null */
     timeFilter: {
       type: Array as unknown as PropType<[number, number] | null>,
@@ -222,12 +231,24 @@ export default defineComponent({
     }
 
     const pipelinesNotRunnable = computed(() => (
-      props.selectedDatasetIds.length < 1 || pipelines.value === null
+      props.selectedDatasetIds.length < 1
+      || pipelines.value === null
+      || props.jobsDisabled
     ));
 
     const pipelinesCurrentlyRunning = computed(
       () => props.selectedDatasetIds.reduce((acc, item) => acc || props.runningPipelines.includes(item), false),
     );
+
+    const runPipelineTooltip = computed(() => {
+      if (props.jobsDisabled) {
+        return props.jobsDisabledMessage || 'Jobs are temporarily disabled';
+      }
+      if (pipelinesCurrentlyRunning.value) {
+        return 'Pipeline is Currently running';
+      }
+      return 'Run CV algorithm pipelines on this data';
+    });
 
     const singlePipelineValue = computed(() => {
       if (props.selectedDatasetIds.length === 1) {
@@ -333,6 +354,7 @@ export default defineComponent({
       pipeTypeDisplay: pipelineTypeDisplay,
       runPipelineOnSelectedItem,
       pipelinesCurrentlyRunning,
+      runPipelineTooltip,
       singlePipelineValue,
       selectedPipeline,
       selectedPipelineName,
@@ -362,34 +384,41 @@ export default defineComponent({
       content-class="pipeline-menu-content"
       v-bind="menuOptions"
       :close-on-content-click="false"
+      :disabled="jobsDisabled"
     >
       <template #activator="{ on: menuOn }">
         <v-tooltip
           bottom
-          :disabled="menuOptions.offsetX"
+          :disabled="menuOptions.offsetX && !jobsDisabled"
         >
           <template #activator="{ on: tooltipOn }">
-            <v-btn
-              v-bind="buttonOptions"
-              :disabled="pipelinesNotRunnable || buttonOptions.disabled"
-              :color="pipelinesCurrentlyRunning ? 'warning' : buttonOptions.color"
-              v-on="{ ...tooltipOn, ...menuOn }"
+            <!-- Wrapper keeps tooltip working when the button is disabled -->
+            <span
+              class="d-inline-block"
+              style="width: 100%"
+              v-on="tooltipOn"
             >
-              <v-icon> mdi-pipe </v-icon>
-              <span
-                v-show="!$vuetify.breakpoint.mdAndDown || buttonOptions.block"
-                class="pl-1"
+              <v-btn
+                v-bind="buttonOptions"
+                :disabled="pipelinesNotRunnable || buttonOptions.disabled"
+                :color="pipelinesCurrentlyRunning ? 'warning' : buttonOptions.color"
+                v-on="jobsDisabled ? {} : menuOn"
               >
-                Run pipeline
-              </span>
-              <v-spacer />
-              <v-icon v-if="menuOptions.right">
-                mdi-chevron-right
-              </v-icon>
-            </v-btn>
+                <v-icon> mdi-pipe </v-icon>
+                <span
+                  v-show="!$vuetify.breakpoint.mdAndDown || buttonOptions.block"
+                  class="pl-1"
+                >
+                  Run pipeline
+                </span>
+                <v-spacer />
+                <v-icon v-if="menuOptions.right">
+                  mdi-chevron-right
+                </v-icon>
+              </v-btn>
+            </span>
           </template>
-          <span v-if="!pipelinesCurrentlyRunning">Run CV algorithm pipelines on this data</span>
-          <span v-else>Pipeline is Currently running </span>
+          <span>{{ runPipelineTooltip }}</span>
         </v-tooltip>
       </template>
 

--- a/client/platform/web-girder/api/configuration.service.ts
+++ b/client/platform/web-girder/api/configuration.service.ts
@@ -50,7 +50,17 @@ export interface DiveConfiguration {
   distributedWorker?: string;
   pipelinesEnabled?: boolean;
   trainingEnabled?: boolean;
+  jobsDisabled?: boolean;
+  jobsDisabledMessage?: string;
 }
+
+export interface JobsDisabledConfig {
+  disabled: boolean;
+  message: string;
+}
+
+export const DEFAULT_JOBS_DISABLED_MESSAGE =
+  'Updates will be happening soon we are disabling jobs until after the updates';
 
 function getConfig() {
   return girderRest.get<DiveConfiguration>('dive_configuration');
@@ -62,6 +72,10 @@ function getBrandData() {
 
 function putBrandData(brandData: BrandData) {
   return girderRest.put('dive_configuration/brand_data', brandData);
+}
+
+function putJobsDisabled(config: JobsDisabledConfig) {
+  return girderRest.put<JobsDisabledConfig>('dive_configuration/jobs_disabled', config);
 }
 
 function getPipelineList() {
@@ -99,6 +113,7 @@ export {
   getBrandData,
   getConfig,
   putBrandData,
+  putJobsDisabled,
   getPipelineList,
   getTrainingConfigurations,
   getAddons,

--- a/client/platform/web-girder/api/configuration.service.ts
+++ b/client/platform/web-girder/api/configuration.service.ts
@@ -59,8 +59,7 @@ export interface JobsDisabledConfig {
   message: string;
 }
 
-export const DEFAULT_JOBS_DISABLED_MESSAGE =
-  'Updates will be happening soon we are disabling jobs until after the updates';
+export const DEFAULT_JOBS_DISABLED_MESSAGE = 'Updates will be happening soon, we are disabling jobs until after the updates';
 
 function getConfig() {
   return girderRest.get<DiveConfiguration>('dive_configuration');

--- a/client/platform/web-girder/store/useConfig.ts
+++ b/client/platform/web-girder/store/useConfig.ts
@@ -1,17 +1,24 @@
 /* eslint-disable import/prefer-default-export -- singleton composable store */
 import { ref } from 'vue';
 
-import { getConfig } from 'platform/web-girder/api/configuration.service';
+import {
+  DEFAULT_JOBS_DISABLED_MESSAGE,
+  getConfig,
+} from 'platform/web-girder/api/configuration.service';
 
 export interface ConfigState {
   distributedWorkerEnabled: boolean;
   pipelinesEnabled: boolean;
   trainingEnabled: boolean;
+  jobsDisabled: boolean;
+  jobsDisabledMessage: string;
 }
 
 const distributedWorkerEnabled = ref(false);
 const pipelinesEnabled = ref(false);
 const trainingEnabled = ref(false);
+const jobsDisabled = ref(false);
+const jobsDisabledMessage = ref(DEFAULT_JOBS_DISABLED_MESSAGE);
 
 export function useConfig() {
   function getDistributedWorkerEnabled(): boolean {
@@ -38,10 +45,28 @@ export function useConfig() {
     trainingEnabled.value = value;
   }
 
+  function getJobsDisabled(): boolean {
+    return jobsDisabled.value;
+  }
+
+  function setJobsDisabled(value: boolean): void {
+    jobsDisabled.value = value;
+  }
+
+  function getJobsDisabledMessage(): string {
+    return jobsDisabledMessage.value;
+  }
+
+  function setJobsDisabledMessage(value: string): void {
+    jobsDisabledMessage.value = value || DEFAULT_JOBS_DISABLED_MESSAGE;
+  }
+
   function setCapabilities(payload: Partial<ConfigState>): void {
     distributedWorkerEnabled.value = payload.distributedWorkerEnabled ?? false;
     pipelinesEnabled.value = payload.pipelinesEnabled ?? false;
     trainingEnabled.value = payload.trainingEnabled ?? false;
+    jobsDisabled.value = payload.jobsDisabled ?? false;
+    jobsDisabledMessage.value = payload.jobsDisabledMessage || DEFAULT_JOBS_DISABLED_MESSAGE;
   }
 
   async function loadConfig(): Promise<void> {
@@ -50,6 +75,8 @@ export function useConfig() {
       distributedWorkerEnabled: !!data.distributedWorker,
       pipelinesEnabled: !!data.pipelinesEnabled,
       trainingEnabled: !!data.trainingEnabled,
+      jobsDisabled: !!data.jobsDisabled,
+      jobsDisabledMessage: data.jobsDisabledMessage || DEFAULT_JOBS_DISABLED_MESSAGE,
     });
   }
 
@@ -57,12 +84,18 @@ export function useConfig() {
     distributedWorkerEnabled,
     pipelinesEnabled,
     trainingEnabled,
+    jobsDisabled,
+    jobsDisabledMessage,
     getDistributedWorkerEnabled,
     setDistributedWorkerEnabled,
     getPipelinesEnabled,
     setPipelinesEnabled,
     getTrainingEnabled,
     setTrainingEnabled,
+    getJobsDisabled,
+    setJobsDisabled,
+    getJobsDisabledMessage,
+    setJobsDisabledMessage,
     setCapabilities,
     loadConfig,
   };

--- a/client/platform/web-girder/store/webGirderStoreComposables.spec.ts
+++ b/client/platform/web-girder/store/webGirderStoreComposables.spec.ts
@@ -45,7 +45,7 @@ function resetAllStoreState() {
     pipelinesEnabled: false,
     trainingEnabled: false,
     jobsDisabled: false,
-    jobsDisabledMessage: 'Updates will be happening soon we are disabling jobs until after the updates',
+    jobsDisabledMessage: 'Updates will be happening soon, we are disabling jobs until after the updates',
   });
 
   const dataset = useDataset();

--- a/client/platform/web-girder/store/webGirderStoreComposables.spec.ts
+++ b/client/platform/web-girder/store/webGirderStoreComposables.spec.ts
@@ -44,6 +44,8 @@ function resetAllStoreState() {
     distributedWorkerEnabled: false,
     pipelinesEnabled: false,
     trainingEnabled: false,
+    jobsDisabled: false,
+    jobsDisabledMessage: 'Updates will be happening soon we are disabling jobs until after the updates',
   });
 
   const dataset = useDataset();
@@ -114,12 +116,16 @@ describe('web-girder store composables', () => {
           distributedWorker: true,
           pipelinesEnabled: true,
           trainingEnabled: false,
+          jobsDisabled: true,
+          jobsDisabledMessage: 'Maintenance in progress',
         },
       } as never);
       await useConfig().loadConfig();
       expect(useConfig().getDistributedWorkerEnabled()).toBe(true);
       expect(useConfig().getPipelinesEnabled()).toBe(true);
       expect(useConfig().getTrainingEnabled()).toBe(false);
+      expect(useConfig().getJobsDisabled()).toBe(true);
+      expect(useConfig().getJobsDisabledMessage()).toBe('Maintenance in progress');
     });
   });
 

--- a/client/platform/web-girder/views/Admin/AdminUpdate.vue
+++ b/client/platform/web-girder/views/Admin/AdminUpdate.vue
@@ -1,13 +1,38 @@
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
-import { updateContainers } from 'platform/web-girder/api/configuration.service';
+import {
+  defineComponent, onBeforeMount, ref,
+} from 'vue';
+import {
+  DEFAULT_JOBS_DISABLED_MESSAGE,
+  putJobsDisabled,
+  updateContainers,
+} from 'platform/web-girder/api/configuration.service';
+import { useConfig } from 'platform/web-girder/store/useConfig';
 
 export default defineComponent({
   name: 'AdminUpdate',
   setup() {
+    const {
+      jobsDisabled: configJobsDisabled,
+      jobsDisabledMessage: configJobsDisabledMessage,
+      loadConfig,
+      setJobsDisabled,
+      setJobsDisabledMessage,
+    } = useConfig();
+
     const loading = ref(false);
     const complete = ref('');
     const reloadTime = ref(0);
+    const savingJobsDisabled = ref(false);
+    const jobsDisabled = ref(false);
+    const jobsDisabledMessage = ref(DEFAULT_JOBS_DISABLED_MESSAGE);
+    const jobsDisabledSaved = ref(false);
+
+    onBeforeMount(async () => {
+      await loadConfig();
+      jobsDisabled.value = configJobsDisabled.value;
+      jobsDisabledMessage.value = configJobsDisabledMessage.value || DEFAULT_JOBS_DISABLED_MESSAGE;
+    });
 
     const update = async () => {
       loading.value = true;
@@ -31,11 +56,37 @@ export default defineComponent({
         }
       }
     };
+
+    const saveJobsDisabled = async () => {
+      savingJobsDisabled.value = true;
+      jobsDisabledSaved.value = false;
+      try {
+        const message = jobsDisabledMessage.value.trim() || DEFAULT_JOBS_DISABLED_MESSAGE;
+        const { data } = await putJobsDisabled({
+          disabled: jobsDisabled.value,
+          message,
+        });
+        jobsDisabled.value = data.disabled;
+        jobsDisabledMessage.value = data.message || DEFAULT_JOBS_DISABLED_MESSAGE;
+        setJobsDisabled(data.disabled);
+        setJobsDisabledMessage(data.message);
+        jobsDisabledSaved.value = true;
+      } finally {
+        savingJobsDisabled.value = false;
+      }
+    };
+
     return {
       update,
       loading,
       complete,
       reloadTime,
+      jobsDisabled,
+      jobsDisabledMessage,
+      savingJobsDisabled,
+      jobsDisabledSaved,
+      saveJobsDisabled,
+      DEFAULT_JOBS_DISABLED_MESSAGE,
     };
   },
 });
@@ -43,6 +94,54 @@ export default defineComponent({
 
 <template>
   <v-container>
+    <v-card class="mb-4">
+      <v-card-title> Disable Jobs </v-card-title>
+      <v-card-text>
+        <p>
+          Temporarily prevent users from launching new pipeline and training jobs
+          while updates are performed. Disabled job buttons are grayed out and show
+          the message below as a tooltip.
+        </p>
+        <v-switch
+          v-model="jobsDisabled"
+          label="Disable running jobs"
+          color="warning"
+          hide-details
+          class="mb-4"
+        />
+        <v-textarea
+          v-model="jobsDisabledMessage"
+          label="Disabled jobs message"
+          :placeholder="DEFAULT_JOBS_DISABLED_MESSAGE"
+          rows="2"
+          auto-grow
+          outlined
+          clearable
+          hint="Shown as a tooltip on disabled Run Pipeline and Run Training buttons"
+          persistent-hint
+        />
+        <v-alert
+          v-if="jobsDisabledSaved"
+          type="success"
+          dense
+          class="mt-4"
+        >
+          Job disable settings saved.
+        </v-alert>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          color="warning"
+          class="ml-2"
+          :loading="savingJobsDisabled"
+          @click="saveJobsDisabled"
+        >
+          Save Job Settings
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
     <v-card>
       <v-card-title> Update </v-card-title>
       <v-card-text>
@@ -74,7 +173,7 @@ export default defineComponent({
         <v-btn
           color="primary"
           class="ml-2"
-          :disable="complete"
+          :disabled="!!complete"
           @click="update"
         >
           <v-icon>

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -62,7 +62,12 @@ export default defineComponent({
     const {
       location, selected, locationIsViameFolder, setSelected,
     } = useLocation();
-    const { pipelinesEnabled, trainingEnabled } = useConfig();
+    const {
+      pipelinesEnabled,
+      trainingEnabled,
+      jobsDisabled,
+      jobsDisabledMessage,
+    } = useConfig();
     const jobs = useJobs();
 
     const clearSelected = () => {
@@ -149,6 +154,8 @@ export default defineComponent({
       locationIsViameFolder,
       pipelinesEnabled,
       trainingEnabled,
+      jobsDisabled,
+      jobsDisabledMessage,
       runningPipelines,
       selectedViameFolderIds,
       selectedViameFolderNames,
@@ -248,6 +255,8 @@ export default defineComponent({
                   :selected-dataset-name="locationInputNames"
                   :running-pipelines="runningPipelines"
                   :exclude-pipeline-terms="webExcludedPipelineTerms"
+                  :jobs-disabled="jobsDisabled"
+                  :jobs-disabled-message="jobsDisabledMessage"
                 />
                 <export
                   v-bind="{ buttonOptions, menuOptions }"

--- a/client/platform/web-girder/views/RunTrainingMenu.vue
+++ b/client/platform/web-girder/views/RunTrainingMenu.vue
@@ -9,6 +9,7 @@ import ImportButton from 'dive-common/components/ImportButton.vue';
 import { useRequest } from 'dive-common/use';
 import { simplifyTrainingName } from 'dive-common/constants';
 import { useBrand } from 'platform/web-girder/store/useBrand';
+import { useConfig } from 'platform/web-girder/store/useConfig';
 
 export default defineComponent({
   name: 'RunTrainingMenu',
@@ -33,6 +34,7 @@ export default defineComponent({
   setup(props) {
     const { brandData } = useBrand();
     const { getTrainingConfigurations, runTraining } = useApi();
+    const { jobsDisabled, jobsDisabledMessage } = useConfig();
 
     const trainingConfigurations = ref<TrainingConfigs | null>(null);
     const selectedTrainingConfig = ref<string | null>(null);
@@ -75,7 +77,14 @@ export default defineComponent({
       selectedTrainingConfig.value = resp.training.default;
     });
 
-    const trainingDisabled = computed(() => props.selectedDatasetIds.length === 0);
+    const trainingDisabled = computed(() => (
+      props.selectedDatasetIds.length === 0 || jobsDisabled.value
+    ));
+    const trainingTooltip = computed(() => (
+      jobsDisabled.value
+        ? (jobsDisabledMessage.value || 'Jobs are temporarily disabled')
+        : 'Train a detector model on this data'
+    ));
     const trainingOutputName = ref<string | null>(null);
     const menuOpen = ref(false);
     const labelText = ref<string>('');
@@ -83,7 +92,7 @@ export default defineComponent({
 
     async function runTrainingOnFolder() {
       const outputPipelineName = trainingOutputName.value;
-      if (trainingDisabled.value || !outputPipelineName) {
+      if (trainingDisabled.value || !outputPipelineName || jobsDisabled.value) {
         return;
       }
       await _runTrainingRequest(() => {
@@ -135,6 +144,8 @@ export default defineComponent({
       trainingOutputName,
       menuOpen,
       trainingDisabled,
+      trainingTooltip,
+      jobsDisabled,
       jobState,
       successMessage,
       dismissJobDialog,
@@ -158,33 +169,41 @@ export default defineComponent({
       max-width="500"
       v-bind="menuOptions"
       :close-on-content-click="false"
+      :disabled="jobsDisabled"
     >
       <template #activator="{ on: menuOn }">
         <v-tooltip
           bottom
           :open-delay="250"
-          :disabled="menuOptions.offsetX"
+          :disabled="menuOptions.offsetX && !jobsDisabled"
         >
           <template #activator="{ on: tooltipOn }">
-            <v-btn
-              v-bind="buttonOptions"
-              :disabled="trainingDisabled || buttonOptions.disabled"
-              v-on="{ ...tooltipOn, ...menuOn }"
+            <!-- Wrapper keeps tooltip working when the button is disabled -->
+            <span
+              class="d-inline-block"
+              style="width: 100%"
+              v-on="tooltipOn"
             >
-              <v-icon>
-                mdi-brain
-              </v-icon>
-              <span
-                v-show="!$vuetify.breakpoint.mdAndDown || buttonOptions.block"
-                class="pl-1"
+              <v-btn
+                v-bind="buttonOptions"
+                :disabled="trainingDisabled || buttonOptions.disabled"
+                v-on="jobsDisabled ? {} : menuOn"
               >
-                Run Training
-              </span>
-              <v-spacer />
-              <v-icon>mdi-chevron-right</v-icon>
-            </v-btn>
+                <v-icon>
+                  mdi-brain
+                </v-icon>
+                <span
+                  v-show="!$vuetify.breakpoint.mdAndDown || buttonOptions.block"
+                  class="pl-1"
+                >
+                  Run Training
+                </span>
+                <v-spacer />
+                <v-icon>mdi-chevron-right</v-icon>
+              </v-btn>
+            </span>
           </template>
-          <span>Train a detector model on this data</span>
+          <span>{{ trainingTooltip }}</span>
         </v-tooltip>
       </template>
 

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -108,7 +108,11 @@ export default defineComponent({
     const viewerRef = ref();
     const calibrationFile = ref<string | null>(null);
     const { brandData } = useBrand();
-    const { pipelinesEnabled } = useConfig();
+    const {
+      pipelinesEnabled,
+      jobsDisabled,
+      jobsDisabledMessage,
+    } = useConfig();
     const { meta: datasetMeta, loadDataset } = useDataset();
     const jobs = useJobs();
     const { locationRoute } = useLocation();
@@ -328,6 +332,8 @@ export default defineComponent({
       cameraNumbers,
       timeFilter,
       pipelinesEnabled,
+      jobsDisabled,
+      jobsDisabledMessage,
       webExcludedPipelineTerms,
       calibrationFile,
       onCalibrationImported,
@@ -383,6 +389,8 @@ export default defineComponent({
         :read-only-mode="revisionNum !== undefined"
         :time-filter="timeFilter"
         :exclude-pipeline-terms="webExcludedPipelineTerms"
+        :jobs-disabled="jobsDisabled"
+        :jobs-disabled-message="jobsDisabledMessage"
       />
       <ImportAnnotations
         :button-options="buttonOptions"

--- a/server/dive_server/views_configuration.py
+++ b/server/dive_server/views_configuration.py
@@ -48,6 +48,13 @@ def validateInstalledAddons(doc):
         assert isinstance(val['downloaded'], list), 'downloaded key is not a list'
 
 
+@setting_utilities.validator({constants.JOBS_DISABLED_CONFIG})
+def validateJobsDisabledConfig(doc):
+    val = doc['value']
+    if val is not None:
+        crud.get_validated_model(models.JobsDisabledConfig, **val)
+
+
 class ConfigurationResource(Resource):
     """Configuration resource handles get/set of global configuration"""
 
@@ -64,6 +71,7 @@ class ConfigurationResource(Resource):
         self.route("PUT", ("brand_data",), self.update_brand_data)
         self.route("PUT", ("static_pipeline_configs",), self.update_static_pipeline_configs)
         self.route("PUT", ("installed_addons",), self.update_installed_addons)
+        self.route("PUT", ("jobs_disabled",), self.update_jobs_disabled)
         self.route("POST", ("upgrade_pipelines",), self.upgrade_pipelines)
         self.route("POST", ("update_containers",), self.update_containers)
         self.route("GET", ("stats",), self.get_dataset_stats)
@@ -74,9 +82,12 @@ class ConfigurationResource(Resource):
         env = os.environ.copy()
         distributed_worker = env.get("RABBITMQ_DISTRIBUTED_WORKER")
         capabilities = worker_capabilities.get_worker_capabilities()
+        jobs_disabled = worker_capabilities.get_jobs_disabled_config()
         return {
             'distributedWorker': distributed_worker,
             **capabilities,
+            'jobsDisabled': jobs_disabled['disabled'],
+            'jobsDisabledMessage': jobs_disabled['message'],
         }
 
     @access.public
@@ -141,6 +152,24 @@ class ConfigurationResource(Resource):
     )
     def update_installed_addons(self, addons: Dict):
         Setting().set(constants.INSTALLED_ADDONS_CONFIGS, addons)
+
+    @access.admin
+    @autoDescribeRoute(
+        Description("Enable or disable job launching with an optional message").jsonParam(
+            "data",
+            "Jobs disabled configuration",
+            paramType='body',
+            requireObject=True,
+            required=True,
+        )
+    )
+    def update_jobs_disabled(self, data):
+        validated = crud.get_validated_model(models.JobsDisabledConfig, **data)
+        payload = validated.dict()
+        if not payload.get('message'):
+            payload['message'] = constants.DEFAULT_JOBS_DISABLED_MESSAGE
+        Setting().set(constants.JOBS_DISABLED_CONFIG, payload)
+        return worker_capabilities.get_jobs_disabled_config()
 
     # https://github.com/VIAME/VIAME/raw/main/cmake/download_viame_addons.csv - CSV URL
     @access.admin

--- a/server/dive_server/views_rpc.py
+++ b/server/dive_server/views_rpc.py
@@ -281,6 +281,7 @@ class RpcResource(Resource):
         )
     )
     def convert_large_image(self, folder):
+        worker_capabilities.require_jobs_enabled()
         return crud_rpc.convert_large_image(self.getCurrentUser(), folder)
 
     @access.user

--- a/server/dive_server/worker_capabilities.py
+++ b/server/dive_server/worker_capabilities.py
@@ -3,9 +3,10 @@ from typing import Any, Dict
 from urllib.parse import quote, urljoin
 
 from girder.exceptions import RestException
+from girder.models.setting import Setting
 import requests
 
-from dive_utils import asbool
+from dive_utils import asbool, constants
 
 
 def _queue_has_consumers(session: requests.Session, base_url: str, vhost: str, queue: str) -> bool:
@@ -60,7 +61,23 @@ def get_worker_capabilities() -> Dict[str, bool]:
     return capabilities
 
 
+def get_jobs_disabled_config() -> Dict[str, Any]:
+    stored = Setting().get(constants.JOBS_DISABLED_CONFIG) or {}
+    message = stored.get('message') or constants.DEFAULT_JOBS_DISABLED_MESSAGE
+    return {
+        'disabled': bool(stored.get('disabled', False)),
+        'message': message,
+    }
+
+
+def require_jobs_enabled():
+    config = get_jobs_disabled_config()
+    if config['disabled']:
+        raise RestException(config['message'], code=503)
+
+
 def require_pipeline_worker():
+    require_jobs_enabled()
     if not get_worker_capabilities()['pipelinesEnabled']:
         raise RestException(
             'Pipeline execution is unavailable because no pipeline workers are connected.',
@@ -69,6 +86,7 @@ def require_pipeline_worker():
 
 
 def require_training_worker():
+    require_jobs_enabled()
     if not get_worker_capabilities()['trainingEnabled']:
         raise RestException(
             'Training is unavailable because no training workers are connected.',

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -3,6 +3,10 @@ import re
 SETTINGS_CONST_JOBS_CONFIGS = 'jobs_configs'
 BRAND_DATA_CONFIG = 'brand_data_config'
 INSTALLED_ADDONS_CONFIGS = 'installed_addons'
+JOBS_DISABLED_CONFIG = 'jobs_disabled_config'
+DEFAULT_JOBS_DISABLED_MESSAGE = (
+    'Updates will be happening soon we are disabling jobs until after the updates'
+)
 
 ImageSequenceType = "image-sequence"
 VideoType = "video"

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -5,7 +5,7 @@ BRAND_DATA_CONFIG = 'brand_data_config'
 INSTALLED_ADDONS_CONFIGS = 'installed_addons'
 JOBS_DISABLED_CONFIG = 'jobs_disabled_config'
 DEFAULT_JOBS_DISABLED_MESSAGE = (
-    'Updates will be happening soon we are disabling jobs until after the updates'
+    'Updates will be happening soon, we are disabling jobs until after the updates'
 )
 
 ImageSequenceType = "image-sequence"

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -379,6 +379,14 @@ class BrandData(BaseModel):
         extra = 'forbid'
 
 
+class JobsDisabledConfig(BaseModel):
+    disabled: bool = False
+    message: Optional[str] = None
+
+    class Config:
+        extra = 'forbid'
+
+
 # interpolate all features [a, b)
 def interpolate(a: Feature, b: Feature) -> List[Feature]:
     if a.interpolate is False:


### PR DESCRIPTION
Added a functionality to the Admin tab to disable job running if the system will be running updates in the future.
This prevents a user from launching longer running jobs (pipelines/training).  It can be used the morning of updates to prevent users from running jobs so that way they aren't interrupted in the future.