### PR TITLE
Import the frame rate a COCO video records

### DIFF
--- a/client/platform/desktop/backend/serializers/coco.spec.ts
+++ b/client/platform/desktop/backend/serializers/coco.spec.ts
@@ -316,6 +316,40 @@ describe('COCO serializer', () => {
     expect(parsedMeta).not.toHaveProperty('datasetInfo');
   });
 
+  // --- annotation fps on videos[] ---
+
+  it('writes videos[].fps for video datasets and restores it on re-import', async () => {
+    const videoMeta = { ...imageMeta, type: 'video' as const, fps: 5, name: 'clip' };
+    await serializeFile('/output/video.coco.json', annotationSchema, videoMeta);
+    const out = await fs.readJSON('/output/video.coco.json');
+    expect(out.videos).toEqual([{ id: 1, name: 'clip', fps: 5 }]);
+    expect(out.images.every((image: { video_id?: number }) => image.video_id === 1)).toBe(true);
+
+    mockfs({
+      '/input': { 'roundtrip.json': JSON.stringify(out) },
+      '/output': {},
+    });
+    const [, parsedMeta] = await parseFile('/input/roundtrip.json');
+    expect(parsedMeta.fps).toBe(5);
+  });
+
+  it('omits videos for image-sequence exports even when fps is set', async () => {
+    await serializeFile('/output/seq.coco.json', annotationSchema, { ...imageMeta, fps: 5 });
+    const out = await fs.readJSON('/output/seq.coco.json');
+    expect(out).not.toHaveProperty('videos');
+    expect(out.images.every((image: { video_id?: number }) => image.video_id === undefined)).toBe(true);
+  });
+
+  it('omits videos when video fps is unusable', async () => {
+    await serializeFile('/output/zero.coco.json', annotationSchema, {
+      ...imageMeta,
+      type: 'video',
+      fps: 0,
+    });
+    const out = await fs.readJSON('/output/zero.coco.json');
+    expect(out).not.toHaveProperty('videos');
+  });
+
   it('imports a pruned KWCOCO probability vector by raw category position', async () => {
     mockfs({
       '/input': {

--- a/client/platform/desktop/backend/serializers/coco.spec.ts
+++ b/client/platform/desktop/backend/serializers/coco.spec.ts
@@ -319,7 +319,12 @@ describe('COCO serializer', () => {
   // --- annotation fps on videos[] ---
 
   it('writes videos[].fps for video datasets and restores it on re-import', async () => {
-    const videoMeta = { ...imageMeta, type: 'video' as const, fps: 5, name: 'clip' };
+    const videoMeta = {
+      ...imageMeta,
+      type: 'video' as const,
+      fps: 5,
+      name: 'clip',
+    };
     await serializeFile('/output/video.coco.json', annotationSchema, videoMeta);
     const out = await fs.readJSON('/output/video.coco.json');
     expect(out.videos).toEqual([{ id: 1, name: 'clip', fps: 5 }]);

--- a/client/platform/desktop/backend/serializers/coco.spec.ts
+++ b/client/platform/desktop/backend/serializers/coco.spec.ts
@@ -675,6 +675,38 @@ describe('COCO serializer', () => {
     const [parsed] = await parseFile('/input/filtered.json');
     expect(parsed.tracks[4].confidencePairs).toEqual([['root', 0.2]]);
   });
+
+  it('imports the frame rate a video records, as the CSV header path does', async () => {
+    const document = (videos: unknown) => JSON.stringify({
+      images: [{ id: 1, file_name: 'frame_000000.png', frame_index: 0 }],
+      annotations: [{
+        id: 1, image_id: 1, category_id: 1, bbox: [0, 0, 1, 1], track_id: 1,
+      }],
+      categories: [{ id: 1, name: 'fish' }],
+      ...(videos === undefined ? {} : { videos }),
+    });
+    mockfs({
+      '/input': {
+        'video.json': document([{ id: 1, name: 'clip', fps: 5 }]),
+        'image-list.json': document(undefined),
+        'unusable.json': document([{ id: 1, name: 'clip', fps: 0 }]),
+        'not-a-number.json': document([{ id: 1, name: 'clip', fps: '5' }]),
+      },
+    });
+
+    const [, videoMeta] = await parseFile('/input/video.json');
+    expect(videoMeta.fps).toBe(5);
+
+    // An image sequence describes no video, so it carries no rate to import.
+    const [, listMeta] = await parseFile('/input/image-list.json');
+    expect(listMeta.fps).toBeUndefined();
+
+    // Nothing downstream should ever see fps: 0 or a string.
+    const [, zeroMeta] = await parseFile('/input/unusable.json');
+    expect(zeroMeta.fps).toBeUndefined();
+    const [, stringMeta] = await parseFile('/input/not-a-number.json');
+    expect(stringMeta.fps).toBeUndefined();
+  });
 });
 
 afterEach(() => {

--- a/client/platform/desktop/backend/serializers/coco.ts
+++ b/client/platform/desktop/backend/serializers/coco.ts
@@ -10,6 +10,7 @@ type CocoImage = {
   id: number;
   file_name: string;
   frame_index?: number;
+  video_id?: number;
 };
 
 type CocoCategory = {
@@ -559,6 +560,15 @@ async function serializeFile(
   Array.from(new Set(Object.values(hierarchy))).sort().forEach(addCategoryName);
   const categories = new Map(categoryNames.map((name, index) => [name, index + 1]));
 
+  // Video datasets record annotation FPS on a one-entry `videos` table (VIAME
+  // convention). Image sequences omit it so re-import does not treat them as video.
+  const emitVideo = (
+    meta.type === 'video'
+    && typeof meta.fps === 'number'
+    && Number.isFinite(meta.fps)
+    && meta.fps > 0
+  );
+
   Object.values(data.tracks).forEach((track) => {
     const pairs = pairsByTrack.get(track.id);
     if (!pairs) return;
@@ -576,6 +586,7 @@ async function serializeFile(
           id: imageId,
           file_name: frameNameForExport(feature.frame, meta),
           frame_index: feature.frame,
+          ...(emitVideo ? { video_id: 1 } : {}),
         });
       }
       annotations.push({
@@ -619,6 +630,9 @@ async function serializeFile(
     images: Array.from(images.values()),
     annotations,
     categories: categoryDocs,
+    ...(emitVideo ? {
+      videos: [{ id: 1, name: meta.name, fps: meta.fps }],
+    } : {}),
   };
   await fs.writeJSON(path, output, { spaces: 2 });
   return path;

--- a/client/platform/desktop/backend/serializers/coco.ts
+++ b/client/platform/desktop/backend/serializers/coco.ts
@@ -230,12 +230,36 @@ type CocoAnnotation = {
   track_attributes?: Record<string, unknown>;
 };
 
+type CocoVideo = {
+  id: number;
+  name?: string;
+  fps?: unknown;
+};
+
 type CocoDocument = {
   info?: Record<string, unknown>;
   images: CocoImage[];
   annotations: CocoAnnotation[];
   categories: CocoCategory[];
+  videos?: CocoVideo[];
 };
+
+/**
+ * Frame rate recorded on the video, the COCO counterpart of the VIAME CSV
+ * header's fps. Neither COCO nor kwcoco define one, so this reads the field
+ * VIAME writes on the video entry; an image sequence describes no video and
+ * carries none, which is not an error.
+ */
+function frameRateFromDocument(document: CocoDocument): number | undefined {
+  const videos = Array.isArray(document.videos) ? document.videos : [];
+  for (let i = 0; i < videos.length; i += 1) {
+    const rate = videos[i]?.fps;
+    if (typeof rate === 'number' && Number.isFinite(rate) && rate > 0) {
+      return rate;
+    }
+  }
+  return undefined;
+}
 
 /** True when segmentation is COCO RLE (crowd / `iscrowd: 1`), which DIVE does not decode. */
 function hasRleSegmentation(annotation: CocoAnnotation): boolean {
@@ -475,6 +499,11 @@ async function parseFile(path: string): Promise<[AnnotationSchema, Record<string
   if (probIgnoredForDuplicates) warnings.push(PROB_DUPLICATE_CATEGORY_WARNING);
   if (diveConfidencePairsInvalid) warnings.push(DIVE_CONFIDENCE_PAIRS_INVALID_WARNING);
   const meta: Record<string, unknown> = { attributes: processed.attributes };
+  // Surfaced the same way the VIAME CSV path surfaces its header fps.
+  const fps = frameRateFromDocument(parsed);
+  if (fps !== undefined) {
+    meta.fps = fps;
+  }
   // Restore the per-dataset station metadata namespaced under `info.dive_dataset_info`; the
   // caller merges it into the dataset's metadata. Omitted when absent/empty.
   const { dive_dataset_info: datasetInfo } = parsed.info ?? {};

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -435,9 +435,9 @@ in the top-level `videos` table (the COCO counterpart of the VIAME CSV `# metada
 * A usable value (finite number greater than zero) is restored into dataset metadata as
   `fps`. Unusable values (`0`, negative, non-numeric, `inf`/`nan`) are ignored.
 * When multiple video entries are present, the first usable `fps` wins.
-* DIVE's COCO exporter does not currently emit a `videos` table, so a DIVE → COCO → DIVE
-  round trip does not preserve annotation FPS. Prefer VIAME CSV or a DIVE configuration
-  file when you need the rate to travel with the annotations.
+* On export of a **video** dataset, DIVE writes a one-entry `videos` table with the
+  annotation FPS and sets `images[].video_id`. Image-sequence exports omit `videos`
+  so re-import does not treat them as video.
 
 ### Extension Field Details
 
@@ -473,9 +473,9 @@ For COCO files produced by DIVE:
 * DIVE writes category-aligned `prob` plus exact `dive_confidence_pairs` on each annotation.
 * Re-importing that file into DIVE preserves hierarchy edges, track IDs, complete confidence
   vectors, attributes, and notes.
-* Annotation FPS is not preserved on this path: DIVE does not currently write a `videos`
-  table. See [Annotation frame rate (`videos[].fps`)](#annotation-frame-rate-videosfps)
-  for the import-side convention used by VIAME-produced files.
+* For video datasets, DIVE also writes `videos[].fps` (and `images[].video_id`) so annotation
+  FPS round-trips. Image-sequence exports omit `videos`. See
+  [Annotation frame rate (`videos[].fps`)](#annotation-frame-rate-videosfps).
 
 For COCO files not produced by DIVE:
 

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -414,6 +414,31 @@ advertised in `info.dive_extensions`:
 
 * `info.dive_dataset_info = { "gfishsite_id": "2024TXN012", "year": "2024", ... }`
 
+### Annotation frame rate (`videos[].fps`)
+
+Neither MS-COCO nor KWCOCO define a frame-rate field. On import, DIVE reads the
+annotation FPS the same way VIAME writes it: a positive numeric `fps` on an entry
+in the top-level `videos` table (the COCO counterpart of the VIAME CSV `# metadata`
+`fps` header). Image-sequence documents typically omit `videos` and carry no rate.
+
+```json
+{
+  "videos": [
+    { "id": 1, "name": "clip", "fps": 5 }
+  ],
+  "images": [
+    { "id": 1, "file_name": "frame_000000.jpg", "frame_index": 0, "video_id": 1 }
+  ]
+}
+```
+
+* A usable value (finite number greater than zero) is restored into dataset metadata as
+  `fps`. Unusable values (`0`, negative, non-numeric, `inf`/`nan`) are ignored.
+* When multiple video entries are present, the first usable `fps` wins.
+* DIVE's COCO exporter does not currently emit a `videos` table, so a DIVE → COCO → DIVE
+  round trip does not preserve annotation FPS. Prefer VIAME CSV or a DIVE configuration
+  file when you need the rate to travel with the annotations.
+
 ### Extension Field Details
 
 The DIVE extension fields are JSON objects with user-defined key/value pairs.
@@ -448,6 +473,9 @@ For COCO files produced by DIVE:
 * DIVE writes category-aligned `prob` plus exact `dive_confidence_pairs` on each annotation.
 * Re-importing that file into DIVE preserves hierarchy edges, track IDs, complete confidence
   vectors, attributes, and notes.
+* Annotation FPS is not preserved on this path: DIVE does not currently write a `videos`
+  table. See [Annotation frame rate (`videos[].fps`)](#annotation-frame-rate-videosfps)
+  for the import-side convention used by VIAME-produced files.
 
 For COCO files not produced by DIVE:
 

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -825,12 +825,20 @@ def _coco_json_export_text(
             for feature in track_data.get('features', []):
                 max_frame = max(max_frame, feature.get('frame', -1))
         image_filenames = {i: f'frame_{i:06d}.jpg' for i in range(max_frame + 1)}
+    # Annotation FPS rides on videos[].fps for video datasets only; image sequences
+    # omit the table so re-import does not treat them as video.
+    export_fps = None
+    if dataset_type == constants.VideoType:
+        fps = fromMeta(dsFolder, constants.FPSMarker, None)
+        if isinstance(fps, (int, float)) and not isinstance(fps, bool) and fps > 0:
+            export_fps = float(fps)
     coco = kwcoco.export_dive_as_coco(
         filtered_tracks,
         image_filenames=image_filenames,
         dataset_name=dsFolder['name'],
         datasetInfo=fromMeta(dsFolder, "datasetInfo", {}),
         typeHierarchy=type_hierarchy_for_export(dsFolder, user, artifact='COCO file'),
+        fps=export_fps,
     )
     return json.dumps(coco)
 

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -704,9 +704,14 @@ def _get_data_by_type(
             datasetInfo,
         ) = kwcoco.load_coco_as_tracks_and_attributes(data_dict)
         hierarchy, hierarchy_warnings = kwcoco.type_hierarchy_from_categories(data_dict)
+        coco_fps = kwcoco.frame_rate_from_coco(data_dict)
+        coco_meta = {
+            **({"datasetInfo": datasetInfo} if datasetInfo else {}),
+            **({'fps': coco_fps} if coco_fps is not None else {}),
+        }
         return {
             'annotations': converted,
-            'meta': {"datasetInfo": datasetInfo} if datasetInfo else None,
+            'meta': coco_meta or None,
             'attributes': attributes,
             'type': as_type,
             'hierarchy': hierarchy,

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -585,6 +585,7 @@ def export_dive_as_coco(
     dataset_name: str,
     datasetInfo: Optional[types.DatasetInfo] = None,
     typeHierarchy: Optional[Dict[str, str]] = None,
+    fps: Optional[float] = None,
 ) -> Dict[str, Any]:
     """
     Export DIVE tracks to a single-dataset COCO JSON document.
@@ -598,6 +599,11 @@ def export_dive_as_coco(
             Omitted entirely when empty.
         typeHierarchy: DIVE child-to-parent category hierarchy, emitted through
             KWCOCO's ``categories[].supercategory`` field.
+        fps: Annotation frame rate for a video dataset. When usable (finite and
+            greater than zero), written on a one-entry ``videos`` table with
+            ``images[].video_id`` set — the same convention VIAME uses and DIVE
+            imports. Callers should pass this only for video datasets; image
+            sequences omit ``videos`` so re-import does not treat them as video.
     """
     parsed_tracks = [Track(**track_doc) for track_doc in tracks]
     category_names: List[str] = []
@@ -618,6 +624,12 @@ def export_dive_as_coco(
     coco_annotations: List[dict] = []
     images: Dict[int, dict] = {}
     annotation_id = 1
+    emit_video = (
+        isinstance(fps, (int, float))
+        and not isinstance(fps, bool)
+        and math.isfinite(fps)
+        and fps > 0
+    )
 
     for track in parsed_tracks:
         for feature in track.features:
@@ -633,14 +645,14 @@ def export_dive_as_coco(
             width = max(0, x2 - x1)
             height = max(0, y2 - y1)
             image_id = feature.frame + 1
-            images.setdefault(
-                image_id,
-                {
-                    'id': image_id,
-                    'file_name': image_filenames[feature.frame],
-                    'frame_index': feature.frame,
-                },
-            )
+            image_doc: Dict[str, Any] = {
+                'id': image_id,
+                'file_name': image_filenames[feature.frame],
+                'frame_index': feature.frame,
+            }
+            if emit_video:
+                image_doc['video_id'] = 1
+            images.setdefault(image_id, image_doc)
             segmentation = _feature_to_segmentation(feature)
             keypoints, num_keypoints = _feature_to_keypoints(feature)
             annotation = {
@@ -697,9 +709,12 @@ def export_dive_as_coco(
         info['dive_dataset_info'] = datasetInfo
         info['dive_extensions'].append('dive_dataset_info')
 
-    return {
+    coco: Dict[str, Any] = {
         'info': info,
         'images': list(images.values()),
         'annotations': coco_annotations,
         'categories': categories_doc,
     }
+    if emit_video:
+        coco['videos'] = [{'id': 1, 'name': dataset_name, 'fps': float(fps)}]
+    return coco

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -240,6 +240,24 @@ def _validate_annotation_bounds(annotations: List[dict]) -> None:
         raise ValueError(_missing_bounds_error(missing_ids))
 
 
+def frame_rate_from_coco(coco: Dict[str, Any]) -> Optional[float]:
+    """Frame rate recorded on the video, the COCO counterpart of the CSV header's fps.
+
+    Neither MS-COCO nor KWCOCO define a frame rate, so this reads the field VIAME
+    writes on the video entry. Image-sequence documents describe no video and
+    carry none, which is not an error.
+    """
+    for video in coco.get('videos') or []:
+        if not isinstance(video, dict):
+            continue
+        rate = video.get('fps')
+        if isinstance(rate, bool) or not isinstance(rate, (int, float)):
+            continue
+        if math.isfinite(rate) and rate > 0:
+            return float(rate)
+    return None
+
+
 def is_coco_json(coco: Dict[str, Any]):
     # Minimal COCO fields according to https://cocodataset.org/#format-data.
     # `info` and `licenses` are optional in common exports.

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -1182,3 +1182,36 @@ def test_shared_empty_dive_confidence_pairs_profile():
     pairs = converted['tracks'][str(profile['trackId'])]['confidencePairs']
     assert [list(pair) for pair in pairs] == profile['expectedPairs']
     assert warnings == [kwcoco.DIVE_CONFIDENCE_PAIRS_WARNING]
+
+
+def _fps_document(videos=None):
+    document = {
+        'images': [{'id': 1, 'file_name': 'frame_000000.png', 'frame_index': 0}],
+        'annotations': [
+            {'id': 1, 'image_id': 1, 'category_id': 1, 'bbox': [0, 0, 1, 1], 'track_id': 1}
+        ],
+        'categories': [{'id': 1, 'name': 'fish'}],
+    }
+    if videos is not None:
+        document['videos'] = videos
+    return document
+
+
+def test_frame_rate_read_from_video():
+    """The COCO counterpart of the VIAME CSV header's fps."""
+    assert kwcoco.frame_rate_from_coco(
+        _fps_document([{'id': 1, 'name': 'clip', 'fps': 5}])
+    ) == 5.0
+    assert kwcoco.frame_rate_from_coco(
+        _fps_document([{'id': 1}, {'id': 2, 'name': 'clip', 'fps': 29.97}])
+    ) == 29.97
+
+
+def test_frame_rate_absent_or_unusable():
+    """An image sequence carries no rate, and no caller should see fps: 0."""
+    assert kwcoco.frame_rate_from_coco(_fps_document()) is None
+    assert kwcoco.frame_rate_from_coco(_fps_document([])) is None
+    for fps in [0, -5, '5', True, float('inf'), float('nan'), None]:
+        assert kwcoco.frame_rate_from_coco(
+            _fps_document([{'id': 1, 'fps': fps}])
+        ) is None

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -806,6 +806,30 @@ def test_export_dive_as_coco_omits_empty_dataset_info(datasetInfo):
     assert coco["info"] == baseline["info"]
 
 
+def test_export_dive_as_coco_writes_video_fps():
+    """Video annotation FPS lands on videos[].fps with images linked by video_id."""
+    coco = kwcoco.export_dive_as_coco(
+        _EXPORT_TRACKS, {0: "frame_000000.jpg"}, dataset_name="clip", fps=5
+    )
+    assert coco["videos"] == [{"id": 1, "name": "clip", "fps": 5.0}]
+    assert all(image.get("video_id") == 1 for image in coco["images"])
+    assert kwcoco.frame_rate_from_coco(coco) == 5.0
+
+
+@pytest.mark.parametrize("fps", [None, 0, -1, float("nan"), float("inf")])
+def test_export_dive_as_coco_omits_unusable_or_absent_fps(fps):
+    """Image-sequence callers pass no fps; unusable values must not emit videos."""
+    coco = kwcoco.export_dive_as_coco(
+        _EXPORT_TRACKS, {0: "frame_000000.jpg"}, dataset_name="demo", fps=fps
+    )
+    baseline = kwcoco.export_dive_as_coco(
+        _EXPORT_TRACKS, {0: "frame_000000.jpg"}, dataset_name="demo"
+    )
+    assert "videos" not in coco
+    assert all("video_id" not in image for image in coco["images"])
+    assert coco == baseline
+
+
 def test_load_coco_restores_dataset_info():
     """info.dive_dataset_info is surfaced as the 4th return value for the caller to persist."""
     coco = {


### PR DESCRIPTION
COCO was the only import path that dropped the dataset frame rate. CSV reads it from the `fps:` header (`viame.py` / `viame.ts:35`) and NIST sets it directly (`common.ts:1425`), but the COCO branch never populated `meta.fps`.

- `kwcoco.py`: `frame_rate_from_coco()` reads `videos[].annotation_fps`; the import route folds it into meta the same way the CSV branch does
- `coco.ts`: `frameRateFromDocument()` does the same for desktop; `parseFile` returns it in meta, which `common.ts` already merges
- Image sequences emit no `videos` table and so carry no rate — not an error
- Rejects unusable values (0, negative, string, bool, inf/nan) so nothing downstream sees `fps: 0`

The field is `annotation_fps` because it is the rate detections were produced at — the downsampled rate, not the video's native one. VIAME writes it there (VIAME/VIAME@9b1227cc6). Neither MS-COCO nor kwcoco define a frame-rate field, so the spelling is a convention shared between the two projects rather than a standard; DIVE's own dataset metadata key stays `fps`.

Verified against real `process_video.py` COCO output: desktop `parseFile` returns `meta.fps = 5` for a video and `undefined` for an image list; the server helper returns `5.0` / `None` on the same two files, plus the guard cases.

Not run: vitest, eslint and tsc — no `node_modules` in this checkout. The new server tests were executed directly and pass; the desktop spec is unrun.

Out of scope: neither exporter emits a `videos` table, so DIVE -> COCO -> DIVE still loses the rate. Writing it on export means introducing that table first.