### PR TITLE
Configure Vitest environments centrally

### DIFF
--- a/client/dive-common/components/BottomPanel.spec.ts
+++ b/client/dive-common/components/BottomPanel.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-/// <reference types="vitest" />
 import { defineComponent, h, ref } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import Track from 'vue-media-annotator/track';

--- a/client/dive-common/components/DatasetInfo/DatasetInfo.spec.ts
+++ b/client/dive-common/components/DatasetInfo/DatasetInfo.spec.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { mount } from '@vue/test-utils';
 import Vue, {
   CreateElement, defineComponent, nextTick, ref,

--- a/client/dive-common/components/GroupSidebar.spec.ts
+++ b/client/dive-common/components/GroupSidebar.spec.ts
@@ -1,6 +1,4 @@
-// @vitest-environment jsdom
 /* eslint-disable vue/one-component-per-file -- harness components for shallow mounting */
-/// <reference types="vitest" />
 import {
   defineComponent, h, reactive, ref,
 } from 'vue';

--- a/client/dive-common/components/TrackDetailsPanel.spec.ts
+++ b/client/dive-common/components/TrackDetailsPanel.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-/// <reference types="vitest" />
 import { defineComponent, h, ref } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import Track from 'vue-media-annotator/track';

--- a/client/dive-common/components/TypeSettingsPanel.spec.ts
+++ b/client/dive-common/components/TypeSettingsPanel.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-/// <reference types="vitest" />
 import {
   defineComponent, h, nextTick, reactive,
 } from 'vue';

--- a/client/dive-common/components/importAnnotationsSets.spec.ts
+++ b/client/dive-common/components/importAnnotationsSets.spec.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { defineComponent, h, ref } from 'vue';
 import { mount } from '@vue/test-utils';
 import { provideAnnotator, dummyState, dummyHandler } from 'vue-media-annotator/provides';

--- a/client/dive-common/frameMetadata/join.spec.ts
+++ b/client/dive-common/frameMetadata/join.spec.ts
@@ -1,5 +1,3 @@
-/// <reference types="vitest" />
-
 import { extractCounter, resolveTableToFrames } from './join';
 import type { ResolvedCameraFrameMetadata } from './join';
 import { parseFrameMetadataTable } from './parser';

--- a/client/dive-common/frameMetadata/parser.spec.ts
+++ b/client/dive-common/frameMetadata/parser.spec.ts
@@ -1,5 +1,3 @@
-/// <reference types="vitest" />
-
 import fs from 'fs';
 import path from 'path';
 

--- a/client/dive-common/frameMetadata/readability.spec.ts
+++ b/client/dive-common/frameMetadata/readability.spec.ts
@@ -1,5 +1,3 @@
-/// <reference types="vitest" />
-
 import { isFrameMetadataReadableName } from './readability';
 
 describe('isFrameMetadataReadableName', () => {

--- a/client/dive-common/frameMetadata/resolve.spec.ts
+++ b/client/dive-common/frameMetadata/resolve.spec.ts
@@ -1,5 +1,3 @@
-/// <reference types="vitest" />
-
 import { buildFrameAlignmentIndex, resolveCameraAttachment } from './resolve';
 import type { FrameMetadataFrameContext } from './resolve';
 

--- a/client/dive-common/use/useModeManager.spec.ts
+++ b/client/dive-common/use/useModeManager.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 /**
  * Functional tests for the Align View cross-camera mirror: drawing/editing a
  * track on one camera while the aligned view is active re-projects the

--- a/client/dive-common/use/useSaveClassification.spec.ts
+++ b/client/dive-common/use/useSaveClassification.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { ref } from 'vue';
 
 import CameraStore from 'vue-media-annotator/CameraStore';

--- a/client/dive-common/utils/warpAnnotationsAcrossCameras.spec.ts
+++ b/client/dive-common/utils/warpAnnotationsAcrossCameras.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import CameraStore from 'vue-media-annotator/CameraStore';
 import type { Matrix3 } from 'vue-media-annotator/alignedView/homography';
 import { IDENTITY3 } from 'vue-media-annotator/alignedView/alignedView';

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -79,7 +79,7 @@
         "ffmpeg-ffprobe-static": "^6.1.2-rc.1",
         "fs-extra": "^9.0.1",
         "js-yaml": "^4.1.0",
-        "jsdom": "^24.1.3",
+        "jsdom": "^30.0.1",
         "mime-types": "^2.1.27",
         "mock-fs": "^5.2.0",
         "proper-lockfile": "^4.1.1",
@@ -100,25 +100,57 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1711,10 +1743,23 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
       "dev": true,
       "funding": [
         {
@@ -1728,13 +1773,13 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
       "dev": true,
       "funding": [
         {
@@ -1748,17 +1793,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.1.tgz",
+      "integrity": "sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==",
       "dev": true,
       "funding": [
         {
@@ -1772,21 +1817,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "dev": true,
       "funding": [
         {
@@ -1800,16 +1845,41 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.9.tgz",
+      "integrity": "sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "dev": true,
       "funding": [
         {
@@ -1823,7 +1893,7 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -2628,6 +2698,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@flatten-js/interval-tree": {
@@ -6569,6 +6657,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7444,6 +7542,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -7456,27 +7568,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/cssstyle": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^3.2.0",
-        "rrweb-cssom": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/cssstyle/node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -7927,17 +8018,32 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -8681,13 +8787,13 @@
       }
     },
     "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -10589,16 +10695,16 @@
       "license": "ISC"
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/html-escaper": {
@@ -11586,39 +11692,39 @@
       "license": "Python-2.0"
     },
     "node_modules/jsdom": {
-      "version": "24.1.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
-      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.0.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.12",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.7.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
-        "ws": "^8.18.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^3.2.3"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -11626,28 +11732,24 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "MIT",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">= 14"
+        "node": "20 || >=22"
       }
     },
-    "node_modules/jsdom/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 14"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/jsesc": {
@@ -12057,6 +12159,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "1.0.1",
@@ -12490,13 +12599,6 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12772,13 +12874,13 @@
       "license": "MIT"
     },
     "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -13226,19 +13328,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -13294,13 +13383,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/queue-lit": {
       "version": "1.5.2",
@@ -13572,13 +13654,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/resedit": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
@@ -13708,13 +13783,6 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
-    },
-    "node_modules/rrweb-cssom": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -14747,6 +14815,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
@@ -14791,42 +14879,29 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^7.0.5"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/truncate-utf8-bytes": {
@@ -15208,17 +15283,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/utf8-byte-length": {
@@ -15738,13 +15802,13 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/webpack": {
@@ -15903,55 +15967,29 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -16138,28 +16176,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "devOptional": true,
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/wslink": {
       "version": "2.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -99,7 +99,7 @@
     "ffmpeg-ffprobe-static": "^6.1.2-rc.1",
     "fs-extra": "^9.0.1",
     "js-yaml": "^4.1.0",
-    "jsdom": "^24.1.3",
+    "jsdom": "^30.0.1",
     "mime-types": "^2.1.27",
     "mock-fs": "^5.2.0",
     "proper-lockfile": "^4.1.1",

--- a/client/platform/desktop/backend/serializers/nist.spec.ts
+++ b/client/platform/desktop/backend/serializers/nist.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import fs from 'fs-extra';
 import { NistFile, exportNist, convertNisttoJSON } from 'platform/desktop/backend/serializers/nist';
 import { AnnotationSchema, MultiTrackRecord } from 'dive-common/apispec';

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { AnnotationSchema, MultiTrackRecord } from 'dive-common/apispec';
 import parseSync from 'csv-parse/lib/sync';
 import fs from 'fs-extra';

--- a/client/platform/desktop/sharedUtils.spec.ts
+++ b/client/platform/desktop/sharedUtils.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import fs from 'fs-extra';
 import { cloneDeep } from 'lodash';
 import { strNumericCompare } from './sharedUtils';

--- a/client/platform/web-girder/api/multicamResolve.spec.ts
+++ b/client/platform/web-girder/api/multicamResolve.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-
 import {
   beforeEach,
   describe,

--- a/client/platform/web-girder/store/webGirderStoreComposables.spec.ts
+++ b/client/platform/web-girder/store/webGirderStoreComposables.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-
 import {
   beforeEach,
   describe,

--- a/client/platform/web-girder/views/Upload.spec.ts
+++ b/client/platform/web-girder/views/Upload.spec.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { mount } from '@vue/test-utils';
 import Vue, {
   CreateElement, defineComponent, h, nextTick,

--- a/client/platform/web-girder/views/UploadGirder.spec.ts
+++ b/client/platform/web-girder/views/UploadGirder.spec.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { mount } from '@vue/test-utils';
 import Vue from 'vue';
 

--- a/client/src/CameraStore.spec.ts
+++ b/client/src/CameraStore.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { compileHierarchy } from 'dive-common/typeHierarchy';
 import CameraStore, { formatDivergentClassificationWarning } from './CameraStore';
 import Group from './Group';

--- a/client/src/TrackFilterControls.spec.ts
+++ b/client/src/TrackFilterControls.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { nextTick, ref } from 'vue';
 import Track, { Feature } from './track';
 import TrackFilterControls from './TrackFilterControls';

--- a/client/src/TrackProjection.spec.ts
+++ b/client/src/TrackProjection.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { createTrackProjection, TrackProjection } from './TrackProjection';
 import Track, { Feature } from './track';
 

--- a/client/src/TrackStore.spec.ts
+++ b/client/src/TrackStore.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import Vue, { watchEffect } from 'vue';
 import TrackStore from './TrackStore';
 

--- a/client/src/alignedView/CameraRegistrationStore.spec.ts
+++ b/client/src/alignedView/CameraRegistrationStore.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import CameraRegistrationStore, { CameraCorrespondences } from './CameraRegistrationStore';
 import { buildPerCameraRegistrationFiles } from './cameraRegistrationFiles';
 

--- a/client/src/alignedView/alignedView.spec.ts
+++ b/client/src/alignedView/alignedView.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import {
   IDENTITY3,
   isIdentityMatrix3,

--- a/client/src/alignedView/homography.spec.ts
+++ b/client/src/alignedView/homography.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import {
   solveHomography,
   applyHomography,

--- a/client/src/alignedView/transform.spec.ts
+++ b/client/src/alignedView/transform.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { applyHomography, solveHomography, Matrix3 } from './homography';
 import {
   TransformType,

--- a/client/src/components/FilterList.spec.ts
+++ b/client/src/components/FilterList.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-/// <reference types="vitest" />
 import {
   defineComponent, h, nextTick, ref, reactive,
 } from 'vue';

--- a/client/src/components/LayerManager.spec.ts
+++ b/client/src/components/LayerManager.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-/// <reference types="vitest" />
 /* eslint-disable max-classes-per-file -- lightweight layer doubles */
 import {
   defineComponent, h, ref,

--- a/client/src/components/Tracks/TrackList.spec.ts
+++ b/client/src/components/Tracks/TrackList.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-/// <reference types="vitest" />
 import {
   defineComponent, h, nextTick, ref, Ref,
 } from 'vue';

--- a/client/src/components/Tracks/bottombar/BottomBarTrackItemView.spec.ts
+++ b/client/src/components/Tracks/bottombar/BottomBarTrackItemView.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-/// <reference types="vitest" />
 import { defineComponent, h, ref } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import Track from '../../../track';

--- a/client/src/components/Tracks/sidebar/SideBarTrackItemView.spec.ts
+++ b/client/src/components/Tracks/sidebar/SideBarTrackItemView.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-/// <reference types="vitest" />
 import { defineComponent, h, ref } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import Track from '../../../track';

--- a/client/src/components/TypeEditor.spec.ts
+++ b/client/src/components/TypeEditor.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-/// <reference types="vitest" />
 import { defineComponent, h, ref } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import { TypeHierarchyError } from 'dive-common/typeHierarchy';

--- a/client/src/components/TypeItem.spec.ts
+++ b/client/src/components/TypeItem.spec.ts
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-/// <reference types="vitest" />
 import {
   defineComponent, h, reactive,
 } from 'vue';

--- a/client/src/components/annotators/largeImageFrameTexture.spec.ts
+++ b/client/src/components/annotators/largeImageFrameTexture.spec.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import {
   composeLargeImageFrameTexture,
   pickOverviewLevel,

--- a/client/src/components/annotators/linkedViewers/useAlignedNavigation.spec.ts
+++ b/client/src/components/annotators/linkedViewers/useAlignedNavigation.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import {
   ref, shallowRef, nextTick, Ref,
 } from 'vue';

--- a/client/src/components/annotators/linkedViewers/useRegistrationNavigation.spec.ts
+++ b/client/src/components/annotators/linkedViewers/useRegistrationNavigation.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import {
   ref, shallowRef, nextTick, Ref,
 } from 'vue';

--- a/client/src/components/annotators/useMediaController.spec.ts
+++ b/client/src/components/annotators/useMediaController.spec.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { defineComponent, ref } from 'vue';
 import { mount } from '@vue/test-utils';
 import { useMediaController } from './useMediaController';

--- a/client/src/components/layerManager/quadMediaSource.spec.ts
+++ b/client/src/components/layerManager/quadMediaSource.spec.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { ref } from 'vue';
 import { getCameraQuadMedia } from './quadMediaSource';
 import type { CameraImage } from '../../layers/cameraImage';

--- a/client/src/components/layerManager/useLayerManagerAlignedView.spec.ts
+++ b/client/src/components/layerManager/useLayerManagerAlignedView.spec.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 /* eslint-disable vue/one-component-per-file -- harness Host components for mount() */
 import {
   defineComponent, ref, shallowRef, nextTick,

--- a/client/src/components/layerManager/useMulticamEditRouting.spec.ts
+++ b/client/src/components/layerManager/useMulticamEditRouting.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { ref } from 'vue';
 import CameraStore from '../../CameraStore';
 import type { Handler } from '../../provides';

--- a/client/src/layers/AnnotationLayers/TailLayer.spec.ts
+++ b/client/src/layers/AnnotationLayers/TailLayer.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import Track from '../../track';
 import { FrameDataTrack } from '../LayerTypes';
 import TailLayer from './TailLayer';

--- a/client/src/layers/AnnotationLayers/TextLayer.spec.ts
+++ b/client/src/layers/AnnotationLayers/TextLayer.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import Group from '../../Group';
 import Track from '../../track';
 import { FrameDataTrack } from '../LayerTypes';

--- a/client/src/layers/AnnotationLayers/rectangleClickTarget.spec.ts
+++ b/client/src/layers/AnnotationLayers/rectangleClickTarget.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import {
   candidateOwnsClick,
   distanceToRingSquared,

--- a/client/src/track.spec.ts
+++ b/client/src/track.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import Track, { TrackData, TrackSupportedFeature } from './track';
 import { RectBounds } from './utils';
 import { ConfidencePair } from './BaseAnnotation';

--- a/client/src/typeListHierarchy.spec.ts
+++ b/client/src/typeListHierarchy.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { compileHierarchy } from 'dive-common/typeHierarchy';
 import {
   buildTypeListModel,

--- a/client/src/use/suppression.spec.ts
+++ b/client/src/use/suppression.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import Track, { TrackData } from '../track';
 import { clientSettings } from '../../dive-common/store/settings';
 import {

--- a/client/src/use/useEventChart.spec.ts
+++ b/client/src/use/useEventChart.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { ref, Ref } from 'vue';
 import type { AnnotationWithContext } from '../BaseFilterControls';
 import type { SortedAnnotation } from '../BaseAnnotationStore';

--- a/client/src/use/useLineChart.spec.ts
+++ b/client/src/use/useLineChart.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { ref, Ref } from 'vue';
 import { clientSettings } from 'dive-common/store/settings';
 import type { TrackWithContext } from '../BaseFilterControls';

--- a/client/src/utils.spec.ts
+++ b/client/src/utils.spec.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import {
   updateSubset,
   reOrdergeoJSON,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,6 +9,16 @@ import { defineConfig } from 'vitest/config';
 import packageJson from './package.json';
 import { cssConfig } from './vite.css';
 
+const testExcludes = ['**/node_modules/**', '**/bin/**'];
+const domTests = [
+  'src/components/**/*.spec.ts',
+  'dive-common/components/**/*.spec.ts',
+  'platform/web-girder/api/multicamResolve.spec.ts',
+  'platform/web-girder/store/webGirderStoreComposables.spec.ts',
+  'platform/web-girder/views/Upload.spec.ts',
+  'platform/web-girder/views/UploadGirder.spec.ts',
+];
+
 function getGitHash() {
   try {
     return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
@@ -108,7 +118,25 @@ export default defineConfig(({ mode }) => {
     base: '/',
     test: {
       globals: true,
-      exclude: ['**/node_modules/**', '**/bin/**'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            exclude: [...testExcludes, ...domTests],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: domTests,
+            exclude: testExcludes,
+          },
+        },
+      ],
     },
   };
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -10,13 +10,12 @@ import packageJson from './package.json';
 import { cssConfig } from './vite.css';
 
 const testExcludes = ['**/node_modules/**', '**/bin/**'];
+// Component specs mount Vue, and the web-girder plugin layer reads `window` at
+// import time, so anything reaching it needs a DOM.
 const domTests = [
   'src/components/**/*.spec.ts',
   'dive-common/components/**/*.spec.ts',
-  'platform/web-girder/api/multicamResolve.spec.ts',
-  'platform/web-girder/store/webGirderStoreComposables.spec.ts',
-  'platform/web-girder/views/Upload.spec.ts',
-  'platform/web-girder/views/UploadGirder.spec.ts',
+  'platform/web-girder/**/*.spec.ts',
 ];
 
 function getGitHash() {


### PR DESCRIPTION
# Configure Vitest environments centrally

Test files should not need repeated Vitest headers.

### Changes

- Select environments by directory. Component specs (`src/components/**`, `dive-common/components/**`) and everything under `platform/web-girder/**` run in a shared jsdom project; the rest stay in Vitest's Node environment.
- Remove per-file jsdom directives and Vitest type references.
- Upgrade jsdom 24 to 30.

The whole `platform/web-girder` tree needs a DOM: its plugin layer reads `window` at import time, so any spec that reaches the API layer fails without one. Naming the directory rather than individual files means a new spec added there needs no config edit.

jsdom 24 implements none of `Blob.text()`, `Blob.arrayBuffer()`, or `Blob.stream()`. Two specs in that tree build `File` objects and passed only because Node's `File` is more spec-compliant than the DOM environment's. jsdom 30 provides `text()` and `arrayBuffer()`. `stream()` is still absent, and is used only by the stereo tests, which stay in Node because they resolve binary fixtures through `fileURLToPath(import.meta.url)`.

Four specs that carried `@vitest-environment jsdom` on main now run in Node: `platform/desktop/backend/serializers/viame.spec.ts`, `platform/desktop/sharedUtils.spec.ts`, and both `src/alignedView/homography.spec.ts` and `src/alignedView/transform.spec.ts`. They pass — the directives were unnecessary.

### Validation

- Client unit tests
- Client lint
- Client typecheck
