### PR TITLE
Allow devDependency imports in TypeScript spec files

### DIFF
--- a/client/dive-common/components/AttributeTrackFilter.vue
+++ b/client/dive-common/components/AttributeTrackFilter.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-/* eslint-disable max-len */
 import { computed, defineComponent, ref } from 'vue';
 import { throttle } from 'lodash';
 import { useAttributes, useTrackFilters, useTrackStyleManager } from 'vue-media-annotator/provides';

--- a/client/dive-common/components/DatasetInfo/DatasetInfo.spec.ts
+++ b/client/dive-common/components/DatasetInfo/DatasetInfo.spec.ts
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-/* eslint-disable import/no-extraneous-dependencies */
 import { mount } from '@vue/test-utils';
 import Vue, {
   CreateElement, defineComponent, nextTick, ref,

--- a/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.spec.ts
+++ b/client/dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/client/dive-common/components/PrimaryAttributeTrackFilter.vue
+++ b/client/dive-common/components/PrimaryAttributeTrackFilter.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-/* eslint-disable max-len */
 import {
   computed, defineComponent, PropType, ref,
 } from 'vue';

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -1662,7 +1662,6 @@ export default defineComponent({
           }
           cameraStore.addCamera(camera);
           addSaveCamera(camera);
-          // eslint-disable-next-line no-await-in-loop
           const {
             tracks,
             groups,

--- a/client/dive-common/components/importAnnotationsSets.spec.ts
+++ b/client/dive-common/components/importAnnotationsSets.spec.ts
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 import { defineComponent, h, ref } from 'vue';
-// eslint-disable-next-line import/no-extraneous-dependencies -- @vue/test-utils is only used in tests
 import { mount } from '@vue/test-utils';
 import { provideAnnotator, dummyState, dummyHandler } from 'vue-media-annotator/provides';
 import { provideApi } from 'dive-common/apispec';

--- a/client/dive-common/compositeDatasetId.spec.ts
+++ b/client/dive-common/compositeDatasetId.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import { describe, expect, it } from 'vitest';
 
 import { parentDatasetId, parseCompositeDatasetId } from './compositeDatasetId';

--- a/client/dive-common/recipes/polygonbase.ts
+++ b/client/dive-common/recipes/polygonbase.ts
@@ -263,7 +263,6 @@ export default class PolygonBoundsExpand implements Recipe {
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
   activate() {
     // no-op
     this.active.value = true;
@@ -274,7 +273,6 @@ export default class PolygonBoundsExpand implements Recipe {
     });
   }
 
-  // eslint-disable-next-line class-methods-use-this
   deactivate() {
     // no-op
     this.active.value = false;

--- a/client/dive-common/recipes/segmentationpointclick.ts
+++ b/client/dive-common/recipes/segmentationpointclick.ts
@@ -457,7 +457,6 @@ export default class SegmentationPointClick implements Recipe {
   update(
     mode: 'in-progress' | 'editing',
     frameNum: number,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     track: Track,
     data: GeoJSON.Feature<GeoJSON.LineString | GeoJSON.Polygon | GeoJSON.Point>[],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/client/dive-common/stereoParentFolder.spec.ts
+++ b/client/dive-common/stereoParentFolder.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import { describe, expect, it } from 'vitest';
 
 import { commonPathPrefix } from 'dive-common/components/ImportMultiCamDialog/multicamSubfolderLayout';

--- a/client/dive-common/use/stereo/tests/stereoOnnx.spec.ts
+++ b/client/dive-common/use/stereo/tests/stereoOnnx.spec.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { PNG } from 'pngjs';
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import {
   describe, it, expect,
 } from 'vitest';

--- a/client/dive-common/use/stereo/tests/stereoTransfer.spec.ts
+++ b/client/dive-common/use/stereo/tests/stereoTransfer.spec.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { ref } from 'vue';
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import {
   describe, it, expect, vi,
 } from 'vitest';

--- a/client/dive-common/use/stereo/tests/triangulate.spec.ts
+++ b/client/dive-common/use/stereo/tests/triangulate.spec.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import {
   describe, it, expect,
 } from 'vitest';

--- a/client/dive-common/use/stereo/useStereoOnnxTransfer.ts
+++ b/client/dive-common/use/stereo/useStereoOnnxTransfer.ts
@@ -466,7 +466,6 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
     });
 
     // Sequential: each job runs a wasm inference and reads frame pixels.
-    // eslint-disable-next-line no-restricted-syntax
     for (let i = 0; i < jobs.length; i += 1) {
       config.onStatus?.(`Warping detection ${i + 1} of ${jobs.length}...`);
       // eslint-disable-next-line no-await-in-loop

--- a/client/dive-common/use/useFrameMetadata.spec.ts
+++ b/client/dive-common/use/useFrameMetadata.spec.ts
@@ -1,6 +1,5 @@
 import { effectScope, nextTick, ref } from 'vue';
 
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import {
   beforeEach, describe, expect, it, vi,
 } from 'vitest';

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "build:electron": "electron-vite build && electron-builder --config electron-builder.json",
     "build:electron:dir": "electron-vite build && electron-builder --config electron-builder.json --dir",
     "divecli": "node ./bin/platform/desktop/backend/cli.js",
-    "lint": "eslint --ext .js,.ts,.vue src/ dive-common/ platform/",
+    "lint": "eslint --ext .js,.ts,.vue --report-unused-disable-directives src/ dive-common/ platform/",
     "lint:templates": "eslint --ext vue src/ dive-common/ platform/",
     "test": "vitest run src/ dive-common/ platform/",
     "typecheck": "vue-tsc --noEmit -p tsconfig.typecheck.json"

--- a/client/package.json
+++ b/client/package.json
@@ -183,6 +183,19 @@
           "@vue/typescript",
           "@vue/typescript/recommended"
         ]
+      },
+      {
+        "files": [
+          "**/*.spec.ts"
+        ],
+        "rules": {
+          "import/no-extraneous-dependencies": [
+            "error",
+            {
+              "devDependencies": true
+            }
+          ]
+        }
       }
     ],
     "parserOptions": {

--- a/client/platform/desktop/backend/native/attributeProcessor.spec.ts
+++ b/client/platform/desktop/backend/native/attributeProcessor.spec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable quote-props */
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { MultiTrackRecord } from 'dive-common/apispec';
 import { TrackData } from 'vue-media-annotator/track';
 import type { Attribute } from 'vue-media-annotator/use/AttributeTypes';

--- a/client/platform/desktop/backend/native/attributeProcessor.ts
+++ b/client/platform/desktop/backend/native/attributeProcessor.ts
@@ -62,7 +62,6 @@ function processTrackAttributes(tracks: TrackData[]):
         if (lowCount >= predefinedMinCount && attributeType.indexOf('text') !== -1) {
           attributeObj[attributeKey].values = values;
         }
-        // eslint-disable-next-line no-param-reassign
         attributeObj[attributeKey].datatype = attributeType;
       }
     });

--- a/client/platform/desktop/backend/native/cameraRegistration.ts
+++ b/client/platform/desktop/backend/native/cameraRegistration.ts
@@ -25,7 +25,6 @@ import {
 } from 'dive-common/registrationParentFolder';
 import { JsonConfig, Settings } from 'platform/desktop/constants';
 
-// eslint-disable-next-line import/no-cycle
 import {
   getValidatedProjectDir, loadJsonConfig, saveConfig,
 } from './common';

--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -129,7 +129,6 @@ vi.mock('./mediaJobs', () => ({
   } as DesktopJob)),
 }));
 // https://github.com/tschaub/mock-fs/issues/234
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const console = new Console(process.stdout, process.stderr);
 
 const emptyCsvString = '# comment line\n# metadata,fps: 32,"whatever"\n#comment line';
@@ -449,10 +448,8 @@ beforeEach(() => {
       },
     },
     '/home/user/viamedata': {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
       DIVE_Jobs: {
         goodTrainingJob: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
           category_models: {
             'detector.pipe': '',
             'trained_detector.zip': '',
@@ -462,17 +459,14 @@ beforeEach(() => {
           missingModelFolder: {},
         },
         missingPipeTrainingJob: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
           category_models: {
             'trained_detector.zip': '',
           },
         },
       },
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       DIVE_Pipelines: {
       /* Empty */
       },
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       DIVE_Projects: {
         projectid1: {
           'meta.json': JSON.stringify({
@@ -817,7 +811,6 @@ beforeEach(() => {
               'bar.png',
             ],
             attributes: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
               track_attribute1: {
                 belongs: 'track',
                 datatype: 'text',
@@ -825,7 +818,6 @@ beforeEach(() => {
                 name: 'attribute1',
                 key: 'track_attribute1',
               },
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               detection_attribute1: {
                 belongs: 'detection',
                 datatype: 'number',

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -42,7 +42,6 @@ import * as dive from 'platform/desktop/backend/serializers/dive';
 import * as coco from 'platform/desktop/backend/serializers/coco';
 import kpf from 'platform/desktop/backend/serializers/kpf';
 // TODO:  Check to Refactor this
-// eslint-disable-next-line import/no-cycle
 import { checkMedia } from 'platform/desktop/backend/native/mediaJobs';
 import {
   websafeImageTypes, websafeVideoTypes, otherImageTypes, otherVideoTypes, fileVideoTypes,
@@ -63,7 +62,6 @@ import { parseFrameTimestamp } from 'dive-common/frameTimestamp';
 import processTrackAttributes from './attributeProcessor';
 import { upgrade } from './migrations';
 // TODO:  Check to Refactor this
-// eslint-disable-next-line import/no-cycle
 import { getMultiCamUrls, transcodeMultiCam } from './multiCamUtils';
 import {
   loadRegistrationFiles, referenceCameraName, saveRegistrationToDatasetDir,
@@ -966,7 +964,7 @@ async function autodiscoverData(settings: Settings): Promise<JsonConfig[]> {
   const dspath = npath.join(settings.dataPath, ProjectsFolderName);
   const dsids = await fs.readdir(dspath);
   const metas: JsonConfig[] = [];
-  /* eslint-disable no-await-in-loop,no-continue */
+  /* eslint-disable no-await-in-loop */
   for (let i = 0; i < dsids.length; i += 1) {
     const datasetId = dsids[i];
     try {

--- a/client/platform/desktop/backend/native/datasetCalibration.ts
+++ b/client/platform/desktop/backend/native/datasetCalibration.ts
@@ -15,7 +15,6 @@ import parseStereoCalibrationJson from 'dive-common/utils/parseStereoCalibration
 import { Settings, LastCalibrationBaseName } from 'platform/desktop/constants';
 
 import { prepareDatasetCalibration } from './calibrationConvert';
-// eslint-disable-next-line import/no-cycle
 import {
   autodiscoverData, getValidatedProjectDir, loadJsonConfig, saveProjectConfig,
 } from './common';

--- a/client/platform/desktop/backend/native/mediaJobs.ts
+++ b/client/platform/desktop/backend/native/mediaJobs.ts
@@ -15,7 +15,6 @@ import {
   jobFileEchoMiddleware, spawnResult, createWorkingDirectory, getBinaryPath,
 } from './utils';
 // TODO:  Check to Refactor this
-// eslint-disable-next-line import/no-cycle
 import {
   getTranscodedMultiCamType,
 } from './multiCamUtils';
@@ -265,7 +264,6 @@ async function convertMedia(
         endTime: new Date(),
       });
       // Update meta to reflect error
-      // eslint-disable-next-line no-param-reassign
       onFail?.(jobKey, args.meta, `Transcoding job failed with exit code ${code}`);
     } else {
       if (args.meta.type === 'video' || multiType === 'video') {

--- a/client/platform/desktop/backend/native/multiCamUtils.ts
+++ b/client/platform/desktop/backend/native/multiCamUtils.ts
@@ -7,7 +7,6 @@ import {
 } from 'dive-common/apispec';
 
 import { JsonConfig, Settings } from 'platform/desktop/constants';
-// eslint-disable-next-line import/no-cycle
 import { loadAnnotationFile, loadJsonConfig, getValidatedProjectDir } from 'platform/desktop/backend/native/common';
 import { serialize } from 'platform/desktop/backend/serializers/viame';
 import { parseFrameTimestamp } from 'dive-common/frameTimestamp';
@@ -34,7 +33,6 @@ function transcodeMultiCam(
 
         if (cameraData.type === 'image-sequence') {
           if (!cameraData.transcodedImageFiles) {
-          // eslint-disable-next-line no-param-reassign
             cameraData.transcodedImageFiles = [];
           }
           if (cameraData.originalImageFiles.includes(npath.basename(item))) {
@@ -45,7 +43,6 @@ function transcodeMultiCam(
         } else if (cameraData.type === 'video') {
           if (item === npath.join(cameraData.originalBasePath, cameraData.originalVideoFile)) {
             destLoc = destLoc.replace(cameraData.originalBasePath, `${projectDirAbsPath}/${cameraName}`);
-            // eslint-disable-next-line no-param-reassign
             cameraData.transcodedVideoFile = npath.basename(destLoc);
             break;
           }

--- a/client/platform/desktop/backend/native/multicamExport.spec.ts
+++ b/client/platform/desktop/backend/native/multicamExport.spec.ts
@@ -102,7 +102,6 @@ beforeEach(() => {
       right: { 'img_right.png': '' },
     },
     '/home/user/viamedata': {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       DIVE_Projects: {
         multicamExport: {
           'meta.json': JSON.stringify({

--- a/client/platform/desktop/backend/native/multicamExport.ts
+++ b/client/platform/desktop/backend/native/multicamExport.ts
@@ -18,7 +18,6 @@ import {
 import * as viameSerializers from 'platform/desktop/backend/serializers/viame';
 import * as dive from 'platform/desktop/backend/serializers/dive';
 
-// eslint-disable-next-line import/no-cycle
 import {
   ArchiveMetadataFolderName, getValidatedProjectDir, loadAnnotationFile, loadJsonConfig,
 } from './common';

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -366,7 +366,6 @@ async function runPipeline(
 
   let multiOutFiles: Record<string, string>;
   if (meta.multiCam && stereoOrMultiCam) {
-    // eslint-disable-next-line max-len
     const { argFilePair, outFiles } = await writeMultiCamStereoPipelineArgs(jobWorkDir, meta, settings, requiresInput);
     Object.entries(argFilePair).forEach(([arg, file]) => {
       command.push(`-s ${arg}="${file}"`);

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -182,12 +182,10 @@ const meta = {
 } as JsonConfig;
 const testFiles: Record<string, string> = { };
 testData.forEach((item, index) => {
-  // eslint-disable-next-line prefer-destructuring
   testFiles[`${index}.csv`] = item[0].join('\n');
 });
 const imageOrderFiles: Record<string, string> = { };
 imageFilenameTests.forEach((item, index) => {
-  // eslint-disable-next-line prefer-destructuring
   imageOrderFiles[`${index}.csv`] = item.csv.join('\n');
 });
 
@@ -242,7 +240,6 @@ describe('VIAME Python Compatibility Check', () => {
       // eslint-disable-next-line no-await-in-loop
       const results = await parse(csvStream);
       expect(Object.values(results[0].tracks)).toEqual(trackArray);
-      // eslint-disable-next-line no-await-in-loop
       const attData = processTrackAttributes(Object.values(results[0].tracks));
       expect(testAttributes).toEqual(attData.attributes);
     }

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * VIAME CSV parser/serializer copied logically from
  * dive_utils.serializers.viame python module

--- a/client/platform/desktop/backend/server.ts
+++ b/client/platform/desktop/backend/server.ts
@@ -354,7 +354,6 @@ apirouter.get('/media', (req, res, next) => {
   }
 
   const range = ranges[0];
-  // eslint-disable-next-line no-param-reassign
   res.status(206);
   res.setHeader('Content-Length', range.end - range.start + 1);
   res.setHeader('Content-Range', `bytes ${range.start}-${range.end}/${filestat.size}`);

--- a/client/platform/desktop/frontend/components/BulkImportDialog.vue
+++ b/client/platform/desktop/frontend/components/BulkImportDialog.vue
@@ -76,7 +76,6 @@ export default defineComponent({
       ctx.emit('finalize-import', finalImports);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     function updateImportConfig(oldItem: DesktopMediaImportResponse, newItem: DesktopMediaImportResponse) {
       const itemIndex = imports.value.indexOf(oldItem);
 

--- a/client/platform/web-girder/api/dataset.service.spec.ts
+++ b/client/platform/web-girder/api/dataset.service.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import {
   beforeEach, describe, expect, it, vi,
 } from 'vitest';

--- a/client/platform/web-girder/api/frameMetadata.service.spec.ts
+++ b/client/platform/web-girder/api/frameMetadata.service.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import {
   beforeEach, describe, expect, it, vi,
 } from 'vitest';

--- a/client/platform/web-girder/api/multicamResolve.spec.ts
+++ b/client/platform/web-girder/api/multicamResolve.spec.ts
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import {
   beforeEach,
   describe,

--- a/client/platform/web-girder/multicamCalibration.spec.ts
+++ b/client/platform/web-girder/multicamCalibration.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/client/platform/web-girder/multicamFileRegistry.spec.ts
+++ b/client/platform/web-girder/multicamFileRegistry.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import {
   describe, expect, it, beforeEach, vi,
 } from 'vitest';

--- a/client/platform/web-girder/store/useConfig.ts
+++ b/client/platform/web-girder/store/useConfig.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export -- singleton composable store */
 import { ref } from 'vue';
 
 import {

--- a/client/platform/web-girder/store/useJobs.ts
+++ b/client/platform/web-girder/store/useJobs.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export -- singleton composable store */
 import Vue, { computed, ref } from 'vue';
 import { GirderJob } from '@girder/components/src';
 import { all } from '@girder/components/src/components/Job/status';

--- a/client/platform/web-girder/store/useLocation.ts
+++ b/client/platform/web-girder/store/useLocation.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export -- singleton composable store */
 import type { GirderModel } from '@girder/components/src';
 import { computed, ref } from 'vue';
 import type { Route } from 'vue-router';

--- a/client/platform/web-girder/store/webGirderStoreComposables.spec.ts
+++ b/client/platform/web-girder/store/webGirderStoreComposables.spec.ts
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import {
   beforeEach,
   describe,

--- a/client/platform/web-girder/uploadSlots.spec.ts
+++ b/client/platform/web-girder/uploadSlots.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import { describe, expect, it } from 'vitest';
 
 import suggestUploadSlots from './uploadSlots';

--- a/client/platform/web-girder/useStereoOnnxWeb.ts
+++ b/client/platform/web-girder/useStereoOnnxWeb.ts
@@ -91,7 +91,6 @@ export default function useStereoOnnxWeb(opts: StereoOnnxWebOptions) {
       try {
         matcher = await StereoOnnxMatcher.create(modelUrl);
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.warn('[StereoOnnx] failed to load model', modelUrl, err);
         matcher = null;
       }
@@ -149,13 +148,11 @@ export default function useStereoOnnxWeb(opts: StereoOnnxWebOptions) {
       const fromSession = await rigFromSession();
       if (fromSession) return fromSession;
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('[StereoOnnx] failed to parse the session calibration', err);
     }
     try {
       return await rigFromDataset();
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('[StereoOnnx] failed to load the dataset calibration', err);
       return null;
     }

--- a/client/platform/web-girder/views/Upload.spec.ts
+++ b/client/platform/web-girder/views/Upload.spec.ts
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-/* eslint-disable import/no-extraneous-dependencies */
 import { mount } from '@vue/test-utils';
 import Vue, {
   CreateElement, defineComponent, h, nextTick,

--- a/client/platform/web-girder/views/UploadGirder.spec.ts
+++ b/client/platform/web-girder/views/UploadGirder.spec.ts
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-/* eslint-disable import/no-extraneous-dependencies */
 import { mount } from '@vue/test-utils';
 import Vue from 'vue';
 

--- a/client/platform/web-girder/views/UploadGirder.vue
+++ b/client/platform/web-girder/views/UploadGirder.vue
@@ -63,7 +63,6 @@ export default Vue.extend({
           // eslint-disable-next-line no-await-in-loop
           await this.uploadPending(pendingUplodsCopy[i], uploaded);
         } catch (err) {
-          // eslint-disable-next-line no-console
           console.error(err);
           error = err;
           break;

--- a/client/src/AttributeTrackFilterControls.ts
+++ b/client/src/AttributeTrackFilterControls.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { isArray } from 'lodash';
 import { AnnotationId } from './BaseAnnotation';
 import type Track from './track';

--- a/client/src/alignedView/cameraRegistrationFiles.spec.ts
+++ b/client/src/alignedView/cameraRegistrationFiles.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies -- Vitest is only used in tests
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/client/src/components/AttributeTrackFilters.vue
+++ b/client/src/components/AttributeTrackFilters.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-/* eslint-disable max-len */
 import {
   computed, defineComponent, reactive, ref, Ref,
 } from 'vue';

--- a/client/src/components/annotators/ImageAnnotator.vue
+++ b/client/src/components/annotators/ImageAnnotator.vue
@@ -80,7 +80,6 @@ export default defineComponent({
       externallyDriven,
     } = cameraInitializer(props.camera, 'image-sequence', {
       // allow hoisting for these functions to pass a reference before defining them.
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
       seek, pause, play, setVolume: unimplemented, setSpeed: unimplemented,
     });
     const { playbackCursor } = useAnnotatorImageCursor(

--- a/client/src/components/annotators/LargeImageAnnotator.vue
+++ b/client/src/components/annotators/LargeImageAnnotator.vue
@@ -138,7 +138,6 @@ export default defineComponent({
       mediaController,
     } = cameraInitializer(props.camera, 'large-image', {
       // allow hoisting for these functions to pass a reference before defining them.
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
       seek, pause, play, setVolume: unimplemented, setSpeed: unimplemented,
     });
     const { playbackCursor } = useAnnotatorImageCursor(
@@ -379,7 +378,6 @@ export default defineComponent({
       return returnFunc;
     }
     async function cacheFrame(frame: number) {
-      // eslint-disable-next-line no-unreachable
       const resp2 = await props.getTiles(props.imageData[frame].id, projection);
       const newParams = geo.util.pixelCoordinateParams(
         container.value,

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -124,7 +124,6 @@ export default defineComponent({
       externallyDriven,
     } = cameraInitializer(props.camera, 'video', {
       // allow hoisting for these functions.
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
       seek,
       pause,
       play,

--- a/client/src/components/annotators/useMediaController.spec.ts
+++ b/client/src/components/annotators/useMediaController.spec.ts
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 import { defineComponent, ref } from 'vue';
-// eslint-disable-next-line import/no-extraneous-dependencies -- @vue/test-utils is only used in tests
 import { mount } from '@vue/test-utils';
 import { useMediaController } from './useMediaController';
 import type { AlignedFrameResolver } from './mediaControllerType';

--- a/client/src/components/layerManager/useLayerManagerAlignedView.spec.ts
+++ b/client/src/components/layerManager/useLayerManagerAlignedView.spec.ts
@@ -3,7 +3,6 @@
 import {
   defineComponent, ref, shallowRef, nextTick,
 } from 'vue';
-// eslint-disable-next-line import/no-extraneous-dependencies -- @vue/test-utils is only used in tests
 import { mount } from '@vue/test-utils';
 import { clientSettings } from 'dive-common/store/settings';
 import type { MediaController, AggregateMediaController } from '../annotators/mediaControllerType';

--- a/client/src/layers/AnnotationLayers/AttributeBoxLayer.ts
+++ b/client/src/layers/AnnotationLayers/AttributeBoxLayer.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-len */
-/* eslint-disable class-methods-use-this */
-
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import { boundToGeojson } from '../../utils';
 import BaseLayer, { LayerStyle, BaseLayerParams } from '../BaseLayer';

--- a/client/src/layers/AnnotationLayers/AttributeLayer.ts
+++ b/client/src/layers/AnnotationLayers/AttributeLayer.ts
@@ -1,5 +1,4 @@
 /* eslint-disable prefer-destructuring */
-/* eslint-disable max-len */
 import type { Attribute } from 'vue-media-annotator/use/AttributeTypes';
 import { StringKeyObject } from 'vue-media-annotator/BaseAnnotation';
 import { RectBounds } from 'vue-media-annotator/utils';

--- a/client/src/layers/AnnotationLayers/PolygonLayer.ts
+++ b/client/src/layers/AnnotationLayers/PolygonLayer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import geo, { GeoEvent } from 'geojs';
 import { Ref } from 'vue';
 

--- a/client/src/layers/AnnotationLayers/RectangleLayer.ts
+++ b/client/src/layers/AnnotationLayers/RectangleLayer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import geo, { GeoEvent } from 'geojs';
 import { Ref } from 'vue';
 
@@ -326,7 +325,6 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
           .draw();
       }
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.warn('Annotation layer disable skipped after map/renderer teardown', err);
     }
   }

--- a/client/src/layers/AnnotationLayers/RegistrationKeypointLayer.ts
+++ b/client/src/layers/AnnotationLayers/RegistrationKeypointLayer.ts
@@ -285,7 +285,7 @@ export default class RegistrationKeypointLayer extends BaseLayer<RegistrationPoi
     window.removeEventListener('mouseup', this.boundDragEnd);
   }
 
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   formatData(_frameData: FrameDataTrack[]): RegistrationPointData[] {
     const result: RegistrationPointData[] = [];
     if (!this.registration) {
@@ -414,7 +414,6 @@ export default class RegistrationKeypointLayer extends BaseLayer<RegistrationPoi
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
   createStyle(): LayerStyle<RegistrationPointData> {
     return {
       ...super.createStyle(),

--- a/client/src/layers/BaseLayer.ts
+++ b/client/src/layers/BaseLayer.ts
@@ -6,7 +6,6 @@ import { applyHomography, Matrix3 } from '../alignedView/homography';
 import { StateStyles, TypeStyling } from '../StyleManager';
 import { FrameDataTrack } from './LayerTypes';
 
-// eslint-disable-next-line max-len
 export type StyleFunction<T, D> = T | ((point: [number, number], index: number, data: D) => T | undefined);
 export type ObjectFunction<T, D> = T | ((data: D, index: number) => T | undefined);
 export type PointFunction<T, D> = T | ((data: D) => T | undefined);
@@ -179,7 +178,6 @@ export default abstract class BaseLayer<D> {
       try {
         this.redraw();
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.warn('Annotation layer redraw skipped after map/renderer teardown');
       }
     }

--- a/client/src/layers/EditAnnotationLayer.ts
+++ b/client/src/layers/EditAnnotationLayer.ts
@@ -803,7 +803,6 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
    * True when a finalized annotation has enough vertices to be a real shape.
    * Guards against degenerate geometry emitted by a programmatic mode change.
    */
-  // eslint-disable-next-line class-methods-use-this
   isValidCompletedGeometry(feature: GeoJSON.Feature): boolean {
     const { geometry } = feature;
     if (!geometry) return false;

--- a/client/src/notificatonBus.ts
+++ b/client/src/notificatonBus.ts
@@ -52,7 +52,6 @@ export default function registerNotifications(_rc: any) {
 
   function onWebSocketError() {
     disconnect();
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     window.setTimeout(connect, retryMsDefault);
   }
 

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -336,7 +336,6 @@ export interface State {
   percentileHistogramLoading: PercentileHistogramLoadingType;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 const markChangesPending = () => { };
 
 /**

--- a/server/dive_tasks/utils.py
+++ b/server/dive_tasks/utils.py
@@ -182,7 +182,7 @@ def ffprobe_supports_option_from_file() -> bool:
         combined = f'{completed.stdout or ""}{completed.stderr or ""}'
         # FFmpeg 4.x reports: Failed to set value '...' for option '/headers': Option not found
         return 'Option not found' not in combined and 'Unrecognized option' not in combined
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired):
         return False
     finally:
         with suppress(OSError):

--- a/server/tests/test_remote_ffprobe.py
+++ b/server/tests/test_remote_ffprobe.py
@@ -348,7 +348,7 @@ def test_convert_video_downloads_when_transcode_required():
 
 
 def test_convert_video_cancel_during_remote_probe_does_not_download():
-    """CanceledError from remote ffprobe must abort, not fall back to download."""
+    """Canceling remote ffprobe must abort, not fall back to download."""
     task = MagicMock()
     task.canceled = False
     gc = MagicMock()


### PR DESCRIPTION
# Allow devDependency imports in TypeScript spec files

The client lint command did not report unused ESLint directives. As a result, obsolete directives
could remain after the related lint errors were fixed.

The Airbnb `import/no-extraneous-dependencies` rule also permits test dependencies only in
JavaScript test files. TypeScript spec files needed a manual directive when they imported `vitest`
or `@vue/test-utils`.

### Changes

- Make the client lint command report unused ESLint directives.
- Remove directives that no longer suppress an error.
- Permit devDependency imports in `**/*.spec.ts` files.
- Remove the related directives from 18 TypeScript spec files.
- Correct two existing server lint findings: a test docstring and a redundant exception type.

This PR does not change application or test behavior. It changes the lint gate and removes obsolete
lint comments.

### Hierarchy prerequisite

The hierarchy PRs add TypeScript spec files that import devDependencies, so this change lets them
pass the stricter lint gate without manual suppressions.

### Stack

This is PR 1 of 9. [Next: preserve Desktop import warnings](https://github.com/Kitware/dive/pull/1845).

1. **Current — Allow devDependency imports in TypeScript spec files**
2. [Preserve warnings from every Desktop import file](https://github.com/Kitware/dive/pull/1845)
3. [Copy source metadata when creating a single-camera soft clone](https://github.com/Kitware/dive/pull/1846)
4. [Add hierarchical track classification](https://github.com/Kitware/dive/pull/1847)
5. [Centralize hierarchical classification changes](https://github.com/Kitware/dive/pull/1848)
6. [Replace mutable merged tracks with read-only projections](https://github.com/Kitware/dive/pull/1849)
7. [Make track lifecycle operations classification-safe](https://github.com/Kitware/dive/pull/1850)
8. [Add lossless DIVE KWCOCO classification support](https://github.com/Kitware/dive/pull/1851)
9. [Define raw and resolved classification boundaries](https://github.com/Kitware/dive/pull/1852)

This PR contains 2 commits on `origin/main`:

- `455c1524 Remove stale eslint-disable directives`
- `637984a3 Allow devDependency imports in spec files`

Overall: 64 files, +18/-89.
