### PR TITLE
Copy source metadata when creating a single-camera soft clone

### DIFF
--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -180,7 +180,7 @@ def _create_single_camera_soft_clone(
         reuseExisting=False,
         creator=owner,
     )
-    cloned_folder['meta'] = source_folder['meta']
+    cloned_folder['meta'] = copy.deepcopy(source_folder['meta'])
     media_source_folder = crud.getCloneRoot(owner, source_folder)
     cloned_folder[constants.ForeignMediaIdMarker] = str(media_source_folder['_id'])
     cloned_folder['meta'][constants.PublishedMarker] = False

--- a/server/tests/test_multicam_export_clone.py
+++ b/server/tests/test_multicam_export_clone.py
@@ -58,6 +58,46 @@ def _descriptor(name: str):
     return {'itemId': f'{name}-id', 'name': name}
 
 
+@patch('dive_server.crud_dataset.crud_annotation.clone_annotations')
+@patch('dive_server.crud_dataset.crud.get_or_create_auxiliary_folder')
+@patch('dive_server.crud_dataset.crud.getCloneRoot')
+@patch('dive_server.crud_dataset.Folder')
+def test_create_single_camera_soft_clone_copies_metadata(
+    folder_cls, get_clone_root_mock, _aux, _clone_ann
+):
+    owner = {'login': 'tester'}
+    source = {
+        '_id': 'source-id',
+        'name': 'source-dataset',
+        'meta': {
+            'annotate': True,
+            'type': 'image-sequence',
+            'custom': {'labels': ['fish'], 'settings': {'enabled': True}},
+        },
+    }
+    parent = {'_id': 'dest-parent'}
+    cloned_folder = {'_id': 'clone-id', 'name': 'Clone dataset'}
+    folder_cls.return_value.createFolder.return_value = cloned_folder
+    get_clone_root_mock.return_value = source
+
+    result = crud_dataset.createSoftClone(owner, source, parent, 'Clone dataset', None)
+
+    assert result is cloned_folder
+    source['meta']['custom']['labels'].append('shark')
+    source['meta']['custom']['settings']['enabled'] = False
+    assert cloned_folder['meta']['custom'] == {
+        'labels': ['fish'],
+        'settings': {'enabled': True},
+    }
+
+    cloned_folder['meta']['custom']['labels'].append('ray')
+    cloned_folder['meta']['custom']['settings']['enabled'] = None
+    assert source['meta']['custom'] == {
+        'labels': ['fish', 'shark'],
+        'settings': {'enabled': False},
+    }
+
+
 @patch('dive_server.crud_dataset.find_json_calibration_item_id', return_value=None)
 @patch('dive_server.crud_dataset.find_calibration_item_id', return_value=None)
 @patch('dive_server.crud_dataset.crud_annotation.clone_annotations')


### PR DESCRIPTION
# Copy source metadata when DIVE creates a single-camera soft clone

### Failure case

A single-camera soft clone used the source metadata object directly. The source and clone then
shared one mutable object. Clone markers and later nested changes could modify the source metadata.

The multicamera clone path already makes an independent copy.

### Steps to reproduce

1. Create a source folder object that has nested metadata.
2. Call the public `createSoftClone` server entry point.
3. Change a nested value in the source metadata object and inspect the clone metadata object.
4. Change a nested value in the clone metadata object and inspect the source metadata object.
5. Expect each object to keep its own value. Before this fix, each object receives the change from
   the other object.

This object-isolation defect has no supported user-interface reproduction. The automated
`createSoftClone` test is the authoritative reproduction.

### Changes

- Make a deep copy of source metadata before DIVE adds clone markers and default values.
- Test the public `createSoftClone` path.
- Verify that nested changes cannot pass from the source to the clone.
- Verify that nested changes cannot pass from the clone to the source.

### Scope

This PR changes `crud_dataset.py` and `test_multicam_export_clone.py`. It does not test a live
Girder clone, the Mongo save boundary, or a viewer reload.

### Hierarchy prerequisite

The hierarchy is stored in dataset metadata, so a soft clone must copy that metadata without
changing or sharing the source object.

### Stack

This is PR 3 of 9. [Previous: preserve Desktop import warnings](https://github.com/Kitware/dive/pull/1845).
[Next: add hierarchical track classification](https://github.com/Kitware/dive/pull/1847).

1. [Allow devDependency imports in TypeScript spec files](https://github.com/Kitware/dive/pull/1844)
2. [Preserve warnings from every Desktop import file](https://github.com/Kitware/dive/pull/1845)
3. **Current — Copy source metadata when creating a single-camera soft clone**
4. [Add hierarchical track classification](https://github.com/Kitware/dive/pull/1847)
5. [Centralize hierarchical classification changes](https://github.com/Kitware/dive/pull/1848)
6. [Replace mutable merged tracks with read-only projections](https://github.com/Kitware/dive/pull/1849)
7. [Make track lifecycle operations classification-safe](https://github.com/Kitware/dive/pull/1850)
8. [Add lossless DIVE KWCOCO classification support](https://github.com/Kitware/dive/pull/1851)
9. [Define raw and resolved classification boundaries](https://github.com/Kitware/dive/pull/1852)

This PR is stacked on `desktop-warning-preservation`.

Commit: `4ad85091 Copy source metadata when creating a single-camera soft clone`.
