### PR TITLE
Run the server lint gate in CI and format what it finds

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -77,6 +77,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install tox
       run: pip install tox
+    - name: Lint
+      run: tox -e lint
+      working-directory: server
     - name: Run tests
       run: tox -e testunit
       working-directory: server

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -716,7 +716,5 @@ def export_dive_as_coco(
         'categories': categories_doc,
     }
     if emit_video:
-        coco['videos'] = [
-            {'id': 1, 'name': dataset_name, 'annotation_fps': float(fps)}
-        ]
+        coco['videos'] = [{'id': 1, 'name': dataset_name, 'annotation_fps': float(fps)}]
     return coco

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -635,9 +635,7 @@ def export_tracks_as_csv(
         if not confidence_pairs:
             continue
 
-        sorted_confidence_pairs = sorted(
-            confidence_pairs, key=lambda item: item[1], reverse=True
-        )
+        sorted_confidence_pairs = sorted(confidence_pairs, key=lambda item: item[1], reverse=True)
 
         for index, keyframe in enumerate(track.features):
             features = [keyframe]
@@ -709,8 +707,7 @@ def export_tracks_as_csv(
                                     for item in sublist  # type: ignore
                                 ]
                                 columns.append(
-                                    "(poly) "
-                                    + ' '.join(map(lambda x: str(round(x)), outer_coords))
+                                    "(poly) " + ' '.join(map(lambda x: str(round(x)), outer_coords))
                                 )
 
                                 # Write holes (additional rings)

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -1223,12 +1223,16 @@ def _fps_document(videos=None):
 
 def test_frame_rate_read_from_video():
     """The COCO counterpart of the VIAME CSV header's fps."""
-    assert kwcoco.frame_rate_from_coco(
-        _fps_document([{'id': 1, 'name': 'clip', 'annotation_fps': 5}])
-    ) == 5.0
-    assert kwcoco.frame_rate_from_coco(
-        _fps_document([{'id': 1}, {'id': 2, 'name': 'clip', 'annotation_fps': 29.97}])
-    ) == 29.97
+    assert (
+        kwcoco.frame_rate_from_coco(_fps_document([{'id': 1, 'name': 'clip', 'annotation_fps': 5}]))
+        == 5.0
+    )
+    assert (
+        kwcoco.frame_rate_from_coco(
+            _fps_document([{'id': 1}, {'id': 2, 'name': 'clip', 'annotation_fps': 29.97}])
+        )
+        == 29.97
+    )
 
 
 def test_frame_rate_absent_or_unusable():
@@ -1236,6 +1240,6 @@ def test_frame_rate_absent_or_unusable():
     assert kwcoco.frame_rate_from_coco(_fps_document()) is None
     assert kwcoco.frame_rate_from_coco(_fps_document([])) is None
     for fps in [0, -5, '5', True, float('inf'), float('nan'), None]:
-        assert kwcoco.frame_rate_from_coco(
-            _fps_document([{'id': 1, 'annotation_fps': fps}])
-        ) is None
+        assert (
+            kwcoco.frame_rate_from_coco(_fps_document([{'id': 1, 'annotation_fps': fps}])) is None
+        )

--- a/server/tests/test_multicam_export_clone.py
+++ b/server/tests/test_multicam_export_clone.py
@@ -743,7 +743,6 @@ def test_export_multicam_annotations_preflights_invalid_coco_hierarchy(zip_gen_c
         )
 
     assert str(error_info.value) == (
-        'Type hierarchy is invalid: self edge "fish -> fish". '
-        'No COCO file was exported.'
+        'Type hierarchy is invalid: self edge "fish -> fish". No COCO file was exported.'
     )
     zip_gen_cls.assert_not_called()

--- a/server/tests/test_update_metadata.py
+++ b/server/tests/test_update_metadata.py
@@ -451,8 +451,7 @@ def test_type_hierarchy_for_export_names_the_coco_artifact():
         crud_dataset.type_hierarchy_for_export(folder, artifact='COCO file')
 
     assert str(error_info.value) == (
-        'Type hierarchy is invalid: self edge "fish -> fish". '
-        'No COCO file was exported.'
+        'Type hierarchy is invalid: self edge "fish -> fish". No COCO file was exported.'
     )
 
 


### PR DESCRIPTION
CI runs `tox -e testunit` for the server but never `tox -e lint`, so the server side has had no formatting gate since the black pin arrived with #1658. The client is linted in CI; the server was not. Five spots had drifted from the pinned `black == 26.5.1` in the meantime.

Add the lint step to the server job, next to the client's, and apply `tox -e format`. Two of black's rewrites left an implicit string concatenation on one line, which parses fine and reads badly; those two messages are single strings now, which black leaves alone.

Formatting only, no behavior change sides the CI blank.yml change