### PR TITLE
Use ffprobe range requests

### DIFF
--- a/docker/girder_worker.Dockerfile
+++ b/docker/girder_worker.Dockerfile
@@ -1,8 +1,29 @@
+# ====================
+# == FFMPEG FETCHER ==
+# ====================
+# BtbN FFmpeg 7.1 release-branch builds (not git master). Supports -/headers so
+# Girder tokens need not appear in ffprobe argv. See:
+# https://github.com/BtbN/FFmpeg-Builds/releases/latest
+FROM python:3.11-bookworm AS ffmpeg-builder
+ARG TARGETARCH
+RUN apt-get update && apt-get install -qy --no-install-recommends wget ca-certificates xz-utils \
+  && rm -rf /var/lib/apt/lists/*
+RUN case "${TARGETARCH}" in \
+      amd64) FFARCH=linux64 ;; \
+      arm64) FFARCH=linuxarm64 ;; \
+      *) echo "Unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+  && wget -O /tmp/ffmpeg.tar.xz \
+    "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-${FFARCH}-gpl-7.1.tar.xz" \
+  && mkdir /tmp/ffextracted \
+  && tar -xvf /tmp/ffmpeg.tar.xz -C /tmp/ffextracted --strip-components 1 \
+  && rm /tmp/ffmpeg.tar.xz
+
 FROM python:3.11-bookworm AS worker
 
-# install architecture-compatible tini and ffmpeg
+# install architecture-compatible tini (ffmpeg comes from BtbN stage above)
 RUN apt-get update && \
-  apt-get install -qy tini ffmpeg git && \
+  apt-get install -qy tini git && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # use distro-provided tini binary for current architecture
@@ -40,11 +61,9 @@ RUN chown -R dive /opt/dive/local/
 USER dive
 RUN uv sync --frozen --no-dev
 
-# Copy the built python installation
-# Copy ffmpeg
-RUN install -d /opt/dive/local/ffmpeg && \
-  ln -sf /usr/bin/ffmpeg /opt/dive/local/ffmpeg/ffmpeg && \
-  ln -sf /usr/bin/ffprobe /opt/dive/local/ffmpeg/ffprobe
+# Copy BtbN ffmpeg/ffprobe into the path used by entrypoint_worker.sh
+RUN install -d /opt/dive/local/ffmpeg
+COPY --from=ffmpeg-builder /tmp/ffextracted/bin/ffmpeg /tmp/ffextracted/bin/ffprobe /opt/dive/local/ffmpeg/
 # Copy provision scripts
 COPY --chown=dive:dive docker/entrypoint_worker.sh /
 

--- a/docker/girder_worker_gpu.Dockerfile
+++ b/docker/girder_worker_gpu.Dockerfile
@@ -4,10 +4,17 @@
 # ====================
 # == FFMPEG FETCHER ==
 # ====================
-FROM python:3.8-bookworm AS ffmpeg-builder
-RUN wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
-RUN mkdir /tmp/ffextracted
-RUN tar -xvf ffmpeg.tar.xz -C /tmp/ffextracted --strip-components 1
+# BtbN FFmpeg 7.1 release-branch builds (not git master). Supports -/headers so
+# Girder tokens need not appear in ffprobe argv. See:
+# https://github.com/BtbN/FFmpeg-Builds/releases/latest
+FROM python:3.11-bookworm AS ffmpeg-builder
+RUN apt-get update && apt-get install -qy --no-install-recommends wget ca-certificates xz-utils \
+  && rm -rf /var/lib/apt/lists/*
+RUN wget -O /tmp/ffmpeg.tar.xz \
+  https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linux64-gpl-7.1.tar.xz \
+  && mkdir /tmp/ffextracted \
+  && tar -xvf /tmp/ffmpeg.tar.xz -C /tmp/ffextracted --strip-components 1 \
+  && rm /tmp/ffmpeg.tar.xz
 
 # =================
 # == GPU WORKER ==
@@ -58,8 +65,8 @@ USER dive
 RUN uv sync --frozen --no-dev
 
 # Copy the built python installation
-# Copy ffmpeg
-COPY --from=ffmpeg-builder /tmp/ffextracted/ffmpeg /tmp/ffextracted/ffprobe /opt/dive/local/ffmpeg/
+# Copy ffmpeg (BtbN layout: bin/ffmpeg, bin/ffprobe)
+COPY --from=ffmpeg-builder /tmp/ffextracted/bin/ffmpeg /tmp/ffextracted/bin/ffprobe /opt/dive/local/ffmpeg/
 # Copy provision scripts
 COPY --chown=dive:dive docker/entrypoint_worker.sh /
 

--- a/docs/Deployment-AssetStore-Import.md
+++ b/docs/Deployment-AssetStore-Import.md
@@ -17,6 +17,8 @@ When you run **Begin Import** on an S3/GCP (or filesystem) assetstore, Girder in
 3. Pair or discover **frame metadata** attachments (`.json` / `.csv` / `.txt`).
 4. After the index finishes, resolve any sidecars that arrived before their video folders, then queue **batch postprocess** (probe via HTTP Range when possible, transcode only if needed, attach annotations/metadata, finalize FPS). For already web-safe H.264 MP4/WebM, convert jobs avoid downloading the full object from the assetstore.
 
+    Remote probes use Girder's `/file/:id/download` endpoint (not `/item/:id/download`) so HTTP Range seeks work — required when an MP4's `moov` atom is at the end of the object. Auth uses a short-lived Girder job token via ffprobe `-/headers` (temp file) on FFmpeg 7.1 workers; job logs also redact any inline `-headers` values.
+
 Self-hosted deployments need the Compose **`localworker`** service running. Postprocess jobs for assetstore import are routed to the `local` queue. See [Running with Docker Compose](Deployment-Docker-Compose.md).
 
 

--- a/docs/Deployment-AssetStore-Import.md
+++ b/docs/Deployment-AssetStore-Import.md
@@ -15,7 +15,7 @@ When you run **Begin Import** on an S3/GCP (or filesystem) assetstore, Girder in
 1. Detect media (video, image sequence, or large image) and mark parent folders as DIVE datasets.
 2. Pair annotation files (`.json` / `.csv`) with the correct dataset folder.
 3. Pair or discover **frame metadata** attachments (`.json` / `.csv` / `.txt`).
-4. After the index finishes, resolve any sidecars that arrived before their video folders, then queue **batch postprocess** (transcode if needed, attach annotations/metadata, finalize FPS).
+4. After the index finishes, resolve any sidecars that arrived before their video folders, then queue **batch postprocess** (probe via HTTP Range when possible, transcode only if needed, attach annotations/metadata, finalize FPS). For already web-safe H.264 MP4/WebM, convert jobs avoid downloading the full object from the assetstore.
 
 Self-hosted deployments need the Compose **`localworker`** service running. Postprocess jobs for assetstore import are routed to the `local` queue. See [Running with Docker Compose](Deployment-Docker-Compose.md).
 

--- a/server/dive_tasks/frame_alignment.py
+++ b/server/dive_tasks/frame_alignment.py
@@ -1,11 +1,13 @@
 import json
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional, Union
 
 from girder_worker.task import Task
 from girder_worker.utils import JobManager
 
-from dive_tasks.utils import stream_subprocess
+from dive_tasks.utils import log_ffprobe_http_bytes, stream_subprocess
+
+MediaSource = Union[Path, str]
 
 
 def check_and_fix_frame_alignment(
@@ -26,19 +28,45 @@ def check_and_fix_frame_alignment(
     return file_path
 
 
-def is_frame_misaligned(task: Task, file_path: Path, context: Dict, manager: JobManager) -> bool:
-    command = [
-        "ffprobe",
-        str(file_path),
-        "-hide_banner",
-        "-read_intervals",
-        "%+5",
-        "-show_entries",
-        "frame=best_effort_timestamp_time",
-        "-print_format",
-        "json",
-    ]
-    stdout = stream_subprocess(task, context, manager, {'args': command}, keep_stdout=True)
+def is_frame_misaligned(
+    task: Task,
+    input_source: MediaSource,
+    context: Dict,
+    manager: JobManager,
+    *,
+    headers: Optional[str] = None,
+) -> bool:
+    """
+    Return True if the first ~5s of frames contain duplicate timestamps.
+
+    *input_source* may be a local Path or an HTTP(S) URL. Pass *headers* (e.g.
+    ``girder_auth_headers(token)``) when probing a Girder download URL so ffprobe
+    can authenticate and use Range requests.
+    """
+    command = ['ffprobe']
+    if headers:
+        command.extend(['-headers', headers])
+        # Emit HTTP Statistics so the job log can report bytes read.
+        command.extend(['-v', 'info'])
+    command.extend(
+        [
+            str(input_source),
+            '-hide_banner',
+            '-read_intervals',
+            '%+5',
+            '-show_entries',
+            'frame=best_effort_timestamp_time',
+            '-print_format',
+            'json',
+        ]
+    )
+    if headers:
+        stdout, stderr = stream_subprocess(
+            task, context, manager, {'args': command}, keep_stdout=True, keep_stderr=True
+        )
+        log_ffprobe_http_bytes(manager, stderr, label='ffprobe frame-alignment')
+    else:
+        stdout = stream_subprocess(task, context, manager, {'args': command}, keep_stdout=True)
     framejsoninfo = json.loads(stdout)
     if 'frames' not in framejsoninfo:
         raise Exception('Could not read ffprobe frames')

--- a/server/dive_tasks/frame_alignment.py
+++ b/server/dive_tasks/frame_alignment.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Union
 from girder_worker.task import Task
 from girder_worker.utils import JobManager
 
-from dive_tasks.utils import log_ffprobe_http_bytes, stream_subprocess
+from dive_tasks.utils import ffprobe_header_args, log_ffprobe_http_bytes, stream_subprocess
 
 MediaSource = Union[Path, str]
 
@@ -41,32 +41,35 @@ def is_frame_misaligned(
 
     *input_source* may be a local Path or an HTTP(S) URL. Pass *headers* (e.g.
     ``girder_auth_headers(token)``) when probing a Girder download URL so ffprobe
-    can authenticate and use Range requests.
+    can authenticate and use Range requests. Auth prefers ``-/headers`` (temp file)
+    so the token is not in process argv on modern ffprobe.
     """
-    command = ['ffprobe']
+    probe_tail = [
+        str(input_source),
+        '-hide_banner',
+        '-read_intervals',
+        '%+5',
+        '-show_entries',
+        'frame=best_effort_timestamp_time',
+        '-print_format',
+        'json',
+    ]
+
+    def _run(command):
+        if headers:
+            stdout, stderr = stream_subprocess(
+                task, context, manager, {'args': command}, keep_stdout=True, keep_stderr=True
+            )
+            log_ffprobe_http_bytes(manager, stderr, label='ffprobe frame-alignment')
+            return stdout
+        return stream_subprocess(task, context, manager, {'args': command}, keep_stdout=True)
+
     if headers:
-        command.extend(['-headers', headers])
         # Emit HTTP Statistics so the job log can report bytes read.
-        command.extend(['-v', 'info'])
-    command.extend(
-        [
-            str(input_source),
-            '-hide_banner',
-            '-read_intervals',
-            '%+5',
-            '-show_entries',
-            'frame=best_effort_timestamp_time',
-            '-print_format',
-            'json',
-        ]
-    )
-    if headers:
-        stdout, stderr = stream_subprocess(
-            task, context, manager, {'args': command}, keep_stdout=True, keep_stderr=True
-        )
-        log_ffprobe_http_bytes(manager, stderr, label='ffprobe frame-alignment')
+        with ffprobe_header_args(headers) as header_args:
+            stdout = _run(['ffprobe', *header_args, '-v', 'info', *probe_tail])
     else:
-        stdout = stream_subprocess(task, context, manager, {'args': command}, keep_stdout=True)
+        stdout = _run(['ffprobe', *probe_tail])
     framejsoninfo = json.loads(stdout)
     if 'frames' not in framejsoninfo:
         raise Exception('Could not read ffprobe frames')

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -1200,19 +1200,31 @@ def convert_video(
         remote_url: Optional[str] = None
 
         if skip_transcoding:
-            remote_url = utils.item_download_url(gc, itemId)
-            auth_headers = utils.girder_auth_headers(gc.token)
-            manager.updateStatus(JobStatus.RUNNING)
-            manager.write(f'Probing video via HTTP Range requests: {remote_url}\n')
             try:
-                jsoninfo = utils.ffprobe_format_and_streams(
-                    self, context, manager, remote_url, headers=auth_headers
-                )
+                remote_url = utils.item_primary_file_download_url(gc, itemId)
             except Exception as exc:
-                manager.write(f'Remote ffprobe failed ({exc}); falling back to full download\n')
-                jsoninfo = None
-                auth_headers = None
+                manager.write(
+                    f'Could not resolve file download URL ({exc}); '
+                    'falling back to full download\n'
+                )
                 remote_url = None
+            if remote_url is not None:
+                auth_headers = utils.girder_auth_headers(gc.token)
+                manager.updateStatus(JobStatus.RUNNING)
+                manager.write(f'Probing video via HTTP Range requests: {remote_url}\n')
+                try:
+                    jsoninfo = utils.ffprobe_format_and_streams(
+                        self, context, manager, remote_url, headers=auth_headers
+                    )
+                except utils.CanceledError:
+                    raise
+                except Exception as exc:
+                    manager.write(
+                        f'Remote ffprobe failed ({exc}); falling back to full download\n'
+                    )
+                    jsoninfo = None
+                    auth_headers = None
+                    remote_url = None
 
         if jsoninfo is None:
             file_name = _download_video_item(
@@ -1244,6 +1256,8 @@ def convert_video(
                     manager,
                     headers=alignment_headers,
                 )
+            except utils.CanceledError:
+                raise
             except Exception as exc:
                 if file_name is None:
                     manager.write(

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -1,5 +1,4 @@
 from contextlib import suppress
-import json
 import logging
 import os
 from pathlib import Path
@@ -1160,6 +1159,21 @@ def resolve_annotation_fps(
     )
 
 
+def _download_video_item(
+    gc: GirderClient,
+    manager: JobManager,
+    item_id: str,
+    item_name: str,
+    dest_dir: Path,
+) -> str:
+    """Download a Girder video item to *dest_dir*; return the local file path."""
+    file_name = str(dest_dir / item_name)
+    manager.updateStatus(JobStatus.FETCHING_INPUT)
+    manager.write(f'Fetching input from {item_id} to {file_name}...\n')
+    gc.downloadItem(item_id, dest_dir, name=item_name)
+    return file_name
+
+
 @app.task(bind=True, acks_late=True, ignore_result=True)
 def convert_video(
     self: Task, folderId: str, itemId: str, user_id: str, user_login: str, skip_transcoding=False
@@ -1174,27 +1188,39 @@ def convert_video(
     with tempfile.TemporaryDirectory() as _working_directory, suppress(utils.CanceledError):
         _working_directory_path = Path(_working_directory)
         item: GirderModel = gc.getItem(itemId)
-        file_name = str(_working_directory_path / item['name'])
-        output_file_path = (_working_directory_path / item['name']).with_suffix('.transcoded.mp4')
-        manager.updateStatus(JobStatus.FETCHING_INPUT)
-        manager.write(f'Fetching input from {itemId} to {file_name}...\n')
-        gc.downloadItem(itemId, _working_directory_path, name=item.get('name'))
-        manager.updateStatus(JobStatus.RUNNING)
+        item_name = item['name']
+        output_file_path = (_working_directory_path / item_name).with_suffix('.transcoded.mp4')
 
-        command = [
-            "ffprobe",
-            "-print_format",
-            "json",
-            "-v",
-            "quiet",
-            "-show_format",
-            "-show_streams",
-            file_name,
-        ]
-        stdout = utils.stream_subprocess(
-            self, context, manager, {'args': command}, keep_stdout=True
-        )
-        jsoninfo = json.loads(stdout)
+        # When skip_transcoding is requested, probe via authenticated HTTP Range
+        # requests first so web-ready S3/filesystem videos never need a full download.
+        # Fall back to downloading the whole object if remote probe/alignment fails.
+        jsoninfo = None
+        file_name: Optional[str] = None
+        auth_headers: Optional[str] = None
+        remote_url: Optional[str] = None
+
+        if skip_transcoding:
+            remote_url = utils.item_download_url(gc, itemId)
+            auth_headers = utils.girder_auth_headers(gc.token)
+            manager.updateStatus(JobStatus.RUNNING)
+            manager.write(f'Probing video via HTTP Range requests: {remote_url}\n')
+            try:
+                jsoninfo = utils.ffprobe_format_and_streams(
+                    self, context, manager, remote_url, headers=auth_headers
+                )
+            except Exception as exc:
+                manager.write(f'Remote ffprobe failed ({exc}); falling back to full download\n')
+                jsoninfo = None
+                auth_headers = None
+                remote_url = None
+
+        if jsoninfo is None:
+            file_name = _download_video_item(
+                gc, manager, itemId, item_name, _working_directory_path
+            )
+            manager.updateStatus(JobStatus.RUNNING)
+            jsoninfo = utils.ffprobe_format_and_streams(self, context, manager, file_name)
+
         videostream = list(filter(lambda x: x["codec_type"] == "video", jsoninfo["streams"]))
         if len(videostream) != 1:
             print('Expected 1 video stream, found {}'.format(len(videostream)))
@@ -1208,21 +1234,53 @@ def convert_video(
 
         source_misaligned = False
         if skip_transcoding:
-            source_misaligned = is_frame_misaligned(self, Path(file_name), context, manager)
+            alignment_source: Optional[str] = file_name or remote_url
+            alignment_headers = auth_headers if file_name is None else None
+            try:
+                source_misaligned = is_frame_misaligned(
+                    self,
+                    alignment_source,
+                    context,
+                    manager,
+                    headers=alignment_headers,
+                )
+            except Exception as exc:
+                if file_name is None:
+                    manager.write(
+                        f'Remote frame-alignment check failed ({exc}); '
+                        'falling back to full download\n'
+                    )
+                    file_name = _download_video_item(
+                        gc, manager, itemId, item_name, _working_directory_path
+                    )
+                    manager.updateStatus(JobStatus.RUNNING)
+                    # Re-probe locally so metadata matches the file we will encode.
+                    jsoninfo = utils.ffprobe_format_and_streams(self, context, manager, file_name)
+                    videostream = list(
+                        filter(lambda x: x["codec_type"] == "video", jsoninfo["streams"])
+                    )
+                    format_info = jsoninfo.get('format') or {}
+                    format_name = format_info.get('format_name') or ''
+                    originalFpsString, originalFps = utils.fps_from_ffprobe_stream(videostream[0])
+                    source_misaligned = is_frame_misaligned(self, Path(file_name), context, manager)
+                else:
+                    raise
 
         # Skip remux/transcode only for browser-safe sources, matching desktop checks.
-        can_skip_transcode = (
-            skip_transcoding
-            and videostream[0]['codec_name'] == 'h264'
-            and videostream[0].get('sample_aspect_ratio') == '1:1'
-            and utils.container_allows_skip_transcoding(format_name)
-            and not source_misaligned
+        can_skip_transcode = utils.can_skip_video_transcoding(
+            skip_transcoding=skip_transcoding,
+            codec_name=videostream[0]['codec_name'],
+            sample_aspect_ratio=videostream[0].get('sample_aspect_ratio'),
+            format_name=format_name,
+            source_misaligned=source_misaligned,
         )
 
         # lets determine if we don't need to transcode this file
         if can_skip_transcode:
             # Now we can update the meta data and push the values
             manager.updateStatus(JobStatus.PUSHING_OUTPUT)
+            if file_name is None:
+                manager.write('Skip transcode: no full download required\n')
             newAnnotationFps = resolve_annotation_fps(gc, folderId, native_fps=originalFps)
             gc.addMetadataToItem(
                 itemId,
@@ -1260,6 +1318,12 @@ def convert_video(
                 print('Container is not web-safe (e.g. mpegts); file will be transcoded')
             elif source_misaligned:
                 print('Frame timestamps are misaligned; file will be transcoded')
+
+        if file_name is None:
+            file_name = _download_video_item(
+                gc, manager, itemId, item_name, _working_directory_path
+            )
+            manager.updateStatus(JobStatus.RUNNING)
 
         command = [
             "ffmpeg",

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import signal
 import subprocess
@@ -9,7 +10,7 @@ from subprocess import Popen
 import tempfile
 import threading
 import time
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from urllib import request
 from urllib.parse import urlencode, urljoin
 
@@ -116,6 +117,105 @@ def container_allows_skip_transcoding(format_name: str) -> bool:
     return bool(parts & _WEBSAFE_SKIP_TRANSCODE_FORMAT_FRAGMENTS)
 
 
+def format_byte_count(num_bytes: int) -> str:
+    """Human-readable byte count for job logs (binary units)."""
+    units = ('B', 'KiB', 'MiB', 'GiB', 'TiB')
+    value = float(num_bytes)
+    for unit in units:
+        if value < 1024.0 or unit == units[-1]:
+            if unit == 'B':
+                return f'{int(value)} {unit}'
+            return f'{value:.2f} {unit}'
+        value /= 1024.0
+    return f'{num_bytes} B'
+
+
+def parse_ffmpeg_http_bytes_read(stderr: str) -> Optional[int]:
+    """
+    Sum ``Statistics: N bytes read`` lines from ffmpeg/ffprobe HTTP stderr.
+
+    When probing a remote URL, libavformat logs one Statistics line per HTTP
+    context as it closes. Multiple lines are common with Range seeks.
+    """
+    if not stderr:
+        return None
+    total = 0
+    found = False
+    for match in re.finditer(r'Statistics:\s+(\d+)\s+bytes read', stderr):
+        total += int(match.group(1))
+        found = True
+    return total if found else None
+
+
+def girder_auth_headers(token: str) -> str:
+    """Header block for ffprobe/ffmpeg HTTP requests (requires CRLF line endings)."""
+    return f'Girder-Token: {token}\r\n'
+
+
+def item_download_url(gc: GirderClient, item_id: str) -> str:
+    """Absolute Girder item download URL (supports HTTP Range when the store does)."""
+    return urljoin(gc.urlBase, f'item/{item_id}/download')
+
+
+def can_skip_video_transcoding(
+    *,
+    skip_transcoding: bool,
+    codec_name: str,
+    sample_aspect_ratio,
+    format_name: str,
+    source_misaligned: bool,
+) -> bool:
+    """True when convert_video may tag the source as playable without remux/encode."""
+    return (
+        skip_transcoding
+        and codec_name == 'h264'
+        and sample_aspect_ratio == '1:1'
+        and container_allows_skip_transcoding(format_name)
+        and not source_misaligned
+    )
+
+
+def ffprobe_format_and_streams(
+    task: Task,
+    context: dict,
+    manager: JobManager,
+    input_source: str,
+    *,
+    headers: Optional[str] = None,
+) -> dict:
+    """
+    Run ffprobe -show_format -show_streams on a local path or HTTP URL.
+
+    When *headers* is set (e.g. Girder-Token), ffprobe can issue authenticated
+    Range requests against Girder/S3 instead of requiring a full local download.
+    HTTP probes use ``-v info`` so libavformat Statistics lines are available and
+    the job log reports how many bytes were read.
+    """
+    command = ['ffprobe']
+    if headers:
+        command.extend(['-headers', headers])
+    # Quiet for local files; info for HTTP so Statistics: N bytes read is emitted.
+    command.extend(
+        [
+            '-print_format',
+            'json',
+            '-v',
+            'info' if headers else 'quiet',
+            '-show_format',
+            '-show_streams',
+            input_source,
+        ]
+    )
+    if headers:
+        stdout, stderr = stream_subprocess(
+            task, context, manager, {'args': command}, keep_stdout=True, keep_stderr=True
+        )
+        log_ffprobe_http_bytes(manager, stderr, label='ffprobe format/streams')
+    else:
+        stdout = stream_subprocess(task, context, manager, {'args': command}, keep_stdout=True)
+    return json.loads(stdout)
+
+
 def authenticate_urllib(gc: GirderClient):
     """Enable authenticated requests to girder backend using normal urllib"""
     opener = request.build_opener()
@@ -193,7 +293,8 @@ def stream_subprocess(
     manager: JobManager,
     popen_kwargs: dict,
     keep_stdout: bool = False,
-) -> str:
+    keep_stderr: bool = False,
+) -> Union[str, Tuple[str, str]]:
     """
     Stream live results from process to job manager
 
@@ -201,6 +302,7 @@ def stream_subprocess(
     :param manager: job manager
     :param popen_kwargs: a dict to pass as kwargs to popen.  Must include 'args'
     :param keep_stdout: will return stdout as a string if needed
+    :param keep_stderr: when True, return ``(stdout, stderr)`` instead of stdout
     """
     start_time = datetime.now()
     stdout = ""
@@ -288,19 +390,32 @@ def stream_subprocess(
             manager.updateStatus(JobStatus.CANCELED)
             raise CanceledError('Job was canceled')
 
+        stderr_file.seek(0)
+        stderr = stderr_file.read().decode('utf-8', errors='replace')
+
         # Popen reports death by signal as a negative return code, so anything other
         # than 0 is a failure.  Treating only code > 0 as failure let a SIGKILLed
         # pipeline (-9, typically the OOM killer) report success, and callers then
         # ingested whatever partial or empty output file it left behind.
         if code != 0:
-            stderr_file.seek(0)
-            stderr = stderr_file.read().decode('utf-8', errors='replace')
             raise RuntimeError(f'Pipeline {describe_exit(code)}: {stderr}')
         else:
             end_time = datetime.now()
             manager.write(f"\nProcess completed in {str((end_time - start_time))}\n")
 
+        if keep_stderr:
+            return stdout, stderr
         return stdout
+
+
+def log_ffprobe_http_bytes(manager: JobManager, stderr: str, *, label: str) -> Optional[int]:
+    """Write HTTP bytes-read stats from ffprobe stderr to the job log."""
+    nbytes = parse_ffmpeg_http_bytes_read(stderr)
+    if nbytes is None:
+        manager.write(f'{label}: HTTP bytes read unknown (no Statistics line in stderr)\n')
+    else:
+        manager.write(f'{label}: HTTP bytes read {nbytes} ({format_byte_count(nbytes)})\n')
+    return nbytes
 
 
 def download_revision_csv(gc: GirderClient, dataset_id: str, revision: int, path: Path):

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -1,4 +1,6 @@
+from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta
+from functools import lru_cache
 import json
 import os
 from pathlib import Path
@@ -10,7 +12,7 @@ from subprocess import Popen
 import tempfile
 import threading
 import time
-from typing import List, Optional, Tuple, Union
+from typing import Iterator, List, Optional, Tuple, Union
 from urllib import request
 from urllib.parse import urlencode, urljoin
 
@@ -148,13 +150,108 @@ def parse_ffmpeg_http_bytes_read(stderr: str) -> Optional[int]:
 
 
 def girder_auth_headers(token: str) -> str:
-    """Header block for ffprobe/ffmpeg HTTP requests (requires CRLF line endings)."""
+    """
+    Header block for ffprobe/ffmpeg HTTP requests (requires CRLF line endings).
+
+    Prefer passing this through :func:`ffprobe_header_args` so modern ffprobe
+    loads the value from a temp file via ``-/headers`` (token not in process argv).
+    Older ffprobe falls back to inline ``-headers``; job logs still redact that value.
+    """
     return f'Girder-Token: {token}\r\n'
 
 
-def item_download_url(gc: GirderClient, item_id: str) -> str:
-    """Absolute Girder item download URL (supports HTTP Range when the store does)."""
-    return urljoin(gc.urlBase, f'item/{item_id}/download')
+@lru_cache(maxsize=1)
+def ffprobe_supports_option_from_file() -> bool:
+    """
+    True if this ffprobe accepts ``-/option file`` value loading (FFmpeg 5+).
+
+    Worker images ship BtbN FFmpeg 7.1, which supports it. Cached after one probe
+    so local/dev hosts with older distro ffprobe can still fall back to ``-headers``.
+    """
+    fd, path = tempfile.mkstemp(prefix='ffprobe-headers-probe-', suffix='.txt')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8', newline='') as header_file:
+            header_file.write('X-DIVE-Probe: 1\r\n')
+        completed = subprocess.run(
+            ['ffprobe', '-hide_banner', '-/headers', path, '-version'],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        combined = f'{completed.stdout or ""}{completed.stderr or ""}'
+        # FFmpeg 4.x reports: Failed to set value '...' for option '/headers': Option not found
+        return 'Option not found' not in combined and 'Unrecognized option' not in combined
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return False
+    finally:
+        with suppress(OSError):
+            os.unlink(path)
+
+
+@contextmanager
+def ffprobe_header_args(headers: str) -> Iterator[List[str]]:
+    """
+    Yield ffprobe argv fragments that supply *headers* without leaking the token
+    into process argv when ``-/headers`` is supported.
+
+    Modern ffprobe (worker images): ``['-/headers', temp_path]``.
+    Older ffprobe: ``['-headers', headers]`` (token visible in ``ps``; job logs redact).
+    """
+    if not ffprobe_supports_option_from_file():
+        yield ['-headers', headers]
+        return
+
+    fd, path = tempfile.mkstemp(prefix='ffprobe-headers-', suffix='.txt')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8', newline='') as header_file:
+            header_file.write(headers)
+        yield ['-/headers', path]
+    finally:
+        with suppress(OSError):
+            os.unlink(path)
+
+
+def sanitize_subprocess_args_for_log(args: List[str]) -> List[str]:
+    """
+    Copy *args* for job logs, redacting values that may contain secrets.
+
+    Inline ``-headers`` values (Girder tokens) are replaced with ``<redacted>``.
+    ``-/headers`` paths are left as-is (token lives in the file, not argv).
+    """
+    sanitized: List[str] = []
+    skip_next = False
+    for i, arg in enumerate(args):
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == '-headers' and i + 1 < len(args):
+            sanitized.extend(['-headers', '<redacted>'])
+            skip_next = True
+            continue
+        sanitized.append(arg)
+    return sanitized
+
+
+def file_download_url(gc: GirderClient, file_id: str) -> str:
+    """Absolute Girder file download URL (parses HTTP Range; see Girder file API)."""
+    return urljoin(gc.urlBase, f'file/{file_id}/download')
+
+
+def item_primary_file_download_url(gc: GirderClient, item_id: str) -> str:
+    """
+    Download URL for the first file on an item, suitable for remote ffprobe.
+
+    Uses ``/file/:id/download`` rather than ``/item/:id/download``. Girder's item
+    download endpoint only honors an ``offset`` query param and ignores the HTTP
+    ``Range`` header, so ffprobe cannot seek to a trailing MP4 ``moov`` atom and
+    fails with ``moov atom not found``. The file endpoint supports Range (and
+    assetstore adapters pass it through for filesystem/S3).
+    """
+    files = list(gc.listFile(item_id, limit=2))
+    if not files:
+        raise Exception(f'Item {item_id} has no files to probe')
+    return file_download_url(gc, str(files[0]['_id']))
 
 
 def can_skip_video_transcoding(
@@ -188,31 +285,35 @@ def ffprobe_format_and_streams(
 
     When *headers* is set (e.g. Girder-Token), ffprobe can issue authenticated
     Range requests against Girder/S3 instead of requiring a full local download.
-    HTTP probes use ``-v info`` so libavformat Statistics lines are available and
-    the job log reports how many bytes were read.
+    Auth headers prefer ``-/headers`` (temp file) so the token is not in process
+    argv on modern ffprobe. HTTP probes use ``-v info`` so libavformat Statistics
+    lines are available and the job log reports how many bytes were read.
     """
-    command = ['ffprobe']
-    if headers:
-        command.extend(['-headers', headers])
+
+    def _run(command: List[str]):
+        if headers:
+            stdout, stderr = stream_subprocess(
+                task, context, manager, {'args': command}, keep_stdout=True, keep_stderr=True
+            )
+            log_ffprobe_http_bytes(manager, stderr, label='ffprobe format/streams')
+            return stdout
+        return stream_subprocess(task, context, manager, {'args': command}, keep_stdout=True)
+
     # Quiet for local files; info for HTTP so Statistics: N bytes read is emitted.
-    command.extend(
-        [
-            '-print_format',
-            'json',
-            '-v',
-            'info' if headers else 'quiet',
-            '-show_format',
-            '-show_streams',
-            input_source,
-        ]
-    )
+    probe_tail = [
+        '-print_format',
+        'json',
+        '-v',
+        'info' if headers else 'quiet',
+        '-show_format',
+        '-show_streams',
+        input_source,
+    ]
     if headers:
-        stdout, stderr = stream_subprocess(
-            task, context, manager, {'args': command}, keep_stdout=True, keep_stderr=True
-        )
-        log_ffprobe_http_bytes(manager, stderr, label='ffprobe format/streams')
+        with ffprobe_header_args(headers) as header_args:
+            stdout = _run(['ffprobe', *header_args, *probe_tail])
     else:
-        stdout = stream_subprocess(task, context, manager, {'args': command}, keep_stdout=True)
+        stdout = _run(['ffprobe', *probe_tail])
     return json.loads(stdout)
 
 
@@ -336,7 +437,8 @@ def stream_subprocess(
                 return
 
     with tempfile.TemporaryFile() as stderr_file:
-        manager.write(f"Running command: {str(launch_kwargs['args'])}\n", forceFlush=True)
+        logged_args = sanitize_subprocess_args_for_log(list(launch_kwargs['args']))
+        manager.write(f"Running command: {str(logged_args)}\n", forceFlush=True)
         process = Popen(
             **launch_kwargs,
             stdout=subprocess.PIPE,

--- a/server/tests/test_remote_ffprobe.py
+++ b/server/tests/test_remote_ffprobe.py
@@ -1,0 +1,268 @@
+"""Tests for remote ffprobe helpers used by convert_video."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dive_tasks import utils
+from dive_tasks.frame_alignment import is_frame_misaligned
+
+
+class _FakeGirderClient:
+    def __init__(self, url_base='http://girder.example/api/v1/', token='tok-123'):
+        self.urlBase = url_base
+        self.token = token
+
+
+def test_girder_auth_headers_use_crlf():
+    assert utils.girder_auth_headers('abc') == 'Girder-Token: abc\r\n'
+
+
+def test_item_download_url_joins_api_base():
+    gc = _FakeGirderClient()
+    assert utils.item_download_url(gc, 'item99') == (
+        'http://girder.example/api/v1/item/item99/download'
+    )
+
+
+def test_format_byte_count():
+    assert utils.format_byte_count(512) == '512 B'
+    assert utils.format_byte_count(2048) == '2.00 KiB'
+    assert utils.format_byte_count(5 * 1024 * 1024) == '5.00 MiB'
+
+
+def test_parse_ffmpeg_http_bytes_read_sums_statistics_lines():
+    stderr = (
+        '[http @ 0x1] Opening...\n'
+        '[http @ 0x1] Statistics: 12345 bytes read, 2 seeks\n'
+        '[http @ 0x2] Statistics: 1000 bytes read, 0 seeks\n'
+    )
+    assert utils.parse_ffmpeg_http_bytes_read(stderr) == 13345
+    assert utils.parse_ffmpeg_http_bytes_read('no stats here') is None
+
+
+@pytest.mark.parametrize(
+    'kwargs,expected',
+    [
+        (
+            {
+                'skip_transcoding': True,
+                'codec_name': 'h264',
+                'sample_aspect_ratio': '1:1',
+                'format_name': 'mov,mp4,m4a,3gp,3g2,mj2',
+                'source_misaligned': False,
+            },
+            True,
+        ),
+        (
+            {
+                'skip_transcoding': False,
+                'codec_name': 'h264',
+                'sample_aspect_ratio': '1:1',
+                'format_name': 'mp4',
+                'source_misaligned': False,
+            },
+            False,
+        ),
+        (
+            {
+                'skip_transcoding': True,
+                'codec_name': 'hevc',
+                'sample_aspect_ratio': '1:1',
+                'format_name': 'mp4',
+                'source_misaligned': False,
+            },
+            False,
+        ),
+        (
+            {
+                'skip_transcoding': True,
+                'codec_name': 'h264',
+                'sample_aspect_ratio': '1:1',
+                'format_name': 'mpegts',
+                'source_misaligned': False,
+            },
+            False,
+        ),
+        (
+            {
+                'skip_transcoding': True,
+                'codec_name': 'h264',
+                'sample_aspect_ratio': '1:1',
+                'format_name': 'mp4',
+                'source_misaligned': True,
+            },
+            False,
+        ),
+    ],
+)
+def test_can_skip_video_transcoding(kwargs, expected):
+    assert utils.can_skip_video_transcoding(**kwargs) is expected
+
+
+def test_ffprobe_format_and_streams_passes_headers_before_url():
+    task = MagicMock()
+    manager = MagicMock()
+    probe_json = '{"streams":[],"format":{}}'
+    stderr = '[http @ 0x1] Statistics: 4096 bytes read, 1 seeks\n'
+
+    with patch.object(utils, 'stream_subprocess', return_value=(probe_json, stderr)) as mock_run:
+        result = utils.ffprobe_format_and_streams(
+            task,
+            {},
+            manager,
+            'http://girder.example/api/v1/item/1/download',
+            headers='Girder-Token: tok\r\n',
+        )
+
+    assert result == {'streams': [], 'format': {}}
+    command = mock_run.call_args[0][3]['args']
+    assert command[0] == 'ffprobe'
+    assert '-headers' in command
+    header_idx = command.index('-headers')
+    assert command[header_idx + 1] == 'Girder-Token: tok\r\n'
+    assert command[-1] == 'http://girder.example/api/v1/item/1/download'
+    assert '-show_format' in command
+    assert '-show_streams' in command
+    assert command[command.index('-v') + 1] == 'info'
+    assert mock_run.call_args[1].get('keep_stderr') is True
+    written = ''.join(str(c.args[0]) for c in manager.write.call_args_list)
+    assert '4096' in written
+    assert 'HTTP bytes read' in written
+
+
+def test_is_frame_misaligned_accepts_url_and_headers():
+    task = MagicMock()
+    manager = MagicMock()
+    frame_json = (
+        '{"frames":[{"best_effort_timestamp_time":"0.0"},'
+        '{"best_effort_timestamp_time":"0.033"}]}'
+    )
+    stderr = '[http @ 0x1] Statistics: 8192 bytes read, 0 seeks\n'
+
+    with patch(
+        'dive_tasks.frame_alignment.stream_subprocess', return_value=(frame_json, stderr)
+    ) as mock_run:
+        assert (
+            is_frame_misaligned(
+                task,
+                'http://girder.example/api/v1/item/1/download',
+                {},
+                manager,
+                headers='Girder-Token: tok\r\n',
+            )
+            is False
+        )
+
+    command = mock_run.call_args[0][3]['args']
+    assert command[0] == 'ffprobe'
+    assert command[command.index('-headers') + 1] == 'Girder-Token: tok\r\n'
+    assert 'http://girder.example/api/v1/item/1/download' in command
+    written = ''.join(str(c.args[0]) for c in manager.write.call_args_list)
+    assert '8192' in written
+
+
+def _run_convert_video(task, **kwargs):
+    """Invoke convert_video's underlying function with an explicit bound self."""
+    from dive_tasks.tasks import convert_video
+
+    # PromiseProxy.__wrapped__ is a bound method; call the unbound function.
+    return convert_video.__wrapped__.__func__(task, **kwargs)
+
+
+def test_convert_video_skip_path_avoids_download():
+    """Remote probe + skippable media must not call downloadItem."""
+    probe = {
+        'streams': [
+            {
+                'codec_type': 'video',
+                'codec_name': 'h264',
+                'sample_aspect_ratio': '1:1',
+                'avg_frame_rate': '30/1',
+                'r_frame_rate': '30/1',
+            }
+        ],
+        'format': {'format_name': 'mov,mp4,m4a,3gp,3g2,mj2'},
+    }
+
+    task = MagicMock()
+    task.canceled = False
+    gc = MagicMock()
+    gc.urlBase = 'http://girder.example/api/v1/'
+    gc.token = 'tok-123'
+    gc.getItem.return_value = {'name': 'clip.mp4'}
+    task.girder_client = gc
+    task.job_manager = MagicMock()
+
+    with (
+        patch('dive_tasks.tasks.patch_manager') as patch_mgr,
+        patch('dive_tasks.tasks.utils.ffprobe_format_and_streams', return_value=probe),
+        patch('dive_tasks.tasks.is_frame_misaligned', return_value=False),
+        patch('dive_tasks.tasks.resolve_annotation_fps', return_value=30.0),
+    ):
+        patch_mgr.return_value = MagicMock()
+        _run_convert_video(
+            task,
+            folderId='folder1',
+            itemId='item1',
+            user_id='user1',
+            user_login='alice',
+            skip_transcoding=True,
+        )
+
+    gc.downloadItem.assert_not_called()
+    gc.addMetadataToItem.assert_called_once()
+    gc.addMetadataToFolder.assert_called_once()
+    item_meta = gc.addMetadataToItem.call_args[0][1]
+    assert item_meta['codec'] == 'h264'
+    folder_meta = gc.addMetadataToFolder.call_args[0][1]
+    assert folder_meta['annotate'] is True
+
+
+def test_convert_video_downloads_when_transcode_required():
+    probe = {
+        'streams': [
+            {
+                'codec_type': 'video',
+                'codec_name': 'mpeg4',
+                'sample_aspect_ratio': '1:1',
+                'avg_frame_rate': '25/1',
+                'r_frame_rate': '25/1',
+            }
+        ],
+        'format': {'format_name': 'avi'},
+    }
+
+    task = MagicMock()
+    task.canceled = False
+    gc = MagicMock()
+    gc.urlBase = 'http://girder.example/api/v1/'
+    gc.token = 'tok-123'
+    gc.getItem.return_value = {'name': 'clip.avi'}
+    gc.uploadFileToFolder.return_value = {'itemId': 'new-item'}
+    task.girder_client = gc
+    task.job_manager = MagicMock()
+
+    with (
+        patch('dive_tasks.tasks.patch_manager') as patch_mgr,
+        patch('dive_tasks.tasks.utils.ffprobe_format_and_streams', return_value=probe),
+        patch('dive_tasks.tasks.is_frame_misaligned', return_value=False),
+        patch('dive_tasks.tasks.utils.stream_subprocess'),
+        patch(
+            'dive_tasks.tasks.check_and_fix_frame_alignment',
+            side_effect=lambda task, path, context, manager: path,
+        ),
+        patch('dive_tasks.tasks.resolve_annotation_fps', return_value=25.0),
+    ):
+        patch_mgr.return_value = MagicMock()
+        _run_convert_video(
+            task,
+            folderId='folder1',
+            itemId='item1',
+            user_id='user1',
+            user_login='alice',
+            skip_transcoding=True,
+        )
+
+    gc.downloadItem.assert_called_once()
+    gc.uploadFileToFolder.assert_called_once()

--- a/server/tests/test_remote_ffprobe.py
+++ b/server/tests/test_remote_ffprobe.py
@@ -1,11 +1,13 @@
 """Tests for remote ffprobe helpers used by convert_video."""
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from dive_tasks import utils
 from dive_tasks.frame_alignment import is_frame_misaligned
+from dive_tasks.utils import CanceledError
 
 
 class _FakeGirderClient:
@@ -18,11 +20,29 @@ def test_girder_auth_headers_use_crlf():
     assert utils.girder_auth_headers('abc') == 'Girder-Token: abc\r\n'
 
 
-def test_item_download_url_joins_api_base():
+def test_file_download_url_joins_api_base():
     gc = _FakeGirderClient()
-    assert utils.item_download_url(gc, 'item99') == (
-        'http://girder.example/api/v1/item/item99/download'
+    assert utils.file_download_url(gc, 'file99') == (
+        'http://girder.example/api/v1/file/file99/download'
     )
+
+
+def test_item_primary_file_download_url_uses_file_endpoint():
+    gc = MagicMock()
+    gc.urlBase = 'http://girder.example/api/v1/'
+    gc.listFile.return_value = iter([{'_id': 'file42', 'name': 'clip.mp4'}])
+    assert utils.item_primary_file_download_url(gc, 'item99') == (
+        'http://girder.example/api/v1/file/file42/download'
+    )
+    gc.listFile.assert_called_once_with('item99', limit=2)
+
+
+def test_item_primary_file_download_url_requires_a_file():
+    gc = MagicMock()
+    gc.urlBase = 'http://girder.example/api/v1/'
+    gc.listFile.return_value = iter([])
+    with pytest.raises(Exception, match='no files'):
+        utils.item_primary_file_download_url(gc, 'item99')
 
 
 def test_format_byte_count():
@@ -39,6 +59,45 @@ def test_parse_ffmpeg_http_bytes_read_sums_statistics_lines():
     )
     assert utils.parse_ffmpeg_http_bytes_read(stderr) == 13345
     assert utils.parse_ffmpeg_http_bytes_read('no stats here') is None
+
+
+def test_sanitize_subprocess_args_redacts_inline_headers():
+    args = [
+        'ffprobe',
+        '-headers',
+        'Girder-Token: secret-tok\r\n',
+        '-show_format',
+        'http://example/item/1/download',
+    ]
+    sanitized = utils.sanitize_subprocess_args_for_log(args)
+    assert sanitized[sanitized.index('-headers') + 1] == '<redacted>'
+    assert 'secret-tok' not in str(sanitized)
+    # Original untouched
+    assert args[2] == 'Girder-Token: secret-tok\r\n'
+
+
+def test_sanitize_subprocess_args_keeps_header_file_path():
+    args = ['ffprobe', '-/headers', '/tmp/ffprobe-headers-xyz.txt', 'http://example/x']
+    assert utils.sanitize_subprocess_args_for_log(args) == args
+
+
+def test_ffprobe_header_args_uses_file_when_supported():
+    headers = 'Girder-Token: tok\r\n'
+    with patch.object(utils, 'ffprobe_supports_option_from_file', return_value=True):
+        with utils.ffprobe_header_args(headers) as header_args:
+            assert header_args[0] == '-/headers'
+            path = header_args[1]
+            assert os.path.isfile(path)
+            with open(path, encoding='utf-8', newline='') as f:
+                assert f.read() == headers
+        assert not os.path.exists(path)
+
+
+def test_ffprobe_header_args_falls_back_to_inline_headers():
+    headers = 'Girder-Token: tok\r\n'
+    with patch.object(utils, 'ffprobe_supports_option_from_file', return_value=False):
+        with utils.ffprobe_header_args(headers) as header_args:
+            assert header_args == ['-headers', headers]
 
 
 @pytest.mark.parametrize(
@@ -100,28 +159,32 @@ def test_can_skip_video_transcoding(kwargs, expected):
     assert utils.can_skip_video_transcoding(**kwargs) is expected
 
 
-def test_ffprobe_format_and_streams_passes_headers_before_url():
+def test_ffprobe_format_and_streams_passes_headers_via_file():
     task = MagicMock()
     manager = MagicMock()
     probe_json = '{"streams":[],"format":{}}'
     stderr = '[http @ 0x1] Statistics: 4096 bytes read, 1 seeks\n'
 
-    with patch.object(utils, 'stream_subprocess', return_value=(probe_json, stderr)) as mock_run:
+    with (
+        patch.object(utils, 'ffprobe_supports_option_from_file', return_value=True),
+        patch.object(utils, 'stream_subprocess', return_value=(probe_json, stderr)) as mock_run,
+    ):
         result = utils.ffprobe_format_and_streams(
             task,
             {},
             manager,
-            'http://girder.example/api/v1/item/1/download',
+            'http://girder.example/api/v1/file/1/download',
             headers='Girder-Token: tok\r\n',
         )
 
     assert result == {'streams': [], 'format': {}}
     command = mock_run.call_args[0][3]['args']
     assert command[0] == 'ffprobe'
-    assert '-headers' in command
-    header_idx = command.index('-headers')
-    assert command[header_idx + 1] == 'Girder-Token: tok\r\n'
-    assert command[-1] == 'http://girder.example/api/v1/item/1/download'
+    assert '-/headers' in command
+    assert '-headers' not in command
+    header_idx = command.index('-/headers')
+    assert 'tok' not in command[header_idx + 1]
+    assert command[-1] == 'http://girder.example/api/v1/file/1/download'
     assert '-show_format' in command
     assert '-show_streams' in command
     assert command[command.index('-v') + 1] == 'info'
@@ -140,13 +203,16 @@ def test_is_frame_misaligned_accepts_url_and_headers():
     )
     stderr = '[http @ 0x1] Statistics: 8192 bytes read, 0 seeks\n'
 
-    with patch(
-        'dive_tasks.frame_alignment.stream_subprocess', return_value=(frame_json, stderr)
-    ) as mock_run:
+    with (
+        patch.object(utils, 'ffprobe_supports_option_from_file', return_value=True),
+        patch(
+            'dive_tasks.frame_alignment.stream_subprocess', return_value=(frame_json, stderr)
+        ) as mock_run,
+    ):
         assert (
             is_frame_misaligned(
                 task,
-                'http://girder.example/api/v1/item/1/download',
+                'http://girder.example/api/v1/file/1/download',
                 {},
                 manager,
                 headers='Girder-Token: tok\r\n',
@@ -156,8 +222,10 @@ def test_is_frame_misaligned_accepts_url_and_headers():
 
     command = mock_run.call_args[0][3]['args']
     assert command[0] == 'ffprobe'
-    assert command[command.index('-headers') + 1] == 'Girder-Token: tok\r\n'
-    assert 'http://girder.example/api/v1/item/1/download' in command
+    assert '-/headers' in command
+    assert '-headers' not in command
+    assert 'tok' not in command[command.index('-/headers') + 1]
+    assert 'http://girder.example/api/v1/file/1/download' in command
     written = ''.join(str(c.args[0]) for c in manager.write.call_args_list)
     assert '8192' in written
 
@@ -191,6 +259,7 @@ def test_convert_video_skip_path_avoids_download():
     gc.urlBase = 'http://girder.example/api/v1/'
     gc.token = 'tok-123'
     gc.getItem.return_value = {'name': 'clip.mp4'}
+    gc.listFile.return_value = iter([{'_id': 'file1', 'name': 'clip.mp4'}])
     task.girder_client = gc
     task.job_manager = MagicMock()
 
@@ -211,6 +280,7 @@ def test_convert_video_skip_path_avoids_download():
         )
 
     gc.downloadItem.assert_not_called()
+    gc.listFile.assert_called()
     gc.addMetadataToItem.assert_called_once()
     gc.addMetadataToFolder.assert_called_once()
     item_meta = gc.addMetadataToItem.call_args[0][1]
@@ -239,6 +309,7 @@ def test_convert_video_downloads_when_transcode_required():
     gc.urlBase = 'http://girder.example/api/v1/'
     gc.token = 'tok-123'
     gc.getItem.return_value = {'name': 'clip.avi'}
+    gc.listFile.return_value = iter([{'_id': 'file1', 'name': 'clip.avi'}])
     gc.uploadFileToFolder.return_value = {'itemId': 'new-item'}
     task.girder_client = gc
     task.job_manager = MagicMock()
@@ -266,3 +337,109 @@ def test_convert_video_downloads_when_transcode_required():
 
     gc.downloadItem.assert_called_once()
     gc.uploadFileToFolder.assert_called_once()
+
+
+def test_convert_video_cancel_during_remote_probe_does_not_download():
+    """CanceledError from remote ffprobe must abort, not fall back to download."""
+    task = MagicMock()
+    task.canceled = False
+    gc = MagicMock()
+    gc.urlBase = 'http://girder.example/api/v1/'
+    gc.token = 'tok-123'
+    gc.getItem.return_value = {'name': 'clip.mp4'}
+    gc.listFile.return_value = iter([{'_id': 'file1', 'name': 'clip.mp4'}])
+    task.girder_client = gc
+    task.job_manager = MagicMock()
+
+    with (
+        patch('dive_tasks.tasks.patch_manager') as patch_mgr,
+        patch(
+            'dive_tasks.tasks.utils.ffprobe_format_and_streams',
+            side_effect=CanceledError('Job was canceled'),
+        ),
+    ):
+        patch_mgr.return_value = MagicMock()
+        # Outer suppress(CanceledError) swallows the re-raised cancel.
+        _run_convert_video(
+            task,
+            folderId='folder1',
+            itemId='item1',
+            user_id='user1',
+            user_login='alice',
+            skip_transcoding=True,
+        )
+
+    gc.downloadItem.assert_not_called()
+    gc.addMetadataToItem.assert_not_called()
+
+
+def test_convert_video_cancel_during_remote_alignment_does_not_download():
+    probe = {
+        'streams': [
+            {
+                'codec_type': 'video',
+                'codec_name': 'h264',
+                'sample_aspect_ratio': '1:1',
+                'avg_frame_rate': '30/1',
+                'r_frame_rate': '30/1',
+            }
+        ],
+        'format': {'format_name': 'mp4'},
+    }
+
+    task = MagicMock()
+    task.canceled = False
+    gc = MagicMock()
+    gc.urlBase = 'http://girder.example/api/v1/'
+    gc.token = 'tok-123'
+    gc.getItem.return_value = {'name': 'clip.mp4'}
+    gc.listFile.return_value = iter([{'_id': 'file1', 'name': 'clip.mp4'}])
+    task.girder_client = gc
+    task.job_manager = MagicMock()
+
+    with (
+        patch('dive_tasks.tasks.patch_manager') as patch_mgr,
+        patch('dive_tasks.tasks.utils.ffprobe_format_and_streams', return_value=probe),
+        patch(
+            'dive_tasks.tasks.is_frame_misaligned',
+            side_effect=CanceledError('Job was canceled'),
+        ),
+    ):
+        patch_mgr.return_value = MagicMock()
+        _run_convert_video(
+            task,
+            folderId='folder1',
+            itemId='item1',
+            user_id='user1',
+            user_login='alice',
+            skip_transcoding=True,
+        )
+
+    gc.downloadItem.assert_not_called()
+    gc.addMetadataToItem.assert_not_called()
+
+
+def test_stream_subprocess_redacts_headers_in_job_log():
+    task = MagicMock()
+    task.canceled = False
+    manager = MagicMock()
+    manager.status = None
+
+    utils.stream_subprocess(
+        task,
+        {},
+        manager,
+        {
+            'args': [
+                'bash',
+                '-c',
+                'exit 0',
+                '-headers',
+                'Girder-Token: secret\r\n',
+            ]
+        },
+    )
+    written = ''.join(str(c.args[0]) for c in manager.write.call_args_list)
+    assert 'Running command:' in written
+    assert 'secret' not in written
+    assert '<redacted>' in written


### PR DESCRIPTION
#1791 

- Updated the conversion process to utilize ffprobe header range requests to get information instead of downloading the full file.  This should greatly speed up the postprocess event run on data, including S3/GCP assetStore imports.
- Updated the ffmpeg/ffprobe version to use -headers so the header token for range requests passed into ffprobe can be hidden from the job log
