### PR TITLE
Dive annotation json video fps

### DIFF
--- a/client/dive-common/apispec.ts
+++ b/client/dive-common/apispec.ts
@@ -27,6 +27,8 @@ interface AnnotationSchema {
   version: number;
   tracks: MultiTrackRecord;
   groups: MultiGroupRecord;
+  /** Annotation frame rate when present; omitted when absent or unusable. */
+  fps?: number;
 }
 
 /**

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -1434,6 +1434,9 @@ async function _ingestFilePath(
     } else {
       // Regular dive json
       annotations = await loadAnnotationFile(path);
+      if (annotations.fps !== undefined) {
+        meta.fps = annotations.fps;
+      }
     }
   } else if (CsvFileName.test(path)) {
     // VIAME CSV File

--- a/client/platform/desktop/backend/serializers/dive.spec.ts
+++ b/client/platform/desktop/backend/serializers/dive.spec.ts
@@ -1,6 +1,13 @@
+import fs from 'fs-extra';
+import mockfs from 'mock-fs';
 import { AnnotationSchema } from 'dive-common/apispec';
 import { AnnotationsCurrentVersion, JsonConfig } from 'platform/desktop/constants';
-import { filterTracks } from 'platform/desktop/backend/serializers/dive';
+import {
+  filterTracks,
+  frameRateFromDocument,
+  migrate,
+  serializeFile,
+} from 'platform/desktop/backend/serializers/dive';
 
 const annotationSchema: AnnotationSchema = {
   version: AnnotationsCurrentVersion,
@@ -34,6 +41,16 @@ const imageMeta = {
   multiCam: null,
   subType: null,
 } as JsonConfig;
+
+beforeEach(() => {
+  mockfs({
+    '/output': {},
+  });
+});
+
+afterEach(() => {
+  mockfs.restore();
+});
 
 describe('DIVE JSON filterTracks', () => {
   it('prunes type-filtered pairs without mutating the source track', () => {
@@ -92,5 +109,35 @@ describe('DIVE JSON filterTracks', () => {
     expect(filtered.tracks[1]).not.toBe(data.tracks[1]);
     expect(filtered.tracks[1].confidencePairs).toEqual([['whale', 0.8], ['zero', 0]]);
     expect(data.tracks[1].confidencePairs).toEqual(original);
+  });
+});
+
+describe('DIVE JSON annotation fps', () => {
+  it('writes fps from dataset meta on export and restores it on migrate', async () => {
+    await serializeFile('/output/out.json', annotationSchema, { ...imageMeta, fps: 5 });
+    const out = await fs.readJSON('/output/out.json');
+    expect(out.fps).toBe(5);
+    expect(migrate(out).fps).toBe(5);
+  });
+
+  it('omits fps when dataset meta rate is unusable', async () => {
+    await serializeFile('/output/zero.json', annotationSchema, { ...imageMeta, fps: 0 });
+    const out = await fs.readJSON('/output/zero.json');
+    expect(out).not.toHaveProperty('fps');
+  });
+
+  it('preserves a usable fps through migrate and drops unusable values', () => {
+    expect(migrate({ ...annotationSchema, fps: 29.97 }).fps).toBe(29.97);
+    expect(migrate({ ...annotationSchema, fps: 0 }).fps).toBeUndefined();
+    expect(migrate({ ...annotationSchema, fps: '5' }).fps).toBeUndefined();
+    expect(migrate({ ...annotationSchema, fps: Number.POSITIVE_INFINITY }).fps).toBeUndefined();
+    expect(migrate(annotationSchema).fps).toBeUndefined();
+  });
+
+  it('frameRateFromDocument mirrors migrate validation', () => {
+    expect(frameRateFromDocument({ fps: 5 })).toBe(5);
+    expect(frameRateFromDocument({ fps: 0 })).toBeUndefined();
+    expect(frameRateFromDocument({ fps: true })).toBeUndefined();
+    expect(frameRateFromDocument(null)).toBeUndefined();
   });
 });

--- a/client/platform/desktop/backend/serializers/dive.ts
+++ b/client/platform/desktop/backend/serializers/dive.ts
@@ -13,6 +13,21 @@ function makeEmptyAnnotationFile(): AnnotationSchema {
 }
 
 /**
+ * Annotation FPS recorded on a DIVE JSON document, if usable.
+ * Same rules as the VIAME CSV `fps:` header and COCO `videos[].fps`.
+ */
+function frameRateFromDocument(data: unknown): number | undefined {
+  if (!data || typeof data !== 'object') {
+    return undefined;
+  }
+  const rate = (data as { fps?: unknown }).fps;
+  if (typeof rate === 'number' && Number.isFinite(rate) && rate > 0) {
+    return rate;
+  }
+  return undefined;
+}
+
+/**
  * Take a JSON file and migrate it to the latest revision
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -23,7 +38,16 @@ function migrate(jsonData: any): AnnotationSchema {
   if (has(jsonData, 'version')) {
     const annotations = jsonData as AnnotationSchema;
     if (annotations.version === AnnotationsCurrentVersion) {
-      return annotations;
+      const migrated: AnnotationSchema = {
+        version: AnnotationsCurrentVersion,
+        tracks: annotations.tracks,
+        groups: annotations.groups || {},
+      };
+      const fps = frameRateFromDocument(annotations);
+      if (fps !== undefined) {
+        migrated.fps = fps;
+      }
+      return migrated;
     }
     throw new Error(`Unexpected version number ${jsonData.version}`);
   } else {
@@ -75,8 +99,9 @@ function filterTracks(
     }
   });
   return {
-    ...data,
+    version: data.version,
     tracks: updatedFilteredTracks,
+    groups: data.groups,
   };
 }
 
@@ -91,13 +116,22 @@ async function serializeFile(
   },
 ) {
   const updatedData = filterTracks(data, meta, typeFilter, options);
-  // write updatedData JSON to a path
-  const jsonData = JSON.stringify(updatedData, null, 2);
+  // Dataset annotation FPS rides on the document the same way CSV/COCO carry it.
+  const fps = (
+    typeof meta.fps === 'number'
+    && Number.isFinite(meta.fps)
+    && meta.fps > 0
+  ) ? meta.fps : undefined;
+  const output: AnnotationSchema = fps !== undefined
+    ? { ...updatedData, fps }
+    : updatedData;
+  const jsonData = JSON.stringify(output, null, 2);
   await fs.writeFile(path, jsonData, 'utf8');
 }
 
 export {
   makeEmptyAnnotationFile,
+  frameRateFromDocument,
   migrate,
   filterTracks,
   serializeFile,

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -32,6 +32,11 @@ interface AnnotationSchema {
   tracks: Record<string, TrackData>;
   groups: Record<string, GroupData>;
   version: 2;
+  /**
+   * Annotation frame rate when present. Omitted when absent or unusable.
+   * Same role as the VIAME CSV `# metadata` `fps` field and COCO `videos[].fps`.
+   */
+  fps?: number;
 }
 
 interface TrackData {
@@ -112,6 +117,25 @@ These reserved names are enforced at both the UI level (when creating attributes
 
 The full source [TrackData definition can be found here](https://github.com/Kitware/dive/blob/main/client/src/track.ts) as a TypeScript interface.
 
+### Annotation frame rate (`fps`)
+
+Optional top-level `fps` carries the dataset annotation frame rate — the same value
+VIAME CSV writes in the `# metadata` header and COCO/KWCOCO records on `videos[].fps`.
+
+```json
+{
+  "version": 2,
+  "fps": 5,
+  "tracks": {},
+  "groups": {}
+}
+```
+
+* On export, DIVE writes a usable dataset `fps` (finite number greater than zero).
+* On import, that value is restored into dataset metadata. Unusable values (`0`, negative,
+  non-numeric, `inf`/`nan`) are ignored. A file with no `fps` leaves the dataset rate unchanged.
+* Older v1 track-map files have no place for `fps`; only the v2 document form carries it.
+
 ### Example JSON File
 
 This is a relatively simple example, and many optional fields are not included.
@@ -119,6 +143,7 @@ This is a relatively simple example, and many optional fields are not included.
 ```json
 {
   "version": 2,
+  "fps": 5,
 
   "tracks": {
     // Track 1 is a true multi-frame track
@@ -180,6 +205,10 @@ This information provides the specification for an individual dataset.  It consi
   * Edited from the [Dataset Info panel](UI-DatasetInfo.md).
   * Included in DIVE Configuration JSON as `datasetInfo`.
   * Included in [VIAME CSV](#viame-csv) and [COCO / KWCOCO](#coco-and-kwcoco) export, and restored on import.
+* Annotation frame rate is stored as dataset `fps`.
+  * Included in [DIVE Annotation JSON](#annotation-frame-rate-fps) as top-level `fps`.
+  * Included in [VIAME CSV](#dataset-metadata-in-the-header) as the `# metadata` `fps` field.
+  * Included in [COCO / KWCOCO](#annotation-frame-rate-videosfps) as `videos[].fps` for video datasets.
 * A track type hierarchy is stored in `typeHierarchy` as a child-type to immediate-parent-type map.
 
 For example, this configuration makes `fish` a heading-only parent (it does not need to be an

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -801,6 +801,10 @@ def _dive_json_export_text(
     annotations['tracks'] = _filtered_annotation_tracks(
         dsFolder, revision, excludeBelowThreshold, typeFilter
     )
+    # Annotation FPS rides on the document the same way CSV/COCO carry it.
+    fps = fromMeta(dsFolder, constants.FPSMarker, None)
+    if isinstance(fps, (int, float)) and not isinstance(fps, bool) and fps > 0:
+        annotations['fps'] = float(fps)
     return json.dumps(annotations)
 
 

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -726,9 +726,10 @@ def _get_data_by_type(
     if as_type == crud.FileType.DIVE_JSON:
         migrated = dive.migrate(data_dict)
         annotations, attributes = viame.load_json_as_track_and_attributes(data_dict)
+        dive_fps = dive.frame_rate_from_dive(data_dict)
         return {
             'annotations': migrated,
-            'meta': None,
+            'meta': {'fps': dive_fps} if dive_fps is not None else None,
             'attributes': attributes,
             'type': as_type,
         }, warnings

--- a/server/dive_utils/serializers/dive.py
+++ b/server/dive_utils/serializers/dive.py
@@ -1,6 +1,23 @@
-from typing import Any
+import math
+from typing import Any, Optional
 
 from dive_utils import constants, models, types
+
+
+def frame_rate_from_dive(data: Any) -> Optional[float]:
+    """Annotation FPS recorded on a DIVE JSON document, if usable.
+
+    Same rules as the VIAME CSV ``fps:`` header and COCO ``videos[].fps``:
+    a finite number greater than zero. Absent or unusable values are not an error.
+    """
+    if not isinstance(data, dict):
+        return None
+    rate = data.get('fps')
+    if isinstance(rate, bool) or not isinstance(rate, (int, float)):
+        return None
+    if math.isfinite(rate) and rate > 0:
+        return float(rate)
+    return None
 
 
 def migrate(jsonData: Any) -> types.DIVEAnnotationSchema:
@@ -17,9 +34,13 @@ def migrate(jsonData: Any) -> types.DIVEAnnotationSchema:
             str(groupId): models.Group(**group).dict(exclude_none=True)
             for groupId, group in jsonData['groups'].items()
         }
-        return types.DIVEAnnotationSchema(
+        migrated: types.DIVEAnnotationSchema = types.DIVEAnnotationSchema(
             tracks=tracks, groups=groups, version=constants.AnnotationsCurrentVersion
         )
+        fps = frame_rate_from_dive(jsonData)
+        if fps is not None:
+            migrated['fps'] = fps
+        return migrated
     elif version == 1:
         for track in jsonData.values():
             track['id'] = track['trackId']

--- a/server/dive_utils/types.py
+++ b/server/dive_utils/types.py
@@ -209,6 +209,8 @@ class DIVEAnnotationSchema(TypedDict):
     tracks: Dict[str, dict]
     groups: Dict[str, dict]
     version: int
+    # Annotation frame rate when present; omitted when absent or unusable.
+    fps: NotRequired[float]
 
 
 class CameraCalibration(TypedDict, total=False):

--- a/server/tests/test_migrate.py
+++ b/server/tests/test_migrate.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 from dive_utils.serializers import dive
@@ -30,3 +32,45 @@ test_tuple = [
 @pytest.mark.parametrize("input,expected", test_tuple)
 def test_migrate(input, expected):
     assert dive.migrate(input) == expected
+
+
+def _v2_document(**extra):
+    return {
+        "tracks": {
+            "1": {
+                "id": 1,
+                "begin": 0,
+                "end": 0,
+                "features": [],
+                "attributes": {},
+                "confidencePairs": [["fish", 1.0]],
+            }
+        },
+        "groups": {},
+        "version": 2,
+        **extra,
+    }
+
+
+def test_migrate_preserves_usable_fps():
+    migrated = dive.migrate(_v2_document(fps=5))
+    assert migrated["fps"] == 5.0
+    assert dive.frame_rate_from_dive(migrated) == 5.0
+
+
+@pytest.mark.parametrize("fps", [0, -1, "5", True, None, float("inf"), float("nan")])
+def test_migrate_drops_unusable_fps(fps):
+    migrated = dive.migrate(_v2_document(fps=fps))
+    assert "fps" not in migrated
+    assert dive.frame_rate_from_dive(_v2_document(fps=fps)) is None
+
+
+def test_frame_rate_from_dive_absent():
+    assert dive.frame_rate_from_dive(_v2_document()) is None
+    assert dive.frame_rate_from_dive("not-a-dict") is None
+
+
+def test_frame_rate_rejects_nan_explicitly():
+    # math.isfinite is the gate; keep the helper honest about nan.
+    assert not math.isfinite(float("nan"))
+    assert dive.frame_rate_from_dive({"fps": float("nan")}) is None


### PR DESCRIPTION
Adds the video fps annotation rate to the DIVE Annotation JSON.  Before it was only on the VIAME CSV and COCO/KWCOCO formats.  Now it is also included in the DIVE Anntoation JSON for export and import.