### PR TITLE
Centralize hierarchical classification changes

### DIFF
--- a/client/dive-common/components/BottomPanel.spec.ts
+++ b/client/dive-common/components/BottomPanel.spec.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+/// <reference types="vitest" />
+import { defineComponent, h, ref } from 'vue';
+import { shallowMount } from '@vue/test-utils';
+import Track from 'vue-media-annotator/track';
+import BottomPanel from './BottomPanel.vue';
+
+const state = vi.hoisted(() => ({ acceptTrackType: vi.fn() }));
+
+vi.mock('vue-media-annotator/provides', () => ({
+  useCameraStore: () => ({ acceptTrackType: state.acceptTrackType }),
+  useTrackFilters: () => ({ hierarchyIndex: ref(undefined) }),
+}));
+
+describe('BottomPanel track details classification editing', () => {
+  beforeEach(() => state.acceptTrackType.mockClear());
+
+  it('routes Accept Correct Type through the logical-track command', () => {
+    const track = new Track(1, {
+      confidencePairs: [['root', 0.9], ['leaf', 0.7]],
+      features: [{ frame: 0, bounds: [0, 0, 1, 1], keyframe: true }],
+    });
+    // `@vue/test-utils` types a mount target as a Vue 2 constructor, which a
+    // `defineComponent` SFC is not, so the panel renders from a host that captures the real
+    // instance. It stays unstubbed to keep shallow semantics for its own children.
+    let child: InstanceType<typeof BottomPanel> | undefined;
+    const Host = defineComponent({
+      setup: () => () => h(BottomPanel, {
+        ref: (instance) => {
+          if (instance && !(instance instanceof Element)) {
+            child = instance as InstanceType<typeof BottomPanel>;
+          }
+        },
+        props: {
+          sidebarMode: 'bottom',
+          controlsRef: null,
+          controlsCollapsed: false,
+          lineChartData: [],
+          eventChartData: {},
+          groupChartData: {},
+          datasetType: 'video',
+          isDefaultImage: false,
+          clientSettings: {
+            trackSettings: { newTrackSettings: { mode: 'Track', type: 'unknown' } },
+            typeSettings: { lockTypes: false, showEmptyTypes: false },
+          },
+          trackFilters: {
+            allTypes: ref(['root', 'leaf']),
+            hierarchyActive: ref(true),
+            importTypes: vi.fn(),
+          },
+          attributes: [],
+          frameRate: 30,
+          readonlyState: false,
+          disableAnnotationFilters: false,
+          promptVisible: () => false,
+          confidenceFilters: { default: 0.1 },
+          aggregateSeek: vi.fn(),
+          trackStyleManager: {},
+          bottomRightPanelView: 'details',
+          toggleBottomRightPanel: vi.fn(),
+          selectedTrackForDetails: track,
+          showConfidenceFirst: true,
+          showTrackAttributesFirst: true,
+          editIndividual: null,
+          setEditIndividual: vi.fn(),
+          resetEditIndividual: vi.fn(),
+          addAttribute: vi.fn(),
+          editAttribute: vi.fn(),
+          saveThreshold: vi.fn(),
+        },
+      }),
+    });
+    shallowMount(Host, { stubs: { BottomPanel: false } });
+    if (!child) {
+      throw new Error('BottomPanel did not mount');
+    }
+    child.acceptTrackType('leaf');
+
+    expect(state.acceptTrackType).toHaveBeenCalledWith(1, 'leaf', undefined);
+  });
+});

--- a/client/dive-common/components/BottomPanel.vue
+++ b/client/dive-common/components/BottomPanel.vue
@@ -16,6 +16,7 @@ import type StyleManager from 'vue-media-annotator/StyleManager';
 import type TrackFilterControls from 'vue-media-annotator/TrackFilterControls';
 import type { AnnotationSettings } from 'dive-common/store/settings';
 import type { DatasetType } from 'dive-common/apispec';
+import { useCameraStore, useTrackFilters } from 'vue-media-annotator/provides';
 
 export default defineComponent({
   name: 'BottomPanel',
@@ -71,8 +72,19 @@ export default defineComponent({
     saveThreshold: { type: Function as PropType<() => void>, required: true },
     isStereoDataset: { type: Boolean, default: false },
   },
-  setup() {
-    return { context };
+  setup(props) {
+    const cameraStore = useCameraStore();
+    const trackFilters = useTrackFilters();
+    function acceptTrackType(type: string) {
+      if (props.selectedTrackForDetails) {
+        cameraStore.acceptTrackType(
+          props.selectedTrackForDetails.id,
+          type,
+          trackFilters.hierarchyIndex.value,
+        );
+      }
+    }
+    return { acceptTrackType, context };
   },
 });
 </script>
@@ -212,7 +224,7 @@ export default defineComponent({
               v-if="showConfidenceFirst"
               :confidence-pairs="selectedTrackForDetails.confidencePairs"
               :disabled="false"
-              @set-type="selectedTrackForDetails.setType($event)"
+              @set-type="acceptTrackType($event)"
             />
             <template v-if="showTrackAttributesFirst">
               <AttributeSubsection
@@ -254,7 +266,7 @@ export default defineComponent({
               v-if="!showConfidenceFirst"
               :confidence-pairs="selectedTrackForDetails.confidencePairs"
               :disabled="false"
-              @set-type="selectedTrackForDetails.setType($event)"
+              @set-type="acceptTrackType($event)"
             />
           </div>
           <div v-else class="pa-3 text-caption grey--text">

--- a/client/dive-common/components/TrackDetailsPanel.spec.ts
+++ b/client/dive-common/components/TrackDetailsPanel.spec.ts
@@ -8,6 +8,9 @@ import TrackDetailsPanel from './TrackDetailsPanel.vue';
 const state = vi.hoisted(() => ({
   displayPairIndex: vi.fn(() => 1),
   track: null as Track | null,
+  multiSelectList: [] as number[],
+  acceptTrackType: vi.fn(),
+  assignTrackType: vi.fn(),
 }));
 
 vi.mock('vue-media-annotator/provides', () => ({
@@ -26,9 +29,10 @@ vi.mock('vue-media-annotator/provides', () => ({
   useTrackFilters: () => ({
     allTypes: ref(['root', 'leaf']),
     displayPairIndex: state.displayPairIndex,
+    hierarchyIndex: ref(undefined),
   }),
   useAttributes: () => ref([]),
-  useMultiSelectList: () => ref([]),
+  useMultiSelectList: () => ref(state.multiSelectList),
   useTime: () => ({ frame: ref(0) }),
   useReadOnlyMode: () => ref(false),
   useTrackStyleManager: () => ({
@@ -41,7 +45,8 @@ vi.mock('vue-media-annotator/provides', () => ({
     camMap: ref(new Map([['singleCam', { groupStore: undefined }]])),
     getAnyTrack: () => state.track,
     getAnyPossibleTrack: () => state.track,
-    setTrackType: vi.fn(),
+    acceptTrackType: state.acceptTrackType,
+    assignTrackType: state.assignTrackType,
   }),
   useSelectedCamera: () => ref('singleCam'),
 }));
@@ -73,6 +78,9 @@ function mountPanel() {
 describe('TrackDetailsPanel hierarchy summary', () => {
   beforeEach(() => {
     state.displayPairIndex.mockReturnValue(1);
+    state.multiSelectList = [];
+    state.acceptTrackType.mockClear();
+    state.assignTrackType.mockClear();
     state.track = new Track(1, {
       confidencePairs: [['root', 0.9], ['leaf', 0.7]],
       features: [{ frame: 0, bounds: [0, 0, 1, 1], keyframe: true }],
@@ -105,5 +113,22 @@ describe('TrackDetailsPanel hierarchy summary', () => {
     });
     const { wrapper } = mountPanel();
     expect(wrapper.findComponent({ name: 'TrackItem' }).exists()).toBe(false);
+  });
+
+  it('routes Accept Correct Type through the acceptance command', () => {
+    const { vm } = mountPanel();
+    vm.acceptTrackType('leaf');
+    expect(state.acceptTrackType).toHaveBeenCalledWith(1, 'leaf', undefined);
+  });
+
+  it('routes bulk assignment through the same hierarchy-aware command', () => {
+    state.multiSelectList = [1];
+    const { vm } = mountPanel();
+    vm.updateMultiTrackType('new leaf');
+    vm.updateSelectedTracksType();
+    expect(state.assignTrackType).toHaveBeenCalledWith(1, 'new leaf', {
+      hierarchyIndex: undefined,
+      replaceType: 'leaf',
+    });
   });
 });

--- a/client/dive-common/components/TrackDetailsPanel.vue
+++ b/client/dive-common/components/TrackDetailsPanel.vue
@@ -238,8 +238,12 @@ export default defineComponent({
     });
 
     function updateSelectedTracksType() {
-      multiSelectList.value.forEach((trackId: number) => {
-        cameraStore.setTrackType(trackId, multiTrackType.value);
+      selectedTrackList.value.forEach((track) => {
+        const pairIndex = Math.max(trackFilters.displayPairIndex(track, 0), 0);
+        cameraStore.assignTrackType(track.id, multiTrackType.value, {
+          hierarchyIndex: trackFilters.hierarchyIndex.value,
+          replaceType: track.confidencePairs[pairIndex]?.[0],
+        });
       });
     }
 
@@ -254,11 +258,10 @@ export default defineComponent({
       return pairs.sort((a, b) => b[1] - a[1]);
     });
 
-    function setTrackType(type: string) {
+    function acceptTrackType(type: string) {
       const track = selectedTrackList.value[0];
       if (!track) return;
-      const currentType = track.confidencePairs[0]?.[0];
-      cameraStore.setTrackType(track.id, type, 1, currentType);
+      cameraStore.acceptTrackType(track.id, type, trackFilters.hierarchyIndex.value);
     }
 
     const displayRows = computed(() => selectedTrackList.value.map((track) => {
@@ -314,7 +317,7 @@ export default defineComponent({
       toggleMerge,
       unstageFromMerge,
       updateSelectedTracksType,
-      setTrackType,
+      acceptTrackType,
       displayConfidencePairs,
       displayRows,
       trackFilters,
@@ -626,7 +629,7 @@ export default defineComponent({
         :confidence-pairs="displayConfidencePairs"
         :disabled="selectedTrackList.length > 1"
         :user-modified="isUserModified"
-        @set-type="setTrackType($event)"
+        @set-type="acceptTrackType($event)"
       />
       <attribute-subsection
         v-if="!multiSelectInProgress"

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -667,6 +667,9 @@ export default defineComponent({
       lookupGroups: cameraStore.lookupGroups,
       getTrack: (track: AnnotationId, camera = 'singleCam') => (cameraStore.getTrack(track, camera)),
       getTracks: (track: AnnotationId) => cameraStore.getTrackAll(track),
+      renameTrackPair: (id, currentType, newType) => (
+        cameraStore.renameTrackPair(id, currentType, newType)
+      ),
       groupFilterControls: groupFilters,
       setType: setTrackType,
       removeTypes,

--- a/client/dive-common/typeHierarchy.spec.ts
+++ b/client/dive-common/typeHierarchy.spec.ts
@@ -1,10 +1,14 @@
 import fs from 'fs-extra';
 import {
+  acceptPairAsCorrect,
   compileHierarchy,
   normalizeTypeHierarchy,
+  reassignPairs,
+  removePair,
   resolveTypeHierarchy,
   rewriteHierarchyType,
   selectPairIndex,
+  setPairConfidence,
   TypeHierarchyError,
 } from './typeHierarchy';
 
@@ -45,11 +49,48 @@ interface SelectionCase {
   expectedIndex: number;
 }
 
+interface ReassignmentCase {
+  name: string;
+  hierarchy: Record<string, string>;
+  pairs: [string, number][];
+  replaceType: string;
+  newType: string;
+  confidence: number;
+  expected: [string, number][];
+}
+
+interface AcceptanceCase {
+  name: string;
+  hierarchy: Record<string, string>;
+  pairs: [string, number][];
+  acceptedType: string;
+  expected: [string, number][];
+}
+
+interface PairConfidenceCase {
+  name: string;
+  pairs: [string, number][];
+  type: string;
+  confidence: number;
+  expected: [string, number][];
+}
+
+interface PairRemovalCase {
+  name: string;
+  pairs: [string, number][];
+  type: string;
+  expected: [string, number][];
+}
+
 interface TypeHierarchyCorpus {
   normalizationCases: NormalizationCase[];
   resolutionCases: ResolutionCase[];
   renameCases: RenameCase[];
   selectionCases: SelectionCase[];
+  reassignmentCases: ReassignmentCase[];
+  acceptanceCases: AcceptanceCase[];
+  pairConfidenceCases: PairConfidenceCase[];
+  pairRemovalCases: PairRemovalCase[];
 }
 
 const corpus = fs.readJSONSync('../testutils/typeHierarchy.spec.json') as TypeHierarchyCorpus;
@@ -132,6 +173,46 @@ describe('shared type hierarchy corpus', () => {
       )).toBe(testCase.expectedIndex);
     });
   });
+
+  describe.each(corpus.reassignmentCases)('reassignment: $name', (testCase) => {
+    it('matches the shared result', () => {
+      const hierarchy = normalizeTypeHierarchy(testCase.hierarchy) || {};
+      expect(reassignPairs(
+        compileHierarchy(hierarchy),
+        testCase.pairs,
+        testCase.replaceType,
+        testCase.newType,
+        testCase.confidence,
+      )).toEqual(testCase.expected);
+    });
+  });
+
+  describe.each(corpus.acceptanceCases)('acceptance: $name', (testCase) => {
+    it('matches the shared result', () => {
+      const hierarchy = normalizeTypeHierarchy(testCase.hierarchy) || {};
+      expect(acceptPairAsCorrect(
+        compileHierarchy(hierarchy),
+        testCase.pairs,
+        testCase.acceptedType,
+      )).toEqual(testCase.expected);
+    });
+  });
+
+  describe.each(corpus.pairConfidenceCases)('pair confidence: $name', (testCase) => {
+    it('matches the shared result', () => {
+      expect(setPairConfidence(
+        testCase.pairs,
+        testCase.type,
+        testCase.confidence,
+      )).toEqual(testCase.expected);
+    });
+  });
+
+  describe.each(corpus.pairRemovalCases)('pair removal: $name', (testCase) => {
+    it('matches the shared result', () => {
+      expect(removePair(testCase.pairs, testCase.type)).toEqual(testCase.expected);
+    });
+  });
 });
 
 describe('type hierarchy index', () => {
@@ -147,5 +228,22 @@ describe('type hierarchy index', () => {
     expect(() => selectPairIndex(index, [['cod', 0.9]], [])).toThrow(
       'passes and pairs must have the same length',
     );
+  });
+
+  it('classification operations do not mutate or reuse their input pairs', () => {
+    const pairs: [string, number][] = [['cod', 0.8], ['fish', 0.7], ['bird', 0.2]];
+    const snapshot = pairs.map(([type, confidence]) => [type, confidence] as [string, number]);
+    const results = [
+      reassignPairs(index, pairs, 'cod', 'haddock', 0.8),
+      acceptPairAsCorrect(index, pairs, 'cod'),
+      setPairConfidence(pairs, 'cod', 1.0),
+      removePair(pairs, 'bird'),
+    ];
+
+    expect(pairs).toEqual(snapshot);
+    results.forEach((result) => {
+      expect(result).not.toBe(pairs);
+      result.forEach((pair) => expect(pairs).not.toContain(pair));
+    });
   });
 });

--- a/client/dive-common/typeHierarchy.ts
+++ b/client/dive-common/typeHierarchy.ts
@@ -224,6 +224,20 @@ function ancestorsOf(index: TypeHierarchyIndex, type: string): readonly string[]
     : [];
 }
 
+function sortPairsByConfidence(
+  pairs: readonly (readonly [string, number])[],
+): [string, number][] {
+  return pairs
+    .map(([type, confidence]) => [type, confidence] as [string, number])
+    .sort((left, right) => right[1] - left[1]);
+}
+
+function inLineage(index: TypeHierarchyIndex, type: string, lineageType: string): boolean {
+  return type === lineageType
+    || ancestorsOf(index, lineageType).includes(type)
+    || ancestorsOf(index, type).includes(lineageType);
+}
+
 export function rewriteHierarchyType(
   hierarchy: TypeHierarchy,
   currentType: string,
@@ -262,6 +276,55 @@ export function rewriteHierarchyType(
     }
     throw error;
   }
+}
+
+// Assignment replaces the selected claim's lineage while retaining unrelated claims and the
+// stored ancestors still implied by the new type. No missing hierarchy members are synthesized.
+export function reassignPairs(
+  index: TypeHierarchyIndex,
+  pairs: readonly (readonly [string, number])[],
+  replaceType: string,
+  newType: string,
+  confidence: number,
+): [string, number][] {
+  const newAncestors = ancestorsOf(index, newType);
+  const retained = pairs.filter(([type]) => type !== newType
+    && (newAncestors.includes(type) || !inLineage(index, type, replaceType)));
+  return sortPairsByConfidence([...retained, [newType, confidence]]);
+}
+
+// Acceptance is deliberately distinct from assignment: it keeps only the accepted lineage and
+// changes only the accepted node's score. The accepted node itself is upserted, but absent
+// ancestors and descendants remain absent.
+export function acceptPairAsCorrect(
+  index: TypeHierarchyIndex,
+  pairs: readonly (readonly [string, number])[],
+  acceptedType: string,
+): [string, number][] {
+  return setPairConfidence(pairs, acceptedType, 1.0)
+    .filter(([type]) => inLineage(index, type, acceptedType));
+}
+
+// Confidence is data, not an instruction. In particular, 1.0 has no destructive behavior.
+export function setPairConfidence(
+  pairs: readonly (readonly [string, number])[],
+  type: string,
+  confidence: number,
+): [string, number][] {
+  return sortPairsByConfidence([
+    ...pairs.filter(([pairType]) => pairType !== type),
+    [type, confidence],
+  ]);
+}
+
+// Pair removal is exact; lineage, subtree, and hierarchy-node removal are separate operations.
+export function removePair(
+  pairs: readonly (readonly [string, number])[],
+  type: string,
+): [string, number][] {
+  return pairs
+    .filter(([pairType]) => pairType !== type)
+    .map(([pairType, confidence]) => [pairType, confidence]);
 }
 
 export function selectPairIndex(

--- a/client/dive-common/use/useModeManager.spec.ts
+++ b/client/dive-common/use/useModeManager.spec.ts
@@ -60,6 +60,9 @@ function makeHarness() {
     lookupGroups: cameraStore.lookupGroups.bind(cameraStore),
     getTrack: (id: AnnotationId, camera = 'singleCam') => cameraStore.getTrack(id, camera),
     getTracks: (id: AnnotationId) => cameraStore.getTrackAll(id),
+    renameTrackPair: (id, currentType, newType) => (
+      cameraStore.renameTrackPair(id, currentType, newType)
+    ),
     groupFilterControls,
     setType: () => undefined,
     removeTypes: () => [],
@@ -197,6 +200,9 @@ function makeSingleCamHarness() {
     lookupGroups: cameraStore.lookupGroups.bind(cameraStore),
     getTrack: (id: AnnotationId, camera = 'singleCam') => cameraStore.getTrack(id, camera),
     getTracks: (id: AnnotationId) => cameraStore.getTrackAll(id),
+    renameTrackPair: (id, currentType, newType) => (
+      cameraStore.renameTrackPair(id, currentType, newType)
+    ),
     groupFilterControls,
     setType: () => undefined,
     removeTypes: () => [],

--- a/client/dive-common/use/useSaveClassification.spec.ts
+++ b/client/dive-common/use/useSaveClassification.spec.ts
@@ -1,0 +1,115 @@
+/// <reference types="vitest" />
+import { ref } from 'vue';
+
+import CameraStore from 'vue-media-annotator/CameraStore';
+import Track, { Feature, TrackData } from 'vue-media-annotator/track';
+
+import useSave from './useSave';
+
+const apiMocks = vi.hoisted(() => ({
+  saveConfig: vi.fn(),
+  saveDetections: vi.fn(),
+  saveAttributes: vi.fn(),
+  saveAttributeTrackFilters: vi.fn(),
+}));
+
+vi.mock('dive-common/apispec', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('dive-common/apispec')>();
+  return {
+    ...actual,
+    useApi: () => apiMocks,
+  };
+});
+
+const TRACK_ID = 7;
+
+function features(): Feature[] {
+  return [{
+    frame: 0,
+    keyframe: true,
+    bounds: [0, 0, 1, 1],
+  }];
+}
+
+function makeTrack(confidencePairs: [string, number][]) {
+  return new Track(TRACK_ID, {
+    confidencePairs,
+    features: features(),
+  });
+}
+
+function savedTrack(call: unknown[]): TrackData {
+  const payload = call[1] as {
+    tracks: { upsert: TrackData[] };
+  };
+  return payload.tracks.upsert[0];
+}
+
+describe('classification save and reload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMocks.saveConfig.mockResolvedValue(undefined);
+    apiMocks.saveDetections.mockResolvedValue(undefined);
+    apiMocks.saveAttributes.mockResolvedValue(undefined);
+    apiMocks.saveAttributeTrackFilters.mockResolvedValue(undefined);
+  });
+
+  it('persists an ordinary 1.0 confidence edit for a single camera', async () => {
+    const saveControls = useSave(ref('single-dataset'), ref(false));
+    const cameraStore = new CameraStore({
+      markChangesPending: saveControls.markChangesPending,
+    });
+    cameraStore.camMap.value.get('singleCam')?.trackStore.insert(makeTrack([
+      ['fish', 0.8],
+      ['shark', 0.2],
+    ]), { imported: true });
+
+    cameraStore.setTrackPairConfidence(TRACK_ID, 'shark', 1.0);
+    await saveControls.save();
+
+    expect(apiMocks.saveDetections).toHaveBeenCalledTimes(1);
+    expect(apiMocks.saveDetections.mock.calls[0][0]).toBe('single-dataset');
+    const serialized = savedTrack(apiMocks.saveDetections.mock.calls[0]);
+    const reloaded = Track.fromJSON(serialized);
+    expect(reloaded.confidencePairs).toEqual([
+      ['shark', 1.0],
+      ['fish', 0.8],
+    ]);
+  });
+
+  it('persists synchronized independent vectors for every camera', async () => {
+    const saveControls = useSave(ref('multicam-dataset'), ref(false));
+    saveControls.removeCamera('singleCam');
+    saveControls.addCamera('left');
+    saveControls.addCamera('right');
+    const cameraStore = new CameraStore({
+      markChangesPending: saveControls.markChangesPending,
+    });
+    cameraStore.removeCamera('singleCam');
+    cameraStore.addCamera('left');
+    cameraStore.addCamera('right');
+    cameraStore.camMap.value.get('left')?.trackStore.insert(makeTrack([
+      ['fish', 0.8],
+      ['shark', 0.2],
+    ]), { imported: true });
+    cameraStore.camMap.value.get('right')?.trackStore.insert(makeTrack([
+      ['rock', 0.9],
+      ['fish', 0.1],
+    ]), { imported: true });
+
+    cameraStore.acceptTrackType(TRACK_ID, 'fish');
+    await saveControls.save();
+
+    expect(apiMocks.saveDetections.mock.calls.map(([datasetId]) => datasetId))
+      .toEqual(['multicam-dataset/left', 'multicam-dataset/right']);
+    const [leftData, rightData] = apiMocks.saveDetections.mock.calls.map(savedTrack);
+    const leftReloaded = Track.fromJSON(leftData);
+    const rightReloaded = Track.fromJSON(rightData);
+    expect(leftReloaded.confidencePairs).toEqual([['fish', 1.0]]);
+    expect(rightReloaded.confidencePairs).toEqual(leftReloaded.confidencePairs);
+    expect(rightReloaded.confidencePairs).not.toBe(leftReloaded.confidencePairs);
+    rightReloaded.confidencePairs.forEach((pair) => (
+      expect(leftReloaded.confidencePairs).not.toContain(pair)
+    ));
+  });
+});

--- a/client/src/BaseAnnotation.ts
+++ b/client/src/BaseAnnotation.ts
@@ -140,6 +140,12 @@ export default abstract class BaseAnnotation {
     return this.confidencePairs;
   }
 
+  setConfidencePairs(pairs: readonly (readonly [string, number])[]) {
+    const old = this.confidencePairs;
+    this.confidencePairs = pairs.map(([type, confidence]) => [type, confidence]);
+    this.notify('confidencePairs', old);
+  }
+
   setType(annotationType: string, confidenceVal = 1, replace: string | undefined = undefined) {
     const old = this.confidencePairs;
     if (confidenceVal >= 1) {

--- a/client/src/CameraStore.spec.ts
+++ b/client/src/CameraStore.spec.ts
@@ -1,0 +1,138 @@
+/// <reference types="vitest" />
+import { compileHierarchy } from 'dive-common/typeHierarchy';
+import CameraStore from './CameraStore';
+import Track, { Feature } from './track';
+
+const HIERARCHY_INDEX = compileHierarchy({
+  'great white shark': 'shark',
+  shark: 'fish',
+  tern: 'bird',
+});
+
+const TRACK_ID = 7;
+
+function features(): Feature[] {
+  return [{
+    frame: 0,
+    keyframe: true,
+    bounds: [0, 0, 1, 1],
+  }];
+}
+
+function confidencePairs(value: [string, number][]): [string, number][] {
+  return value.map(([type, confidence]) => [type, confidence]);
+}
+
+function makeTwoCameraStore() {
+  const markChangesPending = vi.fn();
+  const store = new CameraStore({ markChangesPending });
+  store.removeCamera('singleCam');
+  store.addCamera('left');
+  store.addCamera('right');
+
+  const left = new Track(TRACK_ID, {
+    confidencePairs: confidencePairs([
+      ['fish', 0.9],
+      ['shark', 0.7],
+      ['great white shark', 0.4],
+      ['bird', 0.2],
+    ]),
+    features: features(),
+  });
+  const right = new Track(TRACK_ID, {
+    confidencePairs: confidencePairs([
+      ['rock', 0.95],
+      ['shark', 0.1],
+    ]),
+    features: features(),
+  });
+  store.camMap.value.get('left')?.trackStore.insert(left, { imported: true });
+  store.camMap.value.get('right')?.trackStore.insert(right, { imported: true });
+  markChangesPending.mockClear();
+  return {
+    store, left, right, markChangesPending,
+  };
+}
+
+function expectSynchronizedWrite(
+  fixture: ReturnType<typeof makeTwoCameraStore>,
+  result: [string, number][],
+  expected: [string, number][],
+) {
+  const {
+    left, right, markChangesPending,
+  } = fixture;
+  expect(result).toEqual(expected);
+  expect(left.confidencePairs).toEqual(expected);
+  expect(right.confidencePairs).toEqual(expected);
+  expect(left.confidencePairs).not.toBe(right.confidencePairs);
+  expect(result).not.toBe(left.confidencePairs);
+  expect(result).not.toBe(right.confidencePairs);
+  left.confidencePairs.forEach((pair) => expect(right.confidencePairs).not.toContain(pair));
+  result.forEach((pair) => expect(left.confidencePairs).not.toContain(pair));
+  expect(markChangesPending).toHaveBeenCalledTimes(2);
+  expect(markChangesPending.mock.calls.map(([change]) => change.cameraName))
+    .toEqual(['left', 'right']);
+}
+
+describe('CameraStore classification commands', () => {
+  it('calculates assignment once from the first camera and synchronizes independent copies', () => {
+    const fixture = makeTwoCameraStore();
+    const result = fixture.store.assignTrackType(TRACK_ID, 'great white shark', {
+      hierarchyIndex: HIERARCHY_INDEX,
+      replaceType: 'shark',
+      confidence: 0.7,
+    });
+
+    expectSynchronizedWrite(fixture, result, [
+      ['fish', 0.9],
+      ['shark', 0.7],
+      ['great white shark', 0.7],
+      ['bird', 0.2],
+    ]);
+  });
+
+  it('accepts a hierarchy node without changing stored relative scores', () => {
+    const fixture = makeTwoCameraStore();
+    const result = fixture.store.acceptTrackType(TRACK_ID, 'shark', HIERARCHY_INDEX);
+
+    expectSynchronizedWrite(fixture, result, [
+      ['shark', 1.0],
+      ['fish', 0.9],
+      ['great white shark', 0.4],
+    ]);
+  });
+
+  it.each([0.99, 1.0])(
+    'treats confidence %s as a single-pair update',
+    (confidence) => {
+      const fixture = makeTwoCameraStore();
+      const result = fixture.store.setTrackPairConfidence(TRACK_ID, 'shark', confidence);
+
+      expectSynchronizedWrite(fixture, result, [
+        ['shark', confidence],
+        ['fish', 0.9],
+        ['great white shark', 0.4],
+        ['bird', 0.2],
+      ]);
+    },
+  );
+
+  it('removes exactly one type and returns the logical result', () => {
+    const fixture = makeTwoCameraStore();
+    const result = fixture.store.removeTrackPair(TRACK_ID, 'shark');
+
+    expectSynchronizedWrite(fixture, result, [
+      ['fish', 0.9],
+      ['great white shark', 0.4],
+      ['bird', 0.2],
+    ]);
+  });
+
+  it('rejects a classification command for a missing logical track', () => {
+    const fixture = makeTwoCameraStore();
+    expect(() => fixture.store.setTrackPairConfidence(99, 'fish', 1.0))
+      .toThrow('TrackId 99 not found in any camera');
+    expect(fixture.markChangesPending).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/CameraStore.spec.ts
+++ b/client/src/CameraStore.spec.ts
@@ -129,6 +129,18 @@ describe('CameraStore classification commands', () => {
     ]);
   });
 
+  it('renames one pair without applying assignment or acceptance semantics', () => {
+    const fixture = makeTwoCameraStore();
+    const result = fixture.store.renameTrackPair(TRACK_ID, 'shark', 'selachimorpha');
+
+    expectSynchronizedWrite(fixture, result, [
+      ['fish', 0.9],
+      ['selachimorpha', 0.7],
+      ['great white shark', 0.4],
+      ['bird', 0.2],
+    ]);
+  });
+
   it('rejects a classification command for a missing logical track', () => {
     const fixture = makeTwoCameraStore();
     expect(() => fixture.store.setTrackPairConfidence(99, 'fish', 1.0))

--- a/client/src/CameraStore.ts
+++ b/client/src/CameraStore.ts
@@ -2,12 +2,6 @@ import {
   Ref, computed, shallowRef, triggerRef,
 } from 'vue';
 import { cloneDeep, uniq } from 'lodash';
-import type Track from './track';
-import type Group from './Group';
-import { AnnotationId, ConfidencePair } from './BaseAnnotation';
-import { MarkChangesPending, SortedAnnotation } from './BaseAnnotationStore';
-import GroupStore from './GroupStore';
-import TrackStore from './TrackStore';
 import {
   acceptPairAsCorrect,
   compileHierarchy,
@@ -16,6 +10,12 @@ import {
   setPairConfidence,
   TypeHierarchyIndex,
 } from 'dive-common/typeHierarchy';
+import type Track from './track';
+import type Group from './Group';
+import { AnnotationId, ConfidencePair } from './BaseAnnotation';
+import { MarkChangesPending, SortedAnnotation } from './BaseAnnotationStore';
+import GroupStore from './GroupStore';
+import TrackStore from './TrackStore';
 
 const FLAT_HIERARCHY_INDEX = compileHierarchy({});
 
@@ -316,6 +316,20 @@ export default class CameraStore {
 
   removeTrackPair(id: AnnotationId, type: string): ConfidencePair[] {
     return this.updateTrackConfidencePairs(id, (pairs) => removePair(pairs, type));
+  }
+
+  renameTrackPair(
+    id: AnnotationId,
+    currentType: string,
+    newType: string,
+  ): ConfidencePair[] {
+    return this.updateTrackConfidencePairs(id, (pairs) => {
+      const current = pairs.find(([type]) => type === currentType);
+      if (!current) {
+        return pairs.map(([type, confidence]) => [type, confidence]);
+      }
+      return setPairConfidence(removePair(pairs, currentType), newType, current[1]);
+    });
   }
 
   removeTypes(id: AnnotationId, types: string[]) {

--- a/client/src/CameraStore.ts
+++ b/client/src/CameraStore.ts
@@ -8,6 +8,22 @@ import { AnnotationId, ConfidencePair } from './BaseAnnotation';
 import { MarkChangesPending, SortedAnnotation } from './BaseAnnotationStore';
 import GroupStore from './GroupStore';
 import TrackStore from './TrackStore';
+import {
+  acceptPairAsCorrect,
+  compileHierarchy,
+  reassignPairs,
+  removePair,
+  setPairConfidence,
+  TypeHierarchyIndex,
+} from 'dive-common/typeHierarchy';
+
+const FLAT_HIERARCHY_INDEX = compileHierarchy({});
+
+interface TrackAssignmentOptions {
+  hierarchyIndex?: TypeHierarchyIndex;
+  replaceType?: string;
+  confidence?: number;
+}
 
 /**
  * CameraStore is a warapper for holding and collating tracks from multiple cameras.
@@ -241,6 +257,65 @@ export default class CameraStore {
         track.setType(newType, confidenceVal, currentType);
       }
     });
+  }
+
+  private updateTrackConfidencePairs(
+    id: AnnotationId,
+    update: (pairs: readonly ConfidencePair[]) => ConfidencePair[],
+  ): ConfidencePair[] {
+    const tracks = this.getTrackAll(id);
+    if (tracks.length === 0) {
+      throw new Error(`TrackId ${id} not found in any camera`);
+    }
+    const canonicalPairs = tracks[0].confidencePairs
+      .map(([type, confidence]) => [type, confidence] as ConfidencePair);
+    const nextPairs = update(canonicalPairs);
+    tracks.forEach((track) => track.setConfidencePairs(nextPairs));
+    return nextPairs.map(([type, confidence]) => [type, confidence]);
+  }
+
+  assignTrackType(
+    id: AnnotationId,
+    newType: string,
+    {
+      hierarchyIndex = FLAT_HIERARCHY_INDEX,
+      replaceType,
+      confidence = 1,
+    }: TrackAssignmentOptions = {},
+  ): ConfidencePair[] {
+    return this.updateTrackConfidencePairs(id, (pairs) => reassignPairs(
+      hierarchyIndex,
+      pairs,
+      replaceType ?? pairs[0]?.[0] ?? newType,
+      newType,
+      confidence,
+    ));
+  }
+
+  acceptTrackType(
+    id: AnnotationId,
+    acceptedType: string,
+    hierarchyIndex: TypeHierarchyIndex = FLAT_HIERARCHY_INDEX,
+  ): ConfidencePair[] {
+    return this.updateTrackConfidencePairs(
+      id,
+      (pairs) => acceptPairAsCorrect(hierarchyIndex, pairs, acceptedType),
+    );
+  }
+
+  setTrackPairConfidence(
+    id: AnnotationId,
+    type: string,
+    confidence: number,
+  ): ConfidencePair[] {
+    return this.updateTrackConfidencePairs(
+      id,
+      (pairs) => setPairConfidence(pairs, type, confidence),
+    );
+  }
+
+  removeTrackPair(id: AnnotationId, type: string): ConfidencePair[] {
+    return this.updateTrackConfidencePairs(id, (pairs) => removePair(pairs, type));
   }
 
   removeTypes(id: AnnotationId, types: string[]) {

--- a/client/src/TrackFilterControls.spec.ts
+++ b/client/src/TrackFilterControls.spec.ts
@@ -111,6 +111,9 @@ function makeTrackFilterControls(markPending: MarkChangesPendingFilter = markCha
     lookupGroups: cameraStore.lookupGroups,
     getTrack: (track: AnnotationId, camera = 'singleCam') => (cameraStore.getTrack(track, camera)),
     getTracks: (track: AnnotationId) => cameraStore.getTrackAll(track),
+    renameTrackPair: (id, currentType, newType) => (
+      cameraStore.renameTrackPair(id, currentType, newType)
+    ),
     setType: setTrackType,
     removeTypes,
   });
@@ -135,6 +138,9 @@ function makePairFixture(
     lookupGroups: cameraStore.lookupGroups,
     getTrack: (id, camera = 'singleCam') => cameraStore.getTrack(id, camera),
     getTracks: (id) => cameraStore.getTrackAll(id),
+    renameTrackPair: (id, currentType, newType) => (
+      cameraStore.renameTrackPair(id, currentType, newType)
+    ),
     setType: (id, type, confidence, current) => (
       cameraStore.setTrackType(id, type, confidence, current)
     ),
@@ -555,6 +561,16 @@ describe('useAnnotationFilters', () => {
     expect(groupFilters.configuredTypes.value).not.toContain('renamed group');
   });
 
+  it('renames a flat confidence-1 pair without collapsing the vector', () => {
+    const { cameraStore, filters } = makePairFixture([
+      [['leaf', 1], ['other', 0.4]],
+    ]);
+    filters.updateTypeName({ currentType: 'leaf', newType: 'fin' });
+    expect(cameraStore.getTrack(0).confidencePairs).toEqual([
+      ['fin', 1], ['other', 0.4],
+    ]);
+  });
+
   it('rewrites hierarchy, annotations, configured types, filters, and checks on rename', () => {
     const markPending = vi.fn();
     const { cameraStore, filters } = makePairFixture([[['leaf', 0.8], ['root', 0.7]]], markPending);
@@ -591,7 +607,7 @@ describe('useAnnotationFilters', () => {
     ]);
   });
 
-  it('preserves each camera confidence vector while renaming exact occurrences', () => {
+  it('renames from the canonical vector and synchronizes every camera', () => {
     const { cameraStore, filters } = makePairFixture([
       [['leaf', 1], ['root', 0.8]],
     ]);
@@ -606,8 +622,10 @@ describe('useAnnotationFilters', () => {
       ['fin', 1], ['root', 0.8],
     ]);
     expect(cameraStore.getTrack(0, 'right').confidencePairs).toEqual([
-      ['other', 0.6], ['fin', 0.4],
+      ['fin', 1], ['root', 0.8],
     ]);
+    expect(cameraStore.getTrack(0, 'singleCam').confidencePairs)
+      .not.toBe(cameraStore.getTrack(0, 'right').confidencePairs);
   });
 
   it('rejects invalid hierarchy renames before any mutation or pending event', () => {

--- a/client/src/TrackFilterControls.ts
+++ b/client/src/TrackFilterControls.ts
@@ -25,6 +25,11 @@ interface TrackFilterControlsParams extends FilterControlsParams<Track> {
   getTrack: (annotationId: AnnotationId, camera?: string) => Track;
   groupFilterControls: BaseFilterControls<Group>;
   getTracks: (annotationId: AnnotationId) => Track[];
+  renameTrackPair: (
+    annotationId: AnnotationId,
+    currentType: string,
+    newType: string,
+  ) => [string, number][];
 }
 
 export default class TrackFilterControls extends BaseFilterControls<Track> {
@@ -54,10 +59,13 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
 
   private getTracks: (annotationId: AnnotationId) => Track[];
 
+  private renameTrackPair: TrackFilterControlsParams['renameTrackPair'];
+
   constructor(params: TrackFilterControlsParams) {
     super(params);
 
     this.getTracks = params.getTracks;
+    this.renameTrackPair = params.renameTrackPair;
 
     const flatAllTypes = this.allTypes;
     this.typeHierarchy = ref(undefined);
@@ -250,17 +258,20 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
 
   updateTypeName({ currentType, newType }: { currentType: string; newType: string }) {
     if (!this.hierarchyActive.value) {
-      super.updateTypeName({ currentType, newType });
-      // The base pass walks the merged view, whose confidence vector can hide a type that an
-      // individual camera still carries. Rename those per-camera tracks too.
       this.sorted.value.forEach((annotation) => {
-        this.getTracks(annotation.id).forEach((track) => {
-          const pair = track.confidencePairs.find(([name]) => name === currentType);
-          if (pair) {
-            track.setType(newType, pair[1], currentType);
-          }
-        });
+        if (this.getTracks(annotation.id)
+          .some((track) => track.confidencePairs.some(([name]) => name === currentType))) {
+          this.renameTrackPair(annotation.id, currentType, newType);
+        }
       });
+      if (!(newType in this.confidenceFilters.value)
+        && currentType in this.confidenceFilters.value) {
+        this.setConfidenceFilters({
+          ...this.confidenceFilters.value,
+          [newType]: this.confidenceFilters.value[currentType],
+        });
+      }
+      this.deleteType(currentType);
       return;
     }
     const tracks = this.sorted.value.flatMap((annotation) => this.getTracks(annotation.id));
@@ -282,24 +293,9 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
     const newWasChecked = this.checkedTypes.value.includes(newType);
 
     this.sorted.value.forEach((annotation) => {
-      const storedTracks = this.getTracks(annotation.id);
-      const rewrittenPairs = storedTracks.map((track) => track.confidencePairs.map(
-        ([name, confidence]) => [
-          name === currentType ? newType : name,
-          confidence,
-        ] as [string, number],
-      ));
-      const triggerPair = storedTracks
-        .flatMap((track) => track.confidencePairs)
-        .find(([name]) => name === currentType);
-      if (triggerPair) {
-        this.setType(annotation.id, newType, triggerPair[1], currentType);
-        storedTracks.forEach((track, index) => {
-          // setType emits the existing annotation notification. Restore the exact
-          // preflighted vector because its confidence-1 branch intentionally collapses pairs.
-          // eslint-disable-next-line no-param-reassign
-          track.confidencePairs = rewrittenPairs[index];
-        });
+      if (this.getTracks(annotation.id)
+        .some((track) => track.confidencePairs.some(([name]) => name === currentType))) {
+        this.renameTrackPair(annotation.id, currentType, newType);
       }
     });
     if (!(newType in this.confidenceFilters.value)

--- a/client/src/components/LayerManager.spec.ts
+++ b/client/src/components/LayerManager.spec.ts
@@ -263,6 +263,9 @@ function makeMultiCamFixture(
     lookupGroups: cameraStore.lookupGroups.bind(cameraStore),
     getTrack: (id: AnnotationId, camera = 'left') => cameraStore.getTrack(id, camera),
     getTracks: (id: AnnotationId) => cameraStore.getTrackAll(id),
+    renameTrackPair: (id, currentType, newType) => (
+      cameraStore.renameTrackPair(id, currentType, newType)
+    ),
     groupFilterControls,
     setType: () => undefined,
     removeTypes: () => [],

--- a/client/src/components/Tracks/bottombar/BottomBarTrackItemView.spec.ts
+++ b/client/src/components/Tracks/bottombar/BottomBarTrackItemView.spec.ts
@@ -5,13 +5,22 @@ import { shallowMount } from '@vue/test-utils';
 import Track from '../../../track';
 import BottomBarTrackItemView from './BottomBarTrackItemView.vue';
 
-const providerState = vi.hoisted(() => ({ setTrackType: vi.fn() }));
+const providerState = vi.hoisted(() => ({
+  assignTrackType: vi.fn(),
+  setTrackPairConfidence: vi.fn(),
+}));
 
 vi.mock('../../../provides', () => ({
   useHandler: () => ({ trackSeek: vi.fn(), removeTrack: vi.fn(), trackEdit: vi.fn() }),
   useReadOnlyMode: () => ref(false),
-  useTrackFilters: () => ({ allTypes: ref(['root', 'leaf']) }),
-  useCameraStore: () => ({ setTrackType: providerState.setTrackType }),
+  useTrackFilters: () => ({
+    allTypes: ref(['root', 'leaf']),
+    hierarchyIndex: ref(undefined),
+  }),
+  useCameraStore: () => ({
+    assignTrackType: providerState.assignTrackType,
+    setTrackPairConfidence: providerState.setTrackPairConfidence,
+  }),
 }));
 
 function mountItem(displayPairIndex: number) {
@@ -53,6 +62,11 @@ function mountItem(displayPairIndex: number) {
 }
 
 describe('BottomBarTrackItemView hierarchy display', () => {
+  beforeEach(() => {
+    providerState.assignTrackType.mockClear();
+    providerState.setTrackPairConfidence.mockClear();
+  });
+
   it('renders and seeds editing from the selected hierarchy pair', () => {
     const { wrapper, vm } = mountItem(1);
     expect(wrapper.find('.track-type-compact').text()).toBe('leaf');
@@ -65,5 +79,26 @@ describe('BottomBarTrackItemView hierarchy display', () => {
     const { wrapper } = mountItem(0);
     expect(wrapper.find('.track-type-compact').text()).toBe('root');
     expect(wrapper.find('.track-confidence-compact').text()).toBe('0.90');
+  });
+
+  it('routes type assignment through the logical-track command', () => {
+    const { vm, props } = mountItem(1);
+    vm.setEditTypeValue('new leaf');
+    vm.saveType();
+
+    expect(providerState.assignTrackType).toHaveBeenCalledWith(1, 'new leaf', {
+      hierarchyIndex: undefined,
+      replaceType: 'leaf',
+      confidence: 0.7,
+    });
+    expect(props.track.confidencePairs).toEqual([['root', 0.9], ['leaf', 0.7]]);
+  });
+
+  it.each(['0.99', '1.00'])('routes confidence %s as a pair update', (value) => {
+    const { vm } = mountItem(1);
+    vm.setEditConfidenceValue(value);
+    vm.saveConfidence();
+
+    expect(providerState.setTrackPairConfidence).toHaveBeenCalledWith(1, 'leaf', Number(value));
   });
 });

--- a/client/src/components/Tracks/bottombar/BottomBarTrackItemView.vue
+++ b/client/src/components/Tracks/bottombar/BottomBarTrackItemView.vue
@@ -34,7 +34,8 @@ export default defineComponent({
   setup(props) {
     const handler = useHandler();
     const readOnlyMode = useReadOnlyMode();
-    const { allTypes } = useTrackFilters();
+    const trackFilters = useTrackFilters();
+    const { allTypes } = trackFilters;
     const cameraStore = useCameraStore();
 
     const editingType = ref(false);
@@ -149,7 +150,11 @@ export default defineComponent({
     function saveType() {
       if (editTypeValue.value.trim() && editTypeValue.value !== props.trackType) {
         const confidence = topConfidence.value !== null ? topConfidence.value : 1;
-        props.track.setType(editTypeValue.value.trim(), confidence, props.trackType);
+        cameraStore.assignTrackType(props.track.id, editTypeValue.value.trim(), {
+          hierarchyIndex: trackFilters.hierarchyIndex.value,
+          replaceType: props.trackType,
+          confidence,
+        });
       }
       editingType.value = false;
     }
@@ -172,7 +177,7 @@ export default defineComponent({
     function saveConfidence() {
       const val = parseFloat(editConfidenceValue.value);
       if (!Number.isNaN(val) && val >= 0 && val <= 1) {
-        cameraStore.setTrackType(props.track.id, props.trackType, val);
+        cameraStore.setTrackPairConfidence(props.track.id, props.trackType, val);
       }
       editingConfidence.value = false;
     }

--- a/client/src/components/Tracks/sidebar/SideBarTrackItemView.spec.ts
+++ b/client/src/components/Tracks/sidebar/SideBarTrackItemView.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+/// <reference types="vitest" />
+import { defineComponent, h, ref } from 'vue';
+import { shallowMount } from '@vue/test-utils';
+import Track from '../../../track';
+import SideBarTrackItemView from './SideBarTrackItemView.vue';
+
+const state = vi.hoisted(() => ({ assignTrackType: vi.fn() }));
+
+vi.mock('../../../provides', () => ({
+  useHandler: () => ({ trackSeek: vi.fn(), removeTrack: vi.fn() }),
+  useReadOnlyMode: () => ref(false),
+  useTrackFilters: () => ({
+    allTypes: ref(['root', 'leaf']),
+    hierarchyIndex: ref(undefined),
+    updateCheckedId: vi.fn(),
+  }),
+  useCameraStore: () => ({
+    camMap: ref(new Map([['singleCam', {}]])),
+    assignTrackType: state.assignTrackType,
+  }),
+  useTrackStyleManager: () => ({ typeStyling: ref({}) }),
+}));
+
+/**
+ * `@vue/test-utils` types a mount target as a Vue 2 constructor, which a `defineComponent`
+ * SFC is not, so the row is rendered from a host that captures the real instance. It is left
+ * unstubbed to keep shallow semantics for its own children.
+ */
+function mountRow(props: Record<string, unknown>) {
+  let child: InstanceType<typeof SideBarTrackItemView> | undefined;
+  const Host = defineComponent({
+    setup: () => () => h(SideBarTrackItemView, {
+      props,
+      ref: (instance) => {
+        if (instance && !(instance instanceof Element)) {
+          child = instance as InstanceType<typeof SideBarTrackItemView>;
+        }
+      },
+    }),
+  });
+  const wrapper = shallowMount(Host, { stubs: { SideBarTrackItemView: false } });
+  if (!child) {
+    throw new Error('SideBarTrackItemView did not mount');
+  }
+  return { wrapper, vm: child };
+}
+
+describe('SideBarTrackItemView classification editing', () => {
+  beforeEach(() => state.assignTrackType.mockClear());
+
+  it('routes assignment through the logical-track command', () => {
+    const track = new Track(1, {
+      confidencePairs: [['root', 0.9], ['leaf', 0.7]],
+      features: [{ frame: 0, bounds: [0, 0, 1, 1], keyframe: true }],
+    });
+    const { vm } = mountRow({
+      selected: true,
+      trackType: 'leaf',
+      itemStyle: {},
+      color: '#fff',
+      track,
+      inputValue: true,
+      isTrack: true,
+      feature: {},
+      keyframeDisabled: false,
+      frame: 0,
+      toggleKeyframe: vi.fn(),
+      clickToggleInterpolation: vi.fn(),
+      toggleInterpolation: vi.fn(),
+      toggleAllInterpolation: vi.fn(),
+      gotoPrevious: vi.fn(),
+      gotoNext: vi.fn(),
+      editing: false,
+    });
+    vm.setTrackType('new leaf');
+
+    expect(state.assignTrackType).toHaveBeenCalledWith(1, 'new leaf', {
+      hierarchyIndex: undefined,
+      replaceType: 'leaf',
+    });
+  });
+});

--- a/client/src/components/Tracks/sidebar/SideBarTrackItemView.vue
+++ b/client/src/components/Tracks/sidebar/SideBarTrackItemView.vue
@@ -70,7 +70,10 @@ export default defineComponent({
     ));
 
     function setTrackType(type: string) {
-      cameraStore.setTrackType(props.track.id, type);
+      cameraStore.assignTrackType(props.track.id, type, {
+        hierarchyIndex: trackFilters.hierarchyIndex.value,
+        replaceType: props.trackType,
+      });
     }
 
     function openMultiCamTools() {

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -370,6 +370,9 @@ function dummyState(): State {
     lookupGroups: cameraStore.lookupGroups,
     getTrack: (track: AnnotationId, camera = 'singleCam') => (cameraStore.getTrack(track, camera)),
     getTracks: (track: AnnotationId) => cameraStore.getTrackAll(track),
+    renameTrackPair: (id, currentType, newType) => (
+      cameraStore.renameTrackPair(id, currentType, newType)
+    ),
     setType: setTrackType,
     removeTypes,
 

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -24,7 +24,9 @@ When a dataset has a type hierarchy, DIVE displays the deepest checked type whos
 
 Track attribute filters are an exception: they match a track's raw top confidence pair, not the hierarchy-selected pair.
 
-Assigning a type to a track is not hierarchy-aware: setting a type that is not a descendant of the track's retained pairs keeps the ancestor pairs, and the display re-selects among the qualifying pairs, which may not be the newly assigned type.
+Assigning a type to a track is hierarchy-aware. A type together with its ancestors and descendants is one classification claim, so assigning over any pair in that lineage replaces the whole chain rather than leaving a relative behind for the display to select instead. Stored ancestors of the newly assigned type survive because the assignment still implies them, and pairs on unrelated branches are untouched.
+
+**Accept as correct** is a separate command: it sets the accepted pair to `1.0`, keeps stored ancestors and descendants at their existing scores, and removes unrelated pairs. Editing a confidence value to `1.0` does not accept the type or remove any other pair.
 
 Hierarchy members remain ordinary flat Type List rows. A parent with no annotations or explicit style configuration is visible when **Show Empty** is enabled. The Type List does not render a tree or offer subtree controls or hierarchy editing.
 

--- a/testutils/typeHierarchy.spec.json
+++ b/testutils/typeHierarchy.spec.json
@@ -444,5 +444,191 @@
       "passes": [false, true],
       "expectedIndex": 1
     }
+  ],
+  "reassignmentCases": [
+    {
+      "name": "unrelated type replaces the whole lineage",
+      "hierarchy": { "great white shark": "shark", "shark": "fish" },
+      "pairs": [["fish", 0.9], ["shark", 0.7], ["great white shark", 0.4], ["bird", 0.2]],
+      "replaceType": "shark",
+      "newType": "tuna",
+      "confidence": 0.7,
+      "expected": [["tuna", 0.7], ["bird", 0.2]]
+    },
+    {
+      "name": "descendant assignment keeps stored ancestors",
+      "hierarchy": { "great white shark": "shark", "shark": "fish" },
+      "pairs": [["fish", 0.9], ["shark", 0.7], ["great white shark", 0.4]],
+      "replaceType": "shark",
+      "newType": "great white shark",
+      "confidence": 0.7,
+      "expected": [["fish", 0.9], ["shark", 0.7], ["great white shark", 0.7]]
+    },
+    {
+      "name": "ancestor assignment drops deeper claims",
+      "hierarchy": { "great white shark": "shark", "shark": "fish" },
+      "pairs": [["fish", 0.9], ["shark", 0.7], ["great white shark", 0.4]],
+      "replaceType": "shark",
+      "newType": "fish",
+      "confidence": 0.7,
+      "expected": [["fish", 0.7]]
+    },
+    {
+      "name": "other branches survive in-branch assignment",
+      "hierarchy": { "cod": "fish", "shark": "fish", "tern": "bird" },
+      "pairs": [["cod", 0.8], ["shark", 0.6], ["tern", 0.3]],
+      "replaceType": "cod",
+      "newType": "shark",
+      "confidence": 0.8,
+      "expected": [["shark", 0.8], ["tern", 0.3]]
+    },
+    {
+      "name": "flat assignment replaces only the named pair",
+      "hierarchy": {},
+      "pairs": [["cod", 0.8], ["bird", 0.3]],
+      "replaceType": "cod",
+      "newType": "tuna",
+      "confidence": 0.8,
+      "expected": [["tuna", 0.8], ["bird", 0.3]]
+    },
+    {
+      "name": "absent replacement adds the new pair",
+      "hierarchy": { "great white shark": "shark", "shark": "fish" },
+      "pairs": [["bird", 0.5]],
+      "replaceType": "shark",
+      "newType": "tuna",
+      "confidence": 0.5,
+      "expected": [["bird", 0.5], ["tuna", 0.5]]
+    },
+    {
+      "name": "assignment confidence one retains unrelated claims",
+      "hierarchy": { "cod": "fish", "tern": "bird" },
+      "pairs": [["cod", 0.8], ["fish", 0.7], ["tern", 0.6]],
+      "replaceType": "cod",
+      "newType": "tuna",
+      "confidence": 1.0,
+      "expected": [["tuna", 1.0], ["tern", 0.6]]
+    }
+  ],
+  "acceptanceCases": [
+    {
+      "name": "accept leaf keeps stored ancestors",
+      "hierarchy": { "juvenile cod": "cod", "cod": "fish", "tern": "bird" },
+      "pairs": [["cod", 0.9], ["fish", 0.8], ["juvenile cod", 0.7], ["tern", 0.6]],
+      "acceptedType": "juvenile cod",
+      "expected": [["juvenile cod", 1.0], ["cod", 0.9], ["fish", 0.8]]
+    },
+    {
+      "name": "accept intermediate keeps ancestors and descendants",
+      "hierarchy": { "juvenile cod": "cod", "cod": "fish", "tern": "bird" },
+      "pairs": [["tern", 0.95], ["fish", 0.9], ["cod", 0.8], ["juvenile cod", 0.7]],
+      "acceptedType": "cod",
+      "expected": [["cod", 1.0], ["fish", 0.9], ["juvenile cod", 0.7]]
+    },
+    {
+      "name": "accept root keeps independently scored descendants",
+      "hierarchy": { "cod": "fish", "tuna": "fish", "tern": "bird" },
+      "pairs": [["tern", 0.95], ["cod", 0.9], ["tuna", 0.8], ["fish", 0.6]],
+      "acceptedType": "fish",
+      "expected": [["fish", 1.0], ["cod", 0.9], ["tuna", 0.8]]
+    },
+    {
+      "name": "accept does not synthesize missing ancestors",
+      "hierarchy": { "juvenile cod": "cod", "cod": "fish" },
+      "pairs": [["cod", 0.7], ["juvenile cod", 0.6], ["bird", 0.5]],
+      "acceptedType": "cod",
+      "expected": [["cod", 1.0], ["juvenile cod", 0.6]]
+    },
+    {
+      "name": "accept upserts an absent accepted node without ancestors",
+      "hierarchy": { "juvenile cod": "cod", "cod": "fish" },
+      "pairs": [["fish", 0.8], ["juvenile cod", 0.7], ["bird", 0.6]],
+      "acceptedType": "cod",
+      "expected": [["cod", 1.0], ["fish", 0.8], ["juvenile cod", 0.7]]
+    },
+    {
+      "name": "accept preserves non-monotone lineage scores",
+      "hierarchy": { "juvenile cod": "cod", "cod": "fish" },
+      "pairs": [["juvenile cod", 0.95], ["fish", 0.9], ["cod", 0.2]],
+      "acceptedType": "cod",
+      "expected": [["cod", 1.0], ["juvenile cod", 0.95], ["fish", 0.9]]
+    },
+    {
+      "name": "flat acceptance keeps only the accepted pair",
+      "hierarchy": {},
+      "pairs": [["cod", 0.8], ["bird", 0.7]],
+      "acceptedType": "cod",
+      "expected": [["cod", 1.0]]
+    }
+  ],
+  "pairConfidenceCases": [
+    {
+      "name": "confidence below one updates only one pair",
+      "pairs": [["cod", 0.8], ["fish", 0.7]],
+      "type": "cod",
+      "confidence": 0.99,
+      "expected": [["cod", 0.99], ["fish", 0.7]]
+    },
+    {
+      "name": "confidence one updates only one pair",
+      "pairs": [["cod", 0.8], ["fish", 0.7]],
+      "type": "cod",
+      "confidence": 1.0,
+      "expected": [["cod", 1.0], ["fish", 0.7]]
+    },
+    {
+      "name": "confidence upsert inserts a missing pair",
+      "pairs": [["fish", 0.7]],
+      "type": "cod",
+      "confidence": 0.8,
+      "expected": [["cod", 0.8], ["fish", 0.7]]
+    },
+    {
+      "name": "confidence update reorders by score",
+      "pairs": [["cod", 0.8], ["fish", 0.7]],
+      "type": "cod",
+      "confidence": 0.6,
+      "expected": [["fish", 0.7], ["cod", 0.6]]
+    },
+    {
+      "name": "equal confidence retains existing pair order before upsert",
+      "pairs": [["bird", 0.8], ["fish", 0.8]],
+      "type": "cod",
+      "confidence": 0.8,
+      "expected": [["bird", 0.8], ["fish", 0.8], ["cod", 0.8]]
+    },
+    {
+      "name": "confidence upsert coalesces duplicate names",
+      "pairs": [["cod", 0.8], ["fish", 0.7], ["cod", 0.6]],
+      "type": "cod",
+      "confidence": 0.5,
+      "expected": [["fish", 0.7], ["cod", 0.5]]
+    }
+  ],
+  "pairRemovalCases": [
+    {
+      "name": "exact removal leaves relatives and unrelated pairs",
+      "pairs": [["juvenile cod", 0.9], ["cod", 0.8], ["fish", 0.7], ["bird", 0.6]],
+      "type": "cod",
+      "expected": [["juvenile cod", 0.9], ["fish", 0.7], ["bird", 0.6]]
+    },
+    {
+      "name": "absent removal leaves values unchanged",
+      "pairs": [["cod", 0.8], ["fish", 0.7]],
+      "type": "bird",
+      "expected": [["cod", 0.8], ["fish", 0.7]]
+    },
+    {
+      "name": "removal deletes every duplicate exact pair",
+      "pairs": [["cod", 0.8], ["fish", 0.7], ["cod", 0.6]],
+      "type": "cod",
+      "expected": [["fish", 0.7]]
+    },
+    {
+      "name": "removing the only pair returns empty",
+      "pairs": [["cod", 1.0]],
+      "type": "cod",
+      "expected": []
+    }
   ]
 }


### PR DESCRIPTION
# Centralize hierarchical classification changes

PR 1 lets several user actions change classifications through existing model methods. In a
multicamera dataset, those methods can change only one camera or a temporary merged track.

This PR adds commands for one logical track. A command calculates one canonical confidence vector.
It then installs independent copies on all linked camera tracks.

### Changes

- Add pure operations for reassignment, acceptance, confidence changes, and pair removal.
- Add `CameraStore` commands for all linked camera tracks.
- Use the first configured camera as the canonical source.
- Notify each changed camera one time.
- Route the sidebar, bottom bar, Track Details, confidence editor, and rename actions through the
  new commands.
- Preserve the commands after save and reload.

### Behavior

- Reassignment replaces one hierarchy lineage and keeps unrelated alternatives.
- **Accept as correct** sets the selected pair to `1.0`. It keeps related pairs and removes
  unrelated pairs.
- A normal confidence edit to `1.0` does not accept the pair as correct.
- Pair removal removes only the selected pair.
- PR 4 handles deletion of a logical track when its last pair is removed.

### Manual tests

Test data: download and extract
[classification.zip](https://github.com/user-attachments/files/31053807/classification.zip). Paths
below are relative to `dive-classification-test-data/`.

#### Single-camera classification commands

1. Create the dataset from
   `dive-classification-test-data/classification/single-camera-linked-types/`.
2. In separate save-and-reload cycles, reassign a leaf, accept a parent, change a confidence to
   `1.0` without accepting it, and remove one pair.

Verify: Reassignment changes one lineage, acceptance removes only unrelated pairs, a normal `1.0`
edit keeps unrelated pairs, and pair removal removes only the selected pair.

#### Multicamera classification synchronization

1. Create the dataset from
   `dive-classification-test-data/classification/multicamera-linked-types/`.
2. Reassign, accept, change confidence, and remove a pair; save and switch cameras after each
   action.

Verify: Both camera tracks contain equal confidence vectors after each action.

### Stack

This is PR 5 of 9. [Previous: add hierarchical track classification](https://github.com/Kitware/dive/pull/1847).
[Next: add read-only track projections](https://github.com/Kitware/dive/pull/1849).

1. [Allow devDependency imports in TypeScript spec files](https://github.com/Kitware/dive/pull/1844)
2. [Preserve warnings from every Desktop import file](https://github.com/Kitware/dive/pull/1845)
3. [Copy source metadata when creating a single-camera soft clone](https://github.com/Kitware/dive/pull/1846)
4. [Add hierarchical track classification](https://github.com/Kitware/dive/pull/1847)
5. **Current — Centralize hierarchical classification changes**
6. [Replace mutable merged tracks with read-only projections](https://github.com/Kitware/dive/pull/1849)
7. [Make track lifecycle operations classification-safe](https://github.com/Kitware/dive/pull/1850)
8. [Add lossless DIVE KWCOCO classification support](https://github.com/Kitware/dive/pull/1851)
9. [Define raw and resolved classification boundaries](https://github.com/Kitware/dive/pull/1852)

This PR is stacked on `hierarchical-classification-pr1`.

Overall: 22 files, +1,036/-50. Commits: `b1774226` through `1d2597d6`.
