### PR TITLE
Render hierarchical types as a tree

### DIFF
--- a/client/dive-common/components/GroupSidebar.spec.ts
+++ b/client/dive-common/components/GroupSidebar.spec.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+/* eslint-disable vue/one-component-per-file -- harness components for shallow mounting */
+/// <reference types="vitest" />
+import {
+  defineComponent, h, reactive, ref,
+} from 'vue';
+import { shallowMount } from '@vue/test-utils';
+import { clientSettings } from 'dive-common/store/settings';
+import FilterList from 'vue-media-annotator/components/FilterList.vue';
+import GroupSidebar from './GroupSidebar.vue';
+
+const provideMocks = vi.hoisted(() => ({
+  groupFilterControls: undefined as unknown,
+  groupStyleManager: undefined as unknown,
+}));
+
+vi.mock('dive-common/vue-utilities/prompt-service', () => ({
+  usePrompt: () => ({ prompt: vi.fn(), visible: () => false }),
+}));
+
+vi.mock('vue-media-annotator/provides', () => ({
+  useCameraStore: () => ({ camMap: ref(new Map()) }),
+  useGroupFilterControls: () => provideMocks.groupFilterControls,
+  useGroupStyleManager: () => provideMocks.groupStyleManager,
+  useHandler: () => ({ seekFrame: vi.fn() }),
+  usePendingSaveCount: () => ref(0),
+  useReadOnlyMode: () => ref(false),
+  useSelectedCamera: () => ref(''),
+  useTime: () => ({ frame: ref(0) }),
+}));
+
+describe('GroupSidebar type filter', () => {
+  it('wires the group FilterList to flat show-empty behavior', () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    clientSettings.typeSettings.suppressionType = '';
+    const checkedTypes = ref(['school', 'pod']);
+    provideMocks.groupFilterControls = Object.freeze({
+      allTypes: ref(['school', 'pod']),
+      usedTypes: ref(['school']),
+      configuredTypes: ref(['pod']),
+      checkedTypes,
+      filteredAnnotations: ref([]),
+      confidenceFilters: ref({ default: 0 }),
+      disableAnnotationFilters: ref(false),
+      updateCheckedTypes: (types: string[]) => { checkedTypes.value = types; },
+      removeTypeAnnotations: vi.fn(),
+    });
+    provideMocks.groupStyleManager = Object.freeze({
+      typeStyling: ref({
+        color: () => '#fff',
+        strokeWidth: () => 1,
+        fill: () => false,
+        opacity: () => 1,
+      }),
+    });
+
+    const ContainerStub = defineComponent({
+      setup: (_props, { slots }) => () => h(
+        'div',
+        slots.default?.({ topHeight: 240, bottomHeight: 120 }),
+      ),
+    });
+    const props = reactive({ width: 320 });
+    const Host = defineComponent({
+      setup: () => () => h(GroupSidebar, { props }),
+    });
+    const wrapper = shallowMount(Host, {
+      stubs: {
+        GroupSidebar: false,
+        FilterList: false,
+        StackedVirtualSidebarContainer: ContainerStub,
+        'v-divider': true,
+      },
+    });
+    const filterList = wrapper.findComponent(FilterList);
+
+    expect(filterList.exists()).toBe(true);
+    expect(filterList.props()).toEqual(expect.objectContaining({
+      filterControls: provideMocks.groupFilterControls,
+      group: true,
+      showEmptyTypes: true,
+      width: 320,
+    }));
+  });
+});

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -639,14 +639,6 @@ export default defineComponent({
     const removeGroups = (id: AnnotationId) => {
       cameraStore.removeGroups(id);
     };
-    const setTrackType = (
-      id: AnnotationId,
-      newType: string,
-      confidenceVal?: number,
-      currentType?: string,
-    ) => {
-      cameraStore.setTrackType(id, newType, confidenceVal, currentType);
-    };
     const removeTypes = (id: AnnotationId, types: string[]) => cameraStore.removeTypes(id, types);
     const setGroupType = (
       id: AnnotationId,
@@ -664,7 +656,7 @@ export default defineComponent({
       sorted: cameraStore.sortedGroups,
       markChangesPending: (markChangesPending as MarkChangesPendingFilter),
       remove: removeGroups,
-      setType: setGroupType,
+      setGroupType,
       removeTypes: removeGroupTypes,
     });
 
@@ -682,7 +674,6 @@ export default defineComponent({
         cameraStore.renameTrackPair(id, currentType, newType)
       ),
       groupFilterControls: groupFilters,
-      setType: setTrackType,
       removeTypes,
     });
 

--- a/client/dive-common/typeHierarchy.ts
+++ b/client/dive-common/typeHierarchy.ts
@@ -257,7 +257,7 @@ export function compileHierarchy(hierarchy: TypeHierarchy): TypeHierarchyIndex {
   return { hierarchy: normalized, ancestors: Object.fromEntries(ancestorEntries) };
 }
 
-function ancestorsOf(index: TypeHierarchyIndex, type: string): readonly string[] {
+export function ancestorsOf(index: TypeHierarchyIndex, type: string): readonly string[] {
   return Object.prototype.hasOwnProperty.call(index.ancestors, type)
     ? index.ancestors[type]
     : [];

--- a/client/dive-common/use/useModeManager.spec.ts
+++ b/client/dive-common/use/useModeManager.spec.ts
@@ -51,7 +51,7 @@ function makeHarness(markChangesPending: MarkChangesPending = () => undefined) {
     sorted: cameraStore.sortedGroups,
     remove: () => undefined,
     markChangesPending: () => undefined,
-    setType: () => undefined,
+    setGroupType: () => undefined,
     removeTypes: () => [],
   });
   const trackFilterControls = new TrackFilterControls({
@@ -64,7 +64,6 @@ function makeHarness(markChangesPending: MarkChangesPending = () => undefined) {
       cameraStore.renameTrackPair(id, currentType, newType)
     ),
     groupFilterControls,
-    setType: () => undefined,
     removeTypes: () => [],
   });
 
@@ -190,7 +189,7 @@ function makeSingleCamHarness() {
     sorted: cameraStore.sortedGroups,
     remove: () => undefined,
     markChangesPending: () => undefined,
-    setType: () => undefined,
+    setGroupType: () => undefined,
     removeTypes: () => [],
   });
   const trackFilterControls = new TrackFilterControls({
@@ -203,7 +202,6 @@ function makeSingleCamHarness() {
       cameraStore.renameTrackPair(id, currentType, newType)
     ),
     groupFilterControls,
-    setType: () => undefined,
     removeTypes: () => [],
   });
   const modeManager = useModeManager({

--- a/client/src/BaseFilterControls.ts
+++ b/client/src/BaseFilterControls.ts
@@ -32,8 +32,6 @@ export interface FilterControlsParams<T extends Track | Group> {
   sorted: Ref<SortedAnnotation<T>[]>;
   markChangesPending: MarkChangesPendingFilter;
   remove: (id: AnnotationId) => void;
-  setType: (id: AnnotationId, newType: string,
-    confidenceVal?: number, currentType?: string) => void;
   removeTypes: (id: AnnotationId, types: string[]) => ConfidencePair[];
   getTrack?: (trackId: Readonly<AnnotationId>, cameraName?: string) => T;
 }
@@ -81,9 +79,6 @@ export default abstract class BaseFilterControls<T extends Track | Group> {
 
   remove: (id: AnnotationId) => void;
 
-  setType: (id: AnnotationId, newType: string,
-    confidenceVal?: number, currentType?: string) => void;
-
   removeTypes: (id: AnnotationId, types: string[]) => ConfidencePair[];
 
   disableAnnotationFilters: Ref<boolean>;
@@ -100,8 +95,6 @@ export default abstract class BaseFilterControls<T extends Track | Group> {
     this.sorted = params.sorted;
 
     this.remove = params.remove;
-
-    this.setType = params.setType;
 
     this.removeTypes = params.removeTypes;
 
@@ -174,6 +167,19 @@ export default abstract class BaseFilterControls<T extends Track | Group> {
     }
   }
 
+  /**
+   * Carry a renamed type's confidence threshold over to its new name, unless
+   * the new name already carries one of its own.
+   */
+  protected carryConfidenceFilter(currentType: string, newType: string) {
+    if (!(newType in this.confidenceFilters.value) && currentType in this.confidenceFilters.value) {
+      this.setConfidenceFilters({
+        ...this.confidenceFilters.value,
+        [newType]: this.confidenceFilters.value[currentType],
+      });
+    }
+  }
+
   protected deleteTypeConfiguration(type: string) {
     if (this.configuredTypes.value.includes(type)) {
       this.configuredTypes.value.splice(this.configuredTypes.value.indexOf(type), 1);
@@ -197,25 +203,7 @@ export default abstract class BaseFilterControls<T extends Track | Group> {
     this.timeFilters.value = val;
   }
 
-  updateTypeName({ currentType, newType }: { currentType: string; newType: string }) {
-    //Go through the entire list and replace the oldType with the new Type
-    this.sorted.value.forEach((annotation) => {
-      for (let i = 0; i < annotation.confidencePairs.length; i += 1) {
-        const [name, confidenceVal] = annotation.confidencePairs[i];
-        if (name === currentType) {
-          this.setType(annotation.id, newType, confidenceVal, currentType);
-          break;
-        }
-      }
-    });
-    if (!(newType in this.confidenceFilters.value) && currentType in this.confidenceFilters.value) {
-      this.setConfidenceFilters({
-        ...this.confidenceFilters.value,
-        [newType]: this.confidenceFilters.value[currentType],
-      });
-    }
-    this.deleteType(currentType);
-  }
+  abstract updateTypeName(params: { currentType: string; newType: string }): void;
 
   removeTypeAnnotations(types: string[]) {
     const processedIds = new Set<AnnotationId>();

--- a/client/src/CameraStore.ts
+++ b/client/src/CameraStore.ts
@@ -364,16 +364,6 @@ export default class CameraStore {
     });
   }
 
-  // Update all cameras to have the same track type
-  setTrackType(id: AnnotationId, newType: string, confidenceVal?: number, currentType?: string) {
-    this.camMap.value.forEach((camera) => {
-      const track = camera.trackStore.getPossible(id);
-      if (track !== undefined) {
-        track.setType(newType, confidenceVal, currentType);
-      }
-    });
-  }
-
   setGroupType(id: AnnotationId, newType: string, confidenceVal?: number, currentType?: string) {
     this.camMap.value.forEach((camera) => {
       const group = camera.groupStore.getPossible(id);

--- a/client/src/GroupFilterControls.ts
+++ b/client/src/GroupFilterControls.ts
@@ -1,13 +1,27 @@
 import { computed, ref, Ref } from 'vue';
 import { cloneDeep } from 'lodash';
+import { AnnotationId } from './BaseAnnotation';
 import BaseFilterControls, { AnnotationWithContext, FilterControlsParams } from './BaseFilterControls';
 import type Group from './Group';
+
+export interface GroupFilterControlsParams extends FilterControlsParams<Group> {
+  setGroupType: (
+    id: AnnotationId,
+    newType: string,
+    confidenceVal?: number,
+    currentType?: string,
+  ) => void;
+}
 
 export default class GroupFilterControls extends BaseFilterControls<Group> {
   filteredAnnotations: Ref<AnnotationWithContext<Group>[]>;
 
-  constructor(params: FilterControlsParams<Group>) {
+  private setGroupType: GroupFilterControlsParams['setGroupType'];
+
+  constructor(params: GroupFilterControlsParams) {
     super(params);
+
+    this.setGroupType = params.setGroupType;
 
     /**
      * Override default confidence filters.  There is no UI to adjust this,
@@ -45,5 +59,19 @@ export default class GroupFilterControls extends BaseFilterControls<Group> {
       });
       return resultsArr;
     });
+  }
+
+  updateTypeName({ currentType, newType }: { currentType: string; newType: string }) {
+    this.sorted.value.forEach((annotation) => {
+      for (let i = 0; i < annotation.confidencePairs.length; i += 1) {
+        const [name, confidenceVal] = annotation.confidencePairs[i];
+        if (name === currentType) {
+          this.setGroupType(annotation.id, newType, confidenceVal, currentType);
+          break;
+        }
+      }
+    });
+    this.carryConfidenceFilter(currentType, newType);
+    this.deleteType(currentType);
   }
 }

--- a/client/src/TrackFilterControls.spec.ts
+++ b/client/src/TrackFilterControls.spec.ts
@@ -67,7 +67,7 @@ function makeCameraStore() {
 }
 
 function makeGroupFilterControls(store: CameraStore) {
-  const setTrackType = (
+  const setGroupType = (
     id: AnnotationId,
     newType: string,
     confidenceVal?: number,
@@ -83,7 +83,7 @@ function makeGroupFilterControls(store: CameraStore) {
     sorted: store.sortedGroups,
     remove,
     markChangesPending,
-    setType: setTrackType,
+    setGroupType,
     removeTypes,
   });
 }
@@ -91,14 +91,6 @@ function makeGroupFilterControls(store: CameraStore) {
 function makeTrackFilterControls(markPending: MarkChangesPendingFilter = markChangesPending) {
   const cameraStore = makeCameraStore();
   const groupFilterControls = makeGroupFilterControls(cameraStore);
-  const setTrackType = (
-    id: AnnotationId,
-    newType: string,
-    confidenceVal?: number,
-    currentType?: string,
-  ) => {
-    cameraStore.setTrackType(id, newType, confidenceVal, currentType);
-  };
   const removeTypes = (id: AnnotationId, types: string[]) => cameraStore.removeTypes(id, types);
 
   const remove = (id: AnnotationId) => {
@@ -115,7 +107,6 @@ function makeTrackFilterControls(markPending: MarkChangesPendingFilter = markCha
     renameTrackPair: (id, currentType, newType) => (
       cameraStore.renameTrackPair(id, currentType, newType)
     ),
-    setType: setTrackType,
     removeTypes,
   });
 }
@@ -140,9 +131,6 @@ function makePairFixture(
     getTracks: (id) => cameraStore.getTrackAll(id),
     renameTrackPair: (id, currentType, newType) => (
       cameraStore.renameTrackPair(id, currentType, newType)
-    ),
-    setType: (id, type, confidence, current) => (
-      cameraStore.setTrackType(id, type, confidence, current)
     ),
     removeTypes: (id, types) => cameraStore.removeTypes(id, types),
   });
@@ -527,6 +515,20 @@ describe('useAnnotationFilters', () => {
     expect(withoutPrevent).toBe(1);
   });
 
+  it('does not synthesize an unstored parent when the stored child cannot qualify', () => {
+    const { cameraStore, filters } = makePairFixture([[['leaf', 0.8]]]);
+    filters.setTypeHierarchy({ leaf: 'root' });
+
+    filters.updateCheckedTypes(['root']);
+    expect(filters.displayPairIndex(cameraStore.getTrack(0), 0)).toBe(-1);
+    expect(filters.filteredAnnotations.value).toEqual([]);
+
+    filters.updateCheckedTypes(['root', 'leaf']);
+    filters.setConfidenceFilters({ leaf: 0.9, default: 0.1 });
+    expect(filters.displayPairIndex(cameraStore.getTrack(0), 0)).toBe(-1);
+    expect(filters.filteredAnnotations.value).toEqual([]);
+  });
+
   it('keeps empty flat-mode annotations when Prevent Cascade is enabled', () => {
     const { filters } = makePairFixture([[]]);
     clientSettings.typeSettings.preventCascadeTypes = true;
@@ -643,9 +645,6 @@ describe('useAnnotationFilters', () => {
       renameTrackPair: (id, currentType, newType) => (
         cameraStore.renameTrackPair(id, currentType, newType)
       ),
-      setType: (id, type, confidence, current) => (
-        cameraStore.setTrackType(id, type, confidence, current)
-      ),
       removeTypes: (id, types) => cameraStore.removeTypes(id, types),
     });
     filters.loadTrackAttributesFilter([{
@@ -747,6 +746,29 @@ describe('useAnnotationFilters', () => {
     groupFilters.updateTypeName({ currentType: 'unused group', newType: 'renamed group' });
     expect(groupFilters.configuredTypes.value).not.toContain('unused group');
     expect(groupFilters.configuredTypes.value).not.toContain('renamed group');
+  });
+
+  it('renames assigned group pairs across camera replicas without collapsing the vector', () => {
+    const cameraStore = new CameraStore({ markChangesPending });
+    cameraStore.removeCamera('singleCam');
+    cameraStore.addCamera('left');
+    cameraStore.addCamera('right');
+    cameraStore.camMap.value.forEach(({ groupStore }) => {
+      groupStore.insert(new Group(7, {
+        confidencePairs: [['school', 0.7], ['other', 0.4]],
+        members: {},
+      }), { imported: true });
+      groupStore.setEnableSorting();
+    });
+    const groupFilters = makeGroupFilterControls(cameraStore);
+
+    groupFilters.updateTypeName({ currentType: 'school', newType: 'shoal' });
+
+    cameraStore.camMap.value.forEach(({ groupStore }) => {
+      expect(groupStore.get(7).confidencePairs).toEqual([
+        ['shoal', 0.7], ['other', 0.4],
+      ]);
+    });
   });
 
   it('renames a flat confidence-1 pair without collapsing the vector', () => {

--- a/client/src/TrackFilterControls.ts
+++ b/client/src/TrackFilterControls.ts
@@ -256,13 +256,7 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
           this.renameTrackPair(annotation.id, currentType, newType);
         }
       });
-      if (!(newType in this.confidenceFilters.value)
-        && currentType in this.confidenceFilters.value) {
-        this.setConfidenceFilters({
-          ...this.confidenceFilters.value,
-          [newType]: this.confidenceFilters.value[currentType],
-        });
-      }
+      this.carryConfidenceFilter(currentType, newType);
       this.deleteType(currentType);
       return;
     }
@@ -290,13 +284,7 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
         this.renameTrackPair(annotation.id, currentType, newType);
       }
     });
-    if (!(newType in this.confidenceFilters.value)
-      && currentType in this.confidenceFilters.value) {
-      this.setConfidenceFilters({
-        ...this.confidenceFilters.value,
-        [newType]: this.confidenceFilters.value[currentType],
-      });
-    }
+    this.carryConfidenceFilter(currentType, newType);
     if (this.configuredTypes.value.includes(currentType)
       && !this.configuredTypes.value.includes(newType)) {
       this.configuredTypes.value.push(newType);

--- a/client/src/components/FilterList.spec.ts
+++ b/client/src/components/FilterList.spec.ts
@@ -296,9 +296,6 @@ describe('FilterList hierarchy members', () => {
     });
 
     expect(vm.hierarchyActive).toBe(true);
-    expect(vm.hierarchyHelpText).toBe(
-      'Hierarchical types: DIVE displays the deepest checked stored type above its threshold. A parent that is not stored on a track is not used as a fallback. Parent counts include displayed descendants.',
-    );
     expect(wrapper.find('v-virtual-scroll').attributes()).toEqual(expect.objectContaining({
       role: 'list',
       'aria-label': 'Track type hierarchy',

--- a/client/src/components/FilterList.spec.ts
+++ b/client/src/components/FilterList.spec.ts
@@ -5,10 +5,24 @@ import {
 } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import { clientSettings } from 'dive-common/store/settings';
+import TrackFilterControls from '../TrackFilterControls';
+import Track, { Feature } from '../track';
+import BaseFilterControls from '../BaseFilterControls';
+import Group from '../Group';
+import CameraStore from '../CameraStore';
 import FilterList from './FilterList.vue';
 
 vi.mock('dive-common/vue-utilities/prompt-service', () => ({
   usePrompt: () => ({ prompt: vi.fn(), visible: () => false }),
+}));
+
+const provideMocks = vi.hoisted(() => ({
+  seekFrame: vi.fn(),
+  intervalSearch: vi.fn<(range: [number, number]) => string[]>(() => []),
+  getPossible: vi.fn(),
+  annotationMap: new Map<number, unknown>(),
+  selectedCameraValue: 'singleCam',
+  selectedCameraRef: undefined as { value: string } | undefined,
 }));
 
 /**
@@ -45,21 +59,133 @@ vi.mock('../provides', () => ({
   useCameraStore: () => ({
     camMap: ref(new Map([['singleCam', {
       trackStore: {
-        annotationMap: new Map(),
-        intervalTree: { search: () => [] },
-        getPossible: () => undefined,
+        annotationMap: provideMocks.annotationMap,
+        intervalTree: { search: provideMocks.intervalSearch },
+        getPossible: provideMocks.getPossible,
       },
     }]])),
-    getAnyPossibleTrack: () => undefined,
   }),
-  useHandler: () => ({ seekFrame: vi.fn() }),
+  useHandler: () => ({ seekFrame: provideMocks.seekFrame }),
   useReadOnlyMode: () => ref(false),
-  useSelectedCamera: () => ref('singleCam'),
+  useSelectedCamera: () => {
+    const selectedCamera = ref(provideMocks.selectedCameraValue);
+    provideMocks.selectedCameraRef = selectedCamera;
+    return selectedCamera;
+  },
   useTime: () => ({ frame: ref(0) }),
   usePendingSaveCount: () => ref(0),
 }));
 
+function makeFilterListFixture({
+  tracks,
+  hierarchy = null,
+  checkedTypes,
+  confidenceFilters,
+}: {
+  tracks: Track[];
+  hierarchy?: Record<string, string> | null;
+  checkedTypes: string[];
+  confidenceFilters?: Record<string, number>;
+}) {
+  const cameraStore = new CameraStore({ markChangesPending: vi.fn() });
+  const trackStore = cameraStore.camMap.value.get('singleCam')?.trackStore;
+  tracks.forEach((track) => trackStore?.insert(track));
+  trackStore?.setEnableSorting();
+  const filterControls = new TrackFilterControls({
+    sorted: cameraStore.sortedTracks,
+    remove: vi.fn(),
+    markChangesPending: vi.fn(),
+    removeTypes: vi.fn(() => []),
+    lookupGroups: () => [],
+    groupFilterControls: { enabledAnnotations: ref([]) } as unknown as BaseFilterControls<Group>,
+    getTracks: (id) => tracks.filter((track) => track.id === id),
+    renameTrackPair: vi.fn(() => []),
+  });
+  if (hierarchy) filterControls.setTypeHierarchy(hierarchy);
+  filterControls.setConfidenceFilters(confidenceFilters);
+  filterControls.updateCheckedTypes(checkedTypes);
+  const updateCheckedTypes = vi.spyOn(filterControls, 'updateCheckedTypes');
+  Object.freeze(filterControls);
+  const styleManager = Object.freeze({
+    customStyles: ref({}),
+    typeStyling: ref({
+      color: (type: string) => `color:${type}`,
+      strokeWidth: () => 1,
+      fill: () => false,
+      opacity: () => 1,
+    }),
+  });
+  return {
+    checkedTypes: filterControls.checkedTypes,
+    filterControls,
+    styleManager,
+    tracks,
+    updateCheckedTypes,
+  };
+}
+
+function makeHierarchyFixture(hierarchy: Record<string, string> = {
+  leaf: 'branch', branch: 'root', sibling: 'root',
+}) {
+  return makeFilterListFixture({
+    tracks: [new Track(1, {
+      confidencePairs: [['leaf', 1]],
+      features: [{ frame: 0, bounds: [0, 0, 1, 1], keyframe: true }],
+    })],
+    hierarchy,
+    checkedTypes: ['leaf'],
+    confidenceFilters: { root: 0.6, default: 0.1 },
+  });
+}
+
+function featuresAt(frames: number[], suppressedFrames: readonly number[] = []) {
+  const features: Feature[] = [];
+  frames.forEach((frame) => {
+    features[frame] = {
+      frame,
+      bounds: [0, 0, 1, 1],
+      keyframe: true,
+      attributes: suppressedFrames.includes(frame) ? { Suppressed: true } : undefined,
+    };
+  });
+  return features;
+}
+
+function makeCountHierarchyFixture({
+  tracks = [
+    new Track(1, {
+      confidencePairs: [['leaf', 1]],
+      features: featuresAt([0, 5]),
+    }),
+    new Track(2, {
+      confidencePairs: [['branch', 1]],
+      features: featuresAt([5]),
+    }),
+    new Track(3, {
+      confidencePairs: [['sibling', 1]],
+      features: featuresAt([5]),
+    }),
+  ],
+  hierarchy = { leaf: 'branch', branch: 'root', sibling: 'root' },
+  checkedTypes = ['root', 'branch', 'leaf', 'sibling'],
+}: {
+  tracks?: Track[];
+  hierarchy?: Record<string, string> | null;
+  checkedTypes?: string[];
+} = {}) {
+  return makeFilterListFixture({ tracks, hierarchy, checkedTypes });
+}
+
 describe('FilterList hierarchy members', () => {
+  beforeEach(() => {
+    provideMocks.seekFrame.mockReset();
+    provideMocks.intervalSearch.mockReset().mockReturnValue([]);
+    provideMocks.getPossible.mockReset();
+    provideMocks.annotationMap.clear();
+    provideMocks.selectedCameraValue = 'singleCam';
+    provideMocks.selectedCameraRef = undefined;
+  });
+
   it('keeps members as ordinary, independently checked flat rows', async () => {
     clientSettings.typeSettings.trackSortDir = 'a-z';
     clientSettings.typeSettings.filterTypesByFrame = false;
@@ -68,6 +194,7 @@ describe('FilterList hierarchy members', () => {
     const filterControls = Object.freeze({
       allTypes: ref(['leaf', 'heading']),
       usedTypes: ref(['leaf']),
+      configuredTypes: ref(['heading']),
       checkedTypes,
       filteredAnnotations: ref([]),
       confidenceFilters: ref({ default: 0.1 }),
@@ -89,6 +216,7 @@ describe('FilterList hierarchy members', () => {
       showEmptyTypes: false,
       height: 240,
       headerHeight: 80,
+      group: false,
     });
     expect(vm.visibleTypes).toEqual(['leaf']);
     expect(vm.virtualHeight).toBe(160);
@@ -96,9 +224,11 @@ describe('FilterList hierarchy members', () => {
     await setProps({ showEmptyTypes: true });
     expect(vm.visibleTypes).toEqual(['heading', 'leaf']);
     expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['heading', 'leaf']);
-    vm.updateCheckedType(false, 'heading');
+    vm.updateCheckedType('heading');
     expect(checkedTypes.value).toEqual(['leaf']);
     expect(vm.virtualTypes.find(({ type }) => type === 'heading')?.checked).toBe(false);
+    vm.updateCheckedType('heading');
+    expect(checkedTypes.value).toEqual(['leaf', 'heading']);
   });
 
   it('counts the type selected by each filtered annotation context', () => {
@@ -109,6 +239,7 @@ describe('FilterList hierarchy members', () => {
     const filterControls = Object.freeze({
       allTypes: ref(['root', 'leaf']),
       usedTypes: ref(['root', 'leaf']),
+      configuredTypes: ref([]),
       checkedTypes: ref(['root', 'leaf']),
       filteredAnnotations: ref([{
         annotation: {
@@ -147,5 +278,416 @@ describe('FilterList hierarchy members', () => {
     }));
     expect(vm.virtualTypes.find(({ type }) => type === 'root')?.displayText)
       .toBe('0 : 0\u00A0 root');
+  });
+
+  it('renders an expanded hierarchy with depth, tri-state, and structural parents', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    clientSettings.typeSettings.suppressionType = 'root';
+    clientSettings.typeSettings.suppressionThreshold = 80;
+    const { filterControls, styleManager } = makeHierarchyFixture();
+    const { wrapper, vm, setProps } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+      group: false,
+    });
+
+    expect(vm.hierarchyActive).toBe(true);
+    expect(vm.hierarchyHelpText).toBe(
+      'Hierarchical types: DIVE displays the deepest checked stored type above its threshold. A parent that is not stored on a track is not used as a fallback. Parent counts include displayed descendants.',
+    );
+    expect(wrapper.find('v-virtual-scroll').attributes()).toEqual(expect.objectContaining({
+      role: 'list',
+      'aria-label': 'Track type hierarchy',
+    }));
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root', 'branch', 'leaf']);
+    expect(vm.virtualTypes).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'root', depth: 0, hasChildren: true, expanded: true, indeterminate: true,
+      }),
+      expect.objectContaining({
+        type: 'branch', depth: 1, hasChildren: true, expanded: true, indeterminate: true,
+      }),
+      expect.objectContaining({
+        type: 'leaf', depth: 2, hasChildren: false, checked: true,
+      }),
+    ]));
+    expect(vm.virtualTypes.find(({ type }) => type === 'root')).toEqual(expect.objectContaining({
+      confidenceFilterNum: 0.6,
+      color: 'color:root',
+      isSuppressionType: true,
+      suppressionThreshold: 80,
+    }));
+
+    await setProps({ showEmptyTypes: true });
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual([
+      'root', 'branch', 'leaf', 'sibling',
+    ]);
+
+    await setProps({ group: true });
+    expect(vm.hierarchyActive).toBe(false);
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual([
+      'branch', 'leaf', 'root', 'sibling',
+    ]);
+    expect(vm.virtualTypes.every(({ tree }) => !tree)).toBe(true);
+  });
+
+  it('shows and recompacts a shared lineage without changing branch collapse state', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    const { filterControls, styleManager } = makeHierarchyFixture({
+      leaf: 'branch',
+      sibling: 'branch',
+      branch: 'class',
+      class: 'phylum',
+      phylum: 'kingdom',
+      kingdom: 'domain',
+    });
+    const { wrapper, vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.sharedLineage).toEqual(['domain', 'kingdom', 'phylum', 'class']);
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['branch', 'leaf']);
+    expect(vm.virtualTypes[0].depth).toBe(0);
+    expect(vm.virtualHeight).toBe(130);
+    expect(wrapper.find('.shared-lineage-text').text()).toBe(
+      'domain › kingdom › phylum › class',
+    );
+    expect(wrapper.find('.shared-lineage-text').classes()).toEqual(expect.arrayContaining([
+      'text-body-2', 'grey--text', 'text--lighten-1',
+    ]));
+    expect(wrapper.find('.shared-lineage-action').text()).toBe('Expand Parents');
+
+    await wrapper.find('.shared-lineage-action').trigger('click');
+    expect(vm.compactSharedLineage).toBe(false);
+    expect(wrapper.find('.shared-lineage-text').exists()).toBe(false);
+    expect(wrapper.find('.shared-lineage-action').text()).toBe('Compact Parents');
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual([
+      'domain', 'kingdom', 'phylum', 'class', 'branch', 'leaf',
+    ]);
+
+    vm.toggleExpanded('branch');
+    vm.toggleSharedLineage();
+    await nextTick();
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['branch']);
+
+    vm.toggleSharedLineage();
+    await nextTick();
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual([
+      'domain', 'kingdom', 'phylum', 'class', 'branch',
+    ]);
+  });
+
+  it('restores collapse after search and keeps parent updates complete and atomic', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    clientSettings.typeSettings.suppressionType = '';
+    const {
+      checkedTypes, filterControls, styleManager, updateCheckedTypes,
+    } = makeHierarchyFixture();
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    vm.toggleExpanded('root');
+    await nextTick();
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root']);
+
+    vm.data.filterText = 'leaf';
+    await nextTick();
+    expect(vm.visibleTypes).toEqual(['leaf']);
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root', 'branch', 'leaf']);
+
+    vm.data.filterText = '';
+    await nextTick();
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root']);
+
+    vm.updateCheckedType('root');
+    expect(updateCheckedTypes).toHaveBeenCalledTimes(1);
+    expect(checkedTypes.value).toEqual(['leaf', 'root', 'branch', 'sibling']);
+
+    vm.updateCheckedType('root');
+    expect(updateCheckedTypes).toHaveBeenCalledTimes(2);
+    expect(checkedTypes.value).toEqual([]);
+  });
+
+  it('ignores hidden disclosure actions while search forces a path open', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    const { filterControls, styleManager } = makeHierarchyFixture();
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    vm.data.filterText = 'leaf';
+    await nextTick();
+    vm.toggleExpanded('root');
+    vm.data.filterText = '';
+    await nextTick();
+
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root', 'branch', 'leaf']);
+  });
+
+  it('resets collapsed branches when a dataset hierarchy is loaded', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    const { filterControls, styleManager } = makeHierarchyFixture();
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    vm.toggleExpanded('root');
+    await nextTick();
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root']);
+
+    filterControls.typeHierarchy.value = {
+      leaf: 'branch', branch: 'root', sibling: 'root',
+    };
+    await nextTick();
+
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root', 'branch', 'leaf']);
+  });
+
+  it('keeps the header query-scoped while a context parent owns its full subtree', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    const {
+      checkedTypes, filterControls, styleManager, updateCheckedTypes,
+    } = makeHierarchyFixture();
+    checkedTypes.value = [];
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: true,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    vm.data.filterText = 'leaf';
+    await nextTick();
+    expect(vm.visibleTypes).toEqual(['leaf']);
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root', 'branch', 'leaf']);
+
+    vm.headCheckClicked();
+    expect(checkedTypes.value).toEqual(['leaf']);
+    expect(updateCheckedTypes).toHaveBeenCalledTimes(1);
+
+    vm.updateCheckedType('root');
+    expect(checkedTypes.value).toEqual(['leaf', 'root', 'branch', 'sibling']);
+    expect(updateCheckedTypes).toHaveBeenCalledTimes(2);
+  });
+
+  it('rolls total and frame counts into ancestors and keeps frame filtering header-independent', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = true;
+    clientSettings.typeSettings.suppressionType = '';
+    provideMocks.intervalSearch.mockImplementation(([frame]: [number, number]) => (
+      frame === 0 ? ['1'] : ['1', '2', '3']
+    ));
+    const { filterControls, styleManager, tracks } = makeCountHierarchyFixture();
+    provideMocks.getPossible.mockImplementation((id: number) => (
+      tracks.find((track) => track.id === id)
+    ));
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.typeCounts).toEqual(new Map([
+      ['leaf', 1], ['branch', 2], ['root', 3], ['sibling', 1],
+    ]));
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root', 'branch', 'leaf']);
+    expect(vm.virtualTypes.map(({ displayText }) => displayText)).toEqual([
+      '3 : 1\u00A0 root',
+      '2 : 1\u00A0 branch',
+      '1 : 1\u00A0 leaf',
+    ]);
+    expect(vm.visibleTypes).toEqual(['root', 'branch', 'leaf', 'sibling']);
+
+    provideMocks.seekFrame.mockClear();
+    vm.goToPeakTrackFrame('branch');
+    expect(provideMocks.seekFrame).toHaveBeenLastCalledWith(5);
+    vm.goToPeakTrackFrame('root');
+    expect(provideMocks.seekFrame).toHaveBeenLastCalledWith(5);
+  });
+
+  it.each([
+    ['flat type', null, 'leaf'],
+    ['hierarchy parent', { leaf: 'root' }, 'root'],
+  ] as const)('jumps to the suppression-aware peak for a %s', (
+    _view,
+    hierarchy,
+    targetType,
+  ) => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    clientSettings.typeSettings.suppressionType = 'Suppressed';
+    provideMocks.intervalSearch.mockImplementation(([frame]: [number, number]) => (
+      frame === 0 ? ['1', '2', '3'] : ['1', '2']
+    ));
+    const tracks = [
+      new Track(1, {
+        confidencePairs: [['leaf', 1]], features: featuresAt([0, 5], [0]),
+      }),
+      new Track(2, {
+        confidencePairs: [['leaf', 1]], features: featuresAt([0, 5], [0]),
+      }),
+      new Track(3, {
+        confidencePairs: [['leaf', 1]], features: featuresAt([0]),
+      }),
+    ];
+    const { filterControls, styleManager } = makeCountHierarchyFixture({
+      tracks,
+      hierarchy,
+      checkedTypes: hierarchy ? ['root', 'leaf'] : ['leaf'],
+    });
+    provideMocks.getPossible.mockImplementation((id: number) => (
+      tracks.find((track) => track.id === id)
+    ));
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.virtualTypes.find(({ type }) => type === targetType)?.displayText)
+      .toBe(`3 : 1\u00A0 ${targetType}`);
+    const intervalSearchCalls = provideMocks.intervalSearch.mock.calls.length;
+
+    vm.goToPeakTrackFrame(targetType);
+
+    expect(provideMocks.seekFrame).toHaveBeenCalledWith(5);
+    expect(provideMocks.intervalSearch).toHaveBeenCalledTimes(intervalSearchCalls);
+  });
+
+  it('finds a region-suppression-aware peak without rescanning each frame', () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    clientSettings.typeSettings.suppressionType = 'Suppressed';
+    clientSettings.typeSettings.suppressionThreshold = 99;
+    provideMocks.intervalSearch.mockImplementation(([frame]: [number, number]) => (
+      frame === 0 ? ['1', '2', '3', '4'] : ['1', '2']
+    ));
+    const tracks = [
+      new Track(1, {
+        confidencePairs: [['leaf', 1]], features: featuresAt([0, 5]),
+      }),
+      new Track(2, {
+        confidencePairs: [['leaf', 1]], features: featuresAt([0, 5]),
+      }),
+      new Track(3, {
+        confidencePairs: [['leaf', 1]], features: featuresAt([0]),
+      }),
+      new Track(4, {
+        confidencePairs: [['Suppressed', 1]], features: featuresAt([0]),
+      }),
+    ];
+    tracks.forEach((track) => provideMocks.annotationMap.set(track.id, track));
+    const { filterControls, styleManager } = makeCountHierarchyFixture({
+      tracks,
+      hierarchy: null,
+      checkedTypes: ['leaf', 'Suppressed'],
+    });
+    provideMocks.getPossible.mockImplementation((id: number) => (
+      tracks.find((track) => track.id === id)
+    ));
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.virtualTypes.find(({ type }) => type === 'leaf')?.displayText)
+      .toBe('3 : 0\u00A0 leaf');
+    const intervalSearchCalls = provideMocks.intervalSearch.mock.calls.length;
+
+    vm.goToPeakTrackFrame('leaf');
+
+    expect(provideMocks.seekFrame).toHaveBeenCalledWith(5);
+    expect(provideMocks.intervalSearch).toHaveBeenCalledTimes(intervalSearchCalls);
+  });
+
+  it('starts current-frame counts when an asynchronous camera selection becomes available', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    clientSettings.typeSettings.suppressionType = '';
+    provideMocks.selectedCameraValue = '';
+    provideMocks.intervalSearch.mockReturnValue(['1']);
+    const { filterControls, styleManager, tracks } = makeCountHierarchyFixture();
+    provideMocks.getPossible.mockImplementation((id: number) => (
+      tracks.find((track) => track.id === id)
+    ));
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.virtualTypes.find(({ type }) => type === 'root')?.displayText)
+      .toBe('3 : 0\u00A0 root');
+
+    if (!provideMocks.selectedCameraRef) {
+      throw new Error('selected camera ref was not captured');
+    }
+    provideMocks.selectedCameraRef.value = 'singleCam';
+    await nextTick();
+
+    expect(vm.virtualTypes.find(({ type }) => type === 'root')?.displayText)
+      .toBe('3 : 1\u00A0 root');
+  });
+
+  it('does not restore attribute-suppressed descendants through ancestor roll-up', () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    clientSettings.typeSettings.suppressionType = 'Suppressed';
+    const { filterControls, styleManager, tracks } = makeCountHierarchyFixture();
+    tracks[0].attributes.Suppressed = true;
+    tracks.forEach((track) => provideMocks.annotationMap.set(track.id, track));
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.typeCounts).toEqual(new Map([
+      ['branch', 1], ['root', 2], ['sibling', 1],
+    ]));
+    expect(vm.virtualTypes.map(({ displayText }) => displayText)).toEqual([
+      '2 : 0\u00A0 root',
+      '1 : 0\u00A0 branch',
+      '0 : 0\u00A0 leaf',
+      '1 : 0\u00A0 sibling',
+    ]);
   });
 });

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -27,7 +27,8 @@ import {
   suppressionTypeResolver,
 } from '../use/suppression';
 import {
-  buildTypeListModel, countResolvedTypes, TypeListModel, updateHierarchyCheckedTypes,
+  buildTypeListModel, countResolvedTypes, TypeListModel, TypeListRow,
+  updateHierarchyCheckedTypes,
 } from '../typeListHierarchy';
 
 /* Row height shared by the type rows, the shared-lineage breadcrumb, and the
@@ -35,17 +36,11 @@ import {
 const ROW_HEIGHT = 30;
 const EMPTY_HIERARCHY_INDEX = compileHierarchy({});
 
-interface VirtualTypeItem {
-  type: string;
+interface VirtualTypeItem extends TypeListRow {
   confidenceFilterNum: number;
   displayText: string;
   color: string;
-  checked: boolean;
-  indeterminate: boolean;
   tree: boolean;
-  depth: number;
-  hasChildren: boolean;
-  expanded: boolean;
   isSuppressionType: boolean;
   suppressionThreshold: number;
 }
@@ -128,7 +123,6 @@ export default defineComponent({
     const typeStylingRef = props.styleManager.typeStyling;
     const filteredTracksRef = trackFilters.filteredAnnotations;
     const confidenceFiltersRef = trackFilters.confidenceFilters;
-    const hierarchyHelpText = 'Hierarchical types: DIVE displays the deepest checked stored type above its threshold. A parent that is not stored on a track is not used as a fallback. Parent counts include displayed descendants.';
     const collapsedTypes: Ref<Set<string>> = ref(new Set<string>());
     const compactSharedLineage = ref(true);
     const hierarchyIndexRef = computed(() => (
@@ -338,9 +332,8 @@ export default defineComponent({
     const typeListModel: Ref<TypeListModel> = computed(() => {
       const sort = sortingMethods[data.sortingMethod];
       const byFrame = filterTypesByFrame.value ?? false;
-      // Frame counts only reach the model through frame-count sorting and the
-      // per-frame filter. Reading them unconditionally would rebuild the whole
-      // tree on every playback frame, so they are withheld otherwise.
+      // The model needs frame counts only when they affect row visibility or order.
+      // Otherwise playback can update displayed counts without rebuilding the tree.
       const usesFrameCounts = byFrame || sort === 'frame count';
       return buildTypeListModel({
         hierarchyIndex: hierarchyIndexRef.value || EMPTY_HIERARCHY_INDEX,
@@ -499,7 +492,6 @@ export default defineComponent({
     return {
       data,
       hierarchyActive,
-      hierarchyHelpText,
       compactSharedLineage,
       sharedLineage,
       sharedLineageText,
@@ -583,27 +575,6 @@ export default defineComponent({
               <b v-on="on">Type Filter</b>
             </template>
             <span>Toggle Type TotalCount:FrameCount Type Name</span>
-          </v-tooltip>
-          <v-tooltip
-            v-if="hierarchyActive"
-            open-delay="100"
-            bottom
-            max-width="420"
-          >
-            <template #activator="{ on, attrs }">
-              <button
-                type="button"
-                class="hierarchy-help ml-1"
-                aria-label="About hierarchical types"
-                v-bind="attrs"
-                v-on="on"
-              >
-                <v-icon small>
-                  mdi-information-outline
-                </v-icon>
-              </button>
-            </template>
-            <span>{{ hierarchyHelpText }}</span>
           </v-tooltip>
           <div class="type-header-actions d-flex align-center ml-auto">
             <tooltip-btn
@@ -735,22 +706,6 @@ $row-height: 30px;
 
 .type-header-actions {
   flex-shrink: 0;
-}
-
-.hierarchy-help {
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border: 0;
-  border-radius: 2px;
-  color: inherit;
-  background: transparent;
-  cursor: pointer;
-}
-
-.hierarchy-help:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 1px;
 }
 
 .shared-lineage {

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -3,10 +3,13 @@ import {
   computed, defineComponent, onBeforeUnmount, PropType, reactive, ref, Ref,
   watch,
 } from 'vue';
-import { debounce, difference, union } from 'lodash';
+import {
+  debounce, difference, union,
+} from 'lodash';
 
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { clientSettings } from 'dive-common/store/settings';
+import { compileHierarchy } from 'dive-common/typeHierarchy';
 import {
   useCameraStore, useHandler, useReadOnlyMode, useSelectedCamera, useTime,
   usePendingSaveCount,
@@ -14,14 +17,23 @@ import {
 import TooltipBtn from './TooltipButton.vue';
 import TypeEditor from './TypeEditor.vue';
 import TypeItem from './TypeItem.vue';
-import BaseFilterControls from '../BaseFilterControls';
+import BaseFilterControls, { AnnotationWithContext } from '../BaseFilterControls';
 import TrackFilterControls from '../TrackFilterControls';
 import Track from '../track';
 import Group from '../Group';
 import StyleManager from '../StyleManager';
 import {
-  getSuppressedTrackIds, hasSuppressionAttribute, suppressionTypeResolver,
+  createRegionSuppressionTester, getSuppressedTrackIds, hasSuppressionAttribute,
+  suppressionTypeResolver,
 } from '../use/suppression';
+import {
+  buildTypeListModel, countResolvedTypes, TypeListModel, updateHierarchyCheckedTypes,
+} from '../typeListHierarchy';
+
+/* Row height shared by the type rows, the shared-lineage breadcrumb, and the
+   scroller's height accounting. Mirrored by `$row-height` in the style block. */
+const ROW_HEIGHT = 30;
+const EMPTY_HIERARCHY_INDEX = compileHierarchy({});
 
 interface VirtualTypeItem {
   type: string;
@@ -29,6 +41,11 @@ interface VirtualTypeItem {
   displayText: string;
   color: string;
   checked: boolean;
+  indeterminate: boolean;
+  tree: boolean;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
   isSuppressionType: boolean;
   suppressionThreshold: number;
 }
@@ -81,7 +98,9 @@ export default defineComponent({
     // counts so they re-evaluate suppression when a region is moved, since a
     // track's geometry is not itself a reactive dependency.
     const pendingSaveCount = usePendingSaveCount();
-    const trackStore = cameraStore.camMap.value.get(selectedCamera.value)?.trackStore;
+    const trackStore = computed(() => (
+      cameraStore.camMap.value.get(selectedCamera.value)?.trackStore
+    ));
     // Ordering of these lists should match
     const sortingMethods: ('a-z' | 'count' | 'frame count')[] = ['a-z', 'count', 'frame count'];
     const sortingMethodIcons = ['mdi-sort-alphabetical-ascending', 'mdi-sort-numeric-ascending', 'mdi-sort-clock-ascending-outline'];
@@ -109,6 +128,21 @@ export default defineComponent({
     const typeStylingRef = props.styleManager.typeStyling;
     const filteredTracksRef = trackFilters.filteredAnnotations;
     const confidenceFiltersRef = trackFilters.confidenceFilters;
+    const hierarchyHelpText = 'Hierarchical types: DIVE displays the deepest checked stored type above its threshold. A parent that is not stored on a track is not used as a fallback. Parent counts include displayed descendants.';
+    const collapsedTypes: Ref<Set<string>> = ref(new Set<string>());
+    const compactSharedLineage = ref(true);
+    const hierarchyIndexRef = computed(() => (
+      !props.group && trackFilters instanceof TrackFilterControls
+        ? trackFilters.hierarchyIndex.value
+        : undefined
+    ));
+    const hierarchyActive = computed(() => hierarchyIndexRef.value !== undefined);
+    if (trackFilters instanceof TrackFilterControls) {
+      watch(trackFilters.typeHierarchy, () => {
+        collapsedTypes.value = new Set<string>();
+        compactSharedLineage.value = true;
+      });
+    }
 
     function clickEdit(type: string) {
       data.selectedType = type;
@@ -224,38 +258,52 @@ export default defineComponent({
     );
     onBeforeUnmount(() => debouncedFullySuppressed.cancel());
 
+    /**
+     * Tally displayed types. With a hierarchy installed each track also counts
+     * toward its ancestors, and a track spanning several cameras counts once.
+     */
+    function countTypes(tracks: readonly AnnotationWithContext<Track | Group>[]) {
+      const entries = tracks.map(({ annotation, context }) => ({
+        id: annotation.id,
+        type: annotation.getType(context.confidencePairIndex),
+      }));
+      const hierarchyIndex = hierarchyIndexRef.value;
+      if (hierarchyIndex) {
+        return countResolvedTypes(entries, hierarchyIndex);
+      }
+      return entries.reduce(
+        (acc, { type }) => acc.set(type, (acc.get(type) || 0) + 1),
+        new Map<string, number>(),
+      );
+    }
+
     const typeCounts = computed(() => {
       const excluded = fullySuppressedIds.value;
-      return filteredTracksRef.value.reduce((acc, filteredTrack) => {
-        if (excluded.has(filteredTrack.annotation.id)) {
-          return acc;
-        }
-        const confidencePair = filteredTrack.annotation
-          .getType(filteredTrack.context.confidencePairIndex);
-        const trackType = confidencePair;
-        acc.set(trackType, (acc.get(trackType) || 0) + 1);
-
-        return acc;
-      }, new Map<string, number>());
+      return countTypes(filteredTracksRef.value
+        .filter(({ annotation }) => !excluded.has(annotation.id)));
     });
 
-    const filteredTracksForFrame = computed(() => {
+    function countedTracksForFrame(targetFrame: number) {
       // Depend on the edit counter so moving/resizing a suppression region
       // (which mutates geometry, not the reactive track set) re-runs the count.
       // It is always >= 0, so this reads the dependency without changing logic.
       const editRevision = pendingSaveCount.value;
-      const trackIdsForFrame = trackStore?.intervalTree
-        .search([frame.value, frame.value])
+      const activeTrackStore = trackStore.value;
+      if (!activeTrackStore) {
+        return [];
+      }
+      const trackIdsForFrame = activeTrackStore.intervalTree
+        .search([targetFrame, targetFrame])
         .map((str) => parseInt(str, 10));
       // Detections suppressed by a region on this frame are dropped so the
       // per-frame type counts read off the interface exclude them, and
       // attribute-suppressed detections (visible, real type retained) don't
       // count toward their own type either.
       const suppType = clientSettings.typeSettings.suppressionType;
-      const suppressedIds = (trackStore && editRevision >= 0)
+      const suppressedIds = editRevision >= 0
         ? getSuppressedTrackIds(
-          trackStore,
-          frame.value,
+          activeTrackStore,
+          targetFrame,
           suppType,
           clientSettings.typeSettings.suppressionThreshold,
           { revision: editRevision, resolver: suppressionResolutionRef.value },
@@ -265,73 +313,69 @@ export default defineComponent({
         if (suppressedIds.has(track.annotation.id)) {
           return false;
         }
-        const realTrack = trackStore?.getPossible(track.annotation.id);
-        if (realTrack && hasSuppressionAttribute(realTrack, frame.value, suppType)) {
+        const realTrack = activeTrackStore.getPossible(track.annotation.id);
+        if (realTrack && hasSuppressionAttribute(realTrack, targetFrame, suppType)) {
           return false;
         }
-        const keyframe = realTrack?.getFeature(frame.value)[0];
+        const keyframe = realTrack?.getFeature(targetFrame)[0];
         return !!keyframe?.keyframe;
       });
-      return (filteredKeyFrameTracks.filter((track) => trackIdsForFrame?.includes(track.annotation.id)));
-    });
-
-    const currentFrameTrackTypes = computed(() => filteredTracksForFrame.value.reduce((acc, filteredTrack) => {
-      const confidencePair = filteredTrack.annotation
-        .getType(filteredTrack.context.confidencePairIndex);
-      const trackType = confidencePair;
-      acc.set(trackType, (acc.get(trackType) || 0) + 1);
-
-      return acc;
-    }, new Map<string, number>()));
-
-    function sortAndFilterTypes(types: Ref<readonly string[]>) {
-      const filtered = types.value
-        .filter((t) => t.toLowerCase().includes(data.filterText.toLowerCase()));
-      switch (sortingMethods[data.sortingMethod]) {
-        case 'a-z':
-          return filtered.sort();
-        case 'count':
-          return filtered.sort(
-            (a, b) => (typeCounts.value.get(b) || 0) - (typeCounts.value.get(a) || 0),
-          );
-        case 'frame count':
-          return filtered.sort(
-            (a, b) => (currentFrameTrackTypes.value.get(b) || 0) - (currentFrameTrackTypes.value.get(a) || 0),
-          );
-        default:
-          return filtered;
-      }
+      return filteredKeyFrameTracks.filter(
+        (track) => trackIdsForFrame.includes(track.annotation.id),
+      );
     }
 
-    const visibleTypes = computed(() => {
-      if (props.showEmptyTypes) {
-        return sortAndFilterTypes(allTypesRef);
-      }
-      return sortAndFilterTypes(usedTypesRef);
-    });
+    const filteredTracksForFrame = computed(() => countedTracksForFrame(frame.value));
+
+    const currentFrameTrackTypes = computed(() => countTypes(filteredTracksForFrame.value));
+
     const filterTypesByFrame = ref(clientSettings.typeSettings.filterTypesByFrame);
 
     watch(() => clientSettings.typeSettings.filterTypesByFrame, (newValue) => {
       filterTypesByFrame.value = newValue;
     });
+    const noFrameCounts = new Map<string, number>();
+    const typeListModel: Ref<TypeListModel> = computed(() => {
+      const sort = sortingMethods[data.sortingMethod];
+      const byFrame = filterTypesByFrame.value ?? false;
+      // Frame counts only reach the model through frame-count sorting and the
+      // per-frame filter. Reading them unconditionally would rebuild the whole
+      // tree on every playback frame, so they are withheld otherwise.
+      const usesFrameCounts = byFrame || sort === 'frame count';
+      return buildTypeListModel({
+        hierarchyIndex: hierarchyIndexRef.value || EMPTY_HIERARCHY_INDEX,
+        allTypes: allTypesRef.value,
+        usedTypes: usedTypesRef.value,
+        configuredTypes: trackFilters.configuredTypes.value,
+        checkedTypes: checkedTypesRef.value,
+        counts: typeCounts.value,
+        frameCounts: usesFrameCounts ? currentFrameTrackTypes.value : noFrameCounts,
+        showEmpty: props.showEmptyTypes,
+        query: data.filterText,
+        filterTypesByFrame: byFrame,
+        sort,
+        collapsed: collapsedTypes.value,
+        compactSharedLineage: compactSharedLineage.value,
+      });
+    });
+    const sharedLineage = computed(() => typeListModel.value.sharedLineage);
+    const sharedLineageText = computed(() => sharedLineage.value.join(' › '));
+    const visibleTypes = computed(() => typeListModel.value.actionableTypes);
     const virtualTypes: Ref<readonly VirtualTypeItem[]> = computed(() => {
       const confidenceFiltersDeRef = confidenceFiltersRef.value;
       const typeCountsDeRef = typeCounts.value;
       const typeStylingDeRef = typeStylingRef.value;
-      const checkedTypesDeRef = checkedTypesRef.value;
       const frameTrackTypesDeRef = currentFrameTrackTypes.value;
-      let filteredTypeList = visibleTypes.value;
-      if (filterTypesByFrame.value) {
-        filteredTypeList = filteredTypeList.filter((item) => frameTrackTypesDeRef.get(item));
-      }
       const { suppressionType, suppressionThreshold } = clientSettings.typeSettings;
-      return filteredTypeList.map((item) => ({
-        type: item,
-        confidenceFilterNum: confidenceFiltersDeRef[item] || 0,
-        displayText: `${typeCountsDeRef.get(item) || 0} : ${frameTrackTypesDeRef.get(item) || 0}\u00A0 ${item}`,
-        color: typeStylingDeRef.color(item),
-        checked: checkedTypesDeRef.includes(item),
-        isSuppressionType: !!suppressionType && item === suppressionType,
+      const { rows } = typeListModel.value;
+      return rows.map(({ type, ...row }) => ({
+        ...row,
+        type,
+        confidenceFilterNum: confidenceFiltersDeRef[type] || 0,
+        displayText: `${typeCountsDeRef.get(type) || 0} : ${frameTrackTypesDeRef.get(type) || 0}\u00A0 ${type}`,
+        color: typeStylingDeRef.color(type),
+        tree: hierarchyActive.value,
+        isSuppressionType: !!suppressionType && type === suppressionType,
         suppressionThreshold: suppressionThreshold ?? 99,
       }));
     });
@@ -362,36 +406,81 @@ export default defineComponent({
       }
     }
 
-    function updateCheckedType(evt: boolean, type: string) {
-      if (evt) {
-        trackFilters.updateCheckedTypes(checkedTypesRef.value.concat([type]));
-      } else {
-        trackFilters.updateCheckedTypes(difference(checkedTypesRef.value, [type]));
-      }
+    function updateCheckedType(type: string) {
+      const model = typeListModel.value;
+      const shouldCheck = model.checkState.get(type) !== 'checked';
+      trackFilters.updateCheckedTypes(updateHierarchyCheckedTypes(
+        checkedTypesRef.value,
+        model.subtree,
+        type,
+        shouldCheck,
+      ));
     }
 
-    const virtualHeight = computed(() => props.height - props.headerHeight);
+    function toggleExpanded(type: string) {
+      if (data.filterText.length > 0) {
+        return;
+      }
+      const next = new Set(collapsedTypes.value);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      collapsedTypes.value = next;
+    }
+
+    function toggleSharedLineage() {
+      compactSharedLineage.value = !compactSharedLineage.value;
+    }
+
+    const showSharedLineageControl = computed(() => (
+      sharedLineage.value.length > 0 && data.filterText.length === 0
+    ));
+    const virtualHeight = computed(() => (
+      props.height - props.headerHeight - (showSharedLineageControl.value ? ROW_HEIGHT : 0)
+    ));
 
     const goToPeakTrackFrame = (trackType: string) => {
-      const frameCounts = new Map<number, number>();
-
-      const tracksFilteredByType = filteredTracksRef.value.filter((track) => track.annotation.getType(track.context.confidencePairIndex) === trackType);
-      tracksFilteredByType.forEach((track) => {
-        const trackObj = cameraStore.getAnyPossibleTrack(track.annotation.id);
-        if (trackObj) {
-          trackObj.features.filter((item) => item.keyframe).forEach((item) => {
-            const current = frameCounts.get(item.frame) || 0;
-            frameCounts.set(item.frame, current + 1);
+      const subtreeSet = new Set(
+        hierarchyActive.value ? typeListModel.value.subtree.get(trackType) : [trackType],
+      );
+      const tracksFilteredByType = filteredTracksRef.value.filter(({ annotation, context }) => (
+        subtreeSet.has(annotation.getType(context.confidencePairIndex))
+      ));
+      const activeTrackStore = trackStore.value;
+      if (!activeTrackStore) {
+        handler.seekFrame(-1);
+        return;
+      }
+      /* The displayed frame counts are selected-camera scoped, so the peak is too. */
+      const suppType = clientSettings.typeSettings.suppressionType;
+      const isRegionSuppressed = createRegionSuppressionTester(
+        activeTrackStore,
+        suppType,
+        clientSettings.typeSettings.suppressionThreshold,
+        suppressionResolutionRef.value,
+      );
+      const countByFrame = new Map<number, number>();
+      tracksFilteredByType.forEach(({ annotation }) => {
+        const realTrack = activeTrackStore.getPossible(annotation.id);
+        realTrack?.features
+          .filter((item) => item?.keyframe)
+          .forEach((item) => {
+            if (hasSuppressionAttribute(realTrack, item.frame, suppType)
+              || isRegionSuppressed(realTrack, item.frame)) {
+              return;
+            }
+            countByFrame.set(item.frame, (countByFrame.get(item.frame) || 0) + 1);
           });
-        }
       });
 
       let maxFrame = -1;
       let maxCount = 0;
-      frameCounts.forEach((count, f) => {
+      countByFrame.forEach((count, candidateFrame) => {
         if (count > maxCount) {
           maxCount = count;
-          maxFrame = f;
+          maxFrame = candidateFrame;
         }
       });
       handler.seekFrame(maxFrame);
@@ -409,6 +498,12 @@ export default defineComponent({
 
     return {
       data,
+      hierarchyActive,
+      hierarchyHelpText,
+      compactSharedLineage,
+      sharedLineage,
+      sharedLineageText,
+      showSharedLineageControl,
       headCheckState,
       visibleTypes,
       usedTypesRef,
@@ -420,6 +515,7 @@ export default defineComponent({
       sortingMethodIcons,
       virtualHeight,
       virtualTypes,
+      rowHeight: ROW_HEIGHT,
       readOnlyMode,
       filteredTracksRef,
       disableAnnotationFilters,
@@ -430,6 +526,8 @@ export default defineComponent({
       headCheckClicked,
       setCheckedTypes: trackFilters.updateCheckedTypes,
       updateCheckedType,
+      toggleExpanded,
+      toggleSharedLineage,
       goToPeakTrackFrame,
       showMaxFrameButton,
     };
@@ -486,6 +584,27 @@ export default defineComponent({
             </template>
             <span>Toggle Type TotalCount:FrameCount Type Name</span>
           </v-tooltip>
+          <v-tooltip
+            v-if="hierarchyActive"
+            open-delay="100"
+            bottom
+            max-width="420"
+          >
+            <template #activator="{ on, attrs }">
+              <button
+                type="button"
+                class="hierarchy-help ml-1"
+                aria-label="About hierarchical types"
+                v-bind="attrs"
+                v-on="on"
+              >
+                <v-icon small>
+                  mdi-information-outline
+                </v-icon>
+              </button>
+            </template>
+            <span>{{ hierarchyHelpText }}</span>
+          </v-tooltip>
           <div class="type-header-actions d-flex align-center ml-auto">
             <tooltip-btn
               :icon="sortingMethodIcons[data.sortingMethod]"
@@ -528,18 +647,47 @@ export default defineComponent({
       placeholder="Search types"
       class="mx-2 mt-2 shrink input-box"
     >
+    <div
+      v-if="showSharedLineageControl"
+      class="shared-lineage d-flex align-center mx-2"
+    >
+      <span
+        v-if="compactSharedLineage"
+        class="shared-lineage-text text-body-2 grey--text text--lighten-1"
+        :title="sharedLineageText"
+      >
+        {{ sharedLineageText }}
+      </span>
+      <v-btn
+        text
+        small
+        class="shared-lineage-action ml-auto flex-shrink-0"
+        :aria-label="compactSharedLineage ? 'Expand parents' : 'Compact parents'"
+        @click="toggleSharedLineage"
+      >
+        {{ compactSharedLineage ? 'Expand Parents' : 'Compact Parents' }}
+      </v-btn>
+    </div>
     <div class="py-2 overflow-y-hidden">
       <v-virtual-scroll
         class="tracks"
         :items="virtualTypes"
-        :item-height="30"
+        :item-height="rowHeight"
         :height="virtualHeight"
+        :role="hierarchyActive ? 'list' : undefined"
+        :aria-label="hierarchyActive ? 'Track type hierarchy' : undefined"
         bench="1"
       >
         <template #default="{ item }">
           <type-item
             :type="item.type"
             :checked="item.checked"
+            :indeterminate="item.indeterminate"
+            :tree="item.tree"
+            :depth="item.depth"
+            :has-children="item.hasChildren"
+            :expanded="item.expanded"
+            :disclosure-visible="data.filterText.length === 0"
             :color="item.color"
             :display-text="item.displayText"
             :confidence-filter-num="item.confidenceFilterNum"
@@ -548,7 +696,8 @@ export default defineComponent({
             :disabled="disableAnnotationFilters"
             :is-suppression-type="item.isSuppressionType"
             :suppression-threshold="item.suppressionThreshold"
-            @setCheckedTypes="updateCheckedType($event, item.type)"
+            @setCheckedTypes="updateCheckedType(item.type)"
+            @toggleExpanded="toggleExpanded(item.type)"
             @goToMaxFrame="goToPeakTrackFrame($event)"
             @clickEdit="clickEdit"
           />
@@ -573,6 +722,8 @@ export default defineComponent({
 <style scoped lang='scss'>
 @import 'src/components/styles/common.scss';
 
+$row-height: 30px;
+
 .border-highlight {
    border-bottom: 1px solid gray;
  }
@@ -586,17 +737,34 @@ export default defineComponent({
   flex-shrink: 0;
 }
 
-.hover-show-parent {
-  .hover-show-child {
-    display: none;
-  }
-
-  &:hover {
-    .hover-show-child {
-      display: inherit;
-    }
-  }
+.hierarchy-help {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 2px;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
 }
+
+.hierarchy-help:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 1px;
+}
+
+.shared-lineage {
+  height: $row-height;
+  min-width: 0;
+}
+
+.shared-lineage-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .outlined {
   background-color: gray;
   color: #222;

--- a/client/src/components/LayerManager.spec.ts
+++ b/client/src/components/LayerManager.spec.ts
@@ -253,7 +253,7 @@ function makeMultiCamFixture(
     sorted: cameraStore.sortedGroups,
     remove: () => undefined,
     markChangesPending: () => undefined,
-    setType: () => undefined,
+    setGroupType: () => undefined,
     removeTypes: () => [],
   });
   const trackFilters = new TrackFilterControls({
@@ -266,7 +266,6 @@ function makeMultiCamFixture(
       cameraStore.renameTrackPair(id, currentType, newType)
     ),
     groupFilterControls,
-    setType: () => undefined,
     removeTypes: () => [],
   });
   trackFilters.setTypeHierarchy(hierarchy);

--- a/client/src/components/TypeItem.spec.ts
+++ b/client/src/components/TypeItem.spec.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+/// <reference types="vitest" />
+import {
+  defineComponent, h, reactive,
+} from 'vue';
+import { shallowMount } from '@vue/test-utils';
+import TypeItem from './TypeItem.vue';
+
+function mountTypeItem(props: Record<string, unknown>) {
+  const state = reactive(props);
+  const toggleExpanded = vi.fn();
+  let child: InstanceType<typeof TypeItem> | undefined;
+  const Host = defineComponent({
+    setup: () => () => h(TypeItem, {
+      props: state,
+      on: { toggleExpanded },
+      ref: (instance) => {
+        if (instance && !(instance instanceof Element)) {
+          child = instance as InstanceType<typeof TypeItem>;
+        }
+      },
+    }),
+  });
+  const wrapper = shallowMount(Host, {
+    stubs: {
+      TypeItem: false,
+      VTooltip: {
+        template: '<div><slot name="activator" :on="{}" :attrs="{}" /><slot /></div>',
+      },
+    },
+  });
+  if (!child) {
+    throw new Error('TypeItem did not mount');
+  }
+  return { wrapper, vm: child, toggleExpanded };
+}
+
+describe('TypeItem hierarchy row', () => {
+  it('exposes hierarchy semantics and keeps the type color active while indeterminate', async () => {
+    const { wrapper, vm, toggleExpanded } = mountTypeItem({
+      type: 'fish',
+      displayText: '3 : 1\u00A0 fish',
+      confidenceFilterNum: 0.4,
+      color: '#abc',
+      checked: false,
+      indeterminate: true,
+      tree: true,
+      depth: 2,
+      hasChildren: true,
+      expanded: true,
+      width: 300,
+      displayMaxButton: true,
+      disabled: true,
+      isSuppressionType: true,
+      suppressionThreshold: 80,
+    });
+
+    const row = wrapper.find('v-row');
+    expect(row.attributes()).toEqual(expect.objectContaining({
+      role: 'listitem',
+      'aria-level': '3',
+    }));
+    expect(row.attributes('aria-expanded')).toBeUndefined();
+    const disclosure = wrapper.find('[aria-label="Collapse descendants of fish"]');
+    expect(disclosure.exists()).toBe(true);
+    expect(disclosure.element.tagName).toBe('BUTTON');
+    expect((disclosure.element as HTMLButtonElement).tabIndex).toBe(0);
+    expect(disclosure.attributes('type')).toBe('button');
+    expect(disclosure.attributes('aria-expanded')).toBe('true');
+    await disclosure.trigger('click');
+    expect(toggleExpanded).toHaveBeenCalledTimes(1);
+
+    const checkbox = wrapper.find('v-checkbox');
+    expect(checkbox.attributes()).toEqual(expect.objectContaining({
+      'input-value': 'true',
+      indeterminate: 'true',
+      color: '#abc',
+      disabled: 'true',
+    }));
+    expect(vm.cssVars)
+      .toEqual(expect.objectContaining({
+        '--content-width': '138px',
+        '--tree-depth': '32px',
+      }));
+    expect(wrapper.find('.row-help').exists()).toBe(false);
+  });
+
+  it('keeps flat rows free of hierarchy roles and disclosure controls', () => {
+    const { wrapper } = mountTypeItem({
+      type: 'fish',
+      displayText: '3 : 1\u00A0 fish',
+      confidenceFilterNum: 0,
+      color: '#abc',
+      checked: true,
+    });
+
+    expect(wrapper.find('v-row').attributes('role')).toBeUndefined();
+    expect(wrapper.find('[aria-label*="descendants of fish"]').exists()).toBe(false);
+    expect(wrapper.find('v-checkbox').attributes('indeterminate')).toBeUndefined();
+  });
+
+  it('uses an indentation spacer while search forces a parent open', () => {
+    const { wrapper } = mountTypeItem({
+      type: 'fish',
+      displayText: '3 : 1\u00A0 fish',
+      confidenceFilterNum: 0,
+      color: '#abc',
+      checked: true,
+      tree: true,
+      hasChildren: true,
+      expanded: true,
+      disclosureVisible: false,
+    });
+
+    expect(wrapper.find('[aria-label="Collapse descendants of fish"]').exists()).toBe(false);
+    expect(wrapper.find('.tree-disclosure-spacer').exists()).toBe(true);
+  });
+});

--- a/client/src/components/TypeItem.vue
+++ b/client/src/components/TypeItem.vue
@@ -28,6 +28,30 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
+    indeterminate: {
+      type: Boolean,
+      default: false,
+    },
+    tree: {
+      type: Boolean,
+      default: false,
+    },
+    depth: {
+      type: Number,
+      default: 0,
+    },
+    hasChildren: {
+      type: Boolean,
+      default: false,
+    },
+    expanded: {
+      type: Boolean,
+      default: false,
+    },
+    disclosureVisible: {
+      type: Boolean,
+      default: true,
+    },
     width: {
       type: Number,
       default: 300,
@@ -58,7 +82,14 @@ export default defineComponent({
       }
       return 42 + 14 + 20 + 30;
     });
-    const cssVars = computed(() => ({ '--content-width': `${props.width - HorizontalPadding.value}px` }));
+    const HierarchyPadding = computed(() => (props.tree ? (props.depth * 16) + 24 : 0));
+    const cssVars = computed(() => ({
+      '--content-width': `${Math.max(
+        0,
+        props.width - HorizontalPadding.value - HierarchyPadding.value,
+      )}px`,
+      '--tree-depth': `${props.depth * 16}px`,
+    }));
     const effectiveOverlapPercent = computed(() => {
       const p = Number(props.suppressionThreshold);
       if (!Number.isFinite(p) || p <= 0 || p > 100) {
@@ -83,10 +114,35 @@ export default defineComponent({
     :style="cssVars"
     align="center"
     class="hover-show-parent"
+    :role="tree ? 'listitem' : undefined"
+    :aria-level="tree ? depth + 1 : undefined"
   >
     <v-col class="d-flex flex-row py-0 align-center">
+      <div
+        v-if="tree"
+        class="tree-prefix d-flex align-center justify-center"
+      >
+        <button
+          v-if="hasChildren && disclosureVisible"
+          type="button"
+          class="tree-disclosure"
+          :aria-label="`${expanded ? 'Collapse' : 'Expand'} descendants of ${type}`"
+          :aria-expanded="expanded"
+          @click="$emit('toggleExpanded')"
+        >
+          <v-icon small>
+            {{ expanded ? 'mdi-chevron-down' : 'mdi-chevron-right' }}
+          </v-icon>
+        </button>
+        <span
+          v-else
+          class="tree-disclosure-spacer"
+          aria-hidden="true"
+        />
+      </div>
       <v-checkbox
-        :input-value="checked"
+        :input-value="checked || indeterminate"
+        :indeterminate="indeterminate"
         :color="color"
         :disabled="disabled"
         dense
@@ -109,7 +165,7 @@ export default defineComponent({
                   {{ displayText }}
                 </span>
               </template>
-              <span>{{ displayText }} </span>
+              <span>{{ displayText }}</span>
             </v-tooltip>
             <v-tooltip
               v-if="confidenceFilterNum"
@@ -206,6 +262,8 @@ export default defineComponent({
 </template>
 
 <style lang="scss" scoped>
+@import 'src/components/styles/hover-reveal.scss';
+
 .nowrap {
   white-space: nowrap;
   overflow: hidden;
@@ -213,17 +271,34 @@ export default defineComponent({
   text-overflow: ellipsis;
 }
 
-.hover-show-parent {
-  .hover-show-child {
-    display: none;
-  }
-
-  &:hover {
-    .hover-show-child {
-      display: inherit;
-    }
-  }
+.tree-prefix {
+  flex: 0 0 24px;
+  height: 30px;
+  margin-left: var(--tree-depth);
 }
+
+.tree-disclosure {
+  min-width: 24px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 2px;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+
+.tree-disclosure:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 1px;
+}
+
+.tree-disclosure-spacer {
+  display: inline-block;
+  width: 24px;
+}
+
 .outlined {
   background-color: gray;
   color: #222;

--- a/client/src/components/styles/hover-reveal.scss
+++ b/client/src/components/styles/hover-reveal.scss
@@ -1,0 +1,16 @@
+/* Controls that stay in the layout but only become visible and clickable while
+   their row is hovered or holds keyboard focus. */
+.hover-show-parent {
+  .hover-show-child {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  &:hover,
+  &:focus-within {
+    .hover-show-child {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+}

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -344,14 +344,6 @@ const markChangesPending = () => { };
  */
 function dummyState(): State {
   const cameraStore = new CameraStore({ markChangesPending });
-  const setTrackType = (
-    id: AnnotationId,
-    newType: string,
-    confidenceVal?: number,
-    currentType?: string,
-  ) => {
-    cameraStore.setTrackType(id, newType, confidenceVal, currentType);
-  };
   const removeTypes = (id: AnnotationId, types: string[]) => cameraStore.removeTypes(id, types);
   const setGroupType = (
     id: AnnotationId,
@@ -367,7 +359,7 @@ function dummyState(): State {
       sorted: cameraStore.sortedGroups,
       remove: cameraStore.removeGroups,
       markChangesPending,
-      setType: setGroupType,
+      setGroupType,
       removeTypes: removeGroupTypes,
     },
   );
@@ -381,7 +373,6 @@ function dummyState(): State {
     renameTrackPair: (id, currentType, newType) => (
       cameraStore.renameTrackPair(id, currentType, newType)
     ),
-    setType: setTrackType,
     removeTypes,
 
   });

--- a/client/src/typeListHierarchy.spec.ts
+++ b/client/src/typeListHierarchy.spec.ts
@@ -1,0 +1,383 @@
+/// <reference types="vitest" />
+import { compileHierarchy } from 'dive-common/typeHierarchy';
+import {
+  buildTypeListModel,
+  BuildTypeListOptions,
+  countResolvedTypes,
+  updateHierarchyCheckedTypes,
+} from './typeListHierarchy';
+
+const hierarchyIndex = compileHierarchy({
+  leaf: 'branch',
+  branch: 'root',
+  sibling: 'root',
+  otherLeaf: 'otherRoot',
+});
+
+function build(overrides: Partial<BuildTypeListOptions> = {}) {
+  return buildTypeListModel({
+    hierarchyIndex,
+    allTypes: ['leaf', 'branch', 'root', 'sibling', 'otherLeaf', 'otherRoot', 'flat'],
+    usedTypes: ['leaf', 'flat'],
+    checkedTypes: ['leaf', 'branch', 'root', 'sibling', 'otherLeaf', 'otherRoot', 'flat'],
+    counts: new Map([
+      ['root', 5], ['branch', 4], ['leaf', 4], ['sibling', 1],
+      ['otherRoot', 2], ['otherLeaf', 2], ['flat', 3],
+    ]),
+    frameCounts: new Map([
+      ['root', 3], ['branch', 3], ['leaf', 3], ['sibling', 0],
+      ['otherRoot', 1], ['otherLeaf', 1], ['flat', 2],
+    ]),
+    showEmpty: true,
+    query: '',
+    filterTypesByFrame: false,
+    sort: 'a-z',
+    collapsed: new Set(),
+    ...overrides,
+  });
+}
+
+describe('typeListHierarchy', () => {
+  it('filters empty flat types and alphabetizes count ties with an empty hierarchy', () => {
+    const flatIndex = compileHierarchy({});
+    const common = {
+      hierarchyIndex: flatIndex,
+      allTypes: ['zebra', 'alpha', 'configured'],
+      usedTypes: ['zebra', 'alpha'],
+      checkedTypes: ['zebra', 'alpha', 'configured'],
+      counts: new Map([['zebra', 1], ['alpha', 1]]),
+      frameCounts: new Map<string, number>(),
+      query: '',
+      filterTypesByFrame: false,
+      sort: 'count' as const,
+      collapsed: new Set<string>(),
+    };
+
+    const showEmpty = buildTypeListModel({ ...common, showEmpty: true });
+    const hideEmpty = buildTypeListModel({ ...common, showEmpty: false });
+
+    expect(showEmpty.actionableTypes).toEqual(['alpha', 'zebra', 'configured']);
+    expect(showEmpty.rows.map(({ type }) => type)).toEqual(['alpha', 'zebra', 'configured']);
+    expect(showEmpty.rows.every(
+      ({ depth, hasChildren }) => depth === 0 && !hasChildren,
+    )).toBe(true);
+    expect(hideEmpty.actionableTypes).toEqual(['alpha', 'zebra']);
+  });
+
+  it('rolls resolved logical IDs into ancestors without double counting replicas or raw pairs', () => {
+    const counts = countResolvedTypes([
+      { id: 1, type: 'leaf' },
+      { id: 1, type: 'leaf' },
+      { id: 2, type: 'branch' },
+      { id: 3, type: 'otherLeaf' },
+      { id: 4 },
+      { id: 5, type: 'toString' },
+    ], hierarchyIndex);
+
+    expect(counts).toEqual(new Map([
+      ['leaf', 1],
+      ['branch', 2],
+      ['root', 2],
+      ['otherLeaf', 1],
+      ['otherRoot', 1],
+      ['toString', 1],
+    ]));
+  });
+
+  it('derives a three-level forest, unrelated roots, depths, and subtrees', () => {
+    const model = build();
+
+    expect(model.subtree.get('branch')).toEqual(['branch', 'leaf']);
+    expect(model.rows.map(({ type }) => type)).toEqual([
+      'flat', 'otherRoot', 'otherLeaf', 'root', 'branch', 'leaf', 'sibling',
+    ]);
+    expect(model.rows.find(({ type }) => type === 'leaf')?.depth).toBe(2);
+    expect(model.rows.find(({ type }) => type === 'flat')?.depth).toBe(0);
+  });
+
+  it('hides disclosure controls when all children are filtered out', () => {
+    const model = build({ showEmpty: false });
+
+    expect(model.rows.find(({ type }) => type === 'otherRoot')).toEqual(expect.objectContaining({
+      hasChildren: false,
+    }));
+    expect(model.rows.some(({ type }) => type === 'otherLeaf')).toBe(false);
+  });
+
+  it('sorts roots and siblings recursively in every mode with alphabetical ties', () => {
+    const alphabetical = build({ sort: 'a-z' });
+    expect(alphabetical.rows.map(({ type }) => type)).toEqual([
+      'flat', 'otherRoot', 'otherLeaf', 'root', 'branch', 'leaf', 'sibling',
+    ]);
+
+    const byCount = build({
+      sort: 'count',
+      counts: new Map([
+        ['root', 3], ['flat', 2], ['otherRoot', 1], ['branch', 1], ['sibling', 2],
+      ]),
+    });
+    expect(byCount.rows.map(({ type }) => type)).toEqual([
+      'root', 'sibling', 'branch', 'leaf', 'flat', 'otherRoot', 'otherLeaf',
+    ]);
+
+    const byFrameCount = build({
+      sort: 'frame count',
+      frameCounts: new Map([
+        ['root', 1], ['flat', 2], ['otherRoot', 3], ['branch', 2], ['sibling', 1],
+      ]),
+    });
+    expect(byFrameCount.rows.map(({ type }) => type)).toEqual([
+      'otherRoot', 'otherLeaf', 'flat', 'root', 'branch', 'leaf', 'sibling',
+    ]);
+  });
+
+  it('applies every sort mode to siblings below the first hierarchy level', () => {
+    const deepIndex = compileHierarchy({
+      leaf: 'branch',
+      bud: 'branch',
+      twig: 'branch',
+      branch: 'root',
+    });
+    const shared = {
+      hierarchyIndex: deepIndex,
+      allTypes: ['root', 'branch', 'leaf', 'bud', 'twig'],
+      usedTypes: ['leaf', 'bud', 'twig'],
+      checkedTypes: ['root', 'branch', 'leaf', 'bud', 'twig'],
+    };
+
+    expect(build({ ...shared, sort: 'a-z' }).rows.filter(({ depth }) => depth === 2)
+      .map(({ type }) => type))
+      .toEqual(['bud', 'leaf', 'twig']);
+    expect(build({
+      ...shared,
+      sort: 'count',
+      counts: new Map([['leaf', 3], ['bud', 1], ['twig', 1]]),
+    }).rows.filter(({ depth }) => depth === 2).map(({ type }) => type))
+      .toEqual(['leaf', 'bud', 'twig']);
+    expect(build({
+      ...shared,
+      sort: 'frame count',
+      frameCounts: new Map([['twig', 4], ['leaf', 2], ['bud', 1]]),
+    }).rows.filter(({ depth }) => depth === 2).map(({ type }) => type))
+      .toEqual(['twig', 'leaf', 'bud']);
+  });
+
+  it('keeps unused structural parents but hides empty leaves and configured flat types', () => {
+    const model = build({
+      allTypes: [
+        'leaf', 'branch', 'root', 'sibling', 'otherLeaf', 'otherRoot', 'flat', 'configured',
+      ],
+      usedTypes: ['leaf', 'flat'],
+      showEmpty: false,
+    });
+
+    expect(model.rows.map(({ type }) => type)).toEqual(['flat', 'otherRoot', 'root', 'branch', 'leaf']);
+    expect(model.rows.map(({ type }) => type)).not.toContain('otherLeaf');
+    expect(model.rows.map(({ type }) => type)).not.toContain('sibling');
+    expect(model.rows.map(({ type }) => type)).not.toContain('configured');
+  });
+
+  it('shows search matches with ancestor context but no unrelated descendants', () => {
+    const model = build({ query: 'leaf' });
+
+    expect(model.actionableTypes).toEqual(['otherLeaf', 'leaf']);
+    expect(model.rows.map(({ type }) => type)).toEqual([
+      'otherRoot', 'otherLeaf', 'root', 'branch', 'leaf',
+    ]);
+    expect(model.rows.map(({ type }) => type)).not.toContain('sibling');
+  });
+
+  it('reveals search paths without mutating or applying saved collapse state', () => {
+    const collapsed = new Set(['root']);
+    const collapsedModel = build({ collapsed });
+    const searchModel = build({ collapsed, query: 'leaf' });
+    const restoredModel = build({ collapsed });
+
+    expect(collapsedModel.rows.map(({ type }) => type)).not.toContain('leaf');
+    expect(searchModel.rows.map(({ type }) => type)).toContain('leaf');
+    expect(searchModel.rows.find(({ type }) => type === 'root')?.expanded).toBe(true);
+    expect(restoredModel.rows.map(({ type }) => type)).not.toContain('leaf');
+    expect(collapsed).toEqual(new Set(['root']));
+  });
+
+  it('compacts a shared leading lineage and restores it during search or on request', () => {
+    const deepIndex = compileHierarchy({
+      speciesA: 'genusA',
+      genusA: 'familyA',
+      familyA: 'orderA',
+      speciesB: 'genusB',
+      genusB: 'familyB',
+      familyB: 'orderB',
+      orderA: 'class',
+      orderB: 'class',
+      class: 'phylum',
+      phylum: 'kingdom',
+      kingdom: 'domain',
+    });
+    const options = {
+      hierarchyIndex: deepIndex,
+      allTypes: [],
+      usedTypes: ['speciesA', 'speciesB'],
+      checkedTypes: [],
+      compactSharedLineage: true,
+    };
+
+    const compact = build(options);
+    expect(compact.sharedLineage).toEqual(['domain', 'kingdom', 'phylum']);
+    expect(compact.rows.slice(0, 3).map(({ type, depth }) => ({ type, depth }))).toEqual([
+      { type: 'class', depth: 0 },
+      { type: 'orderA', depth: 1 },
+      { type: 'familyA', depth: 2 },
+    ]);
+
+    const shown = build({ ...options, compactSharedLineage: false });
+    expect(shown.rows.slice(0, 4).map(({ type, depth }) => ({ type, depth }))).toEqual([
+      { type: 'domain', depth: 0 },
+      { type: 'kingdom', depth: 1 },
+      { type: 'phylum', depth: 2 },
+      { type: 'class', depth: 3 },
+    ]);
+
+    const searched = build({ ...options, query: 'domain' });
+    expect(searched.rows.map(({ type }) => type)).toEqual(['domain']);
+    expect(searched.rows[0].depth).toBe(0);
+  });
+
+  it('preserves depth in unrelated trees while compacting a shared lineage', () => {
+    const forestIndex = compileHierarchy({
+      species: 'genus',
+      genus: 'family',
+      family: 'root',
+      emptyLeaf: 'emptyBranch',
+      emptyBranch: 'emptyRoot',
+    });
+    const model = build({
+      hierarchyIndex: forestIndex,
+      allTypes: [],
+      usedTypes: ['species'],
+      checkedTypes: [],
+      showEmpty: true,
+      compactSharedLineage: true,
+    });
+
+    expect(model.sharedLineage).toEqual(['root', 'family', 'genus']);
+    expect(model.rows.filter(({ type }) => type.startsWith('empty'))
+      .map(({ type, depth }) => ({ type, depth }))).toEqual([
+      { type: 'emptyRoot', depth: 0 },
+      { type: 'emptyBranch', depth: 1 },
+      { type: 'emptyLeaf', depth: 2 },
+    ]);
+    expect(model.rows.find(({ type }) => type === 'species')?.depth).toBe(0);
+  });
+
+  it('does not compact past a branch or a directly used or configured type', () => {
+    const branchAtRoot = build({
+      usedTypes: ['leaf'],
+      configuredTypes: [],
+      compactSharedLineage: true,
+    });
+    expect(branchAtRoot.sharedLineage).toEqual([]);
+
+    const deepIndex = compileHierarchy({
+      leaf: 'configured', configured: 'middle', middle: 'top',
+    });
+    const stopped = build({
+      hierarchyIndex: deepIndex,
+      allTypes: [],
+      usedTypes: ['leaf'],
+      configuredTypes: ['configured'],
+      compactSharedLineage: true,
+    });
+    expect(stopped.sharedLineage).toEqual(['top', 'middle']);
+    expect(stopped.rows[0]).toEqual(expect.objectContaining({
+      type: 'configured', depth: 0,
+    }));
+  });
+
+  it('uses rolled frame counts before adding ancestor context', () => {
+    const model = build({
+      frameCounts: new Map([['branch', 2], ['leaf', 2]]),
+      filterTypesByFrame: true,
+    });
+
+    expect(model.rows.map(({ type }) => type)).toEqual(['root', 'branch', 'leaf']);
+    expect(model.rows.map(({ type }) => type)).not.toContain('otherRoot');
+    expect(model.rows.map(({ type }) => type)).not.toContain('sibling');
+    expect(model.actionableTypes).toContain('flat');
+  });
+
+  it('includes the parent bit when computing checked and indeterminate state', () => {
+    const model = build({ checkedTypes: ['leaf'] });
+
+    expect(model.checkState.get('leaf')).toBe('checked');
+    expect(model.checkState.get('branch')).toBe('indeterminate');
+    expect(model.checkState.get('root')).toBe('indeterminate');
+    expect(model.checkState.get('otherRoot')).toBe('unchecked');
+    expect(model.rows.find(({ type }) => type === 'branch')).toEqual(expect.objectContaining({
+      checked: false,
+      indeterminate: true,
+    }));
+  });
+
+  it('represents the checked set produced when a used unchecked parent gains a new child', () => {
+    const model = build({ usedTypes: ['branch'], checkedTypes: ['leaf'] });
+
+    expect(model.checkState.get('branch')).toBe('indeterminate');
+    expect(model.subtree.get('branch')).toEqual(['branch', 'leaf']);
+  });
+
+  it.each([
+    ['collapse', { showEmpty: true, query: '', collapsed: new Set(['branch']) }],
+    ['Show Empty', {
+      showEmpty: false, usedTypes: ['flat'], query: '', collapsed: new Set<string>(),
+    }],
+    ['search', { showEmpty: true, query: 'branch', collapsed: new Set<string>() }],
+  ] as const)('updates descendants hidden by %s without mutating checked input', (
+    _visibility,
+    overrides,
+  ) => {
+    const model = build(overrides);
+    const checked = Object.freeze(['flat', 'sibling']);
+
+    expect(model.rows.map(({ type }) => type)).not.toContain('leaf');
+    const enabled = updateHierarchyCheckedTypes(checked, model.subtree, 'branch', true);
+    const disabled = updateHierarchyCheckedTypes(enabled, model.subtree, 'branch', false);
+
+    expect(enabled).toEqual(['flat', 'sibling', 'branch', 'leaf']);
+    expect(disabled).toEqual(['flat', 'sibling']);
+    expect(checked).toEqual(['flat', 'sibling']);
+  });
+
+  it('does not mutate hierarchy, arrays, sets, or count maps', () => {
+    const allTypes = Object.freeze(['leaf', 'branch', 'root', 'flat']);
+    const usedTypes = Object.freeze(['leaf']);
+    const checkedTypes = Object.freeze(['leaf']);
+    const counts = new Map([['leaf', 1]]);
+    const frameCounts = new Map([['leaf', 1]]);
+    const collapsed = new Set(['root']);
+    const hierarchy = Object.freeze({ leaf: 'branch', branch: 'root' });
+    const index = compileHierarchy(hierarchy);
+
+    buildTypeListModel({
+      hierarchyIndex: index,
+      allTypes,
+      usedTypes,
+      checkedTypes,
+      counts,
+      frameCounts,
+      showEmpty: false,
+      query: '',
+      filterTypesByFrame: true,
+      sort: 'count',
+      collapsed,
+    });
+
+    expect(index.hierarchy).toEqual(hierarchy);
+    expect(allTypes).toEqual(['leaf', 'branch', 'root', 'flat']);
+    expect(usedTypes).toEqual(['leaf']);
+    expect(checkedTypes).toEqual(['leaf']);
+    expect(counts).toEqual(new Map([['leaf', 1]]));
+    expect(frameCounts).toEqual(new Map([['leaf', 1]]));
+    expect(collapsed).toEqual(new Set(['root']));
+  });
+});

--- a/client/src/typeListHierarchy.ts
+++ b/client/src/typeListHierarchy.ts
@@ -1,0 +1,226 @@
+import { difference, union } from 'lodash';
+import { ancestorsOf, TypeHierarchyIndex } from 'dive-common/typeHierarchy';
+
+export type TypeListSort = 'a-z' | 'count' | 'frame count';
+export type TypeListCheckState = 'checked' | 'unchecked' | 'indeterminate';
+
+export interface TypeListRow {
+  type: string;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
+  checked: boolean;
+  indeterminate: boolean;
+}
+
+export interface TypeListModel {
+  subtree: ReadonlyMap<string, readonly string[]>;
+  checkState: ReadonlyMap<string, TypeListCheckState>;
+  actionableTypes: readonly string[];
+  sharedLineage: readonly string[];
+  rows: readonly TypeListRow[];
+}
+
+export interface BuildTypeListOptions {
+  hierarchyIndex: TypeHierarchyIndex;
+  allTypes: readonly string[];
+  usedTypes: readonly string[];
+  configuredTypes?: readonly string[];
+  checkedTypes: readonly string[];
+  counts: ReadonlyMap<string, number>;
+  frameCounts: ReadonlyMap<string, number>;
+  showEmpty: boolean;
+  query: string;
+  filterTypesByFrame: boolean;
+  sort: TypeListSort;
+  collapsed: ReadonlySet<string>;
+  compactSharedLineage?: boolean;
+}
+
+export interface ResolvedTypeCountEntry {
+  id: string | number;
+  type?: string;
+}
+
+export function countResolvedTypes(
+  entries: readonly ResolvedTypeCountEntry[],
+  hierarchyIndex: TypeHierarchyIndex,
+): Map<string, number> {
+  const idsByType = new Map<string, Set<string | number>>();
+  entries.forEach(({ id, type }) => {
+    if (type === undefined) return;
+    [type, ...ancestorsOf(hierarchyIndex, type)].forEach((rolledType) => {
+      const ids = idsByType.get(rolledType) || new Set<string | number>();
+      ids.add(id);
+      idsByType.set(rolledType, ids);
+    });
+  });
+  return new Map([...idsByType].map(([type, ids]) => [type, ids.size]));
+}
+
+/** Descending by the active count, then alphabetical so ties are deterministic. */
+function typeComparator(
+  sort: TypeListSort,
+  counts: ReadonlyMap<string, number>,
+  frameCounts: ReadonlyMap<string, number>,
+): (left: string, right: string) => number {
+  const rank = { 'a-z': undefined, count: counts, 'frame count': frameCounts }[sort];
+  return (left, right) => {
+    const countDifference = rank ? (rank.get(right) || 0) - (rank.get(left) || 0) : 0;
+    if (countDifference !== 0) return countDifference;
+    if (left < right) return -1;
+    return left > right ? 1 : 0;
+  };
+}
+
+function withAncestorPath(
+  types: Iterable<string>,
+  hierarchyIndex: TypeHierarchyIndex,
+): Set<string> {
+  const withAncestors = new Set(types);
+  [...withAncestors].forEach(
+    (type) => ancestorsOf(hierarchyIndex, type).forEach((ancestor) => withAncestors.add(ancestor)),
+  );
+  return withAncestors;
+}
+
+export function buildTypeListModel({
+  hierarchyIndex,
+  allTypes,
+  usedTypes,
+  configuredTypes = [],
+  checkedTypes,
+  counts,
+  frameCounts,
+  showEmpty,
+  query,
+  filterTypesByFrame,
+  sort,
+  collapsed,
+  compactSharedLineage = false,
+}: BuildTypeListOptions): TypeListModel {
+  const parent = new Map<string, string>();
+  const hierarchyMembers = new Set<string>();
+  Object.entries(hierarchyIndex.hierarchy).forEach(([child, parentType]) => {
+    parent.set(child, parentType);
+    hierarchyMembers.add(child);
+    hierarchyMembers.add(parentType);
+  });
+
+  const knownTypes = new Set([...allTypes, ...usedTypes, ...hierarchyMembers]);
+  const compare = typeComparator(sort, counts, frameCounts);
+  const children = new Map<string, string[]>();
+  knownTypes.forEach((type) => children.set(type, []));
+  parent.forEach((parentType, child) => children.get(parentType)?.push(child));
+  children.forEach((childTypes) => {
+    if (childTypes.length > 1) childTypes.sort(compare);
+  });
+  const roots = [...knownTypes].filter((type) => !parent.has(type)).sort(compare);
+
+  const directlyMeaningfulTypes = new Set([...usedTypes, ...configuredTypes]);
+  const hierarchyTargets = [...directlyMeaningfulTypes].filter((type) => hierarchyMembers.has(type));
+  const targetRoots = new Set(hierarchyTargets.map((type) => {
+    const ancestors = ancestorsOf(hierarchyIndex, type);
+    return ancestors.length > 0 ? ancestors[ancestors.length - 1] : type;
+  }));
+  const unusedLeadingParents: string[] = [];
+  if (hierarchyTargets.length === directlyMeaningfulTypes.size && targetRoots.size === 1) {
+    let current = [...targetRoots][0];
+    while (!directlyMeaningfulTypes.has(current)) {
+      const childTypes = children.get(current) || [];
+      if (childTypes.length !== 1) break;
+      unusedLeadingParents.push(current);
+      [current] = childTypes;
+    }
+  }
+  /* A single unused parent is not worth a breadcrumb; show it as a row instead. */
+  const sharedLineage = unusedLeadingParents.length >= 2 ? unusedLeadingParents : [];
+
+  const checkedSet = new Set(checkedTypes);
+  const subtree = new Map<string, readonly string[]>();
+  const checkState = new Map<string, TypeListCheckState>();
+  /* One pass yields each type's pre-order subtree and its rolled-up tri-state. */
+  const visit = (type: string): { members: string[]; checkedCount: number } => {
+    let checkedCount = checkedSet.has(type) ? 1 : 0;
+    const members = [type];
+    (children.get(type) || []).forEach((child) => {
+      const nested = visit(child);
+      members.push(...nested.members);
+      checkedCount += nested.checkedCount;
+    });
+    subtree.set(type, members);
+    let state: TypeListCheckState = 'indeterminate';
+    if (checkedCount === 0) state = 'unchecked';
+    else if (checkedCount === members.length) state = 'checked';
+    checkState.set(type, state);
+    return { members, checkedCount };
+  };
+  roots.forEach(visit);
+
+  /* Every ancestor of a used type is itself a structural parent, so this set
+     already carries the full path back to each root. */
+  const structuralParents = [...knownTypes].filter(
+    (type) => (children.get(type)?.length || 0) > 0,
+  );
+  const normalizedQuery = query.toLowerCase();
+  const showEmptyCandidates = showEmpty
+    ? knownTypes
+    : new Set([...usedTypes, ...structuralParents]);
+  const queryCandidates = normalizedQuery
+    ? [...showEmptyCandidates].filter((type) => type.toLowerCase().includes(normalizedQuery))
+    : [...showEmptyCandidates];
+  const actionableSet = new Set(queryCandidates);
+  const displayedCandidates = filterTypesByFrame
+    ? queryCandidates.filter((type) => (frameCounts.get(type) || 0) > 0)
+    : queryCandidates;
+  const displayedSet = withAncestorPath(displayedCandidates, hierarchyIndex);
+  const searchActive = normalizedQuery.length > 0;
+  const hiddenSharedLineage = !searchActive && compactSharedLineage
+    ? new Set(sharedLineage)
+    : new Set<string>();
+  const rows: TypeListRow[] = [];
+  const flatten = (type: string, rowDepth: number) => {
+    if (!displayedSet.has(type)) return;
+    const childTypes = children.get(type) || [];
+    if (hiddenSharedLineage.has(type)) {
+      childTypes.forEach((child) => flatten(child, rowDepth));
+      return;
+    }
+    const expanded = searchActive || !collapsed.has(type);
+    const state = checkState.get(type) || 'unchecked';
+    rows.push({
+      type,
+      depth: rowDepth,
+      hasChildren: childTypes.some((child) => displayedSet.has(child)),
+      expanded,
+      checked: state === 'checked',
+      indeterminate: state === 'indeterminate',
+    });
+    if (expanded) {
+      childTypes.forEach((child) => flatten(child, rowDepth + 1));
+    }
+  };
+  roots.forEach((root) => flatten(root, 0));
+
+  return {
+    subtree,
+    checkState,
+    sharedLineage,
+    actionableTypes: roots
+      .flatMap((root) => subtree.get(root) || [root])
+      .filter((type) => actionableSet.has(type)),
+    rows,
+  };
+}
+
+export function updateHierarchyCheckedTypes(
+  checkedTypes: readonly string[],
+  subtree: ReadonlyMap<string, readonly string[]>,
+  type: string,
+  checked: boolean,
+): string[] {
+  const members = subtree.get(type) || [type];
+  return checked
+    ? union(checkedTypes, members)
+    : difference(checkedTypes, members);
+}

--- a/client/src/typeListHierarchy.ts
+++ b/client/src/typeListHierarchy.ts
@@ -1,3 +1,7 @@
+/**
+ * Pure Type List model helpers shared by flat and hierarchical modes.
+ * This module has no Vue or store dependencies; callers provide all state explicitly.
+ */
 import { difference, union } from 'lodash';
 import { ancestorsOf, TypeHierarchyIndex } from 'dive-common/typeHierarchy';
 

--- a/client/src/use/suppression.ts
+++ b/client/src/use/suppression.ts
@@ -206,6 +206,17 @@ function bboxCoverUpperBound(det: Rect, regions: PreparedRegion[]): number {
   return sum / detArea;
 }
 
+function isShapeSuppressed(
+  shape: Shape,
+  regions: PreparedRegion[],
+  threshold: number,
+): boolean {
+  if (!shape.poly && bboxCoverUpperBound(shape.bbox, regions) < threshold) {
+    return false;
+  }
+  return overlapFraction(shape, regions) >= threshold;
+}
+
 interface SuppressionCacheEntry {
   revision: number;
   type: string;
@@ -299,6 +310,55 @@ export function hasSuppressionAttribute(
 }
 
 /**
+ * Build a local region-overlap test for walking known track keyframes. Region
+ * tracks are resolved once and their geometry is prepared once per visited
+ * frame, without scanning the store's interval tree or populating its shared
+ * per-frame suppression cache.
+ */
+export function createRegionSuppressionTester(
+  trackStore: BaseAnnotationStore<Track>,
+  suppressionType: string | undefined,
+  thresholdPercent?: number,
+  resolver?: SuppressionTypeResolver,
+): (track: Track, frame: number) => boolean {
+  if (!suppressionType) return () => false;
+  const threshold = normalizeSuppressionThreshold(thresholdPercent);
+  const displayType = (track: Track) => (
+    resolver ? resolver.displayType(track) : track.confidencePairs[0]?.[0]
+  );
+  const regionTracks: Track[] = [];
+  const regionTrackIds = new Set<AnnotationId>();
+  trackStore.annotationMap.forEach((annotation) => {
+    const track = annotation as Track;
+    if (displayType(track) === suppressionType) {
+      regionTracks.push(track);
+      regionTrackIds.add(track.id);
+    }
+  });
+  if (regionTracks.length === 0) return () => false;
+
+  const regionsByFrame = new Map<number, PreparedRegion[]>();
+  const regionsAt = (frame: number) => {
+    const cached = regionsByFrame.get(frame);
+    if (cached) return cached;
+    const regions = regionTracks
+      .map((track) => featureShape(track.getFeature(frame)[0]))
+      .filter((shape): shape is Shape => shape !== null)
+      .map(prepareRegion);
+    regionsByFrame.set(frame, regions);
+    return regions;
+  };
+
+  return (track, frame) => {
+    if (regionTrackIds.has(track.id)) return false;
+    const shape = featureShape(track.getFeature(frame)[0]);
+    if (!shape) return false;
+    const regions = regionsAt(frame);
+    return regions.length > 0 && isShapeSuppressed(shape, regions, threshold);
+  };
+}
+
+/**
  * Track ids whose detection on `frame` is suppressed by a region on that frame.
  * Empty when suppressionType is falsy (feature disabled) or no regions exist.
  * `thresholdPercent` is the minimum covered fraction as a percent (0-100];
@@ -359,12 +419,7 @@ export function getSuppressedTrackIds(
   });
   if (regions.length > 0) {
     candidates.forEach(({ id, shape }) => {
-      // Bbox prefilter is only sound for bbox-only detections (see
-      // bboxCoverUpperBound). Polygon candidates always go to sampling.
-      if (!shape.poly && bboxCoverUpperBound(shape.bbox, regions) < threshold) {
-        return;
-      }
-      if (overlapFraction(shape, regions) >= threshold) {
+      if (isShapeSuppressed(shape, regions, threshold)) {
         result.add(id);
       }
     });

--- a/client/src/use/suppression.ts
+++ b/client/src/use/suppression.ts
@@ -310,10 +310,10 @@ export function hasSuppressionAttribute(
 }
 
 /**
- * Build a local region-overlap test for walking known track keyframes. Region
- * tracks are resolved once and their geometry is prepared once per visited
- * frame, without scanning the store's interval tree or populating its shared
- * per-frame suppression cache.
+ * Build a region-suppression predicate optimized for peak-frame counting,
+ * where the caller already walks known track keyframes. Region tracks are
+ * resolved once and geometry is cached per visited frame, avoiding an
+ * interval-tree query and shared-cache entry for every candidate frame.
  */
 export function createRegionSuppressionTester(
   trackStore: BaseAnnotationStore<Track>,

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -38,7 +38,7 @@ highest-confidence pair, keeping the first stored pair when scores tie, because 
 have each viewer's checked types and confidence thresholds. Viewer counts and filtering use the
 hierarchy-resolved displayed type.
 
-Hierarchy members remain ordinary flat Type List rows. A parent with no annotations or explicit style configuration is visible when **Show Empty** is enabled. The Type List does not render a tree or offer subtree controls or hierarchy editing.
+Hierarchy members render as an expandable tree rather than ordinary flat rows. Parent checkboxes control their complete subtrees, and parent counts include descendants. The Type List does not offer hierarchy editing.
 
 While a hierarchy is active, **Prevent Cascade Types** is disabled and shows: `Not applicable to hierarchical types; DIVE selects the deepest qualifying type.` Its saved value is preserved and becomes active again when the hierarchy is removed.
 


### PR DESCRIPTION
# Render hierarchical types as a tree

[Bryon called out three follow-ups during review of the original hierarchy PR](https://github.com/Kitware/dive/pull/1847#pullrequestreview-4938834044):
render the Type List as a tree, let a parent toggle its children, and roll child counts into
parents. For datasets without a type hierarchy, the Type List retains its existing flat behavior.

<img width="506" height="602" alt="Screenshot 2026-08-21 160322" src="https://github.com/user-attachments/assets/713ebed4-7aa7-45db-9812-b78540d1561c" />

https://github.com/user-attachments/assets/c8f20ad2-cd02-44e9-a969-f2b2b8529d30


### Changes

- Indent descendants and add branch disclosure controls.
- Give parent checkboxes checked, unchecked, and indeterminate states; toggling a parent applies to
  its complete subtree.
- Keep ancestor paths visible during search and sort siblings within each branch.
- Compact a shared unused leading lineage behind **Expand Parents** and **Compact Parents**.
- Roll descendant totals and current-frame counts into their parents.
- Make parent maximum-count navigation include descendants and use the same selected-camera and
  suppression rules as the displayed counts.
- Keep structural parents visible with **Show Empty** off, without showing disclosure controls for
  children that are filtered out.

### Manual tests

Test data: upload and extract
[hierarchical-type-list.zip](https://github.com/user-attachments/files/31320128/hierarchical-type-list.zip)
The ZIP opens to `hierarchical-type-list/` with self-contained `synthetic/` and `sefsc/` datasets.

#### Type List controls and counts

1. Create a 1 FPS image-sequence dataset from `synthetic/images/`, then import
   `synthetic/annotations.json` and `synthetic/config.json`.
2. Exercise branch collapse, parent checkboxes, search, **Show Empty**, all three sort modes, and
   **Expand Parents** / **Compact Parents**.
3. Compare counts at frames 0, 2, and 4, then use the `fish` maximum-count button.
4. Set the suppression region type to `fish`; uncheck and recheck `juvenile-red-snapper` and
   `red-snapper`.

Verify: The tree and tri-state checkboxes follow the hierarchy, search keeps the ancestor path, and
the compact breadcrumb is `eukaryota › animalia › chordata`. Parent counts include descendants;
`fish` totals four tracks and seeks to frame 2. Suppressed detections do not reappear in parent
counts or peak navigation.

#### Real SEFSC-SEAMAP hierarchy

1. Create a 5 FPS video dataset from the MP4 in `sefsc/`, then import its VIAME CSV and
   configuration from the same directory.
2. Search, collapse branches, and sort the Type List.

Verify: The 24 real tracks render in the correct hierarchy from `eukaryota` through the eight
observed species.


This is a follow-up to
[Define raw and resolved classification boundaries](https://github.com/Kitware/dive/pull/1852).
