### PR TITLE
Add a TypeScript type check gate for the client

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -36,6 +36,10 @@ jobs:
       if: ${{ matrix.target == 'web' }}
       run: npm run lint:templates
     -
+      name: Typecheck
+      if: ${{ matrix.target == 'web' }}
+      run: npm run typecheck
+    -
       name: Run tests
       if: ${{ matrix.target == 'web' }}
       run: npm test -- --coverage

--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -8,7 +8,7 @@ import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import { CustomStyle } from 'vue-media-annotator/StyleManager';
 import { AttributeTrackFilter } from 'vue-media-annotator/AttributeTrackFilterControls';
 import { ImageEnhancements } from 'vue-media-annotator/use/useImageEnhancements';
-import {
+import type {
   CameraHomographies, CameraCorrespondences, CameraTransformTypes, RegistrationSource,
 } from 'vue-media-annotator/alignedView/CameraRegistrationStore';
 import type { PercentileStretch } from 'vue-media-annotator/use/useImageEnhancements';
@@ -659,13 +659,16 @@ export {
 };
 
 export {
+  DatasetConfigMutableKeys,
+  MulticamSharedMutableKeys,
+};
+
+export type {
   AnnotationSchema,
   Api,
   DatasetConfig,
   DatasetConfigMutable,
-  DatasetConfigMutableKeys,
   DatasetInfoFields,
-  MulticamSharedMutableKeys,
   GlobalStyleSettings,
   DatasetType,
   DiveParam,
@@ -694,4 +697,4 @@ export {
   MediaImportResponse,
 };
 
-export type { PercentileStretch };
+export type { PercentileStretch, CameraCorrespondences };

--- a/client/dive-common/components/Attributes/AttributeEditor.vue
+++ b/client/dive-common/components/Attributes/AttributeEditor.vue
@@ -138,7 +138,7 @@ export default defineComponent({
       (v: string) => !isReservedAttributeName(v, baseSettings.belongs)
         || `Reserved name. ${RESERVED_ATTRIBUTES[baseSettings.belongs].join(', ')} are not allowed.`,
     ]);
-    const isValidNumberString = (v: string) => !Number.isNaN(parseFloat(v));
+    const isValidNumberString = (v: string) => !Number.isNaN(parseFloat(v)) || 'Number is required';
     const rangeMinRules = computed(() => [
       isValidNumberString,
       (v: string) => (baseSettings.editor

--- a/client/dive-common/components/Attributes/AttributeEditor.vue
+++ b/client/dive-common/components/Attributes/AttributeEditor.vue
@@ -131,6 +131,38 @@ export default defineComponent({
       }
       baseSettings.datatype = type;
     };
+    const nameRules = computed(() => [
+      (v: string) => !!v || 'Name is required',
+      (v: string) => !v.includes(' ') || 'No spaces',
+      (v: string) => v !== 'userAttributes' || 'Reserved Name',
+      (v: string) => !isReservedAttributeName(v, baseSettings.belongs)
+        || `Reserved name. ${RESERVED_ATTRIBUTES[baseSettings.belongs].join(', ')} are not allowed.`,
+    ]);
+    const isValidNumberString = (v: string) => !Number.isNaN(parseFloat(v));
+    const rangeMinRules = computed(() => [
+      isValidNumberString,
+      (v: string) => (baseSettings.editor
+        && baseSettings.editor.type === 'slider'
+        && baseSettings.editor.range
+        && parseFloat(v) < baseSettings.editor.range[1])
+        || 'Min needs to be smaller than the Max',
+    ]);
+    const rangeMaxRules = computed(() => [
+      isValidNumberString,
+      (v: string) => (baseSettings.editor
+        && baseSettings.editor.type === 'slider'
+        && baseSettings.editor.range
+        && parseFloat(v) > baseSettings.editor.range[0])
+        || 'Max needs to be larger than the Min',
+    ]);
+    const stepsRules = computed(() => [
+      isValidNumberString,
+      (v: string) => (baseSettings.editor
+        && baseSettings.editor.type === 'slider'
+        && baseSettings.editor.range
+        && parseFloat(v) < (baseSettings.editor.range[1] - baseSettings.editor.range[0]))
+        || 'Steps should be smaller than the range',
+    ]);
     const numericChange = (type: 'combo' | 'slider') => {
       if (type === 'combo') {
         baseSettings.editor = {
@@ -210,6 +242,10 @@ export default defineComponent({
       typeChange,
       numericChange,
       launchColorEditor,
+      nameRules,
+      rangeMinRules,
+      rangeMaxRules,
+      stepsRules,
       //utils
       isReservedAttributeName,
       RESERVED_ATTRIBUTES,
@@ -253,13 +289,7 @@ export default defineComponent({
               <v-text-field
                 v-model="baseSettings.name"
                 label="Name"
-                :rules="[
-                  v => !!v || 'Name is required',
-                  v => !v.includes(' ') || 'No spaces',
-                  v => v !== 'userAttributes' || 'Reserved Name',
-                  v => !isReservedAttributeName(v, baseSettings.belongs)
-                    || `Reserved name. ${RESERVED_ATTRIBUTES[baseSettings.belongs].join(', ')} are not allowed.`,
-                ]"
+                :rules="nameRules"
                 required
               />
               <v-select
@@ -289,15 +319,6 @@ export default defineComponent({
                   />
                 </v-radio-group>
               </div>
-              <!-- Hide this functionality for now -->
-              <div v-if="false">
-                <v-checkbox
-                  v-model="user"
-                  label="User Attribute"
-                  hint="Attribute data is saved per user instead of globally."
-                  persistent-hint
-                />
-              </div>
               <div
                 v-if="baseSettings.datatype === 'number'
                   && baseSettings.editor && baseSettings.editor.type === 'slider'"
@@ -313,13 +334,7 @@ export default defineComponent({
                     :step="baseSettings.editor.range[0] > 1 ? 1 : 0.01"
                     type="number"
                     label="Min"
-                    :rules="[
-                      v => !isNaN(parseFloat(v)) || 'Number is required',
-                      v => baseSettings.editor
-                        && baseSettings.editor.type === 'slider'
-                        && baseSettings.editor.range
-                        && v < baseSettings.editor.range[1]
-                        || 'Min needs to be smaller than the Max']"
+                    :rules="rangeMinRules"
                     :max="baseSettings.editor.range[1]"
                     hint="Min limit for slider"
                     persistent-hint
@@ -331,13 +346,7 @@ export default defineComponent({
                     :step="baseSettings.editor.range[1] > 1 ? 1 : 0.01"
                     type="number"
                     label="Max"
-                    :rules="[
-                      v => !isNaN(parseFloat(v)) || 'Number is required',
-                      v => baseSettings.editor
-                        && baseSettings.editor.type === 'slider'
-                        && baseSettings.editor.range
-                        && v > baseSettings.editor.range[0]
-                        || 'Max needs to be larger than the Min']"
+                    :rules="rangeMaxRules"
                     :min="baseSettings.editor.range[0]"
                     hint="Max limit for slider"
                     persistent-hint
@@ -351,13 +360,7 @@ export default defineComponent({
                     :step="baseSettings.editor
                       && baseSettings.editor.steps && baseSettings.editor.steps > 1 ? 1 : 0.01"
                     type="number"
-                    :rules="[
-                      v => !isNaN(parseFloat(v)) || 'Number is required',
-                      v => baseSettings.editor
-                        && baseSettings.editor.type === 'slider'
-                        && baseSettings.editor.range
-                        && v < (baseSettings.editor.range[1] - baseSettings.editor.range[0])
-                        || 'Steps should be smaller than the range']"
+                    :rules="stepsRules"
                     label="Slider Step Interval"
                     min="0"
                     hint="Each movement will move X amount"

--- a/client/dive-common/components/Attributes/AttributeInput.vue
+++ b/client/dive-common/components/Attributes/AttributeInput.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import {
+  computed,
   defineComponent,
   ref,
   PropType,
@@ -7,6 +8,8 @@ import {
   watch,
 } from 'vue';
 import { NumericAttributeEditorOptions, StringAttributeEditorOptions } from 'vue-media-annotator/use/AttributeTypes';
+
+let attributeInputUidCounter = 0;
 
 export default defineComponent({
   props: {
@@ -23,7 +26,7 @@ export default defineComponent({
       required: true,
     },
     values: {
-      type: Array,
+      type: Array as PropType<string[]>,
       default: () => [],
     },
     focus: {
@@ -40,8 +43,22 @@ export default defineComponent({
     },
   },
   setup(props, { emit }) {
+    attributeInputUidCounter += 1;
+    const uid = attributeInputUidCounter;
     const tempVal = ref(props.value as null | boolean | number | string);
     const inputBoxRef = ref(undefined as undefined | HTMLInputElement);
+    const numberValue = computed(() => (
+      typeof props.value === 'number' ? props.value : undefined));
+    const sliderConfig = computed(() => {
+      const { typeSettings } = props;
+      const range = (
+        typeSettings && 'range' in typeSettings && typeSettings.range
+      ) ? typeSettings.range : [0, 1];
+      const steps = (
+        typeSettings && 'steps' in typeSettings && typeSettings.steps
+      ) ? typeSettings.steps : (range[1] - range[0]) / 2.0;
+      return { range, steps };
+    });
     const boolOpts = [
       { text: '', value: undefined },
       { text: 'true', value: true },
@@ -84,8 +101,8 @@ export default defineComponent({
       }
     }
 
-    function change(event: InputEvent): void {
-      const target = event.target as HTMLInputElement;
+    function change(event: Event): void {
+      const target = event.target as HTMLInputElement | HTMLSelectElement;
       const { name } = props;
       const value = target.value.trim();
       if (value) {
@@ -101,8 +118,11 @@ export default defineComponent({
     }
 
     return {
+      uid,
       inputBoxRef,
       tempVal,
+      numberValue,
+      sliderConfig,
       boolOpts,
       blurType,
       onFocus,
@@ -118,7 +138,7 @@ export default defineComponent({
   <div>
     <datalist
       v-if="datatype === 'text' && values && values.length"
-      :id="`optionsList_${_uid}`"
+      :id="`optionsList_${uid}`"
       :disabled="disabled"
     >
       <option
@@ -136,7 +156,7 @@ export default defineComponent({
       v-model="tempVal"
       type="text"
       :disabled="disabled"
-      :list="`optionsList_${_uid}`"
+      :list="`optionsList_${uid}`"
       class="input-box"
       @change="change"
       @focus="onFocus"
@@ -146,9 +166,9 @@ export default defineComponent({
       v-else-if="datatype === 'number' && (!typeSettings || typeSettings.type === 'combo')"
       ref="inputBoxRef"
       :label="datatype"
-      :value="value"
+      :value="numberValue"
       :disabled="disabled"
-      :step="value <= 1 ? .01 : 1"
+      :step="(numberValue ?? 0) <= 1 ? .01 : 1"
       class="input-box"
       type="number"
       @change="change"
@@ -162,10 +182,9 @@ export default defineComponent({
       </div>
       <v-slider
         :value="value"
-        :step="typeSettings.steps ? typeSettings.steps
-          : (typeSettings.range[1] - typeSettings.range[0]) / 2.0"
-        :min="typeSettings.range[0]"
-        :max="typeSettings.range[1]"
+        :step="sliderConfig.steps"
+        :min="sliderConfig.range[0]"
+        :max="sliderConfig.range[1]"
         dense
         class="attribute-slider"
         @input="sliderChange"

--- a/client/dive-common/components/Attributes/AttributeNumberValueColors.vue
+++ b/client/dive-common/components/Attributes/AttributeNumberValueColors.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable max-len -->
 <script lang="ts">
 import {
-  defineComponent, ref, PropType, Ref, watch, onMounted,
+  computed, defineComponent, ref, PropType, Ref, watch, onMounted,
 } from 'vue';
 import * as d3 from 'd3';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
@@ -130,6 +130,12 @@ export default defineComponent({
       }
     };
     const validForm = ref(false);
+    const keyRules = computed(() => [
+      (val: number | string) => Number(val) >= 0 || 'Must be >= 0',
+      (val: number | string) => attributeColors.value
+        .findIndex((item) => item.key.toString() === val.toString()) === -1
+        || 'Values need to be unique',
+    ]);
     return {
       attributeColors,
       editingColor,
@@ -138,6 +144,7 @@ export default defineComponent({
       currentEditKey,
       gradientSVG,
       validForm,
+      keyRules,
       setEditingColor,
       saveEditingColor,
       addColor,
@@ -247,11 +254,7 @@ export default defineComponent({
             <v-row dense>
               <v-text-field
                 v-model="currentEditKey"
-                :rules="[
-                  val => val >= 0 || 'Must be >= 0',
-                  val => attributeColors.findIndex((item) => item.key.toString() === val) === -1 || 'Values need to be unique',
-                ]"
-
+                :rules="keyRules"
                 type="number"
                 label="Value"
               />

--- a/client/dive-common/components/Attributes/AttributeValueColors.vue
+++ b/client/dive-common/components/Attributes/AttributeValueColors.vue
@@ -152,7 +152,7 @@ export default defineComponent({
               :style="{
                 backgroundColor: val,
               }"
-              @click="setEditingColor(key)"
+              @click="setEditingColor(key.toString())"
             />
           </div>
         </v-col>

--- a/client/dive-common/components/Attributes/AttributesSubsection.vue
+++ b/client/dive-common/components/Attributes/AttributesSubsection.vue
@@ -162,18 +162,25 @@ export default defineComponent({
       context.openClose('AttributesSideBar', true, 'Timeline');
     }
 
-    function getAttributeValue(attribute: Attribute) {
+    function toAttributeValue(val: unknown): string | number | boolean | undefined {
+      if (typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean') {
+        return val;
+      }
+      return undefined;
+    }
+
+    function getAttributeValue(attribute: Attribute): string | number | boolean | undefined {
       if (selectedAttributes.value && selectedAttributes.value.attributes) {
         if (!attribute.user) {
-          return selectedAttributes.value.attributes[attribute.name];
+          return toAttributeValue(selectedAttributes.value.attributes[attribute.name]);
         }
         const user = props.user || null;
         if (user && selectedAttributes.value.attributes?.userAttributes !== undefined
         && selectedAttributes.value.attributes.userAttributes[user]) {
-          if ((selectedAttributes.value.attributes
-            .userAttributes[user] as StringKeyObject)[attribute.name]) {
-            return ((selectedAttributes.value.attributes
-              .userAttributes[user] as StringKeyObject)[attribute.name]);
+          const userAttrs = selectedAttributes.value.attributes
+            .userAttributes[user] as StringKeyObject;
+          if (userAttrs[attribute.name]) {
+            return toAttributeValue(userAttrs[attribute.name]);
           }
         }
       }
@@ -310,7 +317,8 @@ export default defineComponent({
           <v-row
             v-if="
               activeSettings
-                || selectedAttributes.attributes[attribute.name] !== undefined
+                || (selectedAttributes.attributes
+                  && selectedAttributes.attributes[attribute.name] !== undefined)
             "
             class="ma-0"
             dense
@@ -330,7 +338,7 @@ export default defineComponent({
                 :datatype="attribute.datatype"
                 :name="attribute.name"
                 :disabled="readOnlyMode"
-                :values="attribute.values ? attribute.values : null"
+                :values="attribute.values ? attribute.values : undefined"
                 :value="getAttributeValue(attribute)"
                 :type-settings="attribute.editor || null"
                 @change="
@@ -349,7 +357,7 @@ export default defineComponent({
                     :datatype="attribute.datatype"
                     :name="attribute.name"
                     :disabled="readOnlyMode"
-                    :values="attribute.values ? attribute.values : null"
+                    :values="attribute.values ? attribute.values : undefined"
                     :value="getAttributeValue(attribute)"
                     :type-settings="attribute.editor || null"
                     focus

--- a/client/dive-common/components/BottomPanel.vue
+++ b/client/dive-common/components/BottomPanel.vue
@@ -10,6 +10,12 @@ import ConfidenceFilter from 'dive-common/components/ConfidenceFilter.vue';
 import ConfidenceSubsection from 'dive-common/components/ConfidenceSubsection.vue';
 import AttributeSubsection from 'dive-common/components/Attributes/AttributesSubsection.vue';
 import context from 'dive-common/store/context';
+import type { Attribute } from 'vue-media-annotator/use/AttributeTypes';
+import type Track from 'vue-media-annotator/track';
+import type StyleManager from 'vue-media-annotator/StyleManager';
+import type TrackFilterControls from 'vue-media-annotator/TrackFilterControls';
+import type { AnnotationSettings } from 'dive-common/store/settings';
+import type { DatasetType } from 'dive-common/apispec';
 
 export default defineComponent({
   name: 'BottomPanel',
@@ -31,29 +37,38 @@ export default defineComponent({
     lineChartData: { type: Array as PropType<unknown[]>, required: true },
     eventChartData: { type: Object as PropType<Record<string, unknown>>, required: true },
     groupChartData: { type: Object as PropType<Record<string, unknown>>, required: true },
-    datasetType: { type: String, required: true },
+    datasetType: { type: String as PropType<DatasetType>, required: true },
     isDefaultImage: { type: Boolean, required: true },
-    clientSettings: { type: Object, required: true },
-    trackFilters: { type: Object, required: true },
-    attributes: { type: Array, required: true },
+    clientSettings: { type: Object as PropType<AnnotationSettings>, required: true },
+    trackFilters: { type: Object as PropType<TrackFilterControls>, required: true },
+    attributes: { type: Array as PropType<Attribute[]>, required: true },
     frameRate: { type: Number, required: true },
     readonlyState: { type: Boolean, required: true },
     disableAnnotationFilters: { type: Boolean, required: true },
-    promptVisible: { type: Function, required: true },
-    confidenceFilters: { type: Object, required: true },
-    aggregateSeek: { type: Function, required: true },
-    trackStyleManager: { type: Object, required: true },
+    promptVisible: { type: Function as PropType<() => boolean>, required: true },
+    confidenceFilters: { type: Object as PropType<Record<string, number>>, required: true },
+    aggregateSeek: { type: Function as PropType<(frame: number) => void>, required: true },
+    trackStyleManager: { type: Object as PropType<StyleManager>, required: true },
     bottomRightPanelView: { type: String, required: true },
-    toggleBottomRightPanel: { type: Function, required: true },
-    selectedTrackForDetails: { type: Object as PropType<object | null>, default: null },
+    toggleBottomRightPanel: { type: Function as PropType<() => void>, required: true },
+    selectedTrackForDetails: { type: Object as PropType<Track | null>, default: null },
     showConfidenceFirst: { type: Boolean, required: true },
     showTrackAttributesFirst: { type: Boolean, required: true },
-    editIndividual: { type: Object as PropType<object | null>, default: null },
-    setEditIndividual: { type: Function, required: true },
-    resetEditIndividual: { type: Function, required: true },
-    addAttribute: { type: Function, required: true },
-    editAttribute: { type: Function, required: true },
-    saveThreshold: { type: Function, required: true },
+    editIndividual: { type: Object as PropType<Attribute | null>, default: null },
+    setEditIndividual: {
+      type: Function as PropType<(attribute: Attribute | null) => void>,
+      required: true,
+    },
+    resetEditIndividual: {
+      type: Function as PropType<(event: MouseEvent) => void>,
+      required: true,
+    },
+    addAttribute: {
+      type: Function as PropType<(mode: 'Track' | 'Detection') => void>,
+      required: true,
+    },
+    editAttribute: { type: Function as PropType<(attribute: Attribute) => void>, required: true },
+    saveThreshold: { type: Function as PropType<() => void>, required: true },
     isStereoDataset: { type: Boolean, default: false },
   },
   setup() {

--- a/client/dive-common/components/ConfidenceFilter.vue
+++ b/client/dive-common/components/ConfidenceFilter.vue
@@ -27,9 +27,10 @@ export default defineComponent({
     },
   },
   setup(props, { emit }) {
-    function _updateConfidence(event: InputEvent & {target: {value: string}}) {
-      if (event.target) {
-        emit('update:confidence', Number.parseFloat(event.target.value));
+    function _updateConfidence(event: Event) {
+      const target = event.target as HTMLInputElement | null;
+      if (target) {
+        emit('update:confidence', Number.parseFloat(target.value));
       }
     }
     function _emitEnd() {

--- a/client/dive-common/components/ControlsContainer.vue
+++ b/client/dive-common/components/ControlsContainer.vue
@@ -513,7 +513,7 @@ export default defineComponent({
           :start-frame="startFrame"
           :end-frame="endFrame"
           :max-frame="endFrame"
-          :data="attributeData.data"
+          :data="attributeData ? attributeData.data : []"
           :client-width="clientWidth"
           :client-height="clientHeight"
           :margin="margin"

--- a/client/dive-common/components/DatasetInfo/DatasetInfo.spec.ts
+++ b/client/dive-common/components/DatasetInfo/DatasetInfo.spec.ts
@@ -117,11 +117,13 @@ function mountDatasetInfo({
   metadata?: DatasetConfig;
 } = {}) {
   const state = dummyState();
+  const selectedCameraRef = ref(selectedCamera);
+  const frameRef = ref(frame);
   state.datasetId = ref('dataset-id');
-  state.selectedCamera = ref(selectedCamera);
+  state.selectedCamera = selectedCameraRef;
   state.time = {
     ...state.time,
-    frame: ref(frame),
+    frame: frameRef,
   };
   state.readOnlyMode = ref(readOnlyMode);
 
@@ -167,6 +169,8 @@ function mountDatasetInfo({
       },
     }),
     state,
+    selectedCameraRef,
+    frameRef,
     loadFrameMetadata: api.loadFrameMetadata,
   };
 }
@@ -242,7 +246,11 @@ describe('DatasetInfo', () => {
     expect(wrapper.find('.custom-dataset-info-section').find('v-btn').exists()).toBe(true);
   });
 
-  it.each([
+  it.each<{
+    name: string;
+    options: Partial<Parameters<typeof mountDatasetInfo>[0]>;
+    expected: string;
+  }>([
     {
       name: 'no attachment',
       options: {},
@@ -333,7 +341,7 @@ describe('DatasetInfo', () => {
   });
 
   it('resolves literal DIVE frame rows for a ready video controller', async () => {
-    const { wrapper, state } = mountDatasetInfo({
+    const { wrapper, frameRef } = mountDatasetInfo({
       metadata: { ...defaultMetadata, type: 'video' },
       mediaNames: { singleCam: [] },
       mediaKinds: { singleCam: 'video' },
@@ -354,7 +362,7 @@ describe('DatasetInfo', () => {
       { key: 'depth', value: '10' },
     ]);
 
-    state.time.frame.value = 2;
+    frameRef.value = 2;
     await settle();
     expect(frameMetadataRows(wrapper)).toEqual([
       { key: 'frame', value: '2' },
@@ -480,7 +488,7 @@ describe('DatasetInfo', () => {
   });
 
   it('follows the selected camera', async () => {
-    const { wrapper, state, loadFrameMetadata } = mountDatasetInfo({
+    const { wrapper, selectedCameraRef, loadFrameMetadata } = mountDatasetInfo({
       frameMetadata: {
         cameras: {
           port: {
@@ -498,7 +506,7 @@ describe('DatasetInfo', () => {
     await settle();
     expect(wrapper.find('.frame-metadata-section').text()).toContain('58.10');
 
-    state.selectedCamera.value = 'starboard';
+    selectedCameraRef.value = 'starboard';
     await settle();
 
     const section = wrapper.find('.frame-metadata-section');

--- a/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamAddType.vue
+++ b/client/dive-common/components/ImportMultiCamDialog/ImportMultiCamAddType.vue
@@ -3,13 +3,15 @@
   add-new. Naming rules match ImportMultiCamDialog/multicamSubfolderLayout isValidCameraName.
 -->
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
+import {
+  defineComponent, PropType, computed, ref,
+} from 'vue';
 
 export default defineComponent({
   name: 'ImportMultiCamAddType',
   props: {
     nameList: {
-      type: Array,
+      type: Array as PropType<string[]>,
       required: true,
     },
   },
@@ -23,10 +25,16 @@ export default defineComponent({
       newSetName.value = '';
       enabled.value = false;
     };
+    const nameRules = computed(() => [
+      (v: string) => !!v || 'Name is required',
+      (v: string) => alphaNumeric.test(v) || 'Letters, numbers, and underscores only',
+      (v: string) => !v.includes(' ') || 'No spaces',
+      (v: string) => !props.nameList.includes(v) || 'No duplicate Names',
+    ]);
     return {
       enabled,
       newSetName,
-      alphaNumeric,
+      nameRules,
       addNewSet,
     };
   },
@@ -53,11 +61,7 @@ export default defineComponent({
     <template v-if="enabled">
       <v-text-field
         v-model="newSetName"
-        :rules="[
-          v => !!v || 'Name is required',
-          v => alphaNumeric.test(v) || 'Letters, numbers, and underscores only',
-          v => !v.includes(' ') || 'No spaces',
-          v => !nameList.includes(v) || 'No duplicate Names']"
+        :rules="nameRules"
         label="name"
         placeholder="Choose a Camera Name"
         outlined

--- a/client/dive-common/components/ImportMultiCamDialog/importMultiCamContext.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/importMultiCamContext.ts
@@ -21,6 +21,6 @@ export type ImportMultiCamContext = ReturnType<typeof useImportMultiCamDialog>;
 export const importMultiCamContextProp = {
   ctx: {
     type: Object as PropType<ImportMultiCamContext>,
-    required: true,
+    required: true as const,
   },
 };

--- a/client/dive-common/components/JobConfigFilterTranscodeDialog.vue
+++ b/client/dive-common/components/JobConfigFilterTranscodeDialog.vue
@@ -20,6 +20,13 @@ type DestinationLocation = {
   meta?: { annotate?: boolean | string };
 };
 
+type RootPathCrumb = {
+  object?: { _modelType?: string; login?: string; name?: string };
+  _modelType?: string;
+  login?: string;
+  name?: string;
+};
+
 export default defineComponent({
   components: { GirderFileManager },
   props: {
@@ -91,7 +98,7 @@ export default defineComponent({
           const { data: rootpath } = await girderRest.get(
             `folder/${loc._id}/rootpath_or_relative`,
           );
-          (rootpath || []).forEach((crumb) => {
+          (rootpath || []).forEach((crumb: RootPathCrumb) => {
             const obj = crumb.object || crumb;
             if (obj._modelType === 'user') {
               parts.push(obj.login || obj.name || 'User');
@@ -218,6 +225,8 @@ export default defineComponent({
       emit('cancel');
     }
 
+    const requiredRule = (v: string) => !!v || 'Each output dataset must have a name';
+
     function submitPipelines() {
       const payload: NewDatasetJobConfig = {
         names: outputDatasetNames.value,
@@ -231,6 +240,7 @@ export default defineComponent({
     return {
       formValid,
       canSubmit,
+      requiredRule,
       outputDatasetNames,
       showDestinationPicker,
       location,
@@ -285,7 +295,7 @@ export default defineComponent({
                     v-model="outputDatasetNames[datasetId]"
                     class="ml-2"
                     label="Output dataset name"
-                    :rules="[v => !!v || 'Each output dataset must have a name']"
+                    :rules="[requiredRule]"
                     hide-details
                   />
                 </v-col>

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -140,12 +140,12 @@ export default defineComponent({
     }
 
     async function confirmPipelineExecution(updatedParams: Record<string, string>) {
-      const configById: Record<string, Record<string, string>> = {};
+      const kwiverParamsById: Record<string, Record<string, string>> = {};
       props.selectedDatasetIds.forEach((id) => {
-        configById[id] = updatedParams;
+        kwiverParamsById[id] = updatedParams;
       });
       showParamsDialog.value = false;
-      await _runPipelineOnSelectedItemInner(selectedPipeline.value!, configById);
+      await _runPipelineOnSelectedItemInner(selectedPipeline.value!, undefined, undefined, kwiverParamsById);
     }
 
     const includesLargeImage = computed(() => props.typeList.includes(LargeImageType));
@@ -261,6 +261,7 @@ export default defineComponent({
       pipeline: Pipe,
       outputDatasetNameById?: Record<string, string>,
       outputParentFolderId?: string,
+      kwiverParamsById?: Record<string, Record<string, string>>,
     ) {
       if (props.selectedDatasetIds.length === 0) {
         throw new Error('No selected datasets to run on');
@@ -292,6 +293,7 @@ export default defineComponent({
           runtimeParams: frameRange ? { frameRange } : undefined,
           outputDatasetName: outputDatasetNameById?.[id],
           outputParentFolderId,
+          kwiverParams: kwiverParamsById?.[id],
         })),
       ));
     }
@@ -579,7 +581,7 @@ export default defineComponent({
     <JobLaunchDialog
       :value="jobState.count > 0"
       :loading="jobState.loading"
-      :error="jobState.error"
+      :error="jobState.error ?? undefined"
       :message="successMessage"
       @close="dismissLaunchDialog"
     />

--- a/client/dive-common/components/TrackDetailsPanel.vue
+++ b/client/dive-common/components/TrackDetailsPanel.vue
@@ -183,7 +183,7 @@ export default defineComponent({
       try {
         await setAttribute({ data, oldAttribute });
       } catch (err) {
-        editingError.value = err.message;
+        editingError.value = err instanceof Error ? err.message : String(err);
       }
       if (!editingError.value && close) {
         closeEditor();
@@ -194,7 +194,7 @@ export default defineComponent({
       try {
         await deleteAttribute({ data });
       } catch (err) {
-        editingError.value = err.message;
+        editingError.value = err instanceof Error ? err.message : String(err);
       }
       if (!editingError.value) {
         closeEditor();
@@ -356,7 +356,7 @@ export default defineComponent({
           <span class="trackNumber">{{ editingGroup.id }}</span>
           <v-spacer />
           <TypePicker
-            :value="editingGroup.getType()"
+            :value="editingGroup.getType()[0]"
             :all-types="allGroupTypesRef"
             :read-only-mode="readOnlyMode"
             data-list-source="allGroupTypesOptions"
@@ -639,7 +639,7 @@ export default defineComponent({
       <attribute-editor
         v-if="editingAttribute != null"
         :selected-attribute="editingAttribute"
-        :error="editingError"
+        :error="editingError ?? undefined"
         @close="closeEditor"
         @save="saveAttributeHandler"
         @delete="deleteAttributeHandler"

--- a/client/dive-common/components/TrackListColumnSettings.vue
+++ b/client/dive-common/components/TrackListColumnSettings.vue
@@ -73,69 +73,71 @@ export default defineComponent({
       Column Visibility
     </div>
 
-    <!-- Core columns -->
-    <div class="text-caption grey--text mb-1">
-      Core Columns
-    </div>
-    <v-checkbox
-      v-model="columnVisibility.type"
-      dense
-      hide-details
-      label="Type"
-      class="my-0 py-0"
-    />
-    <v-checkbox
-      v-model="columnVisibility.confidence"
-      dense
-      hide-details
-      label="Confidence"
-      class="my-0 py-0"
-    />
+    <template v-if="columnVisibility">
+      <!-- Core columns -->
+      <div class="text-caption grey--text mb-1">
+        Core Columns
+      </div>
+      <v-checkbox
+        v-model="columnVisibility.type"
+        dense
+        hide-details
+        label="Type"
+        class="my-0 py-0"
+      />
+      <v-checkbox
+        v-model="columnVisibility.confidence"
+        dense
+        hide-details
+        label="Confidence"
+        class="my-0 py-0"
+      />
 
-    <!-- Frame columns -->
-    <div class="text-caption grey--text mt-2 mb-1">
-      Frame Columns
-    </div>
-    <v-checkbox
-      v-model="columnVisibility.startFrame"
-      dense
-      hide-details
-      label="Start Frame"
-      class="my-0 py-0"
-    />
-    <v-checkbox
-      v-model="columnVisibility.endFrame"
-      dense
-      hide-details
-      label="End Frame"
-      class="my-0 py-0"
-    />
+      <!-- Frame columns -->
+      <div class="text-caption grey--text mt-2 mb-1">
+        Frame Columns
+      </div>
+      <v-checkbox
+        v-model="columnVisibility.startFrame"
+        dense
+        hide-details
+        label="Start Frame"
+        class="my-0 py-0"
+      />
+      <v-checkbox
+        v-model="columnVisibility.endFrame"
+        dense
+        hide-details
+        label="End Frame"
+        class="my-0 py-0"
+      />
 
-    <div class="text-caption grey--text mt-2 mb-1">
-      Timestamp Columns
-    </div>
-    <v-checkbox
-      v-model="columnVisibility.startTimestamp"
-      dense
-      hide-details
-      label="Start Timestamp"
-      class="my-0 py-0"
-      :disabled="!fps"
-    />
-    <v-checkbox
-      v-model="columnVisibility.endTimestamp"
-      dense
-      hide-details
-      label="End Timestamp"
-      class="my-0 py-0"
-      :disabled="!fps"
-    />
-    <div
-      v-if="!fps"
-      class="text-caption orange--text ml-6"
-    >
-      Timestamps require FPS metadata
-    </div>
+      <div class="text-caption grey--text mt-2 mb-1">
+        Timestamp Columns
+      </div>
+      <v-checkbox
+        v-model="columnVisibility.startTimestamp"
+        dense
+        hide-details
+        label="Start Timestamp"
+        class="my-0 py-0"
+        :disabled="!fps"
+      />
+      <v-checkbox
+        v-model="columnVisibility.endTimestamp"
+        dense
+        hide-details
+        label="End Timestamp"
+        class="my-0 py-0"
+        :disabled="!fps"
+      />
+      <div
+        v-if="!fps"
+        class="text-caption orange--text ml-6"
+      >
+        Timestamps require FPS metadata
+      </div>
+    </template>
 
     <!-- Attribute columns -->
     <template v-if="trackAttributes.length > 0">
@@ -204,6 +206,7 @@ export default defineComponent({
       Other Columns
     </div>
     <v-checkbox
+      v-if="columnVisibility"
       v-model="columnVisibility.notes"
       dense
       hide-details

--- a/client/dive-common/components/importAnnotationsSets.spec.ts
+++ b/client/dive-common/components/importAnnotationsSets.spec.ts
@@ -41,6 +41,8 @@ function mountImportAnnotations({
     fileList: fileName === undefined ? [] : [new File(['a'], fileName)],
   }));
 
+  let child: InstanceType<typeof ImportAnnotations> | undefined;
+
   const Parent = defineComponent({
     setup() {
       provideApi({
@@ -54,11 +56,18 @@ function mountImportAnnotations({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         {} as any,
       );
-      return () => h(ImportAnnotations, { props: { datasetId: 'dataset-1' } });
+      return () => h(ImportAnnotations, {
+        props: { datasetId: 'dataset-1' },
+        ref: (instance) => {
+          if (instance && !(instance instanceof Element)) {
+            child = instance as InstanceType<typeof ImportAnnotations>;
+          }
+        },
+      });
     },
   });
 
-  const wrapper = mount(Parent, {
+  mount(Parent, {
     stubs: {
       'v-menu': true,
       'v-tooltip': true,
@@ -68,38 +77,41 @@ function mountImportAnnotations({
     },
     mocks: { $vuetify: { breakpoint: { mdAndDown: false } } },
   });
-  return { vm: wrapper.findComponent(ImportAnnotations), state, importAnnotationFile };
+  if (!child) {
+    throw new Error('ImportAnnotations did not mount');
+  }
+  return { vm: child, state, importAnnotationFile };
 }
 
 describe('ImportAnnotations annotation sets', () => {
   it('exposes sets without requiring a render pass', () => {
     const { vm } = mountImportAnnotations({ annotationSets: ['setA', 'setB'] });
     // Reading from outside render is what regressed: it must not throw.
-    expect(() => vm.vm.sets).not.toThrow();
-    expect(vm.vm.sets).toEqual(['setA', 'setB', 'default']);
+    expect(() => vm.sets).not.toThrow();
+    expect(vm.sets).toEqual(['setA', 'setB', 'default']);
   });
 
   it('always offers the default set when none are defined', () => {
     const { vm } = mountImportAnnotations();
-    expect(vm.vm.sets).toEqual(['default']);
+    expect(vm.sets).toEqual(['default']);
   });
 
   it('does not mutate the provided annotation sets', () => {
     const provided = ['only'];
     const { vm } = mountImportAnnotations({ annotationSets: provided });
-    expect(vm.vm.sets).toEqual(['only', 'default']);
+    expect(vm.sets).toEqual(['only', 'default']);
     expect(provided).toEqual(['only']);
   });
 
   it('seeds currentSet from the provided annotation set, falling back to default', () => {
-    expect(mountImportAnnotations().vm.vm.currentSet).toBe('default');
-    expect(mountImportAnnotations({ annotationSets: ['a'], annotationSet: 'a' }).vm.vm.currentSet)
+    expect(mountImportAnnotations().vm.currentSet).toBe('default');
+    expect(mountImportAnnotations({ annotationSets: ['a'], annotationSet: 'a' }).vm.currentSet)
       .toBe('a');
   });
 
   it('does not alias the injected annotationSet ref', () => {
     const { vm, state } = mountImportAnnotations({ annotationSets: ['a'], annotationSet: 'a' });
-    vm.vm.currentSet = 'other';
+    vm.currentSet = 'other';
     expect(state.annotationSet.value).toBe('a');
   });
 });
@@ -128,7 +140,7 @@ describe('ImportAnnotations frame metadata reject', () => {
   ])('never imports %s as annotations', async (fileName) => {
     const { vm, importAnnotationFile } = mountImportAnnotations({ fileName });
 
-    await vm.vm.openUpload();
+    await vm.openUpload();
 
     expect(importAnnotationFile).not.toHaveBeenCalled();
     expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
@@ -139,7 +151,7 @@ describe('ImportAnnotations frame metadata reject', () => {
   it('names a remedy that exists on this platform', async () => {
     const { vm } = mountImportAnnotations({ fileName: 'frame-metadata.csv' });
 
-    await vm.vm.openUpload();
+    await vm.openUpload();
 
     const { text } = promptMock.mock.calls[0][0];
     // The creation-time picker is the one surface that accepts an attachment.
@@ -151,7 +163,7 @@ describe('ImportAnnotations frame metadata reject', () => {
   it('still imports a normally named annotation file', async () => {
     const { vm, importAnnotationFile } = mountImportAnnotations({ fileName: 'tracks.csv' });
 
-    await vm.vm.openUpload();
+    await vm.openUpload();
 
     expect(importAnnotationFile).toHaveBeenCalled();
     expect(promptMock).not.toHaveBeenCalled();

--- a/client/dive-common/multicamDisplay.spec.ts
+++ b/client/dive-common/multicamDisplay.spec.ts
@@ -47,7 +47,7 @@ describe('multicamDisplay', () => {
 
   it('detects multicam dataset meta for training guards', () => {
     expect(isMultiCamDatasetConfig({ type: 'multi', subType: 'stereo' })).toBe(true);
-    expect(isMultiCamDatasetConfig({ type: 'video', subType: null })).toBe(false);
+    expect(isMultiCamDatasetConfig({ type: 'video', subType: undefined })).toBe(false);
   });
 
   it('detects stereoscopic vs plain multicam datasets', () => {

--- a/client/dive-common/multicamDisplay.ts
+++ b/client/dive-common/multicamDisplay.ts
@@ -68,7 +68,7 @@ export type DatasetConfigLike = {
 
 export type FolderMetaLike = {
   meta?: DatasetConfigLike;
-  parentId?: string;
+  parentId?: string | null;
   _id?: string;
 };
 

--- a/client/dive-common/store/context.ts
+++ b/client/dive-common/store/context.ts
@@ -29,40 +29,44 @@ const state: ContextState = reactive({
   subCategory: null,
 });
 
-const componentMap: Record<string, ComponentMapItem> = {
-  [DatasetInfo.name]: {
+const componentMapEntries: ComponentMapItem[] = [
+  {
     description: 'Dataset Info',
     component: DatasetInfo,
   },
-  [TypeThreshold.name]: {
+  {
     description: 'Threshold Controls',
     component: TypeThreshold,
   },
-  [ImageEnhancements.name]: {
+  {
     description: 'Image Enhancements',
     component: ImageEnhancements,
   },
-  [GroupSidebar.name]: {
+  {
     description: 'Group Manager',
     component: GroupSidebar,
   },
-  [MultiCamTools.name]: {
+  {
     description: 'Multi Camera Tools',
     component: MultiCamTools,
   },
-  [RegistrationTools.name]: {
+  {
     description: 'Camera Registration',
     component: RegistrationTools,
   },
-  [AttributesSideBar.name]: {
+  {
     description: 'Attribute Details',
     component: AttributesSideBar,
   },
-  [AttributeTrackFilters.name]: {
+  {
     description: 'Attribute Track Filters',
     component: AttributeTrackFilters,
   },
-};
+];
+
+const componentMap: Record<string, ComponentMapItem> = Object.fromEntries(
+  componentMapEntries.map((item) => [item.component.name || 'default', item]),
+);
 
 function register(item: ComponentMapItem) {
   componentMap[item.component.name || 'default'] = item;

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -265,6 +265,9 @@ watch(clientSettings, saveSettings, { deep: true });
 export {
   clientSettings,
   isStereoInteractiveModeEnabled,
+};
+
+export type {
   AnnotationSettings,
   ColumnVisibilitySettings,
 };

--- a/client/dive-common/use/useModeManager.spec.ts
+++ b/client/dive-common/use/useModeManager.spec.ts
@@ -4,7 +4,7 @@
  * track on one camera while the aligned view is active re-projects the
  * geometry onto every other aligned camera under the same track id.
  */
-import { ref } from 'vue';
+import { ref, shallowRef } from 'vue';
 import CameraStore from 'vue-media-annotator/CameraStore';
 import AlignedViewStore from 'vue-media-annotator/alignedView/AlignedViewStore';
 import TrackFilterControls from 'vue-media-annotator/TrackFilterControls';
@@ -38,7 +38,7 @@ function makeHarness() {
     left: { frame: ref(0), hasFrame: ref(true) },
     right: { frame: ref(0), hasFrame: ref(true) },
   };
-  const aggregateController = ref({
+  const aggregateController = shallowRef({
     frame: ref(0),
     nextFrame: () => undefined,
     seekCameraFrame: () => undefined,
@@ -163,7 +163,7 @@ describe('useModeManager aligned-view track mirroring', () => {
 
 function makeSingleCamHarness() {
   const cameraStore = new CameraStore({ markChangesPending: () => undefined });
-  const aggregateController = ref({
+  const aggregateController = shallowRef({
     frame: ref(0),
     nextFrame: () => undefined,
     seekCameraFrame: () => undefined,

--- a/client/dive-common/utils/parseStereoCalibrationJson.ts
+++ b/client/dive-common/utils/parseStereoCalibrationJson.ts
@@ -52,7 +52,8 @@ export default function parseStereoCalibrationJson(
       right: parseCameraCalibration(data, 'right'),
     },
   };
-  const optionalFields: [string, keyof DatasetStereoCalibration][] = [
+  type NumericField = 'gridHeight' | 'gridWidth' | 'imageHeight' | 'imageWidth' | 'squareSize' | 'rmsError';
+  const optionalFields: [string, NumericField][] = [
     ['grid_height', 'gridHeight'],
     ['grid_width', 'gridWidth'],
     ['image_height', 'imageHeight'],
@@ -66,7 +67,7 @@ export default function parseStereoCalibrationJson(
       const parsed = (field.startsWith('grid') || field.startsWith('image'))
         ? Math.trunc(value)
         : value;
-      (result as Record<string, unknown>)[field] = parsed;
+      result[field] = parsed;
     }
   });
   return result;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -36,6 +36,7 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.26.0",
+        "@types/archiver": "^7.0.0",
         "@types/body-parser": "^1.19.0",
         "@types/cors": "^2.8.9",
         "@types/csv-parse": "^1.2.2",
@@ -3942,6 +3943,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/@types/archiver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
+      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -4527,6 +4538,16 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/resize-observer-browser": {
       "version": "0.1.11",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -86,10 +86,11 @@
         "sass": "^1.101.0",
         "tsc-alias": "^1.2.0",
         "tslib": "^2.6.2",
-        "typescript": "~4.3.5",
+        "typescript": "~5.6.3",
         "vite": "^6.4.3",
         "vitest": "^4.1.10",
         "vue-template-compiler": "^2.7.16",
+        "vue-tsc": "~2.1.10",
         "webpack": "^5.95.0",
         "wslink": "^2.0.0",
         "xml-js": "^1.6.11",
@@ -504,12 +505,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1696,9 +1697,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -4977,6 +4978,91 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/compiler-vue2": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
     "node_modules/@vue/eslint-config-airbnb": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@vue/eslint-config-airbnb/-/eslint-config-airbnb-7.0.1.tgz",
@@ -5022,6 +5108,54 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.10.tgz",
+      "integrity": "sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "~2.4.8",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^0.2.0",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
       "version": "1.3.6",
@@ -5364,6 +5498,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/alien-signals": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.2.2.tgz",
+      "integrity": "sha512-cZIRkbERILsBOXTQmMrxc9hgpxglstn69zm+F1ARf4aPAzdAFYd6sBq87ErO0Fj3DV94tglcyHG5kQz9nDC/8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -12025,6 +12166,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mylas": {
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
@@ -12529,6 +12677,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -14725,9 +14880,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -14735,7 +14890,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uc.micro": {
@@ -15214,6 +15369,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vtk.js": {
       "version": "36.2.0",
       "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-36.2.0.tgz",
@@ -15338,6 +15500,24 @@
       "dependencies": {
         "de-indent": "^1.0.2",
         "he": "^1.2.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.1.10.tgz",
+      "integrity": "sha512-RBNSfaaRHcN5uqVqJSZh++Gy/YUzryuv9u1aFWhsammDJXNtUiJMNoJ747lZcQ68wUQFx6E73y4FY3D8E7FGMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "~2.4.8",
+        "@vue/language-core": "2.1.10",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/vue/node_modules/@vue/compiler-sfc": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,8 @@
     "divecli": "node ./bin/platform/desktop/backend/cli.js",
     "lint": "eslint --ext .js,.ts,.vue src/ dive-common/ platform/",
     "lint:templates": "eslint --ext vue src/ dive-common/ platform/",
-    "test": "vitest run src/ dive-common/ platform/"
+    "test": "vitest run src/ dive-common/ platform/",
+    "typecheck": "vue-tsc --noEmit -p tsconfig.typecheck.json"
   },
   "files": [
     "/src",
@@ -105,10 +106,11 @@
     "sass": "^1.101.0",
     "tsc-alias": "^1.2.0",
     "tslib": "^2.6.2",
-    "typescript": "~4.3.5",
+    "typescript": "~5.6.3",
     "vite": "^6.4.3",
     "vitest": "^4.1.10",
     "vue-template-compiler": "^2.7.16",
+    "vue-tsc": "~2.1.10",
     "webpack": "^5.95.0",
     "wslink": "^2.0.0",
     "xml-js": "^1.6.11",

--- a/client/package.json
+++ b/client/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.0",
+    "@types/archiver": "^7.0.0",
     "@types/body-parser": "^1.19.0",
     "@types/cors": "^2.8.9",
     "@types/csv-parse": "^1.2.2",

--- a/client/platform/desktop/backend/ipcService.ts
+++ b/client/platform/desktop/backend/ipcService.ts
@@ -124,7 +124,7 @@ export default function register() {
     // eslint-disable-next-line no-param-reassign -- ipcMain event.returnValue API
     event.returnValue = getDiveVersion();
   });
-  ipcMain.handle('desktop:get-app-path', (_, name: Electron.Name) => app.getPath(name));
+  ipcMain.handle('desktop:get-app-path', (_, name: Parameters<typeof app.getPath>[0]) => app.getPath(name));
   ipcMain.handle('desktop:open-path', async (_, targetPath: string) => (
     common.openPathInFileManager(targetPath)
   ));

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -9,16 +9,16 @@ import {
 } from 'platform/desktop/constants';
 import { makeEmptyAnnotationFile } from 'platform/desktop/backend/serializers/dive';
 
-import { MultiTrackRecord } from 'dive-common/apispec';
+import { CameraCorrespondences, MultiTrackRecord } from 'dive-common/apispec';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import * as common from './common';
 import { createWorkingDirectory, buildTrainingExitManifest } from './utils';
 import beginMultiCamImport from './multiCamImport';
 
 vi.mock('fs-extra', async () => {
-  const actual = await vi.importActual<typeof import('fs-extra')>('fs-extra');
+  const actual = await vi.importActual<typeof import('fs-extra') & { default: typeof import('fs-extra') }>('fs-extra');
   const fsNode = await import('node:fs');
-  const existsByStat = (targetPath: fsNode.PathLike) => {
+  const existsByStat = (targetPath: Parameters<typeof fsNode.statSync>[0]) => {
     try {
       fsNode.statSync(targetPath);
       return true;
@@ -1284,7 +1284,7 @@ describe('native.common', () => {
         BtoA: [[1, 0, -5], [0, 1, 3], [0, 0, 1]],
       },
     };
-    const cameraCorrespondences = {
+    const cameraCorrespondences: CameraCorrespondences = {
       'rgb::ir': [
         { id: 1, a: [10, 20], b: [12, 22] },
         { id: 2, a: [30, 40], b: [33, 44] },

--- a/client/platform/desktop/backend/native/interactive.ts
+++ b/client/platform/desktop/backend/native/interactive.ts
@@ -410,7 +410,7 @@ export class InteractiveServiceManager extends EventEmitter {
     }, 'Segmentation stereo_segment');
     return {
       id: r.id,
-      success: r.success,
+      success: r.success ?? false,
       error: r.error,
       polygon: r.polygon,
       bounds: r.bounds,
@@ -579,7 +579,7 @@ export class InteractiveServiceManager extends EventEmitter {
     }, 'set_frame');
     return {
       id: r.id,
-      success: r.success,
+      success: r.success ?? false,
       error: r.error,
       disparityReady: r.disparity_ready || false,
       message: r.message,
@@ -595,7 +595,7 @@ export class InteractiveServiceManager extends EventEmitter {
     const r = await this.sendRequest({ command: 'get_status' }, 'get_status');
     return {
       id: r.id,
-      success: r.success,
+      success: r.success ?? false,
       enabled: r.enabled || false,
       disparityReady: r.disparity_ready || false,
       computing: r.computing,
@@ -612,7 +612,7 @@ export class InteractiveServiceManager extends EventEmitter {
     const r = await this.sendRequest({ command: 'transfer_line', line: request.line }, 'transfer_line');
     return {
       id: r.id,
-      success: r.success,
+      success: r.success ?? false,
       error: r.error,
       transferredLine: r.transferred_line,
       originalLine: r.original_line,
@@ -634,7 +634,7 @@ export class InteractiveServiceManager extends EventEmitter {
     const r = await this.sendRequest({ command: 'transfer_points', points: request.points }, 'transfer_points');
     return {
       id: r.id,
-      success: r.success,
+      success: r.success ?? false,
       error: r.error,
       transferredPoints: r.transferred_points,
       originalPoints: r.original_points,
@@ -652,7 +652,7 @@ export class InteractiveServiceManager extends EventEmitter {
       right_line: request.rightLine,
     }, 'measure_line');
     return {
-      id: r.id, success: r.success, error: r.error, length: r.length, measurement: r.measurement,
+      id: r.id, success: r.success ?? false, error: r.error, length: r.length, measurement: r.measurement,
     };
   }
 
@@ -666,7 +666,7 @@ export class InteractiveServiceManager extends EventEmitter {
       method: request.method || 'average',
     }, 'aggregate_lengths');
     return {
-      id: r.id, success: r.success, error: r.error, avgLength: r.avg_length,
+      id: r.id, success: r.success ?? false, error: r.error, avgLength: r.avg_length,
     };
   }
 

--- a/client/platform/desktop/backend/native/multiCam.spec.ts
+++ b/client/platform/desktop/backend/native/multiCam.spec.ts
@@ -18,9 +18,9 @@ const console = new Console(process.stdout, process.stderr);
 const multiCamSetup = fs.readJSONSync('../testutils/multicam.spec.json');
 
 vi.mock('fs-extra', async () => {
-  const actual = await vi.importActual<typeof import('fs-extra')>('fs-extra');
+  const actual = await vi.importActual<typeof import('fs-extra') & { default: typeof import('fs-extra') }>('fs-extra');
   const fsNode = await import('node:fs');
-  const existsByStat = (targetPath: fsNode.PathLike) => {
+  const existsByStat = (targetPath: Parameters<typeof fsNode.statSync>[0]) => {
     try {
       fsNode.statSync(targetPath);
       return true;

--- a/client/platform/desktop/backend/native/multiCamImport.ts
+++ b/client/platform/desktop/backend/native/multiCamImport.ts
@@ -82,6 +82,10 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
     if (!(args.defaultDisplay in args.sourceList)) {
       throw new Error(`${args.defaultDisplay} is not a camera name`);
     }
+    if (args.type === 'large-image') {
+      throw new Error('large-image is not supported for multi-camera import');
+    }
+    const cameraType = args.type;
     const sourceDirectories = Object.fromEntries(
       Object.entries(args.sourceList).map(([key, item]) => [
         key,
@@ -98,7 +102,7 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
         throw new Error(`file or directory for ${key} not found: ${item.sourcePath}`);
       }
       cameras[key] = {
-        type: args.type,
+        type: cameraType,
         originalBasePath: item.sourcePath,
         originalImageFiles: [],
         originalVideoFile: '',
@@ -373,7 +377,6 @@ async function beginMultiCamImport(args: MultiCamImportArgs): Promise<DesktopMed
     mediaConvertList,
     trackFileAbsPath: '',
     forceMediaTranscode: false,
-    useNativePlayback: false,
     multiCamTrackFiles: trackFileCount === 0 ? null : multiCamTrackFiles,
     ...(sharedMetadataFile ? { metadataFileAbsPath: sharedMetadataFile } : {}),
     ...(importWarnings.length ? { importWarnings } : {}),

--- a/client/platform/desktop/backend/native/multiCollectImport.spec.ts
+++ b/client/platform/desktop/backend/native/multiCollectImport.spec.ts
@@ -6,7 +6,7 @@ import { Console } from 'console';
 const console = new Console(process.stdout, process.stderr);
 
 vi.mock('fs-extra', async () => {
-  const actual = await vi.importActual<typeof import('fs-extra')>('fs-extra');
+  const actual = await vi.importActual<typeof import('fs-extra') & { default: typeof import('fs-extra') }>('fs-extra');
   const fsNode = await import('node:fs');
   const existsByStat = (targetPath: import('node:fs').PathLike) => {
     try {

--- a/client/platform/desktop/backend/native/multicamExport.spec.ts
+++ b/client/platform/desktop/backend/native/multicamExport.spec.ts
@@ -47,9 +47,9 @@ async function snapshot(dir: string, prefix = ''): Promise<Record<string, string
 zipMock.snapshot = (dir: string) => snapshot(dir);
 
 vi.mock('fs-extra', async () => {
-  const actual = await vi.importActual<typeof import('fs-extra')>('fs-extra');
+  const actual = await vi.importActual<typeof import('fs-extra') & { default: typeof import('fs-extra') }>('fs-extra');
   const fsNode = await import('node:fs');
-  const existsByStat = (targetPath: fsNode.PathLike) => {
+  const existsByStat = (targetPath: Parameters<typeof fsNode.statSync>[0]) => {
     try {
       fsNode.statSync(targetPath);
       return true;

--- a/client/platform/desktop/backend/native/stereoCollectImport.spec.ts
+++ b/client/platform/desktop/backend/native/stereoCollectImport.spec.ts
@@ -6,7 +6,7 @@ import { Console } from 'console';
 const console = new Console(process.stdout, process.stderr);
 
 vi.mock('fs-extra', async () => {
-  const actual = await vi.importActual<typeof import('fs-extra')>('fs-extra');
+  const actual = await vi.importActual<typeof import('fs-extra') & { default: typeof import('fs-extra') }>('fs-extra');
   const fsNode = await import('node:fs');
   const existsByStat = (targetPath: import('node:fs').PathLike) => {
     try {

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -430,6 +430,9 @@ async function runPipeline(
     shell: viameConstants.shell,
     cwd: jobWorkDir,
   }));
+  if (job.pid === undefined) {
+    throw new Error('Failed to spawn pipeline process');
+  }
 
   const jobBase: DesktopJob = {
     key: `pipeline_${job.pid}_${jobWorkDir}`,
@@ -631,6 +634,9 @@ async function exportTrainedPipeline(
     shell: viameConstants.shell,
     cwd: jobWorkDir,
   }));
+  if (job.pid === undefined) {
+    throw new Error('Failed to spawn export process');
+  }
 
   const jobBase: DesktopJob = {
     key: `pipeline_${job.pid}_${jobWorkDir}`,
@@ -804,6 +810,9 @@ async function train(
     shell: viameConstants.shell,
     cwd: jobWorkDir,
   }));
+  if (job.pid === undefined) {
+    throw new Error('Failed to spawn training process');
+  }
 
   const cleanPipelineName = cleanString(runTrainingArgs.pipelineName);
 

--- a/client/platform/desktop/backend/serializers/coco.spec.ts
+++ b/client/platform/desktop/backend/serializers/coco.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="jest" />
 import fs from 'fs-extra';
 import mockfs from 'mock-fs';
 import { AnnotationSchema } from 'dive-common/apispec';

--- a/client/platform/desktop/backend/serializers/coco.ts
+++ b/client/platform/desktop/backend/serializers/coco.ts
@@ -118,7 +118,7 @@ type CocoAnnotation = {
    */
   iscrowd?: number;
   keypoints?: number[];
-  segmentation?: number[][] | Record<string, unknown>;
+  segmentation?: number[] | number[][] | Record<string, unknown>;
   dive_detection_attributes?: Record<string, unknown>;
   dive_track_attributes?: Record<string, unknown>;
   dive_notes?: string[];

--- a/client/platform/desktop/backend/server.ts
+++ b/client/platform/desktop/backend/server.ts
@@ -63,7 +63,7 @@ apirouter.get('/dataset/:id/:camera?/meta', async (req, res, next) => {
     const ds = await common.loadConfig(settings.get(), id, makeMediaUrl);
     res.json(ds);
   } catch (err) {
-    err.status = 500;
+    (err as { status?: number }).status = 500;
     next(err);
   }
 });
@@ -78,7 +78,7 @@ apirouter.post('/dataset/:id/:camera?/meta', async (req, res, next) => {
     await common.saveConfig(settings.get(), id, req.body);
     res.status(200).send('done');
   } catch (err) {
-    err.status = 500;
+    (err as { status?: number }).status = 500;
     next(err);
   }
 });
@@ -94,7 +94,7 @@ apirouter.post('/dataset/:id/:camera?/attributes', async (req, res, next) => {
     await common.saveAttributes(settings.get(), id, args);
     res.status(200).send('done');
   } catch (err) {
-    err.status = 500;
+    (err as { status?: number }).status = 500;
     next(err);
   }
   return null;
@@ -110,7 +110,7 @@ apirouter.post('/dataset/:id/:camera?/attribute_track_filters', async (req, res,
     await common.saveAttributeTrackFilters(settings.get(), id, args);
     res.status(200).send('done');
   } catch (err) {
-    err.status = 500;
+    (err as { status?: number }).status = 500;
     next(err);
   }
   return null;
@@ -127,7 +127,7 @@ apirouter.post('/dataset/:id/:camera?/detections', async (req, res, next) => {
     await common.saveDetections(settings.get(), id, args);
     res.status(200).send('done');
   } catch (err) {
-    err.status = 500;
+    (err as { status?: number }).status = 500;
     next(err);
   }
   return null;

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
 
 import type {
+  AnnotationSchema,
   DatasetConfigMutable, DatasetType, MultiCamImportArgs,
   Pipe, Pipelines, PipelineParams, SaveAttributeArgs,
   SaveAttributeTrackFilterArgs, SaveDetectionsArgs, TrainingConfigs,
@@ -42,6 +43,20 @@ function getExtension(filePath: string) {
 function joinPath(dir: string, filename: string) {
   const separator = dir.includes('\\') ? '\\' : '/';
   return `${dir.replace(/[\\/]+$/, '')}${separator}${filename}`;
+}
+
+/**
+ * window.diveDesktop.invoke is typed as Promise<unknown> because it is a generic
+ * ipcRenderer.invoke wrapper. Each channel's actual return shape is defined by its
+ * handler in platform/desktop/backend; callers below narrow to that shape.
+ */
+function invoke<T>(channel: string, ...args: unknown[]): Promise<T> {
+  return window.diveDesktop.invoke(channel, ...args) as Promise<T>;
+}
+
+interface ServerInfo {
+  address: string;
+  port: number;
 }
 
 /**
@@ -132,19 +147,19 @@ async function openFromDisk(datasetType: DatasetType | 'bulk' | 'calibration' | 
  */
 
 function nvidiaSmi(): Promise<NvidiaSmiReply> {
-  return window.diveDesktop.invoke('nvidia-smi');
+  return invoke<NvidiaSmiReply>('nvidia-smi');
 }
 
 function openLink(url: string): Promise<void> {
-  return window.diveDesktop.invoke('open-link-in-browser', url);
+  return invoke<void>('open-link-in-browser', url);
 }
 
 async function getPipelineList(): Promise<Pipelines> {
-  return window.diveDesktop.invoke('get-pipeline-list');
+  return invoke<Pipelines>('get-pipeline-list');
 }
 
 async function getTrainingConfigurations(): Promise<TrainingConfigs> {
-  return window.diveDesktop.invoke('get-training-configs');
+  return invoke<TrainingConfigs>('get-training-configs');
 }
 
 async function runPipeline(itemId: string, pipeline: Pipe, pipelineParams?: PipelineParams): Promise<void> {
@@ -193,11 +208,11 @@ async function runTraining(
 }
 
 async function deleteTrainedPipeline(pipeline: Pipe): Promise<void> {
-  return window.diveDesktop.invoke('delete-trained-pipeline', pipeline);
+  return invoke<void>('delete-trained-pipeline', pipeline);
 }
 
 async function listResumableTrainingJobs(): Promise<DesktopJob[]> {
-  return window.diveDesktop.invoke('list-resumable-training');
+  return invoke<DesktopJob[]>('list-resumable-training');
 }
 
 async function resumeTraining(job: DesktopJob): Promise<void> {
@@ -209,81 +224,81 @@ async function resumeTraining(job: DesktopJob): Promise<void> {
 }
 
 async function discardResumableTraining(job: DesktopJob): Promise<void> {
-  return window.diveDesktop.invoke('discard-resumable-training', job.workingDir);
+  return invoke<void>('discard-resumable-training', job.workingDir);
 }
 
 function importMedia(path: string): Promise<DesktopMediaImportResponse> {
-  return window.diveDesktop.invoke('import-media', { path });
+  return invoke<DesktopMediaImportResponse>('import-media', { path });
 }
 
 function listImmediateSubfolders(parentPath: string): Promise<string[]> {
-  return window.diveDesktop.invoke('list-immediate-subfolders', { path: parentPath });
+  return invoke<string[]>('list-immediate-subfolders', { path: parentPath });
 }
 
 function listParentFolderCameras(
   parentPath: string,
   mediaType: 'image-sequence' | 'video',
 ): Promise<{ name: string; sourcePath: string }[]> {
-  return window.diveDesktop.invoke('list-parent-folder-cameras', { path: parentPath, mediaType });
+  return invoke<{ name: string; sourcePath: string }[]>('list-parent-folder-cameras', { path: parentPath, mediaType });
 }
 
 function resolveMulticamCameraSourcePath(
   subfolderPath: string,
   mediaType: 'image-sequence' | 'video',
 ): Promise<string> {
-  return window.diveDesktop.invoke('resolve-multicam-camera-source-path', {
+  return invoke<string>('resolve-multicam-camera-source-path', {
     path: subfolderPath,
     mediaType,
   });
 }
 
 function findParentFolderCalibrationFile(parentPath: string): Promise<string | null> {
-  return window.diveDesktop.invoke('find-parent-folder-calibration-file', { path: parentPath });
+  return invoke<string | null>('find-parent-folder-calibration-file', { path: parentPath });
 }
 
 function findParentFolderTransformFiles(parentPath: string): Promise<string[]> {
-  return window.diveDesktop.invoke('find-parent-folder-transform-files', { path: parentPath });
+  return invoke<string[]>('find-parent-folder-transform-files', { path: parentPath });
 }
 
 function hasCalibrationFile(datasetId: string): Promise<boolean> {
-  return window.diveDesktop.invoke('dataset-has-calibration-file', { datasetId });
+  return invoke<boolean>('dataset-has-calibration-file', { datasetId });
 }
 
 function bulkImportMedia(path: string): Promise<DesktopMediaImportResponse[]> {
-  return window.diveDesktop.invoke('bulk-import-media', { path });
+  return invoke<DesktopMediaImportResponse[]>('bulk-import-media', { path });
 }
 
 function deleteDataset(datasetId: string): Promise<boolean> {
-  return window.diveDesktop.invoke('delete-dataset', { datasetId });
+  return invoke<boolean>('delete-dataset', { datasetId });
 }
 
 function checkDataset(datasetId: string): Promise<boolean> {
-  return window.diveDesktop.invoke('check-dataset', { datasetId });
+  return invoke<boolean>('check-dataset', { datasetId });
 }
 
 function importMultiCam(args: MultiCamImportArgs):
    Promise<DesktopMediaImportResponse> {
-  return window.diveDesktop.invoke('import-multicam-media', { args });
+  return invoke<DesktopMediaImportResponse>('import-multicam-media', { args });
 }
 
 function scanMultiCamBatch(path: string): Promise<MultiCamBatchScanResult> {
-  return window.diveDesktop.invoke('scan-multicam-batch', { path });
+  return invoke<MultiCamBatchScanResult>('scan-multicam-batch', { path });
 }
 
 function scanStereoBatch(path: string): Promise<MultiCamBatchScanResult> {
-  return window.diveDesktop.invoke('scan-stereo-batch', { path });
+  return invoke<MultiCamBatchScanResult>('scan-stereo-batch', { path });
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function importAnnotationFile(id: string, path: string, _htmlFile = undefined, additive = false, additivePrepend = ''): Promise<boolean | string[]> {
-  return window.diveDesktop.invoke('import-annotation', {
+  return invoke<boolean | string[]>('import-annotation', {
     id, path, additive, additivePrepend,
   });
 }
 
 function finalizeImport(args: DesktopMediaImportResponse): Promise<ConversionArgs> {
   // Have this return JsonConfig as well as everything needed to start a job?
-  return window.diveDesktop.invoke('finalize-import', args);
+  return invoke<ConversionArgs>('finalize-import', args);
 }
 
 async function convert(args: ConversionArgs): Promise<void> {
@@ -308,7 +323,7 @@ async function exportDataset(id: string, exclude: boolean, typeFilter: readonly 
     const args: ExportDatasetArgs = {
       id, exclude, path: location.filePath, typeFilter: new Set(typeFilter), type,
     };
-    return window.diveDesktop.invoke('export-dataset', args);
+    return invoke<string>('export-dataset', args);
   }
   return '';
 }
@@ -320,7 +335,7 @@ async function exportConfiguration(id: string): Promise<string> {
   });
   if (!location.canceled && location.filePath) {
     const args: ExportConfigurationArgs = { id, path: location.filePath };
-    return window.diveDesktop.invoke('export-configuration', args);
+    return invoke<string>('export-configuration', args);
   }
   return '';
 }
@@ -346,13 +361,13 @@ async function exportMulticamEverything(
       path: location.filePath,
       typeFilter: new Set(typeFilter),
     };
-    return window.diveDesktop.invoke('export-multicam-everything', args);
+    return invoke<string>('export-multicam-everything', args);
   }
   return '';
 }
 
 async function cancelJob(job: DesktopJob): Promise<void> {
-  return window.diveDesktop.invoke('cancel-job', job);
+  return invoke<void>('cancel-job', job);
 }
 
 /**
@@ -360,43 +375,43 @@ async function cancelJob(job: DesktopJob): Promise<void> {
  */
 
 async function segmentationInitialize(): Promise<{ success: boolean; noSamInstalled?: boolean }> {
-  return window.diveDesktop.invoke('segmentation-initialize');
+  return invoke<{ success: boolean; noSamInstalled?: boolean }>('segmentation-initialize');
 }
 
 // Start the interactive service process without warming the point-segmentation
 // model (used by text query, which loads its own model lazily).
 async function segmentationEnsureStarted(): Promise<{ success: boolean }> {
-  return window.diveDesktop.invoke('segmentation-ensure-started');
+  return invoke<{ success: boolean }>('segmentation-ensure-started');
 }
 
 async function segmentationPredict(request: SegmentationPredictRequest): Promise<SegmentationPredictResponse> {
-  return window.diveDesktop.invoke('segmentation-predict', request);
+  return invoke<SegmentationPredictResponse>('segmentation-predict', request);
 }
 
 async function segmentationStereoSegment(
   request: SegmentationStereoSegmentRequest,
 ): Promise<SegmentationStereoSegmentResponse> {
-  return window.diveDesktop.invoke('segmentation-stereo-segment', request);
+  return invoke<SegmentationStereoSegmentResponse>('segmentation-stereo-segment', request);
 }
 
 async function segmentationSetImage(imagePath: string): Promise<{ success: boolean }> {
-  return window.diveDesktop.invoke('segmentation-set-image', imagePath);
+  return invoke<{ success: boolean }>('segmentation-set-image', imagePath);
 }
 
 async function segmentationClearImage(): Promise<{ success: boolean }> {
-  return window.diveDesktop.invoke('segmentation-clear-image');
+  return invoke<{ success: boolean }>('segmentation-clear-image');
 }
 
 async function segmentationShutdown(): Promise<{ success: boolean }> {
-  return window.diveDesktop.invoke('segmentation-shutdown');
+  return invoke<{ success: boolean }>('segmentation-shutdown');
 }
 
 async function segmentationIsReady(): Promise<SegmentationStatusResponse> {
-  return window.diveDesktop.invoke('segmentation-is-ready');
+  return invoke<SegmentationStatusResponse>('segmentation-is-ready');
 }
 
 async function segmentationSam3Installed(): Promise<{ installed: boolean }> {
-  return window.diveDesktop.invoke('segmentation-sam3-installed');
+  return invoke<{ installed: boolean }>('segmentation-sam3-installed');
 }
 
 /**
@@ -405,11 +420,11 @@ async function segmentationSam3Installed(): Promise<{ installed: boolean }> {
  */
 
 async function textQuery(request: TextQueryRequest): Promise<TextQueryResponse> {
-  return window.diveDesktop.invoke('segmentation-text-query', request);
+  return invoke<TextQueryResponse>('segmentation-text-query', request);
 }
 
 async function refineDetections(request: RefineDetectionsRequest): Promise<RefineDetectionsResponse> {
-  return window.diveDesktop.invoke('segmentation-refine', request);
+  return invoke<RefineDetectionsResponse>('segmentation-refine', request);
 }
 
 /**
@@ -464,6 +479,8 @@ interface StereoCalibration {
 interface StereoSetFrameRequest {
   leftImagePath: string;
   rightImagePath: string;
+  /** Time in seconds when paths are video files */
+  frameTime?: number;
 }
 
 interface StereoSetFrameResponse {
@@ -556,43 +573,43 @@ async function stereoEnable(
   calibration?: StereoCalibration,
   calibrationFile?: string,
 ): Promise<{ success: boolean; error?: string; launchFailed?: boolean }> {
-  return window.diveDesktop.invoke('stereo-enable', { calibration, calibrationFile });
+  return invoke<{ success: boolean; error?: string; launchFailed?: boolean }>('stereo-enable', { calibration, calibrationFile });
 }
 
 async function stereoDisable(): Promise<{ success: boolean }> {
-  return window.diveDesktop.invoke('stereo-disable');
+  return invoke<{ success: boolean }>('stereo-disable');
 }
 
 async function stereoSetFrame(request: StereoSetFrameRequest): Promise<StereoSetFrameResponse> {
-  return window.diveDesktop.invoke('stereo-set-frame', request);
+  return invoke<StereoSetFrameResponse>('stereo-set-frame', request);
 }
 
 async function stereoGetStatus(): Promise<StereoStatusResponse> {
-  return window.diveDesktop.invoke('stereo-get-status');
+  return invoke<StereoStatusResponse>('stereo-get-status');
 }
 
 async function stereoTransferLine(request: StereoTransferLineRequest): Promise<StereoTransferLineResponse> {
-  return window.diveDesktop.invoke('stereo-transfer-line', request);
+  return invoke<StereoTransferLineResponse>('stereo-transfer-line', request);
 }
 
 async function stereoTransferPoints(request: StereoTransferPointsRequest): Promise<StereoTransferPointsResponse> {
-  return window.diveDesktop.invoke('stereo-transfer-points', request);
+  return invoke<StereoTransferPointsResponse>('stereo-transfer-points', request);
 }
 
 async function stereoMeasureLine(request: StereoMeasureLineRequest): Promise<StereoMeasureLineResponse> {
-  return window.diveDesktop.invoke('stereo-measure-line', request);
+  return invoke<StereoMeasureLineResponse>('stereo-measure-line', request);
 }
 
 async function stereoAggregateLengths(request: StereoAggregateLengthsRequest): Promise<StereoAggregateLengthsResponse> {
-  return window.diveDesktop.invoke('stereo-aggregate-lengths', request);
+  return invoke<StereoAggregateLengthsResponse>('stereo-aggregate-lengths', request);
 }
 
 async function stereoSetCalibration(calibration: StereoCalibration): Promise<{ success: boolean }> {
-  return window.diveDesktop.invoke('stereo-set-calibration', { calibration });
+  return invoke<{ success: boolean }>('stereo-set-calibration', { calibration });
 }
 
 async function stereoIsEnabled(): Promise<{ enabled: boolean }> {
-  return window.diveDesktop.invoke('stereo-is-enabled');
+  return invoke<{ enabled: boolean }>('stereo-is-enabled');
 }
 
 function onStereoDisparityReady(callback: (data: unknown) => void): () => void {
@@ -623,7 +640,7 @@ function formatHostForUrl(host: string) {
 
 async function getClient(): Promise<AxiosInstance> {
   if (_axiosClient === undefined) {
-    const addr = await window.diveDesktop.invoke('server-info');
+    const addr = await invoke<ServerInfo>('server-info');
     _baseURL = `http://${formatHostForUrl(addr.address)}:${addr.port}/api`;
     _axiosClient = axios.create({ baseURL: _baseURL });
   }
@@ -654,7 +671,7 @@ async function loadConfig(id: string) {
 }
 
 async function loadDetections(datasetId: string) {
-  const annotations = await window.diveDesktop.invoke('load-detections', { datasetId });
+  const annotations = await invoke<AnnotationSchema>('load-detections', { datasetId });
   return {
     version: annotations.version,
     tracks: Object.values(annotations.tracks),
@@ -664,7 +681,7 @@ async function loadDetections(datasetId: string) {
 }
 
 function loadFrameMetadata(datasetId: string): Promise<FrameMetadataSourcesResponse> {
-  return window.diveDesktop.invoke('load-frame-metadata', { datasetId });
+  return invoke<FrameMetadataSourcesResponse>('load-frame-metadata', { datasetId });
 }
 
 async function saveConfig(id: string, args: DatasetConfigMutable) {
@@ -688,11 +705,11 @@ async function saveAttributeTrackFilters(id: string, args: SaveAttributeTrackFil
 }
 
 function getLastCalibration(): Promise<string | null> {
-  return window.diveDesktop.invoke('get-last-calibration');
+  return invoke<string | null>('get-last-calibration');
 }
 
 function loadGlobalStyleSettings(): Promise<GlobalStyleSettings> {
-  return window.diveDesktop.invoke('load-global-style-settings');
+  return invoke<GlobalStyleSettings>('load-global-style-settings');
 }
 
 function saveGlobalStyleSettings(settings: GlobalStyleSettings): Promise<unknown> {
@@ -700,15 +717,15 @@ function saveGlobalStyleSettings(settings: GlobalStyleSettings): Promise<unknown
 }
 
 function saveCalibration(path: string): Promise<{ savedPath: string; updatedDatasetIds: string[] }> {
-  return window.diveDesktop.invoke('save-calibration', { path });
+  return invoke<{ savedPath: string; updatedDatasetIds: string[] }>('save-calibration', { path });
 }
 
 function importCalibrationFile(datasetId: string, path: string): Promise<{ calibration: string }> {
-  return window.diveDesktop.invoke('import-calibration', { id: datasetId, path });
+  return invoke<{ calibration: string }>('import-calibration', { id: datasetId, path });
 }
 
 function exportCalibrationFile(datasetId: string, destPath: string): Promise<{ exportedPath: string }> {
-  return window.diveDesktop.invoke('export-calibration', { id: datasetId, destPath });
+  return invoke<{ exportedPath: string }>('export-calibration', { id: datasetId, destPath });
 }
 
 /** Export one camera's *_registration.json file to destPath. */
@@ -717,7 +734,7 @@ function exportCameraRegistration(
   destPath: string,
   camera: string,
 ): Promise<{ exportedPath: string }> {
-  return window.diveDesktop.invoke('export-camera-registration', { id: datasetId, destPath, camera });
+  return invoke<{ exportedPath: string }>('export-camera-registration', { id: datasetId, destPath, camera });
 }
 
 /** Merge a DIVE registration .json into the dataset's camera registration. */
@@ -727,11 +744,11 @@ function importCameraRegistration(
   _file?: File,
   options?: { camera?: string },
 ): Promise<{ cameras: string[]; pairCount: number }> {
-  return window.diveDesktop.invoke('import-camera-registration', { id: datasetId, path, options });
+  return invoke<{ cameras: string[]; pairCount: number }>('import-camera-registration', { id: datasetId, path, options });
 }
 
 function getDatasetCalibration(datasetId: string): Promise<DatasetCalibrationResult | null> {
-  return window.diveDesktop.invoke('get-dataset-calibration', { datasetId });
+  return invoke<DatasetCalibrationResult | null>('get-dataset-calibration', { datasetId });
 }
 
 async function downloadCalibration(datasetId: string): Promise<void> {
@@ -747,7 +764,7 @@ async function downloadCalibration(datasetId: string): Promise<void> {
 }
 
 function deleteCalibration(datasetId: string): Promise<void> {
-  return window.diveDesktop.invoke('delete-calibration', { datasetId });
+  return invoke<void>('delete-calibration', { datasetId });
 }
 
 export {

--- a/client/platform/desktop/frontend/components/MultiPipeline.vue
+++ b/client/platform/desktop/frontend/components/MultiPipeline.vue
@@ -182,22 +182,23 @@ function toggleStaged(item: JsonConfigCache) {
 }
 
 async function runPipelineForDatasets() {
-  if (selectedPipeline.value !== null) {
+  const pipeline = selectedPipeline.value;
+  if (pipeline !== null) {
     // Only the staged datasets compatible with (and displayed for) the
     // selected pipeline; staged ids can hold datasets other pipelines accept.
     const runIds = stagedDatasets.value.map((item: JsonConfigCache) => item.id);
     const results = await Promise.allSettled(
       runIds.map((datasetId: string) => {
-        if (pipelineCreatesNewDataset(selectedPipeline.value)) {
+        if (pipelineCreatesNewDataset(pipeline)) {
           const datasetMeta = availableItems.value.find((item: JsonConfigCache) => item.id === datasetId);
           if (!datasetMeta) {
             throw new Error(`Attempted to run pipeline on nonexistant dataset ${datasetId}`);
           }
-          return runPipeline(datasetId, selectedPipeline.value!, {
+          return runPipeline(datasetId, pipeline, {
             outputDatasetName: computeOutputDatasetName(datasetMeta),
           });
         }
-        return runPipeline(datasetId, selectedPipeline.value!);
+        return runPipeline(datasetId, pipeline);
       }),
     );
     const failed = results

--- a/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
+++ b/client/platform/desktop/frontend/components/MultiTrainingMenu.vue
@@ -23,7 +23,7 @@ import { DesktopJob, RunTraining } from 'platform/desktop/constants';
 import {
   listResumableTrainingJobs, resumeTraining, discardResumableTraining,
 } from '../api';
-import { datasets } from '../store/dataset';
+import { datasets, JsonConfigCache } from '../store/dataset';
 
 function joinPath(dir: string, filename: string) {
   const separator = dir.includes('\\') ? '\\' : '/';
@@ -202,6 +202,10 @@ export default defineComponent({
 
     const stagedItems = computed(() => Object.values(data.stagedItems));
 
+    function getAvailableItemClass({ included }: JsonConfigCache & { included: boolean }) {
+      return included ? 'disabled-row' : '';
+    }
+
     const isReadyToTrain = computed(() => (
       stagedItems.value.length > 0
         && data.selectedTrainingConfig
@@ -223,7 +227,8 @@ export default defineComponent({
           unsortedPipelines.value = await getPipelineList();
         } catch (err) {
           let text = 'Unable to delete model';
-          if (err.response?.status === 403) text = 'You do not have permission to delete the selected resource(s).';
+          const deleteErr = err as { response?: { status?: number } };
+          if (deleteErr.response?.status === 403) text = 'You do not have permission to delete the selected resource(s).';
           prompt({
             title: 'Delete Failed',
             text,
@@ -254,8 +259,9 @@ export default defineComponent({
         }
       } catch (err) {
         const errorTemplate = 'Unable to export model';
+        const exportErr = err as { response?: { status?: number } };
         let text = `${errorTemplate}: ${err}`;
-        if (err.response?.status === 403) text = `${errorTemplate}: You do not have permission to export the selected resource(s).`;
+        if (exportErr.response?.status === 403) text = `${errorTemplate}: You do not have permission to export the selected resource(s).`;
         prompt({
           title: 'Export Failed',
           text,
@@ -283,7 +289,8 @@ export default defineComponent({
         router.push({ name: 'jobs' });
       } catch (err) {
         let text = 'Unable to run training';
-        if (err.response && err.response.status === 403) {
+        const trainingErr = err as { response?: { status?: number } };
+        if (trainingErr.response && trainingErr.response.status === 403) {
           text = 'You do not have permission to run training on the selected resource(s).';
         }
         prompt({
@@ -336,6 +343,7 @@ export default defineComponent({
       labelFile,
       clearLabelText,
       toggleStaged,
+      getAvailableItemClass,
       deleteModel,
       exportModel,
       simplifyTrainingName,
@@ -579,7 +587,7 @@ export default defineComponent({
         v-bind="{ headers: available.headers, items: available.items.value }"
         :footer-props="{ itemsPerPageOptions }"
         :items-per-page.sync="clientSettings.rowsPerPage"
-        :item-class="({ included }) => included ? 'disabled-row' : ''"
+        :item-class="getAvailableItemClass"
         no-data-text="No data meets criteria for chosen configuration"
       >
         <template #[`item.action`]="{ item }">

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -23,6 +23,7 @@ import {
   STEREO_LENGTH_ATTRIBUTE_NAME,
 } from 'dive-common/utils/stereoLengthRendering';
 import type { RectBounds } from 'vue-media-annotator/utils';
+import type Track from 'vue-media-annotator/track';
 import {
   segmentationPredict, segmentationStereoSegment, segmentationInitialize, segmentationIsReady,
   segmentationEnsureStarted,
@@ -330,6 +331,8 @@ export default defineComponent({
       originalImageFiles: string[];
       type: string;
       originalVideoFile?: string;
+      fps?: number;
+      originalFps?: number;
     } | null = null;
 
     // Frame -> media-path / frame-time resolvers built by initializeSegmentation.
@@ -348,14 +351,14 @@ export default defineComponent({
       const { originalBasePath, originalImageFiles, type } = cachedMeta;
       if (type === 'video') {
         // Video datasets require frame extraction - not yet supported
-        return npath.join(originalBasePath, cachedMeta.originalVideoFile || '');
+        return joinPath(originalBasePath, cachedMeta.originalVideoFile || '');
       }
       if (originalImageFiles && originalImageFiles[frameNum]) {
         const imagePath = originalImageFiles[frameNum];
-        if (npath.isAbsolute(imagePath)) {
+        if (isAbsolutePath(imagePath)) {
           return imagePath;
         }
-        return npath.join(originalBasePath, imagePath);
+        return joinPath(originalBasePath, imagePath);
       }
       return '';
     }
@@ -441,7 +444,7 @@ export default defineComponent({
         // frames' annotations are left untouched.
         if (replaceExisting && cameraStore && trackStore) {
           const removeIds: number[] = [];
-          trackStore.annotationMap.forEach((track) => {
+          trackStore.annotationMap.forEach((track: Track) => {
             if (frameNum < track.begin || frameNum > track.end) {
               return;
             }
@@ -646,7 +649,8 @@ export default defineComponent({
         const meta = await loadConfig(props.id);
         // Plain multicam and single-camera datasets have no stereo pair: report
         // no stereo so the caller does not load the stereo service.
-        if (!meta.multiCamMedia || !isStereoscopicDatasetConfig(meta)) return false;
+        if (!meta.multiCamMedia
+          || !isStereoscopicDatasetConfig({ type: meta.type, subType: meta.subType ?? undefined })) return false;
 
         // Extract calibration file path from multiCam metadata
         stereoCalibrationFile = meta.multiCam?.calibration || undefined;

--- a/client/platform/desktop/frontend/store/dataset.ts
+++ b/client/platform/desktop/frontend/store/dataset.ts
@@ -84,7 +84,7 @@ function clearRecents() {
 async function autoDiscover() {
   /* Make sure settings are ready on backend */
   await initializedSettings;
-  const discovered: JsonConfig[] = await window.diveDesktop.invoke('autodiscover-data');
+  const discovered = await window.diveDesktop.invoke<JsonConfig[]>('autodiscover-data');
   const discoveredIds = new Set(discovered.map((d) => d.id));
 
   Object.keys(datasets.value).forEach((id) => {

--- a/client/platform/desktop/frontend/store/queues/asyncCpuJobQueue.ts
+++ b/client/platform/desktop/frontend/store/queues/asyncCpuJobQueue.ts
@@ -10,9 +10,9 @@ export default class AsyncCpuJobQueue extends AsyncJobQueue<ConversionArgs | Exp
   async beginJob(spec: ConversionArgs | ExportTrainedPipeline) {
     let newJob: DesktopJob;
     if (spec.type === JobType.Conversion) {
-      newJob = await this.ipcRenderer.invoke('convert', spec);
+      newJob = await this.ipcRenderer.invoke<DesktopJob>('convert', spec);
     } else if (spec.type === JobType.ExportTrainedPipeline) {
-      newJob = await this.ipcRenderer.invoke('export-trained-pipeline', spec);
+      newJob = await this.ipcRenderer.invoke<DesktopJob>('export-trained-pipeline', spec);
     } else {
       throw new Error('CPU job type not able to be queued');
     }

--- a/client/platform/desktop/frontend/store/queues/asyncGpuJobQueue.ts
+++ b/client/platform/desktop/frontend/store/queues/asyncGpuJobQueue.ts
@@ -28,9 +28,9 @@ export default class AsyncGpuJobQueue extends AsyncJobQueue<RunPipeline | RunTra
   async beginJob(spec: RunPipeline | RunTraining) {
     let newJob: DesktopJob;
     if (spec.type === JobType.RunPipeline) {
-      newJob = await this.ipcRenderer.invoke('run-pipeline', spec);
+      newJob = await this.ipcRenderer.invoke<DesktopJob>('run-pipeline', spec);
     } else if (spec.type === JobType.RunTraining) {
-      newJob = await this.ipcRenderer.invoke('run-training', spec);
+      newJob = await this.ipcRenderer.invoke<DesktopJob>('run-training', spec);
     } else {
       throw new Error('Unsupported job arguments provided to beginJob.');
     }

--- a/client/platform/desktop/frontend/store/settings.ts
+++ b/client/platform/desktop/frontend/store/settings.ts
@@ -39,14 +39,14 @@ const downgradedVersion = computed(() => {
 });
 
 function getDefaultSettings(): Promise<Settings> {
-  return window.diveDesktop.invoke('default-settings');
+  return window.diveDesktop.invoke<Settings>('default-settings');
 }
 
 function validateSettings(s: Settings | null): Promise<string | boolean> {
   if (s === null) {
     return Promise.resolve(false);
   }
-  return window.diveDesktop.invoke('validate-settings', s);
+  return window.diveDesktop.invoke<string | boolean>('validate-settings', s);
 }
 
 // Type Guard https://www.typescriptlang.org/docs/handbook/advanced-types.html

--- a/client/platform/web-girder/api/dataset.service.ts
+++ b/client/platform/web-girder/api/dataset.service.ts
@@ -19,10 +19,6 @@ import girderRest from 'platform/web-girder/plugins/girder';
 import { resolveDatasetFolderId } from './multicamResolve';
 import { postProcess } from './rpc.service';
 
-interface HTMLFile extends File {
-  webkitRelativePath?: string;
-}
-
 async function getDataset(datasetId: string) {
   const { folderId, compositeId } = await resolveDatasetFolderId(datasetId);
   const response = await girderRest.get<GirderConfigStatic>(`dive_dataset/${folderId}`);
@@ -166,7 +162,7 @@ async function uploadFileToFolder(parentId: string, file: File): Promise<{ itemI
   return uploadResponse.status === 200 ? uploadResponse.data : null;
 }
 
-async function importAnnotationFile(datasetId: string, path: string, file?: HTMLFile, additive = false, additivePrepend = '', set: string | undefined = undefined): Promise<boolean | string[]> {
+async function importAnnotationFile(datasetId: string, path: string, file?: File, additive = false, additivePrepend = '', set: string | undefined = undefined): Promise<boolean | string[]> {
   if (file === undefined) {
     return false;
   }
@@ -189,7 +185,7 @@ async function importAnnotationFile(datasetId: string, path: string, file?: HTML
 /** Upload a metadata file into the dataset folder and declare it as the attachment. */
 async function uploadAndSetMetadataFile(
   datasetId: string,
-  file: HTMLFile,
+  file: File,
 ): Promise<void> {
   const folderId = parentDatasetId(datasetId);
   const itemId = await uploadMetadataFileItem(folderId, file);

--- a/client/platform/web-girder/api/girder.service.ts
+++ b/client/platform/web-girder/api/girder.service.ts
@@ -1,7 +1,7 @@
 import type { GirderModel } from '@girder/components/src';
 import girderRest from 'platform/web-girder/plugins/girder';
 
-function deleteResources(resources: Array<GirderModel>) {
+function deleteResources(resources: Array<Pick<GirderModel, '_id' | '_modelType'>>) {
   const formData = new FormData();
   formData.set(
     'resources',

--- a/client/platform/web-girder/constants.ts
+++ b/client/platform/web-girder/constants.ts
@@ -38,6 +38,9 @@ const fileSuffixRegex = /\.[^.]*$/;
 
 export {
   fileSuffixRegex,
+};
+
+export type {
   GirderConfigStatic,
   GirderConfig,
 };

--- a/client/platform/web-girder/main.ts
+++ b/client/platform/web-girder/main.ts
@@ -16,7 +16,6 @@ import { bindWebGirderRouter } from './store/useLocation';
 import { useBrand } from './store/useBrand';
 import { useConfig } from './store/useConfig';
 import { useUser } from './store/useUser';
-import type { UserState } from './store/types';
 import { reportHandledPromiseRejection } from './reportHandledPromiseRejection';
 
 bindWebGirderRouter(router);
@@ -47,7 +46,15 @@ Promise.all([
   useConfig().loadConfig(),
   girderRest.fetchUser(),
 ]).then(() => {
-  useUser().setUser(girderRest.user as UserState['user']);
+  const { user } = girderRest;
+  useUser().setUser(user ? {
+    admin: user.admin,
+    email: user.email,
+    firstName: user.firstName,
+    login: user.login,
+    lastName: user.lastName,
+    status: user.status,
+  } : null);
   const vuetify = getVuetify(useBrand().getBrandData()?.vuetify);
   Vue.use(promptService(vuetify));
   new Vue({

--- a/client/platform/web-girder/multicamFileRegistry.ts
+++ b/client/platform/web-girder/multicamFileRegistry.ts
@@ -1,6 +1,7 @@
 /** Stash browser File selections for multicam import (paths are not filesystem paths on web). */
 
 import { Location } from '@girder/components/src';
+import type { AxiosInstance } from 'axios';
 import { parentDatasetId } from 'dive-common/compositeDatasetId';
 import {
   ImageSequenceType,
@@ -306,7 +307,7 @@ export async function importCalibrationFile(
   // so a top-level import breaks node-environment unit tests that import this module.
   const { default: girderRest } = await import('platform/web-girder/plugins/girder');
   const manager = new GirderUploadManager(file, {
-    $rest: girderRest,
+    $rest: girderRest as unknown as AxiosInstance,
     parent: { _id: parentFolderId, _modelType: 'folder' } as Location,
   });
   const uploaded = await manager.start() as { _id: string };

--- a/client/platform/web-girder/store/useDataset.ts
+++ b/client/platform/web-girder/store/useDataset.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export -- singleton composable store */
+import type { GirderModelType } from '@girder/components/src';
 import type { GirderConfig } from 'platform/web-girder/constants';
 import { ref } from 'vue';
 import {
@@ -64,7 +65,7 @@ export function useDataset() {
     if (browseParentId && browseParentCollection) {
       await useLocation().hydrate({
         _id: browseParentId,
-        _modelType: browseParentCollection,
+        _modelType: browseParentCollection as GirderModelType,
       });
     } else {
       throw new Error(`dataset ${datasetId} was not a valid girder folder`);

--- a/client/platform/web-girder/store/useLocation.ts
+++ b/client/platform/web-girder/store/useLocation.ts
@@ -91,7 +91,7 @@ export function useLocation() {
   }
 
   async function setLocationFromRoute(route: Route): Promise<void> {
-    const newLocation = getLocationFromRoute(route) || getLocationFromRoute(defaultRoute.value as Route);
+    const newLocation = getLocationFromRoute(route) || getLocationFromRoute(defaultRoute.value);
     if (newLocation === null) {
       throw new Error('Unexpected null default route');
     }

--- a/client/platform/web-girder/utils.ts
+++ b/client/platform/web-girder/utils.ts
@@ -7,15 +7,19 @@ import {
 } from 'dive-common/constants';
 import { DatasetType } from 'dive-common/apispec';
 import type { LocationType, RootlessLocationType } from 'platform/web-girder/store/types';
-import { Route } from 'vue-router';
 import { AxiosInstance } from 'axios';
 
 /**
  * If the current route is representable by a LocationType, return it.
  * _modelType comes from the router spec and must be converted into LocationType
  */
-function getLocationFromRoute(route: Route): LocationType | null {
+function getLocationFromRoute(
+  route: { params: { routeType?: string; routeId?: string } },
+): LocationType | null {
   const { params } = route;
+  if (params.routeType === undefined) {
+    return null;
+  }
   if (['root', 'collections', 'users'].indexOf(params.routeType) >= 0) {
     return { type: params.routeType } as LocationType;
   }

--- a/client/platform/web-girder/views/Admin/AdminJobs.vue
+++ b/client/platform/web-girder/views/Admin/AdminJobs.vue
@@ -298,7 +298,7 @@ export default defineComponent({
             {{ item.type }}
           </template>
           <template #item.status="{ item }">
-            <JobProgress :formatted-job="formatStatus(item.status)" />
+            <JobProgress :formatted-job="formatStatus(item.status, item.updated)" />
           </template>
           <template #item.params="{ item }">
             <div v-if="item.type === 'training' && item.params.dataset_input_list">

--- a/client/platform/web-girder/views/Admin/AdminUpdate.vue
+++ b/client/platform/web-girder/views/Admin/AdminUpdate.vue
@@ -2,6 +2,7 @@
 import {
   defineComponent, onBeforeMount, ref,
 } from 'vue';
+import { isAxiosError } from 'axios';
 import {
   DEFAULT_JOBS_DISABLED_MESSAGE,
   putJobsDisabled,
@@ -43,7 +44,7 @@ export default defineComponent({
       } catch (error) {
         // When it is good the container restarts resulting a badgateway 502 error
         // We should wait like 20 seconds after the error and reload the page to show the update
-        if (error.response && error.response.status === 502) {
+        if (isAxiosError(error) && error.response && error.response.status === 502) {
           complete.value = 'Reload';
           reloadTime.value = 20;
           setInterval(() => {

--- a/client/platform/web-girder/views/AnnotationSets.vue
+++ b/client/platform/web-girder/views/AnnotationSets.vue
@@ -61,11 +61,17 @@ export default defineComponent({
       setChange(newSet.value);
     };
 
+    const newSetRules = [
+      (v: string) => !sets.value.includes(v) || 'Using a reserved set',
+      (v: string) => !!v || 'requires at least one character',
+    ];
+
     return {
       currentSet,
       selectSet,
       sets,
       newSet,
+      newSetRules,
       addSet,
       validForm,
       computedSets,
@@ -157,10 +163,7 @@ export default defineComponent({
             <v-text-field
               v-model="newSet"
               label="Set"
-              :rules="[
-                v => !sets.includes(v) || 'Using a reserved set',
-                v => !!v || 'requires at least one character',
-              ]"
+              :rules="newSetRules"
             />
             <v-btn
               :disabled="!validForm"

--- a/client/platform/web-girder/views/AnnotationTags.vue
+++ b/client/platform/web-girder/views/AnnotationTags.vue
@@ -54,11 +54,18 @@ export default defineComponent({
     const selectForComparison = (set: string) => {
       compareChecks.value = sets.value.map((item) => ({ name: item, checked: set === item }));
     };
+
+    const newSetRules = [
+      (v: string) => !sets.value.includes(v) || 'Using a reserved set',
+      (v: string) => !!v || 'Need to have some set name to add',
+    ];
+
     return {
       currentSet,
       selectSet,
       sets,
       newSet,
+      newSetRules,
       addSet,
       validForm,
       typeStyling,
@@ -90,7 +97,7 @@ export default defineComponent({
         </v-row>
       </v-list-item>
       <v-list-item
-        v-for="(set, index) in set"
+        v-for="(set, index) in sets"
         :key="set"
         :class="{ border: (set === currentSet || (!currentSet && set === 'default')) }"
       >
@@ -145,10 +152,7 @@ export default defineComponent({
             <v-text-field
               v-model="newSet"
               label="Set"
-              :rules="[
-                v => !sets.includes(v) || 'Using a reserved set',
-                v => !!v || 'Need to have some set name to add',
-              ]"
+              :rules="newSetRules"
             />
             <v-btn
               :disabled="!validForm"

--- a/client/platform/web-girder/views/DataBrowser.vue
+++ b/client/platform/web-girder/views/DataBrowser.vue
@@ -62,6 +62,16 @@ export default defineComponent({
       return getMultiCamSubType(item.meta);
     }
 
+    function multiCamIcon(item: GirderModel) {
+      const subType = multiCamSubType(item);
+      return subType ? getMultiCamIcon(subType) : '';
+    }
+
+    function multiCamTooltip(item: GirderModel) {
+      const subType = multiCamSubType(item);
+      return subType ? getMultiCamTooltip(subType) : '';
+    }
+
     const shouldShowUpload = computed(() => (
       location.value
       && !locationIsViameFolder.value
@@ -88,8 +98,8 @@ export default defineComponent({
       /* methods */
       isAnnotationFolder,
       multiCamSubType,
-      getMultiCamIcon,
-      getMultiCamTooltip,
+      multiCamIcon,
+      multiCamTooltip,
       handleNotification,
       setLocation,
       updateUploading,
@@ -135,6 +145,7 @@ export default defineComponent({
           </v-btn>
         </template>
         <Upload
+          v-if="location"
           :location="location"
           @update:uploading="updateUploading"
           @close="uploaderDialog = false"
@@ -154,10 +165,10 @@ export default defineComponent({
               v-bind="attrs"
               v-on="on"
             >
-              {{ getMultiCamIcon(multiCamSubType(item)) }}
+              {{ multiCamIcon(item) }}
             </v-icon>
           </template>
-          <span>{{ getMultiCamTooltip(multiCamSubType(item)) }}</span>
+          <span>{{ multiCamTooltip(item) }}</span>
         </v-tooltip>
         <span>{{ item.name }}</span>
         <v-icon

--- a/client/platform/web-girder/views/DataShared.vue
+++ b/client/platform/web-girder/views/DataShared.vue
@@ -65,6 +65,16 @@ export default defineComponent({
       return getMultiCamSubType(item.meta);
     }
 
+    function multiCamIcon(item: GirderModel) {
+      const subType = multiCamSubType(item);
+      return subType ? getMultiCamIcon(subType) : '';
+    }
+
+    function multiCamTooltip(item: GirderModel) {
+      const subType = multiCamSubType(item);
+      return subType ? getMultiCamTooltip(subType) : '';
+    }
+
     watch(tableOptions, updateOptions, {
       deep: true,
     });
@@ -74,8 +84,8 @@ export default defineComponent({
     return {
       isAnnotationFolder,
       multiCamSubType,
-      getMultiCamIcon,
-      getMultiCamTooltip,
+      multiCamIcon,
+      multiCamTooltip,
       dataList,
       updateOptions,
       total,
@@ -124,10 +134,10 @@ export default defineComponent({
               v-bind="attrs"
               v-on="on"
             >
-              {{ getMultiCamIcon(multiCamSubType(item)) }}
+              {{ multiCamIcon(item) }}
             </v-icon>
           </template>
-          <span>{{ getMultiCamTooltip(multiCamSubType(item)) }}</span>
+          <span>{{ multiCamTooltip(item) }}</span>
         </v-tooltip>
         <v-icon class="mr-1">
           mdi-folder{{ item.public ? '' : '-key' }}

--- a/client/platform/web-girder/views/Export.vue
+++ b/client/platform/web-girder/views/Export.vue
@@ -225,7 +225,7 @@ export default defineComponent({
     const isMulticamDataset = computed(() => dataset.value?.type === MultiType);
 
     const mediaType = computed(() => {
-      if (dataset.value === null || isMulticamDataset.value) return null;
+      if (dataset.value === null || dataset.value.type === MultiType) return null;
       const { type } = dataset.value;
       return {
         [ImageSequenceType]: 'Image Sequence',

--- a/client/platform/web-girder/views/Home.vue
+++ b/client/platform/web-girder/views/Home.vue
@@ -4,6 +4,7 @@ import {
   ref,
   computed,
 } from 'vue';
+import { isAxiosError } from 'axios';
 import {
   GirderFileManager, GirderMarkdown,
 } from '@girder/components/src';
@@ -75,18 +76,12 @@ export default defineComponent({
     };
 
     const runningPipelines = computed(() => {
-      const results = [];
       const inputs = locationIsViameFolder.value && location.value
         ? [(location.value as { _id: string })._id]
         : selected.value.filter(
           ({ _modelType, meta }) => _modelType === 'folder' && meta && meta.annotate,
         ).map(({ _id }) => _id);
-      inputs.forEach((item) => {
-        if (jobs.getDatasetRunningState(item)) {
-          results.push(item);
-        }
-      });
-      return results;
+      return inputs.filter((item) => jobs.getDatasetRunningState(item));
     });
 
     const selectedViameFolders = computed(() => selected.value.filter(
@@ -98,7 +93,7 @@ export default defineComponent({
     const selectedViameFolderNames = computed(() => selectedViameFolders.value.map(({ name }) => name));
 
     const pipelineTargetFolders = computed(() => (
-      locationIsViameFolder.value && location.value
+      locationIsViameFolder.value && location.value && isGirderModel(location.value)
         ? [location.value]
         : selectedViameFolders.value
     ));
@@ -192,7 +187,7 @@ export default defineComponent({
         this.clearSelected();
       } catch (err) {
         let text = 'Unable to delete resource(s)';
-        if (err.response && err.response.status === 403) {
+        if (isAxiosError(err) && err.response?.status === 403) {
           text = 'You do not have permission to delete selected resource(s).';
         }
         this.prompt({

--- a/client/platform/web-girder/views/NavigationBar.vue
+++ b/client/platform/web-girder/views/NavigationBar.vue
@@ -8,6 +8,7 @@ import UserGuideButton from 'dive-common/components/UserGuideButton.vue';
 import { useBrand } from '../store/useBrand';
 import { useConfig } from '../store/useConfig';
 import { useLocation } from '../store/useLocation';
+import { useGirderRest } from '../plugins/girder';
 import JobsTab from './JobsTab.vue';
 
 export default defineComponent({
@@ -18,13 +19,14 @@ export default defineComponent({
     JobsTab,
     GirderSearch,
   },
-  inject: ['girderRest'],
   setup() {
+    const girderRest = useGirderRest();
     const { brandData } = useBrand();
     const { pipelinesEnabled, trainingEnabled } = useConfig();
     const { locationRoute, setRouteFromLocation } = useLocation();
 
     return {
+      girderRest,
       brandData,
       pipelinesEnabled,
       trainingEnabled,

--- a/client/platform/web-girder/views/RunTrainingMenu.vue
+++ b/client/platform/web-girder/views/RunTrainingMenu.vue
@@ -333,7 +333,7 @@ export default defineComponent({
     <JobLaunchDialog
       :value="jobState.count > 0"
       :loading="jobState.loading"
-      :error="jobState.error"
+      :error="jobState.error ?? undefined"
       :message="successMessage"
       @close="dismissJobDialog"
     />

--- a/client/platform/web-girder/views/TrainedModels.vue
+++ b/client/platform/web-girder/views/TrainedModels.vue
@@ -2,6 +2,7 @@
 import {
   computed, defineComponent, onBeforeMount, ref,
 } from 'vue';
+import { isAxiosError } from 'axios';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { Pipelines, useApi, Pipe } from 'dive-common/apispec';
 import { DataTableHeader } from 'vuetify';
@@ -51,7 +52,7 @@ export default defineComponent({
           unsortedPipelines.value = await getPipelineList();
         } catch (err) {
           let text = 'Unable to delete model';
-          if (err.response?.status === 403) text = 'You do not have permission to run training on the selected resource(s).';
+          if (isAxiosError(err) && err.response?.status === 403) text = 'You do not have permission to run training on the selected resource(s).';
           prompt({
             title: 'Delete Failed',
             text,

--- a/client/platform/web-girder/views/Upload.spec.ts
+++ b/client/platform/web-girder/views/Upload.spec.ts
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 /* eslint-disable import/no-extraneous-dependencies */
 import { mount } from '@vue/test-utils';
-import Vue, { CreateElement, nextTick } from 'vue';
+import Vue, {
+  CreateElement, defineComponent, h, nextTick,
+} from 'vue';
 
 import {
   beforeEach, describe, expect, it, vi,
@@ -83,9 +85,23 @@ function rejection(message: string): ValidationResponse {
   };
 }
 
+/**
+ * @vue/test-utils' `mount()` typings do not resolve a setup-returned instance shape, so the
+ * component is mounted through a host that captures the real, fully-typed instance via `ref`.
+ */
 function mountUpload(upload: () => Promise<void> = () => Promise.resolve()) {
-  return mount(Upload, {
-    propsData: { location: { _id: 'folder-id', _modelType: 'folder' } },
+  let child: InstanceType<typeof Upload> | undefined;
+  const Host = defineComponent({
+    setup: () => () => h(Upload, {
+      props: { location: { _id: 'folder-id', _modelType: 'folder' } },
+      ref: (instance) => {
+        if (instance && !(instance instanceof Element)) {
+          child = instance as InstanceType<typeof Upload>;
+        }
+      },
+    }),
+  });
+  const wrapper = mount(Host, {
     stubs: {
       ImportButton: Stub,
       ImportMultiCamDialog: Stub,
@@ -93,6 +109,10 @@ function mountUpload(upload: () => Promise<void> = () => Promise.resolve()) {
       UploadGirder: uploadGirderStub(upload),
     },
   });
+  if (!child) {
+    throw new Error('Upload did not mount');
+  }
+  return { wrapper, vm: child };
 }
 
 function pick(files: File[]) {
@@ -121,10 +141,10 @@ describe('Upload pending rows', () => {
       }),
     } as never);
 
-    const wrapper = mountUpload();
-    await wrapper.vm.openImport('video');
+    const { vm } = mountUpload();
+    await vm.openImport('video');
 
-    const [row] = wrapper.vm.pendingUploads;
+    const [row] = vm.pendingUploads;
     expect(row.createSubFolders).toBe(false);
     expect(row.name).toBe('dive.mp4');
     expect(row.uploadFiles.map((f: File) => f.name)).toEqual(['dive.mp4']);
@@ -137,11 +157,11 @@ describe('Upload pending rows', () => {
       data: validation({ roles: { media: ['a.mp4', 'b.mp4'] } }),
     } as never);
 
-    const wrapper = mountUpload();
-    await wrapper.vm.openImport('video');
+    const { wrapper, vm } = mountUpload();
+    await vm.openImport('video');
     await nextTick();
 
-    const [row] = wrapper.vm.pendingUploads;
+    const [row] = vm.pendingUploads;
     expect(row.createSubFolders).toBe(true);
     expect(row.ignored).toEqual([{
       name: 'frame-metadata.csv',
@@ -158,12 +178,12 @@ describe('Upload pending rows', () => {
       data: rejection('Can only upload a single CSV Annotation per import'),
     } as never);
 
-    const wrapper = mountUpload();
-    await wrapper.vm.openImport('image-sequence');
+    const { wrapper, vm } = mountUpload();
+    await vm.openImport('image-sequence');
     await nextTick();
 
-    expect(wrapper.vm.pendingUploads).toHaveLength(1);
-    const [row] = wrapper.vm.pendingUploads;
+    expect(vm.pendingUploads).toHaveLength(1);
+    const [row] = vm.pendingUploads;
     expect(row.error).toBe('Can only upload a single CSV Annotation per import');
     expect(row.uploadFiles).toEqual([]);
     // The slot editor stays usable so the user can correct the selection in place.
@@ -182,14 +202,15 @@ describe('Upload pending rows', () => {
       data: rejection('Can only upload a single CSV Annotation per import'),
     } as never);
 
-    const wrapper = mountUpload();
-    await wrapper.vm.openImport('image-sequence');
+    const { vm } = mountUpload();
+    await vm.openImport('image-sequence');
     await nextTick();
 
-    const [row] = wrapper.vm.pendingUploads;
-    expect(wrapper.vm.mediaSlotAccept(row)).toBeUndefined();
+    const [row] = vm.pendingUploads;
+    expect(vm.mediaSlotAccept(row)).toBeUndefined();
     row.error = null;
-    expect(wrapper.vm.mediaSlotAccept(row)).toEqual(wrapper.vm.filterFileUpload(row.type));
+    expect(row.type).not.toBe('zip');
+    expect(vm.mediaSlotAccept(row)).toEqual(row.type === 'zip' ? undefined : vm.filterFileUpload(row.type));
   });
 
   it('names a corrected row when Start upload finally validates it', async () => {
@@ -201,10 +222,10 @@ describe('Upload pending rows', () => {
     } as never);
     const upload = vi.fn().mockResolvedValue(undefined);
 
-    const wrapper = mountUpload(upload);
-    await wrapper.vm.openImport('video');
+    const { vm } = mountUpload(upload);
+    await vm.openImport('video');
 
-    const [row] = wrapper.vm.pendingUploads;
+    const [row] = vm.pendingUploads;
     expect(row.name).toBe('');
 
     // The user drops the stray image in the slot editor, then starts the upload.
@@ -212,7 +233,7 @@ describe('Upload pending rows', () => {
     vi.mocked(validateUploadGroup).mockResolvedValue({
       data: validation({ roles: { media: ['a.mp4'] } }),
     } as never);
-    await wrapper.vm.prepAndUpload(upload);
+    await vm.prepAndUpload(upload);
 
     expect(row.error).toBeNull();
     expect(row.name).toBe('a.mp4');
@@ -228,10 +249,10 @@ describe('Upload pending rows', () => {
     } as never);
     const upload = vi.fn().mockResolvedValue(undefined);
 
-    const wrapper = mountUpload(upload);
-    await wrapper.vm.openImport('video');
+    const { vm } = mountUpload(upload);
+    await vm.openImport('video');
 
-    const [row] = wrapper.vm.pendingUploads;
+    const [row] = vm.pendingUploads;
     expect(row.type).toBe('video');
 
     row.mediaList = [file('img.png')];
@@ -241,7 +262,7 @@ describe('Upload pending rows', () => {
         roles: { media: ['img.png'] },
       }),
     } as never);
-    await wrapper.vm.prepAndUpload(upload);
+    await vm.prepAndUpload(upload);
 
     expect(row.error).toBeNull();
     expect(row.type).toBe('image-sequence');
@@ -256,11 +277,11 @@ describe('Upload pending rows', () => {
       data: validation({ roles: { media: ['dive.mp4'], annotations: ['tracks.csv'] } }),
     } as never);
 
-    const wrapper = mountUpload();
-    await wrapper.vm.openImport('video');
+    const { wrapper, vm } = mountUpload();
+    await vm.openImport('video');
     await nextTick();
 
-    const [row] = wrapper.vm.pendingUploads;
+    const [row] = vm.pendingUploads;
     expect(row.ignored.map((entry: { name: string }) => entry.name)).toEqual(['notes.csv', 'notes.csv']);
     expect(wrapper.text().match(/notes\.csv/g)).toHaveLength(2);
   });
@@ -270,15 +291,15 @@ describe('Upload pending rows', () => {
       data: validation({ roles: { media: names } }),
     }) as never);
 
-    const wrapper = mountUpload();
+    const { wrapper, vm } = mountUpload();
     pick([file('a.mp4')]);
-    await wrapper.vm.openImport('video');
+    await vm.openImport('video');
     pick([file('b.mp4')]);
-    await wrapper.vm.openImport('video');
+    await vm.openImport('video');
 
-    wrapper.findComponent({ name: 'UploadGirder' }).vm.$emit('remove-upload', wrapper.vm.pendingUploads[0]);
+    wrapper.findComponent({ name: 'UploadGirder' }).vm.$emit('remove-upload', vm.pendingUploads[0]);
 
-    expect(wrapper.vm.pendingUploads.map((row: { name: string }) => row.name)).toEqual(['b.mp4']);
+    expect(vm.pendingUploads.map((row: { name: string }) => row.name)).toEqual(['b.mp4']);
   });
 
   it('opens image-sequence as a multi-file picker and keeps multi-dot frame names', async () => {
@@ -293,11 +314,11 @@ describe('Upload pending rows', () => {
       }),
     } as never);
 
-    const wrapper = mountUpload();
-    await wrapper.vm.openImport('image-sequence');
+    const { vm } = mountUpload();
+    await vm.openImport('image-sequence');
 
     expect(openFromDisk).toHaveBeenCalledWith('image-sequence');
-    const [row] = wrapper.vm.pendingUploads;
+    const [row] = vm.pendingUploads;
     expect(row.name).toBe('20171027.214830.208.029135.png');
     expect(row.type).toBe('image-sequence');
     expect(row.uploadFiles.map((f: File) => f.name)).toEqual([
@@ -313,11 +334,11 @@ describe('Upload pending rows', () => {
     } as never);
     const upload = vi.fn().mockResolvedValue(undefined);
 
-    const wrapper = mountUpload(upload);
-    await wrapper.vm.openImport('video');
+    const { vm } = mountUpload(upload);
+    await vm.openImport('video');
 
     // Both clicks land before the awaited validation round-trip resolves.
-    await Promise.all([wrapper.vm.prepAndUpload(upload), wrapper.vm.prepAndUpload(upload)]);
+    await Promise.all([vm.prepAndUpload(upload), vm.prepAndUpload(upload)]);
 
     expect(upload).toHaveBeenCalledTimes(1);
   });

--- a/client/platform/web-girder/views/Upload.vue
+++ b/client/platform/web-girder/views/Upload.vue
@@ -219,7 +219,7 @@ export default defineComponent({
     /** True from the moment Start upload is clicked until its upload settles. */
     const preparing = ref(false);
     const stereo = ref(false);
-    const multiCamOpenType = ref('image-sequence');
+    const multiCamOpenType = ref<'image-sequence' | 'video'>('image-sequence');
     const importMultiCamDialog = ref(false);
     const importMultiCamBatchDialog = ref(false);
     const batchImportFiles: Ref<File[]> = ref([]);
@@ -315,7 +315,9 @@ export default defineComponent({
      * files the user has to re-pick to clear the error.
      */
     const mediaSlotAccept = (pendingUpload: PendingUpload) => (
-      pendingUpload.error ? undefined : filterFileUpload(pendingUpload.type)
+      pendingUpload.error || pendingUpload.type === 'zip'
+        ? undefined
+        : filterFileUpload(pendingUpload.type)
     );
 
     // Every slot file the server validates, in a single list.
@@ -388,7 +390,7 @@ export default defineComponent({
           await addPendingUpload(ret.fileList, suggestedFps, dstype);
         }
       } catch (err) {
-        preUploadErrorMessage.value = err.response?.data?.message || err;
+        preUploadErrorMessage.value = getResponseError(err);
       }
     };
     const openMultiCamDialog = (args: { stereo: boolean; openType: 'image-sequence' | 'video' }) => {
@@ -396,7 +398,7 @@ export default defineComponent({
       multiCamOpenType.value = args.openType;
       importMultiCamDialog.value = true;
     };
-    const multiCamImportCheck = (sourcePath: string): MediaImportResponse => {
+    const multiCamImportCheck = async (sourcePath: string): Promise<MediaImportResponse> => {
       const files = getFilesForSourceKey(sourcePath) ?? [];
       const mediaType = multiCamOpenType.value === VideoType ? VideoType : ImageSequenceType;
       return {
@@ -492,7 +494,7 @@ export default defineComponent({
           description: 'Multi Camera dataset',
         });
         datasetFolderId = datasetFolder._id;
-        const cameras: Record<string, { folderId: string; type?: string }> = {};
+        const cameras: Record<string, { folderId: string; type?: Exclude<DatasetType, 'multi'> }> = {};
         const cameraOrder = args.cameraOrder?.length
           ? args.cameraOrder
           : Object.keys(args.sourceList);
@@ -541,8 +543,8 @@ export default defineComponent({
           }
           const cameraType = source.type ?? args.type;
           const uploadType = validation.type;
-          const compatibleTypes = new Set([cameraType, args.type, 'large-image', 'image-sequence']);
-          if (!compatibleTypes.has(uploadType)) {
+          const compatibleTypes = new Set<DatasetType>([cameraType, args.type, 'large-image', 'image-sequence']);
+          if (uploadType === 'multi' || !compatibleTypes.has(uploadType)) {
             throw new Error(`Camera "${cameraName}" must use ${cameraType} media`);
           }
           // Server validation is the authority: upload exactly what it accepted,
@@ -705,7 +707,7 @@ export default defineComponent({
           }
         }
         if (showProgressOverlay) {
-          preUploadErrorMessage.value = err.response?.data?.message || err.message || String(err);
+          preUploadErrorMessage.value = getResponseError(err);
           await errorHandler({ err, name: 'Multicam import' });
         }
         throw err;
@@ -861,11 +863,17 @@ export default defineComponent({
         }
         await uploadFn();
       } catch (err) {
-        preUploadErrorMessage.value = err.response?.data?.message || err.message || String(err);
+        preUploadErrorMessage.value = getResponseError(err);
       } finally {
         preparing.value = false;
       }
     };
+    const requiredRule = (val: string | null) => (
+      (val || '').length > 0 || 'This field is required'
+    );
+    const mediaFilesRequiredRule = (val: File[] | null) => (
+      (val || []).length > 0 || 'Media Files are required'
+    );
     const remove = (pendingUpload: PendingUpload) => {
       // Identity, not index: a row retired twice must never take a different row with it.
       pendingUploads.value = pendingUploads.value.filter((row) => row !== pendingUpload);
@@ -944,6 +952,8 @@ export default defineComponent({
       getFilenameInputStateHint,
       filterFileUpload,
       mediaSlotAccept,
+      requiredRule,
+      mediaFilesRequiredRule,
       prepAndUpload,
       remove,
       abort,
@@ -1054,7 +1064,7 @@ export default defineComponent({
                 <v-text-field
                   :value="getFilenameInputValue(pendingUpload)"
                   class="upload-name"
-                  :rules="[val => (val || '').length > 0 || 'This field is required']"
+                  :rules="[requiredRule]"
                   required
                   :label="getFilenameInputStateLabel(pendingUpload)"
                   :disabled="getFilenameInputStateDisabled(pendingUpload)"
@@ -1135,7 +1145,7 @@ export default defineComponent({
                           ? 'Video file'
                           : 'Tiled Image files'
                     "
-                    :rules="[val => (val || '').length > 0 || 'Media Files are required']"
+                    :rules="[mediaFilesRequiredRule]"
                     :accept="mediaSlotAccept(pendingUpload)"
                   />
                 </v-row>

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -128,7 +128,10 @@ export default defineComponent({
       return t ? [t as DatasetType] : [];
     });
     const subTypeList = computed((): SubType[] => [datasetMeta.value?.subType ?? null]);
-    const cameraNumbers = computed(() => [getMultiCamCameraCount(datasetMeta.value)]);
+    const cameraNumbers = computed(() => [getMultiCamCameraCount(datasetMeta.value ? {
+      type: datasetMeta.value.type,
+      multiCamMedia: datasetMeta.value.multiCamMedia ?? undefined,
+    } : undefined)]);
     const timeFilter: Ref<[number, number] | null> = ref(null);
     // Track the active camera so single-camera pipelines target that folder
     // (parentId/cameraName), matching desktop ViewerLoader behavior.

--- a/client/src/@types/desktop-preload.d.ts
+++ b/client/src/@types/desktop-preload.d.ts
@@ -18,9 +18,9 @@ interface DesktopRuntimeInfo {
 }
 
 interface DesktopBridge {
-  invoke(channel: string, ...args: unknown[]): Promise<unknown>;
+  invoke<T = unknown>(channel: string, ...args: unknown[]): Promise<T>;
   send(channel: string, ...args: unknown[]): void;
-  on(channel: string, listener: (...args: unknown[]) => void): () => void;
+  on<T = unknown>(channel: string, listener: (payload: T) => void): () => void;
   showOpenDialog(options: unknown): Promise<DesktopOpenDialogResult>;
   showSaveDialog(options: unknown): Promise<DesktopSaveDialogResult>;
   getAppVersionSync(): string;

--- a/client/src/alignedView/CameraRegistrationStore.spec.ts
+++ b/client/src/alignedView/CameraRegistrationStore.spec.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import CameraRegistrationStore from './CameraRegistrationStore';
+import CameraRegistrationStore, { CameraCorrespondences } from './CameraRegistrationStore';
 import { buildPerCameraRegistrationFiles } from './cameraRegistrationFiles';
 
 /**
@@ -310,7 +310,7 @@ describe('CameraRegistrationStore', () => {
 
   it('hydrates correspondences and resumes id allocation', () => {
     const store = new CameraRegistrationStore();
-    const correspondences = {
+    const correspondences: CameraCorrespondences = {
       'rgb::ir': [
         { id: 1, a: [1, 2], b: [3, 4] },
         { id: 2, a: [5, 6], b: [7, 8] },

--- a/client/src/alignedView/transform.ts
+++ b/client/src/alignedView/transform.ts
@@ -12,6 +12,8 @@ import {
   Point, Matrix3, solveLinearSystem, solveHomography,
 } from './homography';
 
+export type { Point };
+
 export type TransformType = 'translation' | 'rigid' | 'similarity' | 'affine' | 'homography';
 
 /** UI-friendly ordered list of transform types, for dropdowns. */

--- a/client/src/components/AttributeTrackFilters.vue
+++ b/client/src/components/AttributeTrackFilters.vue
@@ -181,10 +181,20 @@ export default defineComponent({
       editing.typeFilter.splice(editing.typeFilter.findIndex((data) => data === item));
     };
 
+    const nameRules = computed(() => [
+      (v: string) => !!v || 'Name is required',
+      (v: string) => (!existingNames.value.includes(v) || editingFilter.value !== filters.value.length) || 'Name needs to be unique',
+    ]);
+    const attributeRules = [(v: string) => !!v || 'Attribute is required'];
+    const operatorRules = [(v: string) => !!v || 'Operator is required'];
+
     return {
       trackFilters,
       filters,
       editingFilter,
+      nameRules,
+      attributeRules,
+      operatorRules,
       attributeTypes,
       types,
       //defaults
@@ -252,7 +262,7 @@ export default defineComponent({
               <v-text-field
                 v-model="editing.name"
                 label="Filter Name"
-                :rules="[v => !!v || 'Name is required', (v) => (!existingNames.includes(v) || editingFilter !== filters.length) || 'Name needs to be unique']"
+                :rules="nameRules"
                 required
               />
             </v-row>
@@ -303,7 +313,7 @@ export default defineComponent({
 
               <v-select
                 v-model="editing.atrKey"
-                :rules="[v => !!v || 'Attribute is required']"
+                :rules="attributeRules"
                 required
                 :items="attributeList"
                 label="Attribute"
@@ -379,7 +389,7 @@ export default defineComponent({
                 v-model="editing.atrOp"
                 :items="editingOps"
                 label="Operator"
-                :rules="[v => !!v || 'Operator is required']"
+                :rules="operatorRules"
                 required
                 @change="changeAttributeType"
               />

--- a/client/src/components/GroupItem.vue
+++ b/client/src/components/GroupItem.vue
@@ -105,7 +105,7 @@ export default defineComponent({
       </v-tooltip>
       <v-spacer />
       <TypePicker
-        :value="group.getType()"
+        :value="group.getType()[0]"
         :all-types="groupFilters.allTypes.value"
         :read-only-mode="readOnlyMode"
         data-list-source="allGroupTypesOptions"

--- a/client/src/components/GroupList.vue
+++ b/client/src/components/GroupList.vue
@@ -82,7 +82,7 @@ export default defineComponent({
       const confidencePair = item.filteredGroup.annotation.getType();
       const members = cameraStore.getGroupMemebers(item.filteredGroup.annotation.id);
       return {
-        group: item.filteredGroup.annotation,
+        group: getAnnotation(item.filteredGroup.annotation.id),
         color: typeStylingRef.value.color(confidencePair[0]),
         selected: item.filteredGroup.annotation.id === selectedId.value,
         selectedTrackId: selectedTrack.value,

--- a/client/src/components/RangeEditor.vue
+++ b/client/src/components/RangeEditor.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 import TooltipBtn from 'vue-media-annotator/components/TooltipButton.vue';
 
 export default defineComponent({
@@ -35,7 +35,7 @@ export default defineComponent({
       default: false,
     },
   },
-  setup(_, { emit }) {
+  setup(props, { emit }) {
     function updateBegin(input: string) {
       const num = parseInt(input, 10);
       emit('update:begin', num);
@@ -44,9 +44,19 @@ export default defineComponent({
       const num = parseInt(input, 10);
       emit('update:end', num);
     }
+    const beginRules = computed(() => [
+      (v: number) => v <= Math.min(props.end, props.max) || 'Begin must be less than end and max',
+      (v: number) => v >= props.min || 'Begin must be >= min',
+    ]);
+    const endRules = computed(() => [
+      (v: number) => v >= Math.max(props.begin, props.min) || 'End must be >= begin and min',
+      (v: number) => v <= props.max || 'End must be <= max',
+    ]);
     return {
       updateBegin,
       updateEnd,
+      beginRules,
+      endRules,
     };
   },
 });
@@ -75,10 +85,7 @@ export default defineComponent({
         hide-details
         :min="min"
         :max="Math.min(end, max)"
-        :rules="[
-          (v) => v <= Math.min(end, max) || 'Begin must be less than end and max',
-          (v) => v >= min || 'Begin must be >= min',
-        ]"
+        :rules="beginRules"
         @input="updateBegin"
       >
         <template
@@ -107,10 +114,7 @@ export default defineComponent({
         label="End frame"
         :min="Math.max(begin, min)"
         :max="max"
-        :rules="[
-          (v) => v >= Math.max(begin, min) || 'End must be >= begin and min',
-          (v) => v <= max || 'End must be <= max',
-        ]"
+        :rules="endRules"
         @input="updateEnd"
       >
         <template

--- a/client/src/components/Tracks/TrackList.vue
+++ b/client/src/components/Tracks/TrackList.vue
@@ -6,6 +6,7 @@ import Vue, {
 
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { AnnotationId } from 'vue-media-annotator/BaseAnnotation';
+import { TrackWithContext } from 'vue-media-annotator/BaseFilterControls';
 
 import { clientSettings } from 'dive-common/store/settings';
 import {
@@ -111,7 +112,7 @@ export default defineComponent({
       },
     );
 
-    const finalFilteredTracks = computed(() => {
+    const finalFilteredTracks = computed<TrackWithContext[]>(() => {
       let tracks = filteredTracksRef.value;
       if (filterDetectionsByFrame.value && !isPlaying.value) {
         // Depend on the edit counter so moving a suppression region re-runs the

--- a/client/src/components/Tracks/sidebar/SideBarTrackItemView.vue
+++ b/client/src/components/Tracks/sidebar/SideBarTrackItemView.vue
@@ -1,6 +1,9 @@
 <script lang="ts">
-import { computed, defineComponent, ref } from 'vue';
+import {
+  computed, defineComponent, PropType, ref,
+} from 'vue';
 import context from 'dive-common/store/context';
+import Track from '../../../track';
 import TooltipBtn from '../../TooltipButton.vue';
 import TypePicker from '../../TypePicker.vue';
 import {
@@ -21,7 +24,7 @@ export default defineComponent({
     trackType: { type: String, required: true },
     itemStyle: { type: Object, required: true },
     color: { type: String, required: true },
-    track: { type: Object, required: true },
+    track: { type: Object as PropType<Track>, required: true },
     inputValue: { type: Boolean, required: true },
     disabled: { type: Boolean, default: false },
     isTrack: { type: Boolean, required: true },
@@ -29,12 +32,12 @@ export default defineComponent({
     keyframeDisabled: { type: Boolean, required: true },
     frame: { type: Number, required: true },
     merging: { type: Boolean, default: false },
-    toggleKeyframe: { type: Function, required: true },
-    clickToggleInterpolation: { type: Function, required: true },
-    toggleInterpolation: { type: Function, required: true },
-    toggleAllInterpolation: { type: Function, required: true },
-    gotoPrevious: { type: Function, required: true },
-    gotoNext: { type: Function, required: true },
+    toggleKeyframe: { type: Function as PropType<() => void>, required: true },
+    clickToggleInterpolation: { type: Function as PropType<(event: MouseEvent) => void>, required: true },
+    toggleInterpolation: { type: Function as PropType<() => void>, required: true },
+    toggleAllInterpolation: { type: Function as PropType<() => void>, required: true },
+    gotoPrevious: { type: Function as PropType<() => void>, required: true },
+    gotoNext: { type: Function as PropType<() => void>, required: true },
     editing: { type: Boolean, required: true },
   },
   setup(props) {

--- a/client/src/components/TypeEditor.vue
+++ b/client/src/components/TypeEditor.vue
@@ -133,6 +133,8 @@ export default defineComponent({
     watch(toRef(props, 'selectedType'), init);
     init();
 
+    const thicknessRules = [(val: number) => val >= 0 || 'Must be >= 0'];
+
     return {
       data,
       isStyleOnly,
@@ -140,6 +142,7 @@ export default defineComponent({
       readOnlyMode,
       acceptChanges,
       clickDeleteType,
+      thicknessRules,
     };
   },
 });
@@ -211,9 +214,7 @@ export default defineComponent({
               <v-text-field
                 v-model="data.editingThickness"
                 type="number"
-                :rules="[
-                  val => val >= 0 || 'Must be >= 0',
-                ]"
+                :rules="thicknessRules"
                 required
                 hide-details
                 label="Box Border Thickness"

--- a/client/src/components/TypePicker.vue
+++ b/client/src/components/TypePicker.vue
@@ -68,11 +68,11 @@ export default defineComponent({
       }
     }
 
-    function blurType(e: KeyboardEvent) {
+    function blurType(e: Event) {
       (e.target as HTMLInputElement).blur();
     }
 
-    function onBlur(e: KeyboardEvent) {
+    function onBlur(e: Event) {
       if (props.updateOnInput) {
         return;
       }

--- a/client/src/components/annotators/LargeImageAnnotator.vue
+++ b/client/src/components/annotators/LargeImageAnnotator.vue
@@ -237,7 +237,8 @@ export default defineComponent({
       params: Record<string, any>,
       proj?: string,
     ) {
-      const updatedParams = { ...params, encoding: 'PNG' };
+      // Spreading a Record into a literal drops its index signature, so restate the param's type.
+      const updatedParams: typeof params = { ...params, encoding: 'PNG' };
       if (proj) {
         updatedParams.projection = proj;
       }

--- a/client/src/components/annotators/linkedViewers/useAlignedNavigation.ts
+++ b/client/src/components/annotators/linkedViewers/useAlignedNavigation.ts
@@ -137,12 +137,13 @@ export default function useAlignedNavigation(
     const matrix = alignedView.cameraTransform(camera);
     let bounds = native;
     if (matrix) {
-      const corners: Point[] = [
+      const nativeCorners: Point[] = [
         [native.left, native.top],
         [native.right, native.top],
         [native.right, native.bottom],
         [native.left, native.bottom],
-      ].map((corner) => applyHomography(matrix, corner));
+      ];
+      const corners = nativeCorners.map((corner) => applyHomography(matrix, corner));
       bounds = {
         left: Math.min(...corners.map((c) => c[0])),
         top: Math.min(...corners.map((c) => c[1])),

--- a/client/src/components/annotators/useMediaController.ts
+++ b/client/src/components/annotators/useMediaController.ts
@@ -654,6 +654,9 @@ export function useMediaController() {
       toggleSynchronizeCameras,
       cameraSync: synchronizeCameras,
       resizeTrigger,
+      resizing,
+      alignedGapSlots,
+      seekCameraFrame: aggregateSeekCameraFrame,
     };
 
     subControllers.push(mediaController);

--- a/client/src/components/layerManager/useLayerManagerAlignedView.spec.ts
+++ b/client/src/components/layerManager/useLayerManagerAlignedView.spec.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 /* eslint-disable vue/one-component-per-file -- harness Host components for mount() */
-import { defineComponent, ref, nextTick } from 'vue';
+import {
+  defineComponent, ref, shallowRef, nextTick,
+} from 'vue';
 // eslint-disable-next-line import/no-extraneous-dependencies -- @vue/test-utils is only used in tests
 import { mount } from '@vue/test-utils';
 import { clientSettings } from 'dive-common/store/settings';
@@ -61,14 +63,15 @@ function makeHarness() {
     layers: () => [nativeLayer, warpLayer],
   };
 
+  const imageRevision = ref(0);
   const annotator = {
     cameraName: ref('rgb'),
     geoViewerRef: ref(viewer),
     frame: ref(0),
-    imageRevision: ref(0),
+    imageRevision,
     frameTexture: ref(null),
   } as unknown as MediaController;
-  const aggregateController = ref({
+  const aggregateController = shallowRef({
     getController: () => annotator,
   } as unknown as AggregateMediaController);
 
@@ -95,7 +98,7 @@ function makeHarness() {
   });
   const wrapper = mount(Host);
   return {
-    wrapper, annotator, nativeFeature, warpFeature, imgA, viewer,
+    wrapper, annotator, nativeFeature, warpFeature, imgA, viewer, imageRevision,
   };
 }
 
@@ -115,30 +118,34 @@ describe('useLayerManagerAlignedView warp refresh', () => {
   });
 
   it('re-renders the warp when imageRevision bumps with a swapped element', async () => {
-    const { annotator, nativeFeature, warpFeature } = makeHarness();
+    const {
+      nativeFeature, warpFeature, imageRevision,
+    } = makeHarness();
     await nextTick();
     // The annotator swaps its displayed <img> (e.g. the percentile-stretch
     // URL remap finishing its load) and bumps imageRevision -- the warp must
     // re-render from the new element with no other trigger.
     const imgB = { naturalWidth: 100, naturalHeight: 50 } as HTMLImageElement;
     nativeFeature.data([{ image: imgB }]);
-    annotator.imageRevision.value += 1;
+    imageRevision.value += 1;
     await nextTick();
     expect(lastWarpSource(warpFeature)).toBe(imgB);
   });
 
   it('clears the warp instead of rendering while the swapped element is unloaded', async () => {
-    const { annotator, nativeFeature, warpFeature } = makeHarness();
+    const {
+      nativeFeature, warpFeature, imageRevision,
+    } = makeHarness();
     await nextTick();
     const pending = { naturalWidth: 0, naturalHeight: 0 } as HTMLImageElement;
     nativeFeature.data([{ image: pending }]);
-    annotator.imageRevision.value += 1;
+    imageRevision.value += 1;
     await nextTick();
     expect(lastWarpSource(warpFeature)).toBeNull();
     // ...and renders it once the load lands and bumps again.
     const loaded = { naturalWidth: 100, naturalHeight: 50 } as HTMLImageElement;
     nativeFeature.data([{ image: loaded }]);
-    annotator.imageRevision.value += 1;
+    imageRevision.value += 1;
     await nextTick();
     expect(lastWarpSource(warpFeature)).toBe(loaded);
   });
@@ -186,7 +193,7 @@ function makeLargeImageHarness() {
     imageRevision: ref(0),
     frameTexture: ref(texture),
   } as unknown as MediaController;
-  const aggregateController = ref({
+  const aggregateController = shallowRef({
     getController: () => annotator,
   } as unknown as AggregateMediaController);
 

--- a/client/src/components/layerManager/useMulticamEditRouting.ts
+++ b/client/src/components/layerManager/useMulticamEditRouting.ts
@@ -3,7 +3,7 @@ import type { AnnotationId } from '../../BaseAnnotation';
 import type CameraStore from '../../CameraStore';
 import type { Handler } from '../../provides';
 import type { EditAnnotationTypes } from '../../layers/EditAnnotationLayer';
-import type TrackStore from '../../trackStore';
+import type TrackStore from '../../TrackStore';
 import { cameraAwaitingGeometry, isCreatingNewDetection } from './multicamCreation';
 
 /**

--- a/client/src/layers/AnnotationLayers/PointLayer.ts
+++ b/client/src/layers/AnnotationLayers/PointLayer.ts
@@ -16,7 +16,9 @@ export default class PointLayer extends BaseLayer<PointGeoJSData> {
     const layer = this.annotator.geoViewerRef.value.createLayer('feature', {
       features: ['point'],
     });
-    this.featureLayer = layer.createFeature('point');
+    this.featureLayer = layer
+      .createFeature('point')
+      .position((data: PointGeoJSData) => this.transformXY(data));
     super.initialize();
   }
 
@@ -54,7 +56,6 @@ export default class PointLayer extends BaseLayer<PointGeoJSData> {
   createStyle(): LayerStyle<PointGeoJSData> {
     return {
       ...super.createStyle(),
-      position: (data: PointGeoJSData) => this.transformXY(data),
       fill: (data: PointGeoJSData) => data.feature === 'head',
       fillColor: (data: PointGeoJSData) => {
         if (data.styleType) {

--- a/client/src/layers/index.ts
+++ b/client/src/layers/index.ts
@@ -25,7 +25,10 @@ export {
   UILayer,
   UILayerTypes,
   /* Other */
-  VisibleAnnotationTypes,
   EditAnnotationLayer,
+};
+
+export type {
+  VisibleAnnotationTypes,
   EditAnnotationTypes,
 };

--- a/client/src/track.spec.ts
+++ b/client/src/track.spec.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import Track, { TrackData } from './track';
+import Track, { TrackData, TrackSupportedFeature } from './track';
 import { RectBounds } from './utils';
 import { ConfidencePair } from './BaseAnnotation';
 
@@ -324,7 +324,7 @@ describe('fromJSON full-box polygon cleanup', () => {
     meta: {},
     id: 7,
   };
-  const boxPoly: GeoJSON.Feature = {
+  const boxPoly: GeoJSON.Feature<TrackSupportedFeature> = {
     type: 'Feature',
     geometry: {
       type: 'Polygon',
@@ -332,7 +332,7 @@ describe('fromJSON full-box polygon cleanup', () => {
     },
     properties: { key: '' },
   };
-  const realPoly: GeoJSON.Feature = {
+  const realPoly: GeoJSON.Feature<TrackSupportedFeature> = {
     type: 'Feature',
     geometry: {
       type: 'Polygon',
@@ -370,7 +370,7 @@ describe('fromJSON full-box polygon cleanup', () => {
   });
 
   it('keeps other geometry while dropping the full-box polygon', () => {
-    const head: GeoJSON.Feature = {
+    const head: GeoJSON.Feature<TrackSupportedFeature> = {
       type: 'Feature',
       geometry: { type: 'Point', coordinates: [1, 1] },
       properties: { key: 'head' },

--- a/client/src/use/suppression.ts
+++ b/client/src/use/suppression.ts
@@ -283,7 +283,7 @@ export function getSuppressedTrackIds(
   }
 
   const result = new Set<AnnotationId>();
-  const ids = trackStore.intervalTree.search([frame, frame])
+  const ids = (trackStore.intervalTree.search([frame, frame]) as string[])
     .map((s: string) => parseInt(s, 10));
   if (ids.length === 0) {
     cacheEntry?.byFrame.set(frame, result);

--- a/client/src/use/useVirtualScrollTo.ts
+++ b/client/src/use/useVirtualScrollTo.ts
@@ -1,4 +1,4 @@
-import Vue, { ref, watch, Ref } from 'vue';
+import Vue, { shallowRef, watch, Ref } from 'vue';
 
 import type Group from '../Group';
 import type Track from '../track';
@@ -20,7 +20,7 @@ export default function useVirtualScrollTo({
   multiSelectList: Ref<Readonly<AnnotationId[]>>;
   selectNext?: (delta: number) => void;
 }) {
-  const virtualList = ref(null as null | Vue);
+  const virtualList = shallowRef(null as null | Vue);
 
   function scrollTo(id: AnnotationId | null): void {
     if (id !== null && virtualList.value !== null) {

--- a/client/tsconfig.typecheck.json
+++ b/client/tsconfig.typecheck.json
@@ -6,12 +6,17 @@
     "types": [
       "vitest/globals",
       "node"
-    ]
+    ],
+    "isolatedModules": true
   },
   "vueCompilerOptions": {
     "target": 2.7
   },
   "include": [
+    "dive-common/**/*.ts",
+    "dive-common/**/*.vue",
+    "platform/**/*.ts",
+    "platform/**/*.vue",
     "src/**/*.ts",
     "src/**/*.vue"
   ]

--- a/client/tsconfig.typecheck.json
+++ b/client/tsconfig.typecheck.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": [
+      "vitest/globals",
+      "node"
+    ]
+  },
+  "vueCompilerOptions": {
+    "target": 2.7
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.vue"
+  ]
+}


### PR DESCRIPTION
# Add a TypeScript type check gate for the client

## Why

The client had no TypeScript type check anywhere. CI ran `lint`, `lint:templates`, `test`, and two
vite builds, and vite/esbuild strips types without checking them. Vue SFC templates were therefore
completely unchecked — including the prop/method seams where a changed type silently becomes a
runtime `TypeError` on click.

## What

- Bump `typescript` to `~5.6.3` and add `vue-tsc@~2.1.10`. The old `~4.3.5` pin (2021) cannot parse
  modern `.d.ts` files in `node_modules`, failing with hundreds of syntax errors before it reaches
  any project code; `skipLibCheck` does not help, since those are parse errors.
- Add `client/tsconfig.typecheck.json`, extending `tsconfig.json` with `noEmit`, `skipLibCheck`,
  `isolatedModules`, `vueCompilerOptions: { target: 2.7 }`, and `types: ["vitest/globals", "node"]`.
- Add `npm run typecheck` and a `Typecheck` step on the `web` matrix leg of CI.
- Fix every error the gate reports, so it starts green.

The gate covers the whole client — `src/`, `dive-common/`, and `platform/`. No Vue 3 migration is
involved; `vue-tsc` checks these Vue 2.7 SFCs directly.

`isolatedModules` is on because a re-exported type in a value `export {}` block type-checks fine but
breaks the rollup build. That happened during this work, so the gate now catches it instead of CI.
Four modules had their export blocks split into value and `export type` blocks as a result.

## Bugs this surfaced

Most of the ~400 errors were honest-typing chores, but the check exposed real defects:

- `ViewerLoader.vue` (desktop) called `npath.join`/`npath.isAbsolute` in `getImagePathForFrame`,
  but `npath` does not exist in that module — the file's own `joinPath`/`isAbsolutePath` helpers are
  used everywhere else. That path threw `ReferenceError` whenever it was reached.
- `RunPipelineMenu.vue` passed the user's configured pipeline parameters into the
  `outputDatasetNameById` argument instead of `kwiverParams`, so parameters entered in the Configure
  dialog were silently dropped on every parameterized pipeline run. Now threaded through
  `kwiverParams`, the channel both the desktop and web-girder backends actually read.
- `AnnotationTags.vue` had `v-for="(set, index) in set"` — iterating an identifier that does not
  exist. Only `sets` is in scope.
- `AdminJobs.vue` called `formatStatus(item.status)` against a two-parameter function, leaving
  `updated` undefined, so `moment(undefined)` rendered the current time as every job's update time.
- `GroupItem.vue` passed `group.getType()` — a `[string, number]` confidence pair — to
  `TypePicker`'s `value` prop, which takes the type name `string`. `TrackDetailsPanel.vue` had the
  same defect.
- `GroupList.vue` passed a narrow `SortedAnnotation` copy as `GroupItem`'s `group` prop, but
  `GroupItem` calls `setType` and reads `memberIds`, neither of which exists on that copy. This is
  the same projection-vs-full-object class of bug the gate exists to catch.
- `useMediaController.ts` built its per-camera controllers without `resizing`, `alignedGapSlots`, or
  `seekCameraFrame`, all of which `MediaController` declares.
- `useMulticamEditRouting.ts` imported `'../../trackStore'`, which does not exist. The import
  resolved only because nothing checked it.
- `multiCamImport.ts` accepted `type: 'large-image'` and produced a camera record no downstream
  branch handles, collecting no media. It now rejects that combination explicitly.
- `AttributeNumberValueColors.vue` compared `item.key.toString() === val` with a numeric `val`, so
  the "values need to be unique" rule could never fire.

## Notes for review

- `SideBarTrackItemView.vue`'s `track` prop was `{ type: Object }`, i.e. `any`, so nothing in that
  template was checked. It is now `PropType<Track>`, which is what makes the gate cover the
  component where `TypeError: _vm.track.canSplit is not a function` originally shipped.
- Several large clusters came from one loose declaration each, fixed once at the source rather than
  at each use site: `DesktopBridge.invoke`/`.on` in `desktop-preload.d.ts` are now generic; the
  desktop `api.ts` routes ~55 IPC calls through one typed `invoke<T>` wrapper; the multi-camera
  import `ctx` prop declared `required: true` without `as const`, which defeated Vue's required-prop
  narrowing across eight components; `BottomPanel.vue`'s props were bare `Object`/`Function`.
- Validation rules in several components moved from inline template arrays into the script.
  `vue-tsc` accepts type annotations inside template expressions, but `vue-template-compiler` does
  not — annotating them in place type-checks and then throws at runtime.
- `@types/archiver` replaces an untyped import rather than a hand-written declaration.
- No error was silenced with `any`, `@ts-ignore`, `@ts-expect-error`, or a non-null assertion. One
  double cast remains, `girderRest as unknown as AxiosInstance` in `multicamFileRegistry.ts`: Girder's
  `RestClient` genuinely lacks members that `UploadManager`'s constructor requires, and that
  constructor is in `node_modules`.

## Verification

- `npm run typecheck` passes, and fails as intended when a bogus method call is added to a typed
  object in a template — verified against `track.canSplit` in `SideBarTrackItemView.vue`, the exact
  expression that produced the original crash.
- Client gate passes: unit tests, lint, lint:templates, build:web, build:electron.
- Server lint and mypy fail on this branch exactly as they do on `main`; no server file is touched.

`@typescript-eslint` 6.x officially supports TypeScript below 5.4 and is now paired with 5.6.
`npm run lint` and `npm run lint:templates` both pass clean, with no version warning, because the
config does not use type-aware linting. Upgrading the eslint stack is left as a separate decision.
