### PR TITLE
Scope the Type List header checkbox to the displayed rows

### DIFF
--- a/client/dive-common/store/settings.spec.ts
+++ b/client/dive-common/store/settings.spec.ts
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+/// <reference types="vitest" />
+
+describe('clientSettings hydration', () => {
+  it('keeps every type-list switch a reactive key when nothing is stored', async () => {
+    localStorage.removeItem('Settings');
+    vi.resetModules();
+
+    const { clientSettings } = await import('./settings');
+
+    expect(Object.keys(clientSettings.typeSettings)).toEqual(expect.arrayContaining([
+      'filterTypesByFrame',
+    ]));
+    expect(clientSettings.typeSettings.filterTypesByFrame).toBe(false);
+  });
+});

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -140,6 +140,7 @@ const defaultSettings: AnnotationSettings = {
     showEmptyTypes: false,
     lockTypes: false,
     preventCascadeTypes: false,
+    filterTypesByFrame: false,
     maxCountButton: false,
     suppressionType: 'Suppressed',
     suppressionThreshold: 99,

--- a/client/src/components/FilterList.spec.ts
+++ b/client/src/components/FilterList.spec.ts
@@ -494,7 +494,7 @@ describe('FilterList hierarchy members', () => {
     expect(updateCheckedTypes).toHaveBeenCalledTimes(2);
   });
 
-  it('rolls total and frame counts into ancestors and keeps frame filtering header-independent', async () => {
+  it('rolls total and frame counts into ancestors and scopes the header to the frame', async () => {
     clientSettings.typeSettings.trackSortDir = 'a-z';
     clientSettings.typeSettings.filterTypesByFrame = true;
     clientSettings.typeSettings.suppressionType = '';
@@ -522,7 +522,7 @@ describe('FilterList hierarchy members', () => {
       '2 : 1\u00A0 branch',
       '1 : 1\u00A0 leaf',
     ]);
-    expect(vm.visibleTypes).toEqual(['root', 'branch', 'leaf', 'sibling']);
+    expect(vm.visibleTypes).toEqual(['root', 'branch', 'leaf']);
 
     provideMocks.seekFrame.mockClear();
     vm.goToPeakTrackFrame('branch');
@@ -660,6 +660,83 @@ describe('FilterList hierarchy members', () => {
 
     expect(vm.virtualTypes.find(({ type }) => type === 'root')?.displayText)
       .toBe('3 : 1\u00A0 root');
+  });
+
+  it.each([
+    ['a flat dataset', null, ['leaf'], ['branch', 'sibling']],
+    [
+      'a hierarchy',
+      { leaf: 'branch', branch: 'root', sibling: 'root' },
+      ['root', 'branch', 'leaf'],
+      ['sibling'],
+    ],
+  ] as const)('scopes the header toggle to the frame filter on %s', async (
+    _view,
+    hierarchy,
+    onFrame,
+    offFrame,
+  ) => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = true;
+    clientSettings.typeSettings.suppressionType = '';
+    /* Only track 1, typed `leaf`, has a detection on frame 0. */
+    provideMocks.intervalSearch.mockImplementation(([frame]: [number, number]) => (
+      frame === 0 ? ['1'] : ['1', '2', '3']
+    ));
+    const {
+      checkedTypes, filterControls, styleManager, tracks, updateCheckedTypes,
+    } = makeCountHierarchyFixture({
+      hierarchy,
+      checkedTypes: [...onFrame, ...offFrame],
+    });
+    provideMocks.getPossible.mockImplementation((id: number) => (
+      tracks.find((track) => track.id === id)
+    ));
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.visibleTypes).toEqual([...onFrame]);
+    expect(vm.headCheckState).toBe(1);
+
+    vm.headCheckClicked();
+    expect(updateCheckedTypes).toHaveBeenCalledTimes(1);
+    expect(checkedTypes.value).toEqual([...offFrame]);
+
+    /* Frame counts are tallied from the filtered annotations, so unchecking a
+       displayed type drops its row exactly as unchecking it from its own row
+       does. Turning the frame filter off brings every type back. */
+    expect(vm.visibleTypes).toEqual([]);
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    await nextTick();
+    expect(vm.visibleTypes).toEqual(expect.arrayContaining([...onFrame, ...offFrame]));
+  });
+
+  it('leaves the header unchecked and disabled on a frame with no types', () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = true;
+    clientSettings.typeSettings.suppressionType = '';
+    provideMocks.intervalSearch.mockReturnValue([]);
+    const { filterControls, styleManager, tracks } = makeCountHierarchyFixture();
+    provideMocks.getPossible.mockImplementation((id: number) => (
+      tracks.find((track) => track.id === id)
+    ));
+    const { wrapper, vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.virtualTypes).toEqual([]);
+    expect(vm.visibleTypes).toEqual([]);
+    expect(vm.headCheckState).toBe(0);
+    expect(wrapper.find('.type-checkbox').attributes('disabled')).toBe('true');
   });
 
   it('does not restore attribute-suppressed descendants through ancestor roll-up', () => {

--- a/client/src/components/FilterList.spec.ts
+++ b/client/src/components/FilterList.spec.ts
@@ -778,6 +778,29 @@ describe('FilterList hierarchy members', () => {
     expect(vm.emptyListText).toBe('No types yet');
   });
 
+  it('counts hierarchy-only types as defined when a search empties the list', async () => {
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    const { filterControls, styleManager } = makeFilterListFixture({
+      tracks: [],
+      hierarchy: { leaf: 'branch' },
+      checkedTypes: [],
+    });
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: true,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['branch', 'leaf']);
+
+    vm.data.filterText = 'zzz';
+    await nextTick();
+    expect(vm.virtualTypes).toEqual([]);
+    expect(vm.emptyListText).toBe('No types match the current filters');
+  });
+
   it('does not restore attribute-suppressed descendants through ancestor roll-up', () => {
     clientSettings.typeSettings.trackSortDir = 'a-z';
     clientSettings.typeSettings.filterTypesByFrame = false;

--- a/client/src/components/FilterList.spec.ts
+++ b/client/src/components/FilterList.spec.ts
@@ -494,6 +494,26 @@ describe('FilterList hierarchy members', () => {
     expect(updateCheckedTypes).toHaveBeenCalledTimes(2);
   });
 
+  it('offers only displayed rows for deletion, not every checked type', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    const { checkedTypes, filterControls, styleManager } = makeHierarchyFixture();
+    checkedTypes.value = ['leaf', 'root', 'branch', 'sibling'];
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: true,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.deletableTypes).toEqual(['root', 'branch', 'leaf', 'sibling']);
+
+    vm.data.filterText = 'leaf';
+    await nextTick();
+    expect(vm.deletableTypes).toEqual(['leaf']);
+  });
+
   it('rolls total and frame counts into ancestors and scopes the header to the frame', async () => {
     clientSettings.typeSettings.trackSortDir = 'a-z';
     clientSettings.typeSettings.filterTypesByFrame = true;

--- a/client/src/components/FilterList.spec.ts
+++ b/client/src/components/FilterList.spec.ts
@@ -514,6 +514,30 @@ describe('FilterList hierarchy members', () => {
     expect(vm.deletableTypes).toEqual(['leaf']);
   });
 
+  it('reaches the whole branch through a collapsed row', async () => {
+    clientSettings.typeSettings.trackSortDir = 'a-z';
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    const { checkedTypes, filterControls, styleManager } = makeHierarchyFixture();
+    checkedTypes.value = [];
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: true,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    vm.toggleExpanded('root');
+    await nextTick();
+    expect(vm.virtualTypes.map(({ type }) => type)).toEqual(['root']);
+
+    vm.headCheckClicked();
+    await nextTick();
+    expect(checkedTypes.value).toEqual(['root', 'branch', 'leaf', 'sibling']);
+    expect(vm.virtualTypes[0]).toMatchObject({ checked: true, indeterminate: false });
+    expect(vm.deletableTypes).toEqual(['root', 'branch', 'leaf', 'sibling']);
+  });
+
   it('rolls total and frame counts into ancestors and scopes the header to the frame', async () => {
     clientSettings.typeSettings.trackSortDir = 'a-z';
     clientSettings.typeSettings.filterTypesByFrame = true;

--- a/client/src/components/FilterList.spec.ts
+++ b/client/src/components/FilterList.spec.ts
@@ -737,6 +737,25 @@ describe('FilterList hierarchy members', () => {
     expect(vm.visibleTypes).toEqual([]);
     expect(vm.headCheckState).toBe(0);
     expect(wrapper.find('.type-checkbox').attributes('disabled')).toBe('true');
+    expect(vm.emptyListText).toBe('No types match the current filters');
+  });
+
+  it('separates a dataset with no types from one the filters emptied', () => {
+    clientSettings.typeSettings.filterTypesByFrame = false;
+    const { filterControls, styleManager } = makeFilterListFixture({
+      tracks: [],
+      checkedTypes: [],
+    });
+    const { vm } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: false,
+      height: 240,
+      headerHeight: 80,
+    });
+
+    expect(vm.virtualTypes).toEqual([]);
+    expect(vm.emptyListText).toBe('No types yet');
   });
 
   it('does not restore attribute-suppressed descendants through ancestor roll-up', () => {

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -153,34 +153,6 @@ export default defineComponent({
       clientSettings.typeSettings.trackSortDir = sortingMethods[data.sortingMethod];
     }
 
-    async function clickDelete() {
-      const typeDisplay: string[] = [];
-      let text: string[] = [];
-      if (props.group) {
-        text = [
-          'This will remove the group assignment from any visible tracks and delete the group. Do you want to delete all groups of the following types:',
-        ];
-      } else {
-        text = [
-          'This will remove the type from any visible track or delete the track if it is the only type. Do you want to delete all tracks of following types:',
-        ];
-      }
-      text.push('-------');
-      checkedTypesRef.value.forEach((item) => {
-        typeDisplay.push(item);
-        text.push(item.toString());
-      });
-
-      const result = await prompt({
-        title: 'Really delete types?',
-        text,
-        confirm: true,
-      });
-      if (result) {
-        trackFilters.removeTypeAnnotations([...checkedTypesRef.value]);
-      }
-    }
-
     /**
      * Ids of tracks whose every keyframe detection is suppressed - covered by
      * a region on each frame it appears, or flagged with the suppression
@@ -354,6 +326,29 @@ export default defineComponent({
     const sharedLineage = computed(() => typeListModel.value.sharedLineage);
     const sharedLineageText = computed(() => sharedLineage.value.join(' › '));
     const visibleTypes = computed(() => typeListModel.value.actionableTypes);
+    /* The delete button carries out what the header selected, so it reads the
+       same displayed rows rather than every type that happens to be checked. */
+    const deletableTypes = computed(() => {
+      const checked = new Set(checkedTypesRef.value);
+      return visibleTypes.value.filter((type) => checked.has(type));
+    });
+    async function clickDelete() {
+      const text: string[] = props.group
+        ? ['This will remove the group assignment from any visible tracks and delete the group. Do you want to delete all groups of the following types:']
+        : ['This will remove the type from any visible track or delete the track if it is the only type. Do you want to delete all tracks of following types:'];
+      text.push('-------');
+      deletableTypes.value.forEach((item) => text.push(item.toString()));
+
+      const result = await prompt({
+        title: 'Really delete types?',
+        text,
+        confirm: true,
+      });
+      if (result) {
+        trackFilters.removeTypeAnnotations([...deletableTypes.value]);
+      }
+    }
+
     const virtualTypes: Ref<readonly VirtualTypeItem[]> = computed(() => {
       const confidenceFiltersDeRef = confidenceFiltersRef.value;
       const typeCountsDeRef = typeCounts.value;
@@ -505,6 +500,7 @@ export default defineComponent({
       showSharedLineageControl,
       headCheckState,
       visibleTypes,
+      deletableTypes,
       emptyListText,
       usedTypesRef,
       checkedTypesRef,
@@ -598,7 +594,7 @@ export default defineComponent({
               <template #activator="{ on }">
                 <v-btn
                   class="hover-show-child"
-                  :disabled="checkedTypesRef.length === 0 || readOnlyMode"
+                  :disabled="deletableTypes.length === 0 || readOnlyMode"
                   icon
                   small
                   v-on="on"

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -377,21 +377,15 @@ export default defineComponent({
       return deletableTypes.value.length === visibleTypes.value.length ? 1 : -1;
     });
 
+    /* Checked types the list is not showing are left alone by the header. */
+    const offscreenCheckedTypes = computed(
+      () => difference(checkedTypesRef.value, visibleTypes.value),
+    );
+
     function headCheckClicked() {
-      if (headCheckState.value === 0) {
-        /* Enable only what is filtered AND don't change what isn't filtered */
-        const allVisibleAndCheckedInvisible = union(
-          /* What was already checked and is currently not visible */
-          difference(checkedTypesRef.value, visibleTypes.value),
-          /* What is visible */
-          visibleTypes.value,
-        );
-        trackFilters.updateCheckedTypes(allVisibleAndCheckedInvisible);
-      } else {
-        /* Disable whatever is both checked and filtered */
-        const invisible = difference(checkedTypesRef.value, visibleTypes.value);
-        trackFilters.updateCheckedTypes(invisible);
-      }
+      trackFilters.updateCheckedTypes(headCheckState.value === 0
+        ? union(offscreenCheckedTypes.value, visibleTypes.value)
+        : offscreenCheckedTypes.value);
     }
 
     function updateCheckedType(type: string) {

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -372,6 +372,14 @@ export default defineComponent({
         suppressionThreshold: suppressionThreshold ?? 99,
       }));
     });
+    /* An empty list is ambiguous on its own: the dataset may define nothing, or
+       the filters may have excluded everything it does define. */
+    const emptyListText = computed(() => {
+      if (virtualTypes.value.length > 0) return '';
+      const noun = props.group ? 'groups' : 'types';
+      const anyDefined = allTypesRef.value.length > 0 || usedTypesRef.value.length > 0;
+      return anyDefined ? `No ${noun} match the current filters` : `No ${noun} yet`;
+    });
     const headCheckState = computed(() => {
       const uncheckedTypes = difference(visibleTypes.value, checkedTypesRef.value);
       /* An empty list lands here too: nothing to act on reads as unchecked. */
@@ -497,6 +505,7 @@ export default defineComponent({
       showSharedLineageControl,
       headCheckState,
       visibleTypes,
+      emptyListText,
       usedTypesRef,
       checkedTypesRef,
       confidenceFiltersRef,
@@ -639,7 +648,14 @@ export default defineComponent({
       </v-btn>
     </div>
     <div class="py-2 overflow-y-hidden">
+      <div
+        v-if="emptyListText"
+        class="empty-list text-body-2 grey--text text--lighten-1 mx-2"
+      >
+        {{ emptyListText }}
+      </div>
       <v-virtual-scroll
+        v-else
         class="tracks"
         :items="virtualTypes"
         :item-height="rowHeight"

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -4,7 +4,7 @@ import {
   watch,
 } from 'vue';
 import {
-  debounce, difference, union,
+  debounce, difference, intersection, union,
 } from 'lodash';
 
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
@@ -328,20 +328,17 @@ export default defineComponent({
     const visibleTypes = computed(() => typeListModel.value.actionableTypes);
     /* The delete button carries out what the header selected, so it reads the
        same displayed rows rather than every type that happens to be checked. */
-    const deletableTypes = computed(() => {
-      const checked = new Set(checkedTypesRef.value);
-      return visibleTypes.value.filter((type) => checked.has(type));
-    });
+    const deletableTypes = computed(
+      () => intersection(visibleTypes.value, checkedTypesRef.value),
+    );
     async function clickDelete() {
-      const text: string[] = props.group
-        ? ['This will remove the group assignment from any visible tracks and delete the group. Do you want to delete all groups of the following types:']
-        : ['This will remove the type from any visible track or delete the track if it is the only type. Do you want to delete all tracks of following types:'];
-      text.push('-------');
-      deletableTypes.value.forEach((item) => text.push(item.toString()));
+      const preamble = props.group
+        ? 'This will remove the group assignment from any visible tracks and delete the group. Do you want to delete all groups of the following types:'
+        : 'This will remove the type from any visible track or delete the track if it is the only type. Do you want to delete all tracks of following types:';
 
       const result = await prompt({
         title: 'Really delete types?',
-        text,
+        text: [preamble, '-------', ...deletableTypes.value],
         confirm: true,
       });
       if (result) {
@@ -370,10 +367,9 @@ export default defineComponent({
     /* An empty list is ambiguous on its own: the dataset may define nothing, or
        the filters may have excluded everything it does define. */
     const emptyListText = computed(() => {
-      if (virtualTypes.value.length > 0) return '';
-      const noun = props.group ? 'groups' : 'types';
-      const anyDefined = allTypesRef.value.length > 0 || usedTypesRef.value.length > 0;
-      return anyDefined ? `No ${noun} match the current filters` : `No ${noun} yet`;
+      const model = typeListModel.value;
+      if (model.rows.length > 0) return '';
+      return model.hasDefinedTypes ? 'No types match the current filters' : 'No types yet';
     });
     const headCheckState = computed(() => {
       const uncheckedTypes = difference(visibleTypes.value, checkedTypesRef.value);

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -4,7 +4,7 @@ import {
   watch,
 } from 'vue';
 import {
-  debounce, difference, intersection, union,
+  debounce, difference, union,
 } from 'lodash';
 
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
@@ -328,9 +328,7 @@ export default defineComponent({
     const visibleTypes = computed(() => typeListModel.value.actionableTypes);
     /* The delete button carries out what the header selected, so it reads the
        same displayed rows rather than every type that happens to be checked. */
-    const deletableTypes = computed(
-      () => intersection(visibleTypes.value, checkedTypesRef.value),
-    );
+    const deletableTypes = computed(() => typeListModel.value.actionableCheckedTypes);
     async function clickDelete() {
       const preamble = props.group
         ? 'This will remove the group assignment from any visible tracks and delete the group. Do you want to delete all groups of the following types:'
@@ -372,12 +370,11 @@ export default defineComponent({
       return model.hasDefinedTypes ? 'No types match the current filters' : 'No types yet';
     });
     const headCheckState = computed(() => {
-      const uncheckedTypes = difference(visibleTypes.value, checkedTypesRef.value);
       /* An empty list lands here too: nothing to act on reads as unchecked. */
-      if (uncheckedTypes.length === visibleTypes.value.length) {
+      if (deletableTypes.value.length === 0) {
         return 0;
       }
-      return uncheckedTypes.length === 0 ? 1 : -1;
+      return deletableTypes.value.length === visibleTypes.value.length ? 1 : -1;
     });
 
     function headCheckClicked() {

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -374,12 +374,11 @@ export default defineComponent({
     });
     const headCheckState = computed(() => {
       const uncheckedTypes = difference(visibleTypes.value, checkedTypesRef.value);
-      if (uncheckedTypes.length === 0) {
-        return 1;
-      } if (uncheckedTypes.length === visibleTypes.value.length) {
+      /* An empty list lands here too: nothing to act on reads as unchecked. */
+      if (uncheckedTypes.length === visibleTypes.value.length) {
         return 0;
       }
-      return -1;
+      return uncheckedTypes.length === 0 ? 1 : -1;
     });
 
     function headCheckClicked() {
@@ -542,7 +541,7 @@ export default defineComponent({
           <v-checkbox
             :input-value="headCheckState !== -1 ? headCheckState : false"
             :indeterminate="headCheckState === -1"
-            :disabled="disableAnnotationFilters"
+            :disabled="disableAnnotationFilters || visibleTypes.length === 0"
             dense
             shrink
             hide-details

--- a/client/src/typeListHierarchy.spec.ts
+++ b/client/src/typeListHierarchy.spec.ts
@@ -194,6 +194,9 @@ describe('typeListHierarchy', () => {
     const restoredModel = build({ collapsed });
 
     expect(collapsedModel.rows.map(({ type }) => type)).not.toContain('leaf');
+    expect(collapsedModel.actionableTypes).toEqual(
+      collapsedModel.rows.map(({ type }) => type),
+    );
     expect(searchModel.rows.map(({ type }) => type)).toContain('leaf');
     expect(searchModel.rows.find(({ type }) => type === 'root')?.expanded).toBe(true);
     expect(restoredModel.rows.map(({ type }) => type)).not.toContain('leaf');
@@ -241,6 +244,29 @@ describe('typeListHierarchy', () => {
     const searched = build({ ...options, query: 'domain' });
     expect(searched.rows.map(({ type }) => type)).toEqual(['domain']);
     expect(searched.rows[0].depth).toBe(0);
+  });
+
+  it('leaves breadcrumb-compacted ancestors out of the actionable set', () => {
+    const deepIndex = compileHierarchy({
+      speciesA: 'genus', speciesB: 'genus', genus: 'family', family: 'order', order: 'class',
+    });
+    const options = {
+      hierarchyIndex: deepIndex,
+      allTypes: [],
+      usedTypes: ['speciesA', 'speciesB'],
+      checkedTypes: [],
+      compactSharedLineage: true,
+    };
+
+    /* The lineage is on screen only as breadcrumb text, so the header checkbox -
+       and the delete button reading its result - must not reach it. */
+    const compact = build(options);
+    expect(compact.sharedLineage.length).toBeGreaterThan(1);
+    expect(compact.actionableTypes).toEqual(compact.rows.map(({ type }) => type));
+
+    /* Expanding the breadcrumb gives the lineage rows, and rows are actionable. */
+    const expanded = build({ ...options, compactSharedLineage: false });
+    expect(expanded.actionableTypes).toEqual(expect.arrayContaining(['order', 'family']));
   });
 
   it('preserves depth in unrelated trees while compacting a shared lineage', () => {
@@ -303,7 +329,40 @@ describe('typeListHierarchy', () => {
     expect(model.rows.map(({ type }) => type)).toEqual(['root', 'branch', 'leaf']);
     expect(model.rows.map(({ type }) => type)).not.toContain('otherRoot');
     expect(model.rows.map(({ type }) => type)).not.toContain('sibling');
-    expect(model.actionableTypes).toContain('flat');
+    /* `root` is only on screen as ancestor context, and `flat` is off frame. */
+    expect(model.actionableTypes).toEqual(['branch', 'leaf']);
+  });
+
+  it('keeps a parent actionable while one of its descendants is on the frame', () => {
+    const model = build({
+      /* `countResolvedTypes` rolls a leaf's frame count up into its ancestors. */
+      frameCounts: new Map([['root', 2], ['branch', 2], ['leaf', 2]]),
+      filterTypesByFrame: true,
+    });
+
+    expect(model.actionableTypes).toEqual(['root', 'branch', 'leaf']);
+  });
+
+  it('narrows actionable flat types by the frame filter and the search box alike', () => {
+    const common = {
+      hierarchyIndex: compileHierarchy({}),
+      allTypes: ['zebra', 'alpha', 'antelope'],
+      usedTypes: ['zebra', 'alpha', 'antelope'],
+      checkedTypes: [],
+      counts: new Map([['zebra', 2], ['alpha', 2], ['antelope', 1]]),
+      frameCounts: new Map([['alpha', 1], ['antelope', 1]]),
+      showEmpty: true,
+      sort: 'a-z' as const,
+      collapsed: new Set<string>(),
+      query: '',
+    };
+
+    expect(buildTypeListModel({ ...common, filterTypesByFrame: false }).actionableTypes)
+      .toEqual(['alpha', 'antelope', 'zebra']);
+    expect(buildTypeListModel({ ...common, filterTypesByFrame: true }).actionableTypes)
+      .toEqual(['alpha', 'antelope']);
+    expect(buildTypeListModel({ ...common, filterTypesByFrame: true, query: 'ant' })
+      .actionableTypes).toEqual(['antelope']);
   });
 
   it('includes the parent bit when computing checked and indeterminate state', () => {

--- a/client/src/typeListHierarchy.spec.ts
+++ b/client/src/typeListHierarchy.spec.ts
@@ -195,6 +195,25 @@ describe('typeListHierarchy', () => {
     expect(model.actionableCheckedTypes).toEqual(['leaf']);
   });
 
+  it('lets a collapsed row stand in for the branch its checkbox owns', () => {
+    const model = build({ collapsed: new Set(['root']) });
+
+    expect(model.rows.map(({ type }) => type)).toEqual([
+      'flat', 'otherRoot', 'otherLeaf', 'root',
+    ]);
+    expect(model.actionableTypes).toEqual([
+      'flat', 'otherRoot', 'otherLeaf', 'root', 'branch', 'leaf', 'sibling',
+    ]);
+  });
+
+  it('keeps a filtered-out descendant out of a collapsed row', () => {
+    const model = build({ collapsed: new Set(['root']), filterTypesByFrame: true });
+
+    expect(model.actionableTypes).toEqual([
+      'flat', 'otherRoot', 'otherLeaf', 'root', 'branch', 'leaf',
+    ]);
+  });
+
   it('reveals search paths without mutating or applying saved collapse state', () => {
     const collapsed = new Set(['root']);
     const collapsedModel = build({ collapsed });
@@ -202,9 +221,6 @@ describe('typeListHierarchy', () => {
     const restoredModel = build({ collapsed });
 
     expect(collapsedModel.rows.map(({ type }) => type)).not.toContain('leaf');
-    expect(collapsedModel.actionableTypes).toEqual(
-      collapsedModel.rows.map(({ type }) => type),
-    );
     expect(searchModel.rows.map(({ type }) => type)).toContain('leaf');
     expect(searchModel.rows.find(({ type }) => type === 'root')?.expanded).toBe(true);
     expect(restoredModel.rows.map(({ type }) => type)).not.toContain('leaf');

--- a/client/src/typeListHierarchy.spec.ts
+++ b/client/src/typeListHierarchy.spec.ts
@@ -96,12 +96,12 @@ describe('typeListHierarchy', () => {
   });
 
   it('hides disclosure controls when all children are filtered out', () => {
-    const model = build({ showEmpty: false });
+    const model = build({ showEmpty: false, usedTypes: ['branch', 'flat'] });
 
-    expect(model.rows.find(({ type }) => type === 'otherRoot')).toEqual(expect.objectContaining({
+    expect(model.rows.find(({ type }) => type === 'branch')).toEqual(expect.objectContaining({
       hasChildren: false,
     }));
-    expect(model.rows.some(({ type }) => type === 'otherLeaf')).toBe(false);
+    expect(model.rows.some(({ type }) => type === 'leaf')).toBe(false);
   });
 
   it('sorts roots and siblings recursively in every mode with alphabetical ties', () => {
@@ -162,7 +162,7 @@ describe('typeListHierarchy', () => {
       .toEqual(['twig', 'leaf', 'bud']);
   });
 
-  it('keeps unused structural parents but hides empty leaves and configured flat types', () => {
+  it('keeps ancestors of used types but hides branches with no annotations', () => {
     const model = build({
       allTypes: [
         'leaf', 'branch', 'root', 'sibling', 'otherLeaf', 'otherRoot', 'flat', 'configured',
@@ -171,7 +171,8 @@ describe('typeListHierarchy', () => {
       showEmpty: false,
     });
 
-    expect(model.rows.map(({ type }) => type)).toEqual(['flat', 'otherRoot', 'root', 'branch', 'leaf']);
+    expect(model.rows.map(({ type }) => type)).toEqual(['flat', 'root', 'branch', 'leaf']);
+    expect(model.actionableTypes).not.toContain('otherRoot');
     expect(model.rows.map(({ type }) => type)).not.toContain('otherLeaf');
     expect(model.rows.map(({ type }) => type)).not.toContain('sibling');
     expect(model.rows.map(({ type }) => type)).not.toContain('configured');

--- a/client/src/typeListHierarchy.spec.ts
+++ b/client/src/typeListHierarchy.spec.ts
@@ -188,6 +188,13 @@ describe('typeListHierarchy', () => {
     expect(model.rows.map(({ type }) => type)).not.toContain('sibling');
   });
 
+  it('narrows the checked set to the rows the header can act on', () => {
+    const model = build({ query: 'leaf', checkedTypes: ['leaf', 'root', 'sibling'] });
+
+    expect(model.rows.map(({ type }) => type)).toContain('root');
+    expect(model.actionableCheckedTypes).toEqual(['leaf']);
+  });
+
   it('reveals search paths without mutating or applying saved collapse state', () => {
     const collapsed = new Set(['root']);
     const collapsedModel = build({ collapsed });

--- a/client/src/typeListHierarchy.ts
+++ b/client/src/typeListHierarchy.ts
@@ -181,8 +181,8 @@ export function buildTypeListModel({
     ? queryCandidates.filter((type) => (frameCounts.get(type) || 0) > 0)
     : queryCandidates;
   /* The header bulk toggle acts on displayed candidates that survive into the
-     final row model. Intersecting after flattening excludes ancestor context,
-     breadcrumbed ancestors, and descendants hidden by a collapsed row. */
+     final row model, which excludes ancestor context and breadcrumbed
+     ancestors. */
   const actionableSet = new Set(displayedCandidates);
   const displayedSet = withAncestorPath(displayedCandidates, hierarchyIndex);
   const rows: TypeListRow[] = [];
@@ -209,7 +209,12 @@ export function buildTypeListModel({
   };
   roots.forEach((root) => flatten(root, 0));
 
-  const actionableTypes = rows.map(({ type }) => type).filter((type) => actionableSet.has(type));
+  /* An expanded row speaks only for itself because its children have rows of
+     their own; a collapsed row is the sole stand-in for the branch its own
+     checkbox owns. A type a filter excluded stays out either way. */
+  const actionableTypes = rows
+    .flatMap(({ type, expanded }) => (expanded ? [type] : subtree.get(type) ?? [type]))
+    .filter((type) => actionableSet.has(type));
 
   return {
     hasDefinedTypes: knownTypes.size > 0,

--- a/client/src/typeListHierarchy.ts
+++ b/client/src/typeListHierarchy.ts
@@ -22,6 +22,7 @@ export interface TypeListModel {
   subtree: ReadonlyMap<string, readonly string[]>;
   checkState: ReadonlyMap<string, TypeListCheckState>;
   actionableTypes: readonly string[];
+  actionableCheckedTypes: readonly string[];
   sharedLineage: readonly string[];
   rows: readonly TypeListRow[];
 }
@@ -208,12 +209,15 @@ export function buildTypeListModel({
   };
   roots.forEach((root) => flatten(root, 0));
 
+  const actionableTypes = rows.map(({ type }) => type).filter((type) => actionableSet.has(type));
+
   return {
     hasDefinedTypes: knownTypes.size > 0,
     subtree,
     checkState,
     sharedLineage,
-    actionableTypes: rows.map(({ type }) => type).filter((type) => actionableSet.has(type)),
+    actionableTypes,
+    actionableCheckedTypes: actionableTypes.filter((type) => checkedSet.has(type)),
     rows,
   };
 }

--- a/client/src/typeListHierarchy.ts
+++ b/client/src/typeListHierarchy.ts
@@ -167,21 +167,24 @@ export function buildTypeListModel({
     (type) => (children.get(type)?.length || 0) > 0,
   );
   const normalizedQuery = query.toLowerCase();
+  const searchActive = normalizedQuery.length > 0;
+  const hiddenSharedLineage = !searchActive && compactSharedLineage
+    ? new Set(sharedLineage)
+    : new Set<string>();
   const showEmptyCandidates = showEmpty
     ? knownTypes
     : new Set([...usedTypes, ...structuralParents]);
   const queryCandidates = normalizedQuery
     ? [...showEmptyCandidates].filter((type) => type.toLowerCase().includes(normalizedQuery))
     : [...showEmptyCandidates];
-  const actionableSet = new Set(queryCandidates);
   const displayedCandidates = filterTypesByFrame
     ? queryCandidates.filter((type) => (frameCounts.get(type) || 0) > 0)
     : queryCandidates;
+  /* The header bulk toggle acts on displayed candidates that survive into the
+     final row model. Intersecting after flattening excludes ancestor context,
+     breadcrumbed ancestors, and descendants hidden by a collapsed row. */
+  const actionableSet = new Set(displayedCandidates);
   const displayedSet = withAncestorPath(displayedCandidates, hierarchyIndex);
-  const searchActive = normalizedQuery.length > 0;
-  const hiddenSharedLineage = !searchActive && compactSharedLineage
-    ? new Set(sharedLineage)
-    : new Set<string>();
   const rows: TypeListRow[] = [];
   const flatten = (type: string, rowDepth: number) => {
     if (!displayedSet.has(type)) return;
@@ -210,9 +213,7 @@ export function buildTypeListModel({
     subtree,
     checkState,
     sharedLineage,
-    actionableTypes: roots
-      .flatMap((root) => subtree.get(root) || [root])
-      .filter((type) => actionableSet.has(type)),
+    actionableTypes: rows.map(({ type }) => type).filter((type) => actionableSet.has(type)),
     rows,
   };
 }

--- a/client/src/typeListHierarchy.ts
+++ b/client/src/typeListHierarchy.ts
@@ -206,10 +206,10 @@ export function buildTypeListModel({
   };
   roots.forEach((root) => flatten(root, 0));
 
-  /* The header bulk toggle acts on every candidate the filters allowed. A type
-     on screen only as ancestor context never was a candidate; a breadcrumb
-     hides its ancestors outright; and a collapsed row keeps its branch, which
-     is what that row's own checkbox owns. */
+  /* The set the header checkbox and the delete button act on: every type the
+     filters kept, minus the ancestors a breadcrumb replaced. Deliberately not
+     the row list, which adds ancestors shown only as context for a match below
+     them and drops the descendants a collapsed row hides. */
   const actionableTypes = roots
     .flatMap((root) => subtree.get(root) ?? [root])
     .filter((type) => actionableSet.has(type) && !hiddenSharedLineage.has(type));

--- a/client/src/typeListHierarchy.ts
+++ b/client/src/typeListHierarchy.ts
@@ -18,6 +18,7 @@ export interface TypeListRow {
 }
 
 export interface TypeListModel {
+  hasDefinedTypes: boolean;
   subtree: ReadonlyMap<string, readonly string[]>;
   checkState: ReadonlyMap<string, TypeListCheckState>;
   actionableTypes: readonly string[];
@@ -161,20 +162,17 @@ export function buildTypeListModel({
   };
   roots.forEach(visit);
 
-  /* Show Empty off keeps the path back to each root, but a branch with no
-     annotations anywhere has nothing to lead to and stays hidden. */
-  const usedAncestors = new Set<string>();
-  usedTypes.forEach(
-    (type) => ancestorsOf(hierarchyIndex, type).forEach((ancestor) => usedAncestors.add(ancestor)),
-  );
   const normalizedQuery = query.toLowerCase();
   const searchActive = normalizedQuery.length > 0;
   const hiddenSharedLineage = !searchActive && compactSharedLineage
     ? new Set(sharedLineage)
     : new Set<string>();
+  /* Show Empty off keeps the path back to each root, so ancestors of a used
+     type stay actionable rows; a branch with no annotations anywhere has
+     nothing to lead to and drops out entirely. */
   const showEmptyCandidates = showEmpty
     ? knownTypes
-    : new Set([...usedTypes, ...usedAncestors]);
+    : withAncestorPath(usedTypes, hierarchyIndex);
   const queryCandidates = normalizedQuery
     ? [...showEmptyCandidates].filter((type) => type.toLowerCase().includes(normalizedQuery))
     : [...showEmptyCandidates];
@@ -211,6 +209,7 @@ export function buildTypeListModel({
   roots.forEach((root) => flatten(root, 0));
 
   return {
+    hasDefinedTypes: knownTypes.size > 0,
     subtree,
     checkState,
     sharedLineage,

--- a/client/src/typeListHierarchy.ts
+++ b/client/src/typeListHierarchy.ts
@@ -161,10 +161,11 @@ export function buildTypeListModel({
   };
   roots.forEach(visit);
 
-  /* Every ancestor of a used type is itself a structural parent, so this set
-     already carries the full path back to each root. */
-  const structuralParents = [...knownTypes].filter(
-    (type) => (children.get(type)?.length || 0) > 0,
+  /* Show Empty off keeps the path back to each root, but a branch with no
+     annotations anywhere has nothing to lead to and stays hidden. */
+  const usedAncestors = new Set<string>();
+  usedTypes.forEach(
+    (type) => ancestorsOf(hierarchyIndex, type).forEach((ancestor) => usedAncestors.add(ancestor)),
   );
   const normalizedQuery = query.toLowerCase();
   const searchActive = normalizedQuery.length > 0;
@@ -173,7 +174,7 @@ export function buildTypeListModel({
     : new Set<string>();
   const showEmptyCandidates = showEmpty
     ? knownTypes
-    : new Set([...usedTypes, ...structuralParents]);
+    : new Set([...usedTypes, ...usedAncestors]);
   const queryCandidates = normalizedQuery
     ? [...showEmptyCandidates].filter((type) => type.toLowerCase().includes(normalizedQuery))
     : [...showEmptyCandidates];

--- a/client/src/typeListHierarchy.ts
+++ b/client/src/typeListHierarchy.ts
@@ -180,9 +180,6 @@ export function buildTypeListModel({
   const displayedCandidates = filterTypesByFrame
     ? queryCandidates.filter((type) => (frameCounts.get(type) || 0) > 0)
     : queryCandidates;
-  /* The header bulk toggle acts on displayed candidates that survive into the
-     final row model, which excludes ancestor context and breadcrumbed
-     ancestors. */
   const actionableSet = new Set(displayedCandidates);
   const displayedSet = withAncestorPath(displayedCandidates, hierarchyIndex);
   const rows: TypeListRow[] = [];
@@ -209,12 +206,13 @@ export function buildTypeListModel({
   };
   roots.forEach((root) => flatten(root, 0));
 
-  /* An expanded row speaks only for itself because its children have rows of
-     their own; a collapsed row is the sole stand-in for the branch its own
-     checkbox owns. A type a filter excluded stays out either way. */
-  const actionableTypes = rows
-    .flatMap(({ type, expanded }) => (expanded ? [type] : subtree.get(type) ?? [type]))
-    .filter((type) => actionableSet.has(type));
+  /* The header bulk toggle acts on every candidate the filters allowed. A type
+     on screen only as ancestor context never was a candidate; a breadcrumb
+     hides its ancestors outright; and a collapsed row keeps its branch, which
+     is what that row's own checkbox owns. */
+  const actionableTypes = roots
+    .flatMap((root) => subtree.get(root) ?? [root])
+    .filter((type) => actionableSet.has(type) && !hiddenSharedLineage.has(type));
 
   return {
     hasDefinedTypes: knownTypes.size > 0,

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -11,10 +11,10 @@ Each dataset maintains its own list of types, and types can be defined on-the-fl
 The Type List is used to control visual styles of the different types as well as filter out types that don't need to be displayed.
 
 * The checkbox next to each type name can be used to toggle types on and off.
-* The checkbox in the list heading toggles every type the list is currently showing, after **Show Empty**, the search box, and **Filter Types by Frame** have narrowed it. Types that are checked but filtered out of view keep their checked state. It is disabled while the list is empty, and the list says whether it is empty because nothing is defined or because the filters excluded everything.
+* The checkbox in the list heading toggles only the types the list is currently showing. A checked type that a filter has hidden keeps its checked state.
 * ==:material-sort-alphabetical-ascending:== toggles the sort order between alphabetical and by number of annotations of each type.
 * ==:material-cog:== opens the type settings menu.
-* ==:material-delete:=={ .error } will remove the type from any visible track or delete the track if it is the only type. It acts on the checked types the list is showing — including those inside a collapsed branch — so a checked type filtered out of view is left alone, and the button is disabled when the list shows no checked type.
+* ==:material-delete:=={ .error } will remove the type from any visible track or delete the track if it is the only type. Like the heading checkbox, it acts only on the types the list is showing.
 * ==:material-swap-horizontal:== will switch the left sidebar panel to show the track attribute editor (and group editor) view.
 
 <div style="clear: both;"/>
@@ -41,7 +41,7 @@ hierarchy-resolved displayed type.
 
 Hierarchy members render as an expandable tree rather than ordinary flat rows. Parent checkboxes control their complete subtrees, and parent counts include descendants. The Type List does not offer hierarchy editing.
 
-A parent row's checkbox and the heading checkbox are deliberately different affordances. The row means "this branch": it toggles the parent's complete subtree, including descendants hidden by a collapsed branch or by **Filter Types by Frame**. The heading means "what I can see": it toggles only the rows on screen. A collapsed row is the only thing on screen for its branch, so the heading reaches the types under it that the filters still allow. A parent that is on screen only as ancestor context for a search or frame-filter match below it is not itself toggled by the heading checkbox.
+A parent row's checkbox always toggles its complete subtree. The heading checkbox is narrower: it skips a parent shown only as ancestor context for a match below it.
 
 While a hierarchy is active, **Prevent Cascade Types** is disabled and shows: `Not applicable to hierarchical types; DIVE selects the deepest qualifying type.` Its saved value is preserved and becomes active again when the hierarchy is removed.
 
@@ -95,7 +95,7 @@ Click the ==:material-cog:== button in the type list heading to open type settin
 In ad-hoc mode, new object classes are added as you annotate.  The type list updates automatically when new classes are added or the last member of a class is deleted.
 
 * Set **Lock Types** to off for ad-hoc type creation.
-* Set **Show Empty** to still show manually defined types with no track/detection examples in the type list. A hierarchy parent appears only when something in its branch is annotated; the ancestors leading to an annotated type are always shown.
+* Set **Show Empty** to still show manually defined types with no track/detection examples in the type list. Hierarchy parents appear only when something in their branch is annotated.
 
 <div style="clear: both;"/>
 

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -11,6 +11,7 @@ Each dataset maintains its own list of types, and types can be defined on-the-fl
 The Type List is used to control visual styles of the different types as well as filter out types that don't need to be displayed.
 
 * The checkbox next to each type name can be used to toggle types on and off.
+* The checkbox in the list heading toggles every type the list is currently showing, after **Show Empty**, the search box, and **Filter Types by Frame** have narrowed it. Types that are checked but filtered out of view keep their checked state. It is disabled while the list is empty.
 * ==:material-sort-alphabetical-ascending:== toggles the sort order between alphabetical and by number of annotations of each type.
 * ==:material-cog:== opens the type settings menu.
 * ==:material-delete:=={ .error } will remove the type from any visible track or delete the track if it is the only type.
@@ -39,6 +40,8 @@ have each viewer's checked types and confidence thresholds. Viewer counts and fi
 hierarchy-resolved displayed type.
 
 Hierarchy members render as an expandable tree rather than ordinary flat rows. Parent checkboxes control their complete subtrees, and parent counts include descendants. The Type List does not offer hierarchy editing.
+
+A parent row's checkbox and the heading checkbox are deliberately different affordances. The row means "this branch": it toggles the parent's complete subtree, including descendants hidden by a collapsed branch or by **Filter Types by Frame**. The heading means "what I can see": it toggles only the rows on screen. A parent that is on screen only as ancestor context for a search or frame-filter match below it is not itself toggled by the heading checkbox.
 
 While a hierarchy is active, **Prevent Cascade Types** is disabled and shows: `Not applicable to hierarchical types; DIVE selects the deepest qualifying type.` Its saved value is preserved and becomes active again when the hierarchy is removed.
 

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -14,7 +14,7 @@ The Type List is used to control visual styles of the different types as well as
 * The checkbox in the list heading toggles every type the list is currently showing, after **Show Empty**, the search box, and **Filter Types by Frame** have narrowed it. Types that are checked but filtered out of view keep their checked state. It is disabled while the list is empty, and the list says whether it is empty because nothing is defined or because the filters excluded everything.
 * ==:material-sort-alphabetical-ascending:== toggles the sort order between alphabetical and by number of annotations of each type.
 * ==:material-cog:== opens the type settings menu.
-* ==:material-delete:=={ .error } will remove the type from any visible track or delete the track if it is the only type. It acts on the checked types the list is showing, so a checked type filtered out of view is left alone, and the button is disabled when the list shows no checked type.
+* ==:material-delete:=={ .error } will remove the type from any visible track or delete the track if it is the only type. It acts on the checked types the list is showing — including those inside a collapsed branch — so a checked type filtered out of view is left alone, and the button is disabled when the list shows no checked type.
 * ==:material-swap-horizontal:== will switch the left sidebar panel to show the track attribute editor (and group editor) view.
 
 <div style="clear: both;"/>
@@ -41,7 +41,7 @@ hierarchy-resolved displayed type.
 
 Hierarchy members render as an expandable tree rather than ordinary flat rows. Parent checkboxes control their complete subtrees, and parent counts include descendants. The Type List does not offer hierarchy editing.
 
-A parent row's checkbox and the heading checkbox are deliberately different affordances. The row means "this branch": it toggles the parent's complete subtree, including descendants hidden by a collapsed branch or by **Filter Types by Frame**. The heading means "what I can see": it toggles only the rows on screen. A parent that is on screen only as ancestor context for a search or frame-filter match below it is not itself toggled by the heading checkbox.
+A parent row's checkbox and the heading checkbox are deliberately different affordances. The row means "this branch": it toggles the parent's complete subtree, including descendants hidden by a collapsed branch or by **Filter Types by Frame**. The heading means "what I can see": it toggles only the rows on screen. A collapsed row is the only thing on screen for its branch, so the heading reaches the types under it that the filters still allow. A parent that is on screen only as ancestor context for a search or frame-filter match below it is not itself toggled by the heading checkbox.
 
 While a hierarchy is active, **Prevent Cascade Types** is disabled and shows: `Not applicable to hierarchical types; DIVE selects the deepest qualifying type.` Its saved value is preserved and becomes active again when the hierarchy is removed.
 

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -95,7 +95,7 @@ Click the ==:material-cog:== button in the type list heading to open type settin
 In ad-hoc mode, new object classes are added as you annotate.  The type list updates automatically when new classes are added or the last member of a class is deleted.
 
 * Set **Lock Types** to off for ad-hoc type creation.
-* Set **Show Empty** to still show manually defined types with no track/detection examples in the type list.
+* Set **Show Empty** to still show manually defined types with no track/detection examples in the type list. A hierarchy parent appears only when something in its branch is annotated; the ancestors leading to an annotated type are always shown.
 
 <div style="clear: both;"/>
 

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -14,7 +14,7 @@ The Type List is used to control visual styles of the different types as well as
 * The checkbox in the list heading toggles every type the list is currently showing, after **Show Empty**, the search box, and **Filter Types by Frame** have narrowed it. Types that are checked but filtered out of view keep their checked state. It is disabled while the list is empty, and the list says whether it is empty because nothing is defined or because the filters excluded everything.
 * ==:material-sort-alphabetical-ascending:== toggles the sort order between alphabetical and by number of annotations of each type.
 * ==:material-cog:== opens the type settings menu.
-* ==:material-delete:=={ .error } will remove the type from any visible track or delete the track if it is the only type.
+* ==:material-delete:=={ .error } will remove the type from any visible track or delete the track if it is the only type. It acts on the checked types the list is showing, so a checked type filtered out of view is left alone, and the button is disabled when the list shows no checked type.
 * ==:material-swap-horizontal:== will switch the left sidebar panel to show the track attribute editor (and group editor) view.
 
 <div style="clear: both;"/>

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -11,7 +11,7 @@ Each dataset maintains its own list of types, and types can be defined on-the-fl
 The Type List is used to control visual styles of the different types as well as filter out types that don't need to be displayed.
 
 * The checkbox next to each type name can be used to toggle types on and off.
-* The checkbox in the list heading toggles every type the list is currently showing, after **Show Empty**, the search box, and **Filter Types by Frame** have narrowed it. Types that are checked but filtered out of view keep their checked state. It is disabled while the list is empty.
+* The checkbox in the list heading toggles every type the list is currently showing, after **Show Empty**, the search box, and **Filter Types by Frame** have narrowed it. Types that are checked but filtered out of view keep their checked state. It is disabled while the list is empty, and the list says whether it is empty because nothing is defined or because the filters excluded everything.
 * ==:material-sort-alphabetical-ascending:== toggles the sort order between alphabetical and by number of annotations of each type.
 * ==:material-cog:== opens the type settings menu.
 * ==:material-delete:=={ .error } will remove the type from any visible track or delete the track if it is the only type.


### PR DESCRIPTION
# Scope the Type List header checkbox to the displayed rows

Follow-up to [Bryon's #1867 review](https://github.com/Kitware/dive/pull/1867#pullrequestreview-5030473848).

With **Filter Types by Frame** on, the list showed only the current frame's types but the header
checkbox still toggled hidden types. Those selections also feed the delete button.

### Changes

- Scope the header checkbox to the rows actually displayed — after search, frame filtering,
  collapsed branches, and **Compact Parents**.
- Scope the delete button the same way. It read every checked type, so it deleted annotations of
  types the list was not showing, and stayed enabled when the only checked types were hidden.
- Keep parent-row checkboxes subtree-wide: parent means "this branch"; header means "what I can
  see."
- Show an empty list as unchecked and disable the header checkbox, and say whether the list is
  empty because nothing is defined or because the filters excluded everything.
- Add the missing default for **Filter Types by Frame**, making the setting reactive on fresh
  profiles.
- Hide hierarchy branches with no annotations while **Show Empty** is off. The candidate set took
  every type with a child, so an unannotated branch held a row whose own leaves stayed hidden.
- Cover flat and hierarchical lists with regression tests.

Frame-filtered rows disappear when unchecked; turning the frame filter off brings them back. This
matches existing per-row behavior.

A parent's tri-state still rolls up its complete subtree, so an ancestor of a used type can read
indeterminate against a hidden checked descendant. That is the row's documented meaning.
