### PR TITLE
Point GPU worker python symlink at 3.12

### DIFF
--- a/docker/girder_worker_gpu.Dockerfile
+++ b/docker/girder_worker_gpu.Dockerfile
@@ -30,8 +30,8 @@ RUN chmod +x /tini
 
 
 
-# VIAME tooling expects `python` to stay on the image default (3.10).
-RUN ln -fs /usr/bin/python3.10 /usr/bin/python
+# VIAME tooling expects `python` to stay on the image default (3.12).
+RUN ln -fs /usr/bin/python3.12 /usr/bin/python
 WORKDIR /opt/dive/src
 
 # Use a globally accessible uv binary (works before/after USER switch)


### PR DESCRIPTION
- kitware/viame:gpu-algorithms-web base moved to Ubuntu 24.04 / Python 3.12; the `ln -fs` to python3.10 now creates a dangling symlink that only fails at runtime
- No other DIVE code depends on the base Python version (girder/worker images and the uv-managed 3.11 venv are independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)