### PR TITLE
Preserve warnings from every Desktop import file

### DIFF
--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -133,6 +133,22 @@ const console = new Console(process.stdout, process.stderr);
 
 const emptyCsvString = '# comment line\n# metadata,fps: 32,"whatever"\n#comment line';
 
+function cocoWithRle(trackId: number, categoryName = 'fish') {
+  return JSON.stringify({
+    images: [{ id: 1, file_name: 'frame_000001.jpg', frame_index: 0 }],
+    annotations: [{
+      id: trackId,
+      image_id: 1,
+      category_id: 5,
+      bbox: [10, 20, 30, 40],
+      track_id: trackId,
+      iscrowd: 1,
+      segmentation: { size: [100, 100], counts: 'abc' },
+    }],
+    categories: [{ id: 5, name: categoryName }],
+  });
+}
+
 // Below sets up data in the mockfs
 type testPairs = [string[], MultiTrackRecord, Record<string, Attribute>];
 /* Viame.spec.json is an array in the format [CSV row Array, MultiTrackRecord, Attributes Object][]
@@ -849,6 +865,90 @@ beforeEach(() => {
 });
 
 describe('native.common', () => {
+  it('preserves warnings from primary COCO files in input order', async () => {
+    const first = '/home/user/output/first.coco.json';
+    const second = '/home/user/output/second.coco.json';
+    await fs.writeFile(first, cocoWithRle(1, 'fish'));
+    await fs.writeFile(second, cocoWithRle(2, 'shark'));
+
+    const result = await common.ingestDataFiles(settings, 'projectid1', [first, second]);
+
+    expect(result.processedFiles).toEqual([first, second]);
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings.every((warning) => warning.includes('segmentation masks'))).toBe(true);
+  });
+
+  it('does not let an empty warning list erase earlier primary warnings', async () => {
+    const first = '/home/user/output/first.coco.json';
+    const empty = '/home/user/output/config.json';
+    const third = '/home/user/output/third.csv';
+    await fs.writeFile(first, cocoWithRle(1));
+    await fs.writeJSON(empty, { confidenceFilters: { default: 0.8 } });
+    await fs.writeFile(third, '# metadata,fps: 30,dataset_info: 42');
+
+    const result = await common.ingestDataFiles(settings, 'projectid1', [first, empty, third]);
+
+    expect(result.processedFiles).toEqual([first, empty, third]);
+    expect(result.warnings).toEqual([
+      'The COCO file included run-length encoded segmentation masks that are not supported. '
+        + 'Bounding boxes and other annotation data were imported, but masks were skipped.',
+      'Ignored dataset_info entry: expected a JSON object but got number',
+    ]);
+  });
+
+  it('preserves identical warnings from separate primary files', async () => {
+    const first = '/home/user/output/first.coco.json';
+    const second = '/home/user/output/second.coco.json';
+    const input = cocoWithRle(1);
+    await fs.writeFile(first, input);
+    await fs.writeFile(second, input);
+
+    const result = await common.ingestDataFiles(settings, 'projectid1', [first, second]);
+
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings[0]).toBe(result.warnings[1]);
+  });
+
+  it('places primary warnings before multicam warnings', async () => {
+    const primary = '/home/user/output/primary.coco.json';
+    const multicam = '/home/user/output/left.csv';
+    await fs.writeFile(primary, cocoWithRle(1));
+    await fs.writeFile(multicam, '# metadata,fps: 30,dataset_info: 42');
+
+    const result = await common.ingestDataFiles(
+      settings,
+      'stereoDataset',
+      [primary],
+      { left: multicam },
+    );
+
+    expect(result.processedFiles).toEqual([primary, multicam]);
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings[0]).toContain('segmentation masks');
+    expect(result.warnings[1]).toContain('expected a JSON object but got number');
+  });
+
+  it('rejects when a COCO annotation has no bbox and no usable polygon segmentation', async () => {
+    const rejectedFile = '/home/user/output/rejected.coco.json';
+    await fs.writeJSON(rejectedFile, {
+      images: [{ id: 1, file_name: 'frame_000001.jpg', frame_index: 0 }],
+      annotations: [{
+        id: 2,
+        image_id: 1,
+        category_id: 5,
+        iscrowd: 1,
+        segmentation: { size: [100, 100], counts: 'abc' },
+      }],
+      categories: [{ id: 5, name: 'fish' }],
+    });
+
+    await expect(common.ingestDataFiles(
+      settings,
+      'projectid1',
+      [rejectedFile],
+    )).rejects.toThrow('no bbox and no usable polygon segmentation');
+  });
+
   it('getPipelineList lists pipelines', async () => {
     const exists = await fs.pathExists(settings.viamePath);
     expect(exists).toBe(true);

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -1458,7 +1458,7 @@ async function ingestDataFiles(
     const results = await _ingestFilePath(settings, datasetId, path, imageMap, additive, additivePrepend);
     if (results !== null) {
       const [newMeta, warnings] = results;
-      outwarnings = warnings;
+      outwarnings = outwarnings.concat(warnings);
       merge(meta, newMeta);
       processedFiles.push(path);
     }


### PR DESCRIPTION
# Preserve warnings from every Desktop import file

### Failure case

A Desktop import can contain more than one primary annotation file. Before this change, each file
replaced the warnings from the preceding file. The import report showed warnings only from the last
file.

Supported annotation data was still imported. However, the missing warnings could hide skipped or
changed data from earlier files.

### Steps to reproduce

Use `dive-classification-test-data/coco/rle-mask-warning-aggregation/` from the test-data ZIP built
by [PaulHax/dive-devkit](https://github.com/PaulHax/dive-devkit).

1. Use `media/image-sequence/` as the image sequence.
2. Call the exported Desktop `ingestDataFiles` function with
   `rle-warning-fish.coco.json` and `rle-warning-shark.coco.json` in the primary input list.
3. Inspect the warnings after the import completes.
4. Expect one warning for each file. Before this fix, the result contains only the last file's
   warning list.

### Changes

- Append warnings from each successful primary file in input order.
- Keep duplicate warnings because each warning can describe a different input file.
- Keep primary-file warnings before multicamera warnings.
- Propagate a later parse error through the exported ingestion entry point.

### Scope

This PR changes `common.ts` and `common.spec.ts`. It does not change the warning text or the import
dialog. The tests use the exported Desktop ingestion entry point. They do not use a live Electron
import dialog.

### Hierarchy prerequisite

The hierarchy feature does not cause this bug, but its KWCOCO imports add warnings that the existing
bug could discard.

### Stack

This is PR 2 of 9. [Previous: TypeScript spec lint](https://github.com/Kitware/dive/pull/1844).
[Next: isolate soft-clone metadata](https://github.com/Kitware/dive/pull/1846).

1. [Allow devDependency imports in TypeScript spec files](https://github.com/Kitware/dive/pull/1844)
2. **Current — Preserve warnings from every Desktop import file**
3. [Copy source metadata when creating a single-camera soft clone](https://github.com/Kitware/dive/pull/1846)
4. [Add hierarchical track classification](https://github.com/Kitware/dive/pull/1847)
5. [Centralize hierarchical classification changes](https://github.com/Kitware/dive/pull/1848)
6. [Replace mutable merged tracks with read-only projections](https://github.com/Kitware/dive/pull/1849)
7. [Make track lifecycle operations classification-safe](https://github.com/Kitware/dive/pull/1850)
8. [Add lossless DIVE KWCOCO classification support](https://github.com/Kitware/dive/pull/1851)
9. [Define raw and resolved classification boundaries](https://github.com/Kitware/dive/pull/1852)

This PR is stacked on `eslint-unused-directives`.

Commit: `a6737794 Preserve warnings from every desktop import file`.
