### PR TITLE
Reclaim Type List row width and read counts as a fraction

### DIFF
--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -29,6 +29,8 @@ export default defineComponent({
       lockTypes: 'Only allows the use of defined types.',
       preventCascadeTypes: 'When a track has multiple types, this will prevent the type from displaying if the max type is not visible in the type list',
       filterTypesByFrame: 'Filters the type list by only types that are visible in the current frame',
+      showTotalCount: 'Show each type\'s count for the whole dataset. Rows read frame count / total count.',
+      showFrameCount: 'Show each type\'s count on the current frame. Rows read frame count / total count.',
       maxCountButton: 'Show a max count button that will jump to the frame with the max count for the type',
       suppressionType: 'Detections lying at least the Suppression Overlap percent under an annotation of this type are hidden and excluded from counts. A detection carrying an attribute of this name set to true stays visible with its real type (optional dashed/fill styling and an eye-off tag) and is excluded from its own type\'s counts. Leave empty to disable.',
       suppressionThreshold: 'Minimum percent of a detection that must lie under suppression regions for it to be hidden (default 99).',
@@ -266,6 +268,70 @@ export default defineComponent({
                   </v-icon>
                 </template>
                 <span>{{ help.filterTypesByFrame }}</span>
+              </v-tooltip>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col class="py-1">
+              <v-switch
+                v-model="clientSettings.typeSettings.showTotalCount"
+                label="Show Total Count"
+                class="my-0 ml-1 pt-0"
+                dense
+                hide-details
+              />
+            </v-col>
+            <v-col
+              cols="2"
+              class="py-1"
+              align="right"
+            >
+              <v-tooltip
+                open-delay="200"
+                bottom
+                max-width="200"
+              >
+                <template #activator="{ on }">
+                  <v-icon
+                    small
+                    v-on="on"
+                  >
+                    mdi-help
+                  </v-icon>
+                </template>
+                <span>{{ help.showTotalCount }}</span>
+              </v-tooltip>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col class="py-1">
+              <v-switch
+                v-model="clientSettings.typeSettings.showFrameCount"
+                label="Show Frame Count"
+                class="my-0 ml-1 pt-0"
+                dense
+                hide-details
+              />
+            </v-col>
+            <v-col
+              cols="2"
+              class="py-1"
+              align="right"
+            >
+              <v-tooltip
+                open-delay="200"
+                bottom
+                max-width="200"
+              >
+                <template #activator="{ on }">
+                  <v-icon
+                    small
+                    v-on="on"
+                  >
+                    mdi-help
+                  </v-icon>
+                </template>
+                <span>{{ help.showFrameCount }}</span>
               </v-tooltip>
             </v-col>
           </v-row>

--- a/client/dive-common/store/settings.spec.ts
+++ b/client/dive-common/store/settings.spec.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+/// <reference types="vitest" />
+
+describe('clientSettings hydration', () => {
+  it('keeps every type-list switch a reactive key when nothing is stored', async () => {
+    localStorage.removeItem('Settings');
+    vi.resetModules();
+
+    const { clientSettings } = await import('./settings');
+
+    expect(Object.keys(clientSettings.typeSettings)).toEqual(expect.arrayContaining([
+      'showTotalCount', 'showFrameCount',
+    ]));
+    expect(clientSettings.typeSettings.showTotalCount).toBe(true);
+    expect(clientSettings.typeSettings.showFrameCount).toBe(true);
+  });
+
+  it('hydrates count switches on unless a stored blob turned one off', async () => {
+    localStorage.setItem('Settings', JSON.stringify({
+      typeSettings: { trackSortDir: 'count', showTotalCount: false },
+    }));
+    vi.resetModules();
+
+    const { clientSettings } = await import('./settings');
+
+    expect(clientSettings.typeSettings.showTotalCount).toBe(false);
+    expect(clientSettings.typeSettings.showFrameCount).toBe(true);
+    expect(clientSettings.typeSettings.trackSortDir).toBe('count');
+  });
+});

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -22,6 +22,8 @@ interface AnnotationSettings {
     preventCascadeTypes?: boolean;
     filterTypesByFrame?: boolean;
     maxCountButton?: boolean;
+    showTotalCount?: boolean;
+    showFrameCount?: boolean;
     // Region of this type: detections whose geometry lies at least
     // suppressionThreshold percent under it are hidden and excluded from
     // counts. Attribute of this name set true: detection stays visible with
@@ -141,6 +143,8 @@ const defaultSettings: AnnotationSettings = {
     lockTypes: false,
     preventCascadeTypes: false,
     maxCountButton: false,
+    showTotalCount: true,
+    showFrameCount: true,
     suppressionType: 'Suppressed',
     suppressionThreshold: 99,
     colorScope: 'shared',

--- a/client/src/components/FilterList.spec.ts
+++ b/client/src/components/FilterList.spec.ts
@@ -184,6 +184,8 @@ describe('FilterList hierarchy members', () => {
     provideMocks.annotationMap.clear();
     provideMocks.selectedCameraValue = 'singleCam';
     provideMocks.selectedCameraRef = undefined;
+    clientSettings.typeSettings.showTotalCount = true;
+    clientSettings.typeSettings.showFrameCount = true;
   });
 
   it('keeps members as ordinary, independently checked flat rows', async () => {
@@ -231,6 +233,40 @@ describe('FilterList hierarchy members', () => {
     expect(checkedTypes.value).toEqual(['leaf', 'heading']);
   });
 
+  it('sizes the virtual list from the flex viewport content box', async () => {
+    let resizeCallback: ResizeObserverCallback | undefined;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+
+      observe = observe;
+
+      disconnect = disconnect;
+    });
+    const { filterControls, styleManager } = makeHierarchyFixture();
+    const { wrapper, vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 320,
+      headerHeight: 80,
+    });
+    const viewport = wrapper.find('.type-list-viewport').element as HTMLElement;
+    expect(observe).toHaveBeenCalledWith(viewport);
+    resizeCallback?.([{
+      contentRect: { height: 236 } as DOMRectReadOnly,
+    } as ResizeObserverEntry], {} as ResizeObserver);
+    await nextTick();
+
+    expect(vm.virtualHeight).toBe(236);
+    wrapper.destroy();
+    expect(disconnect).toHaveBeenCalledOnce();
+    vi.unstubAllGlobals();
+  });
+
   it('counts the type selected by each filtered annotation context', () => {
     clientSettings.typeSettings.trackSortDir = 'a-z';
     clientSettings.typeSettings.filterTypesByFrame = false;
@@ -273,11 +309,11 @@ describe('FilterList hierarchy members', () => {
     });
 
     expect(vm.virtualTypes.find(({ type }) => type === 'leaf')).toEqual(expect.objectContaining({
-      displayText: '1 : 0\u00A0 leaf',
+      displayText: '0 / 1\u00A0 leaf',
       color: 'color:leaf',
     }));
     expect(vm.virtualTypes.find(({ type }) => type === 'root')?.displayText)
-      .toBe('0 : 0\u00A0 root');
+      .toBe('0 / 0\u00A0 root');
   });
 
   it('renders an expanded hierarchy with depth, tri-state, and structural parents', async () => {
@@ -351,16 +387,16 @@ describe('FilterList hierarchy members', () => {
       headerHeight: 80,
     });
 
-    expect(vm.sharedLineage).toEqual(['domain', 'kingdom', 'phylum', 'class']);
-    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['branch', 'leaf']);
+    expect(vm.sharedLineage).toEqual(['domain', 'kingdom', 'phylum', 'class', 'branch']);
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['leaf']);
     expect(vm.virtualTypes[0].depth).toBe(0);
     expect(vm.virtualHeight).toBe(130);
-    expect(wrapper.find('.shared-lineage-text').text()).toBe(
-      'domain › kingdom › phylum › class',
-    );
     expect(wrapper.find('.shared-lineage-text').classes()).toEqual(expect.arrayContaining([
       'text-body-2', 'grey--text', 'text--lighten-1',
     ]));
+    expect(wrapper.find('.shared-lineage-text-inner').text()).toBe(
+      'domain › kingdom › phylum › class › branch',
+    );
     expect(wrapper.find('.shared-lineage-action').text()).toBe('Expand Parents');
 
     await wrapper.find('.shared-lineage-action').trigger('click');
@@ -374,7 +410,7 @@ describe('FilterList hierarchy members', () => {
     vm.toggleExpanded('branch');
     vm.toggleSharedLineage();
     await nextTick();
-    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['branch']);
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['leaf']);
 
     vm.toggleSharedLineage();
     await nextTick();
@@ -518,9 +554,9 @@ describe('FilterList hierarchy members', () => {
     ]));
     expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root', 'branch', 'leaf']);
     expect(vm.virtualTypes.map(({ displayText }) => displayText)).toEqual([
-      '3 : 1\u00A0 root',
-      '2 : 1\u00A0 branch',
-      '1 : 1\u00A0 leaf',
+      '1 / 3\u00A0 root',
+      '1 / 2\u00A0 branch',
+      '1 / 1\u00A0 leaf',
     ]);
     expect(vm.visibleTypes).toEqual(['root', 'branch', 'leaf', 'sibling']);
 
@@ -573,7 +609,7 @@ describe('FilterList hierarchy members', () => {
     });
 
     expect(vm.virtualTypes.find(({ type }) => type === targetType)?.displayText)
-      .toBe(`3 : 1\u00A0 ${targetType}`);
+      .toBe(`1 / 3\u00A0 ${targetType}`);
     const intervalSearchCalls = provideMocks.intervalSearch.mock.calls.length;
 
     vm.goToPeakTrackFrame(targetType);
@@ -622,7 +658,7 @@ describe('FilterList hierarchy members', () => {
     });
 
     expect(vm.virtualTypes.find(({ type }) => type === 'leaf')?.displayText)
-      .toBe('3 : 0\u00A0 leaf');
+      .toBe('0 / 3\u00A0 leaf');
     const intervalSearchCalls = provideMocks.intervalSearch.mock.calls.length;
 
     vm.goToPeakTrackFrame('leaf');
@@ -650,7 +686,7 @@ describe('FilterList hierarchy members', () => {
     });
 
     expect(vm.virtualTypes.find(({ type }) => type === 'root')?.displayText)
-      .toBe('3 : 0\u00A0 root');
+      .toBe('0 / 3\u00A0 root');
 
     if (!provideMocks.selectedCameraRef) {
       throw new Error('selected camera ref was not captured');
@@ -659,7 +695,114 @@ describe('FilterList hierarchy members', () => {
     await nextTick();
 
     expect(vm.virtualTypes.find(({ type }) => type === 'root')?.displayText)
-      .toBe('3 : 1\u00A0 root');
+      .toBe('1 / 3\u00A0 root');
+  });
+
+  it.each([
+    [true, true, ['1 / 3\u00A0 root', '1 / 2\u00A0 branch', '1 / 1\u00A0 leaf', '0 / 1\u00A0 sibling'],
+      '1 / 3\u00A0 root'],
+    [true, false, ['3\u00A0 root', '2\u00A0 branch', '1\u00A0 leaf', '1\u00A0 sibling'],
+      'root - 3 in the dataset'],
+    [false, true, ['1\u00A0 root', '1\u00A0 branch', '1\u00A0 leaf', '0\u00A0 sibling'],
+      'root - 1 on this frame'],
+    [false, false, ['root', 'branch', 'leaf', 'sibling'], 'root'],
+  ] as const)('renders rows with total=%s frame=%s', (
+    showTotalCount,
+    showFrameCount,
+    displayTexts,
+    rootTooltip,
+  ) => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    clientSettings.typeSettings.suppressionType = '';
+    clientSettings.typeSettings.showTotalCount = showTotalCount;
+    clientSettings.typeSettings.showFrameCount = showFrameCount;
+    provideMocks.intervalSearch.mockImplementation(([frame]: [number, number]) => (
+      frame === 0 ? ['1'] : ['1', '2', '3']
+    ));
+    const { filterControls, styleManager, tracks } = makeCountHierarchyFixture();
+    provideMocks.getPossible.mockImplementation((id: number) => (
+      tracks.find((track) => track.id === id)
+    ));
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.virtualTypes.map(({ displayText }) => displayText)).toEqual([...displayTexts]);
+    expect(vm.virtualTypes.find(({ type }) => type === 'root')?.displayTooltip)
+      .toBe(rootTooltip);
+  });
+
+  it('skips the per-frame scan when no frame count is displayed, sorted on, or filtered by', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    clientSettings.typeSettings.suppressionType = '';
+    clientSettings.typeSettings.showFrameCount = false;
+    provideMocks.intervalSearch.mockImplementation(([frame]: [number, number]) => (
+      frame === 0 ? ['1'] : ['1', '2', '3']
+    ));
+    const { filterControls, styleManager, tracks } = makeCountHierarchyFixture();
+    provideMocks.getPossible.mockImplementation((id: number) => (
+      tracks.find((track) => track.id === id)
+    ));
+    await nextTick();
+    provideMocks.intervalSearch.mockClear();
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.virtualTypes.map(({ displayText }) => displayText)).toEqual([
+      '3\u00A0 root', '2\u00A0 branch', '1\u00A0 leaf', '1\u00A0 sibling',
+    ]);
+    expect(provideMocks.intervalSearch).not.toHaveBeenCalled();
+
+    clientSettings.typeSettings.showFrameCount = true;
+    await nextTick();
+
+    expect(vm.virtualTypes.map(({ displayText }) => displayText)).toEqual([
+      '1 / 3\u00A0 root', '1 / 2\u00A0 branch', '1 / 1\u00A0 leaf', '0 / 1\u00A0 sibling',
+    ]);
+  });
+
+  it('never prints a frame count above the total the fraction is read against', () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    clientSettings.typeSettings.suppressionType = 'Suppressed';
+    provideMocks.intervalSearch.mockReturnValue(['1', '2', '3']);
+    const tracks = [
+      new Track(1, { confidencePairs: [['leaf', 1]], features: featuresAt([0, 5]) }),
+      /* Present on frame 0 but suppressed there, and unsuppressed on frame 5. */
+      new Track(2, { confidencePairs: [['branch', 1]], features: featuresAt([0, 5], [0]) }),
+      new Track(3, { confidencePairs: [['sibling', 1]], features: featuresAt([0]) }),
+    ];
+    tracks.forEach((track) => provideMocks.annotationMap.set(track.id, track));
+    const { filterControls, styleManager } = makeCountHierarchyFixture({ tracks });
+    provideMocks.getPossible.mockImplementation((id: number) => (
+      tracks.find((track) => track.id === id)
+    ));
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.virtualTypes.map(({ displayText }) => displayText)).toEqual([
+      '2 / 3\u00A0 root', '1 / 2\u00A0 branch', '1 / 1\u00A0 leaf', '1 / 1\u00A0 sibling',
+    ]);
+    vm.virtualTypes.forEach(({ displayText }) => {
+      const [frame, total] = displayText.split('\u00A0')[0].split('/').map(Number);
+      expect(frame).toBeLessThanOrEqual(total);
+    });
   });
 
   it('does not restore attribute-suppressed descendants through ancestor roll-up', () => {
@@ -681,10 +824,10 @@ describe('FilterList hierarchy members', () => {
       ['branch', 1], ['root', 2], ['sibling', 1],
     ]));
     expect(vm.virtualTypes.map(({ displayText }) => displayText)).toEqual([
-      '2 : 0\u00A0 root',
-      '1 : 0\u00A0 branch',
-      '0 : 0\u00A0 leaf',
-      '1 : 0\u00A0 sibling',
+      '0 / 2\u00A0 root',
+      '0 / 1\u00A0 branch',
+      '0 / 0\u00A0 leaf',
+      '0 / 1\u00A0 sibling',
     ]);
   });
 });

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  computed, defineComponent, onBeforeUnmount, PropType, reactive, ref, Ref,
+  computed, defineComponent, onBeforeUnmount, onMounted, PropType, reactive, ref, Ref,
   watch,
 } from 'vue';
 import {
@@ -39,10 +39,33 @@ const EMPTY_HIERARCHY_INDEX = compileHierarchy({});
 interface VirtualTypeItem extends TypeListRow {
   confidenceFilterNum: number;
   displayText: string;
+  displayTooltip: string;
   color: string;
   tree: boolean;
   isSuppressionType: boolean;
   suppressionThreshold: number;
+}
+
+function countPair(frame: string, total: string, showFrame: boolean, showTotal: boolean): string {
+  return [showFrame ? frame : '', showTotal ? total : ''].filter((part) => part).join(' / ');
+}
+
+function typeRowLabels(
+  type: string,
+  total: number,
+  frame: number,
+  showTotal: boolean,
+  showFrame: boolean,
+): { displayText: string; displayTooltip: string } {
+  const counts = countPair(`${frame}`, `${total}`, showFrame, showTotal);
+  const displayText = counts ? `${counts}\u00A0 ${type}` : type;
+  if (showTotal && !showFrame) {
+    return { displayText, displayTooltip: `${type} - ${total} in the dataset` };
+  }
+  if (showFrame && !showTotal) {
+    return { displayText, displayTooltip: `${type} - ${frame} on this frame` };
+  }
+  return { displayText, displayTooltip: displayText };
 }
 
 export default defineComponent({
@@ -329,12 +352,18 @@ export default defineComponent({
       filterTypesByFrame.value = newValue;
     });
     const noFrameCounts = new Map<string, number>();
+    const showTotalCount = computed(() => clientSettings.typeSettings.showTotalCount ?? true);
+    const showFrameCount = computed(() => clientSettings.typeSettings.showFrameCount ?? true);
+    // Avoid interval-tree and suppression passes unless a consumer needs frame counts.
+    const frameCountsRef = computed(() => {
+      const needed = filterTypesByFrame.value
+        || sortingMethods[data.sortingMethod] === 'frame count'
+        || showFrameCount.value;
+      return needed ? currentFrameTrackTypes.value : noFrameCounts;
+    });
     const typeListModel: Ref<TypeListModel> = computed(() => {
       const sort = sortingMethods[data.sortingMethod];
       const byFrame = filterTypesByFrame.value ?? false;
-      // The model needs frame counts only when they affect row visibility or order.
-      // Otherwise playback can update displayed counts without rebuilding the tree.
-      const usesFrameCounts = byFrame || sort === 'frame count';
       return buildTypeListModel({
         hierarchyIndex: hierarchyIndexRef.value || EMPTY_HIERARCHY_INDEX,
         allTypes: allTypesRef.value,
@@ -342,7 +371,7 @@ export default defineComponent({
         configuredTypes: trackFilters.configuredTypes.value,
         checkedTypes: checkedTypesRef.value,
         counts: typeCounts.value,
-        frameCounts: usesFrameCounts ? currentFrameTrackTypes.value : noFrameCounts,
+        frameCounts: frameCountsRef.value,
         showEmpty: props.showEmptyTypes,
         query: data.filterText,
         filterTypesByFrame: byFrame,
@@ -358,14 +387,22 @@ export default defineComponent({
       const confidenceFiltersDeRef = confidenceFiltersRef.value;
       const typeCountsDeRef = typeCounts.value;
       const typeStylingDeRef = typeStylingRef.value;
-      const frameTrackTypesDeRef = currentFrameTrackTypes.value;
+      const frameTrackTypesDeRef = frameCountsRef.value;
+      const showTotalDeRef = showTotalCount.value;
+      const showFrameDeRef = showFrameCount.value;
       const { suppressionType, suppressionThreshold } = clientSettings.typeSettings;
       const { rows } = typeListModel.value;
       return rows.map(({ type, ...row }) => ({
         ...row,
         type,
         confidenceFilterNum: confidenceFiltersDeRef[type] || 0,
-        displayText: `${typeCountsDeRef.get(type) || 0} : ${frameTrackTypesDeRef.get(type) || 0}\u00A0 ${type}`,
+        ...typeRowLabels(
+          type,
+          typeCountsDeRef.get(type) || 0,
+          frameTrackTypesDeRef.get(type) || 0,
+          showTotalDeRef,
+          showFrameDeRef,
+        ),
         color: typeStylingDeRef.color(type),
         tree: hierarchyActive.value,
         isSuppressionType: !!suppressionType && type === suppressionType,
@@ -430,8 +467,22 @@ export default defineComponent({
     const showSharedLineageControl = computed(() => (
       sharedLineage.value.length > 0 && data.filterText.length === 0
     ));
+    const virtualScrollWrapper = ref<HTMLElement | null>(null);
+    const measuredVirtualHeight = ref<number | null>(null);
+    let resizeObserver: ResizeObserver | null = null;
+
+    onMounted(() => {
+      if (typeof ResizeObserver !== 'undefined' && virtualScrollWrapper.value) {
+        resizeObserver = new ResizeObserver(([entry]) => {
+          measuredVirtualHeight.value = Math.max(0, Math.floor(entry.contentRect.height));
+        });
+        resizeObserver.observe(virtualScrollWrapper.value);
+      }
+    });
+    onBeforeUnmount(() => resizeObserver?.disconnect());
     const virtualHeight = computed(() => (
-      props.height - props.headerHeight - (showSharedLineageControl.value ? ROW_HEIGHT : 0)
+      measuredVirtualHeight.value
+      ?? props.height - props.headerHeight - (showSharedLineageControl.value ? ROW_HEIGHT : 0)
     ));
 
     const goToPeakTrackFrame = (trackType: string) => {
@@ -481,6 +532,11 @@ export default defineComponent({
 
     const showMaxFrameButton = computed(() => clientSettings.typeSettings.maxCountButton);
 
+    const headerTooltip = computed(() => {
+      const counts = countPair('FrameCount', 'TotalCount', showFrameCount.value, showTotalCount.value);
+      return `Toggle Type. Rows read ${counts && `${counts} `}Type Name`;
+    });
+
     const disableAnnotationFilters = computed({
       get: () => props.filterControls.disableAnnotationFilters.value,
       set: (val: boolean) => {
@@ -496,7 +552,9 @@ export default defineComponent({
       sharedLineage,
       sharedLineageText,
       showSharedLineageControl,
+      virtualScrollWrapper,
       headCheckState,
+      headerTooltip,
       visibleTypes,
       usedTypesRef,
       checkedTypesRef,
@@ -528,7 +586,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <div class="d-flex flex-column">
+  <div class="type-list-root d-flex flex-column">
     <v-container
       dense
     >
@@ -574,7 +632,7 @@ export default defineComponent({
             <template #activator="{ on }">
               <b v-on="on">Type Filter</b>
             </template>
-            <span>Toggle Type TotalCount:FrameCount Type Name</span>
+            <span>{{ headerTooltip }}</span>
           </v-tooltip>
           <div class="type-header-actions d-flex align-center ml-auto">
             <tooltip-btn
@@ -626,9 +684,7 @@ export default defineComponent({
         v-if="compactSharedLineage"
         class="shared-lineage-text text-body-2 grey--text text--lighten-1"
         :title="sharedLineageText"
-      >
-        {{ sharedLineageText }}
-      </span>
+      ><span class="shared-lineage-text-inner">{{ sharedLineageText }}</span></span>
       <v-btn
         text
         small
@@ -639,7 +695,10 @@ export default defineComponent({
         {{ compactSharedLineage ? 'Expand Parents' : 'Compact Parents' }}
       </v-btn>
     </div>
-    <div class="py-2 overflow-y-hidden">
+    <div
+      ref="virtualScrollWrapper"
+      class="type-list-viewport py-2 overflow-y-hidden"
+    >
       <v-virtual-scroll
         class="tracks"
         :items="virtualTypes"
@@ -661,6 +720,7 @@ export default defineComponent({
             :disclosure-visible="data.filterText.length === 0"
             :color="item.color"
             :display-text="item.displayText"
+            :display-tooltip="item.displayTooltip"
             :confidence-filter-num="item.confidenceFilterNum"
             :width="width"
             :display-max-button="showMaxFrameButton"
@@ -695,6 +755,16 @@ export default defineComponent({
 
 $row-height: 30px;
 
+.type-list-root {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.type-list-viewport {
+  flex: 1 1 0;
+  min-height: 0;
+}
+
 .border-highlight {
    border-bottom: 1px solid gray;
  }
@@ -718,6 +788,14 @@ $row-height: 30px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* Preserve the most specific end when the breadcrumb overflows. */
+  direction: rtl;
+}
+
+/* Keep names in logical order under the RTL wrapper. */
+.shared-lineage-text-inner {
+  direction: ltr;
+  unicode-bidi: bidi-override;
 }
 
 .outlined {

--- a/client/src/components/TypeItem.spec.ts
+++ b/client/src/components/TypeItem.spec.ts
@@ -39,7 +39,7 @@ describe('TypeItem hierarchy row', () => {
   it('exposes hierarchy semantics and keeps the type color active while indeterminate', async () => {
     const { wrapper, vm, toggleExpanded } = mountTypeItem({
       type: 'fish',
-      displayText: '3 : 1\u00A0 fish',
+      displayText: '1 / 3\u00A0 fish',
       confidenceFilterNum: 0.4,
       color: '#abc',
       checked: false,
@@ -79,30 +79,61 @@ describe('TypeItem hierarchy row', () => {
     }));
     expect(vm.cssVars)
       .toEqual(expect.objectContaining({
-        '--content-width': '138px',
-        '--tree-depth': '32px',
+        '--content-width': '162px',
+        '--tree-depth': '24px',
       }));
     expect(wrapper.find('.row-help').exists()).toBe(false);
   });
 
-  it('keeps flat rows free of hierarchy roles and disclosure controls', () => {
-    const { wrapper } = mountTypeItem({
+  it('keeps flat rows free of hierarchy roles, disclosure controls, and tree spacing', () => {
+    const { wrapper, vm } = mountTypeItem({
       type: 'fish',
-      displayText: '3 : 1\u00A0 fish',
+      displayText: '1 / 3\u00A0 fish',
       confidenceFilterNum: 0,
       color: '#abc',
       checked: true,
+      width: 300,
     });
 
     expect(wrapper.find('v-row').attributes('role')).toBeUndefined();
     expect(wrapper.find('[aria-label*="descendants of fish"]').exists()).toBe(false);
     expect(wrapper.find('v-checkbox').attributes('indeterminate')).toBeUndefined();
+    expect(wrapper.find('.tree-prefix').exists()).toBe(false);
+    expect(wrapper.find('v-checkbox').classes()).toContain('pl-2');
+    expect(wrapper.find('v-row').classes()).not.toContain('tree-row');
+    expect(vm.cssVars).toEqual({ '--content-width': '224px', '--tree-depth': '0px' });
+  });
+
+  it.each([
+    [0, '0px', '216px'],
+    [1, '12px', '204px'],
+    [3, '36px', '180px'],
+  ])('indents a depth %i tree row by the shared step and budgets the label to match', (
+    depth,
+    treeDepth,
+    contentWidth,
+  ) => {
+    const { wrapper, vm } = mountTypeItem({
+      type: 'fish',
+      displayText: '1 / 3\u00A0 fish',
+      confidenceFilterNum: 0,
+      color: '#abc',
+      checked: true,
+      tree: true,
+      depth,
+      width: 300,
+    });
+
+    expect(vm.cssVars).toEqual({ '--content-width': contentWidth, '--tree-depth': treeDepth });
+    expect(wrapper.find('.tree-prefix').exists()).toBe(true);
+    expect(wrapper.find('v-checkbox').classes()).not.toContain('pl-2');
+    expect(wrapper.find('v-row').classes()).toContain('tree-row');
   });
 
   it('uses an indentation spacer while search forces a parent open', () => {
     const { wrapper } = mountTypeItem({
       type: 'fish',
-      displayText: '3 : 1\u00A0 fish',
+      displayText: '1 / 3\u00A0 fish',
       confidenceFilterNum: 0,
       color: '#abc',
       checked: true,

--- a/client/src/components/TypeItem.vue
+++ b/client/src/components/TypeItem.vue
@@ -2,6 +2,11 @@
 import { computed, defineComponent } from 'vue';
 import TooltipBtn from './TooltipButton.vue';
 
+const INDENT_STEP_PX = 12;
+const TREE_PREFIX_PX = 20;
+const CHECKBOX_LEFT_PAD_PX = 8;
+const CHECKBOX_LABEL_GAP_TRIM_PX = 4;
+
 export default defineComponent({
   name: 'TypeItem',
 
@@ -15,6 +20,10 @@ export default defineComponent({
     displayText: {
       type: String,
       required: true,
+    },
+    displayTooltip: {
+      type: String,
+      default: '',
     },
     confidenceFilterNum: {
       type: Number,
@@ -82,13 +91,16 @@ export default defineComponent({
       }
       return 42 + 14 + 20 + 30;
     });
-    const HierarchyPadding = computed(() => (props.tree ? (props.depth * 16) + 24 : 0));
+    const HierarchyPadding = computed(() => (props.tree
+      ? (props.depth * INDENT_STEP_PX) + TREE_PREFIX_PX
+        - CHECKBOX_LEFT_PAD_PX - CHECKBOX_LABEL_GAP_TRIM_PX
+      : 0));
     const cssVars = computed(() => ({
       '--content-width': `${Math.max(
         0,
         props.width - HorizontalPadding.value - HierarchyPadding.value,
       )}px`,
-      '--tree-depth': `${props.depth * 16}px`,
+      '--tree-depth': `${props.depth * INDENT_STEP_PX}px`,
     }));
     const effectiveOverlapPercent = computed(() => {
       const p = Number(props.suppressionThreshold);
@@ -113,7 +125,7 @@ export default defineComponent({
   <v-row
     :style="cssVars"
     align="center"
-    class="hover-show-parent"
+    :class="['hover-show-parent', { 'tree-row': tree }]"
     :role="tree ? 'listitem' : undefined"
     :aria-level="tree ? depth + 1 : undefined"
   >
@@ -148,7 +160,7 @@ export default defineComponent({
         dense
         shrink
         hide-details
-        class="my-1 pl-2"
+        :class="['my-1', { 'pl-2': !tree }]"
         @change="$emit('setCheckedTypes', $event)"
       >
         <template #label>
@@ -165,7 +177,7 @@ export default defineComponent({
                   {{ displayText }}
                 </span>
               </template>
-              <span>{{ displayText }}</span>
+              <span>{{ displayTooltip || displayText }}</span>
             </v-tooltip>
             <v-tooltip
               v-if="confidenceFilterNum"
@@ -264,6 +276,9 @@ export default defineComponent({
 <style lang="scss" scoped>
 @import 'src/components/styles/hover-reveal.scss';
 
+/* Keep in sync with `TREE_PREFIX_PX`. */
+$tree-prefix-width: 20px;
+
 .nowrap {
   white-space: nowrap;
   overflow: hidden;
@@ -271,15 +286,19 @@ export default defineComponent({
   text-overflow: ellipsis;
 }
 
+.tree-row ::v-deep .v-input--selection-controls__input {
+  margin-right: 4px;
+}
+
 .tree-prefix {
-  flex: 0 0 24px;
+  flex: 0 0 $tree-prefix-width;
   height: 30px;
   margin-left: var(--tree-depth);
 }
 
 .tree-disclosure {
-  min-width: 24px;
-  width: 24px;
+  min-width: $tree-prefix-width;
+  width: $tree-prefix-width;
   height: 24px;
   padding: 0;
   border: 0;
@@ -296,7 +315,7 @@ export default defineComponent({
 
 .tree-disclosure-spacer {
   display: inline-block;
-  width: 24px;
+  width: $tree-prefix-width;
 }
 
 .outlined {

--- a/client/src/typeListHierarchy.spec.ts
+++ b/client/src/typeListHierarchy.spec.ts
@@ -223,11 +223,11 @@ describe('typeListHierarchy', () => {
     };
 
     const compact = build(options);
-    expect(compact.sharedLineage).toEqual(['domain', 'kingdom', 'phylum']);
+    expect(compact.sharedLineage).toEqual(['domain', 'kingdom', 'phylum', 'class']);
     expect(compact.rows.slice(0, 3).map(({ type, depth }) => ({ type, depth }))).toEqual([
-      { type: 'class', depth: 0 },
-      { type: 'orderA', depth: 1 },
-      { type: 'familyA', depth: 2 },
+      { type: 'orderA', depth: 0 },
+      { type: 'familyA', depth: 1 },
+      { type: 'genusA', depth: 2 },
     ]);
 
     const shown = build({ ...options, compactSharedLineage: false });
@@ -241,6 +241,45 @@ describe('typeListHierarchy', () => {
     const searched = build({ ...options, query: 'domain' });
     expect(searched.rows.map(({ type }) => type)).toEqual(['domain']);
     expect(searched.rows[0].depth).toBe(0);
+
+    const searchedBranchPoint = build({ ...options, query: 'class' });
+    expect(searchedBranchPoint.rows.map(({ type, depth }) => ({ type, depth }))).toEqual([
+      { type: 'domain', depth: 0 },
+      { type: 'kingdom', depth: 1 },
+      { type: 'phylum', depth: 2 },
+      { type: 'class', depth: 3 },
+    ]);
+  });
+
+  it('absorbs the deepest common ancestor unless it is used or configured', () => {
+    const deepIndex = compileHierarchy({
+      speciesA: 'genusA',
+      speciesB: 'genusB',
+      genusA: 'family',
+      genusB: 'family',
+      family: 'order',
+      order: 'class',
+    });
+    const options = {
+      hierarchyIndex: deepIndex,
+      allTypes: [],
+      checkedTypes: [],
+      usedTypes: ['speciesA', 'speciesB'],
+      compactSharedLineage: true,
+    };
+
+    const absorbed = build(options);
+    expect(absorbed.sharedLineage).toEqual(['class', 'order', 'family']);
+    expect(absorbed.rows.map(({ type, depth }) => ({ type, depth }))).toEqual([
+      { type: 'genusA', depth: 0 },
+      { type: 'speciesA', depth: 1 },
+      { type: 'genusB', depth: 0 },
+      { type: 'speciesB', depth: 1 },
+    ]);
+
+    const used = build({ ...options, usedTypes: ['speciesA', 'speciesB', 'family'] });
+    expect(used.sharedLineage).toEqual(['class', 'order']);
+    expect(used.rows[0]).toEqual(expect.objectContaining({ type: 'family', depth: 0 }));
   });
 
   it('preserves depth in unrelated trees while compacting a shared lineage', () => {

--- a/client/src/typeListHierarchy.ts
+++ b/client/src/typeListHierarchy.ts
@@ -132,8 +132,10 @@ export function buildTypeListModel({
     let current = [...targetRoots][0];
     while (!directlyMeaningfulTypes.has(current)) {
       const childTypes = children.get(current) || [];
-      if (childTypes.length !== 1) break;
+      if (childTypes.length === 0) break;
+      /* Absorb an unused branch point so it does not indent every row below it. */
       unusedLeadingParents.push(current);
+      if (childTypes.length > 1) break;
       [current] = childTypes;
     }
   }

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -10,6 +10,7 @@ Each dataset maintains its own list of types, and types can be defined on-the-fl
 
 The Type List is used to control visual styles of the different types as well as filter out types that don't need to be displayed.
 
+* Rows show *frame count* **/** *total count* before the type name, for example `3 / 12  red-snapper`. Either count can be hidden in type settings.
 * The checkbox next to each type name can be used to toggle types on and off.
 * ==:material-sort-alphabetical-ascending:== toggles the sort order between alphabetical and by number of annotations of each type.
 * ==:material-cog:== opens the type settings menu.
@@ -39,6 +40,8 @@ have each viewer's checked types and confidence thresholds. Viewer counts and fi
 hierarchy-resolved displayed type.
 
 Hierarchy members render as an expandable tree rather than ordinary flat rows. Parent checkboxes control their complete subtrees, and parent counts include descendants. The Type List does not offer hierarchy editing.
+
+**Compact Parents** folds unused shared parent rows into a breadcrumb. Used or configured parents remain as rows. **Expand Parents** restores the full chain, and searching shows a match's complete path.
 
 While a hierarchy is active, **Prevent Cascade Types** is disabled and shows: `Not applicable to hierarchical types; DIVE selects the deepest qualifying type.` Its saved value is preserved and becomes active again when the hierarchy is removed.
 
@@ -93,6 +96,7 @@ In ad-hoc mode, new object classes are added as you annotate.  The type list upd
 
 * Set **Lock Types** to off for ad-hoc type creation.
 * Set **Show Empty** to still show manually defined types with no track/detection examples in the type list.
+* Use **Show Total Count** and **Show Frame Count** to choose which counts appear in each row.
 
 <div style="clear: both;"/>
 


### PR DESCRIPTION
# Reclaim Type List row width and read counts as a fraction

Follow-up to [Bryon's #1867 review](https://github.com/Kitware/dive/pull/1867#pullrequestreview-5030473848).

Deep hierarchy rows run out of room for the type name.

### Changes

- Tighten tree indentation, disclosure width, and checkbox spacing; flat rows are unchanged.
- Fill the Type List's available height instead of leaving space below its rows.
- Render counts as `3 / 12  red-snapper` instead of `12 : 3  red-snapper`.
- Add **Show Total Count** and **Show Frame Count** settings, both on by default.
- Let **Compact Parents** absorb the deepest unused shared ancestor.
- Truncate breadcrumbs at the front so the most specific parent remains visible, while preserving
  character order for names containing digits or punctuation.
- Skip per-frame count work when it is not needed for display, sorting, or filtering.

<img width="359" height="573" alt="image" src="https://github.com/user-attachments/assets/e3ef195b-8595-4b63-9a64-a2865fe7f447" />

