### PR TITLE
Edit type hierarchy relationships in the Type Editor

### DIFF
--- a/client/dive-common/typeHierarchy.spec.ts
+++ b/client/dive-common/typeHierarchy.spec.ts
@@ -1,18 +1,22 @@
 import fs from 'fs-extra';
 import {
   acceptPairAsCorrect,
+  compareTypeNames,
   compileHierarchy,
   mergePairs,
   normalizeTypeHierarchy,
   reassignPairs,
+  removeHierarchyType,
   removePair,
   resolveConfidenceThreshold,
   resolveTypeHierarchy,
   rewriteHierarchyType,
   selectFlatPairIndex,
   selectPairIndex,
+  setHierarchyParent,
   setPairConfidence,
   TypeHierarchyError,
+  updateHierarchyTypeDefinition,
 } from './typeHierarchy';
 
 interface ErrorExpectation {
@@ -247,6 +251,154 @@ describe('type hierarchy index', () => {
     results.forEach((result) => {
       expect(result).not.toBe(pairs);
       result.forEach((pair) => expect(pairs).not.toContain(pair));
+    });
+  });
+});
+
+describe('hierarchy editing transformations', () => {
+  describe('setHierarchyParent', () => {
+    it('sets the first edge from an absent hierarchy', () => {
+      expect(setHierarchyParent(undefined, 'cod', 'fish')).toEqual({ cod: 'fish' });
+    });
+
+    it('reparents a child and clears an edge without disturbing other branches', () => {
+      const hierarchy = { cod: 'fish', tern: 'bird' };
+      expect(setHierarchyParent(hierarchy, 'cod', 'animal')).toEqual({
+        cod: 'animal',
+        tern: 'bird',
+      });
+      expect(setHierarchyParent(hierarchy, 'cod', undefined)).toEqual({ tern: 'bird' });
+    });
+
+    it('returns undefined after clearing the final edge', () => {
+      expect(setHierarchyParent({ cod: 'fish' }, 'cod', undefined)).toBeUndefined();
+    });
+
+    it('rejects blank names, self edges, and cycles', () => {
+      expectHierarchyError(
+        () => setHierarchyParent(undefined, ' ', 'fish'),
+        'empty child',
+        'malformed',
+      );
+      expectHierarchyError(
+        () => setHierarchyParent(undefined, 'cod', '\u001c'),
+        'empty parent for "cod"',
+        'malformed',
+      );
+      expectHierarchyError(
+        () => setHierarchyParent(undefined, 'cod', 'cod'),
+        'self edge "cod -> cod"',
+        'malformed',
+      );
+      expectHierarchyError(
+        () => setHierarchyParent({ cod: 'fish' }, 'fish', 'cod'),
+        'cycle cod -> fish -> cod',
+        'malformed',
+      );
+    });
+
+    it('returns a fresh map without changing its input', () => {
+      const hierarchy = Object.freeze({ cod: 'fish', tern: 'bird' });
+      const result = setHierarchyParent(hierarchy, 'cod', 'fish');
+      expect(result).toEqual(hierarchy);
+      expect(result).not.toBe(hierarchy);
+      expect(hierarchy).toEqual({ cod: 'fish', tern: 'bird' });
+    });
+
+    it('orders keys by code point', () => {
+      const bmp = '\uE000';
+      const astral = '\u{10000}';
+      const result = setHierarchyParent({ [astral]: 'root' }, bmp, 'root');
+      expect(compareTypeNames(bmp, astral)).toBeLessThan(0);
+      expect(Object.keys(result || {})).toEqual([bmp, astral]);
+    });
+  });
+
+  describe('removeHierarchyType', () => {
+    it('removes a middle node and promotes all of its children', () => {
+      expect(removeHierarchyType({
+        cod: 'fish',
+        haddock: 'fish',
+        fish: 'animal',
+        tern: 'bird',
+      }, 'fish')).toEqual({
+        cod: 'animal',
+        haddock: 'animal',
+        tern: 'bird',
+      });
+    });
+
+    it('makes children of a removed top-level node top level', () => {
+      expect(removeHierarchyType({
+        cod: 'fish',
+        haddock: 'fish',
+        tern: 'bird',
+      }, 'fish')).toEqual({ tern: 'bird' });
+    });
+
+    it('removes a leaf and returns undefined when the final edge is removed', () => {
+      expect(removeHierarchyType({ cod: 'fish', tern: 'bird' }, 'cod'))
+        .toEqual({ tern: 'bird' });
+      expect(removeHierarchyType({ cod: 'fish' }, 'cod')).toBeUndefined();
+    });
+
+    it('normalizes an absent-type no-op into a fresh map', () => {
+      const hierarchy = Object.freeze({ cod: 'fish', tern: 'bird' });
+      const result = removeHierarchyType(hierarchy, 'shark');
+      expect(result).toEqual(hierarchy);
+      expect(result).not.toBe(hierarchy);
+      expect(hierarchy).toEqual({ cod: 'fish', tern: 'bird' });
+    });
+  });
+
+  describe('updateHierarchyTypeDefinition', () => {
+    it('builds a valid rename and reparent result without validating an invalid intermediate map', () => {
+      const hierarchy = {
+        cod: 'fish',
+        haddock: 'animal',
+        sole: 'cod',
+        tern: 'bird',
+      };
+      expect(() => rewriteHierarchyType(hierarchy, 'cod', 'haddock'))
+        .toThrow('conflicting parents for "haddock": "animal" and "fish"');
+
+      expect(updateHierarchyTypeDefinition(
+        hierarchy,
+        'cod',
+        'haddock',
+        'fish',
+      )).toEqual({
+        haddock: 'fish',
+        sole: 'haddock',
+        tern: 'bird',
+      });
+    });
+
+    it('rewrites child references while applying the final edited parent', () => {
+      expect(updateHierarchyTypeDefinition(
+        { cod: 'fish', fish: 'animal' },
+        'fish',
+        'vertebrate',
+        'life',
+      )).toEqual({ cod: 'vertebrate', vertebrate: 'life' });
+    });
+
+    it('validates the complete final map and leaves its input unchanged', () => {
+      const hierarchy = Object.freeze({ cod: 'fish', fish: 'animal' });
+      expectHierarchyError(
+        () => updateHierarchyTypeDefinition(hierarchy, 'fish', 'fish', 'cod'),
+        'cycle cod -> fish -> cod',
+        'malformed',
+      );
+      expect(hierarchy).toEqual({ cod: 'fish', fish: 'animal' });
+    });
+
+    it('rejects a blank final name even when it would have no edge', () => {
+      expectHierarchyError(
+        () => updateHierarchyTypeDefinition(undefined, 'cod', ' ', undefined),
+        'empty child',
+        'malformed',
+      );
     });
   });
 });

--- a/client/dive-common/typeHierarchy.spec.ts
+++ b/client/dive-common/typeHierarchy.spec.ts
@@ -13,7 +13,6 @@ import {
   rewriteHierarchyType,
   selectFlatPairIndex,
   selectPairIndex,
-  setHierarchyParent,
   setPairConfidence,
   TypeHierarchyError,
   updateHierarchyTypeDefinition,
@@ -256,64 +255,6 @@ describe('type hierarchy index', () => {
 });
 
 describe('hierarchy editing transformations', () => {
-  describe('setHierarchyParent', () => {
-    it('sets the first edge from an absent hierarchy', () => {
-      expect(setHierarchyParent(undefined, 'cod', 'fish')).toEqual({ cod: 'fish' });
-    });
-
-    it('reparents a child and clears an edge without disturbing other branches', () => {
-      const hierarchy = { cod: 'fish', tern: 'bird' };
-      expect(setHierarchyParent(hierarchy, 'cod', 'animal')).toEqual({
-        cod: 'animal',
-        tern: 'bird',
-      });
-      expect(setHierarchyParent(hierarchy, 'cod', undefined)).toEqual({ tern: 'bird' });
-    });
-
-    it('returns undefined after clearing the final edge', () => {
-      expect(setHierarchyParent({ cod: 'fish' }, 'cod', undefined)).toBeUndefined();
-    });
-
-    it('rejects blank names, self edges, and cycles', () => {
-      expectHierarchyError(
-        () => setHierarchyParent(undefined, ' ', 'fish'),
-        'empty child',
-        'malformed',
-      );
-      expectHierarchyError(
-        () => setHierarchyParent(undefined, 'cod', '\u001c'),
-        'empty parent for "cod"',
-        'malformed',
-      );
-      expectHierarchyError(
-        () => setHierarchyParent(undefined, 'cod', 'cod'),
-        'self edge "cod -> cod"',
-        'malformed',
-      );
-      expectHierarchyError(
-        () => setHierarchyParent({ cod: 'fish' }, 'fish', 'cod'),
-        'cycle cod -> fish -> cod',
-        'malformed',
-      );
-    });
-
-    it('returns a fresh map without changing its input', () => {
-      const hierarchy = Object.freeze({ cod: 'fish', tern: 'bird' });
-      const result = setHierarchyParent(hierarchy, 'cod', 'fish');
-      expect(result).toEqual(hierarchy);
-      expect(result).not.toBe(hierarchy);
-      expect(hierarchy).toEqual({ cod: 'fish', tern: 'bird' });
-    });
-
-    it('orders keys by code point', () => {
-      const bmp = '\uE000';
-      const astral = '\u{10000}';
-      const result = setHierarchyParent({ [astral]: 'root' }, bmp, 'root');
-      expect(compareTypeNames(bmp, astral)).toBeLessThan(0);
-      expect(Object.keys(result || {})).toEqual([bmp, astral]);
-    });
-  });
-
   describe('removeHierarchyType', () => {
     it('removes a middle node and promotes all of its children', () => {
       expect(removeHierarchyType({
@@ -352,6 +293,20 @@ describe('hierarchy editing transformations', () => {
   });
 
   describe('updateHierarchyTypeDefinition', () => {
+    it('sets, reparents, and clears edges without mutating unrelated branches', () => {
+      expect(updateHierarchyTypeDefinition(undefined, 'cod', 'cod', 'fish'))
+        .toEqual({ cod: 'fish' });
+      const hierarchy = { cod: 'fish', tern: 'bird' };
+      expect(updateHierarchyTypeDefinition(hierarchy, 'cod', 'cod', 'animal')).toEqual({
+        cod: 'animal',
+        tern: 'bird',
+      });
+      expect(updateHierarchyTypeDefinition(hierarchy, 'cod', 'cod', undefined))
+        .toEqual({ tern: 'bird' });
+      expect(updateHierarchyTypeDefinition({ cod: 'fish' }, 'cod', 'cod', undefined))
+        .toBeUndefined();
+    });
+
     it('builds a valid rename and reparent result without validating an invalid intermediate map', () => {
       const hierarchy = {
         cod: 'fish',
@@ -391,6 +346,30 @@ describe('hierarchy editing transformations', () => {
         'malformed',
       );
       expect(hierarchy).toEqual({ cod: 'fish', fish: 'animal' });
+    });
+
+    it('rejects blank parents and self edges', () => {
+      expectHierarchyError(
+        () => updateHierarchyTypeDefinition(undefined, 'cod', 'cod', '\u001c'),
+        'empty parent for "cod"',
+        'malformed',
+      );
+      expectHierarchyError(
+        () => updateHierarchyTypeDefinition(undefined, 'cod', 'cod', 'cod'),
+        'self edge "cod -> cod"',
+        'malformed',
+      );
+    });
+
+    it('returns a fresh map ordered by code point', () => {
+      const bmp = '\uE000';
+      const astral = '\u{10000}';
+      const hierarchy = Object.freeze({ [astral]: 'root' });
+      const result = updateHierarchyTypeDefinition(hierarchy, bmp, bmp, 'root');
+      expect(compareTypeNames(bmp, astral)).toBeLessThan(0);
+      expect(Object.keys(result || {})).toEqual([bmp, astral]);
+      expect(result).not.toBe(hierarchy);
+      expect(hierarchy).toEqual({ [astral]: 'root' });
     });
 
     it('rejects a blank final name even when it would have no edge', () => {

--- a/client/dive-common/typeHierarchy.ts
+++ b/client/dive-common/typeHierarchy.ts
@@ -64,7 +64,7 @@ export function selectFlatPairIndex(
 
 // Python orders strings by code point; JS compares UTF-16 units, which sorts astral
 // names before U+E000-U+FFFF. Compare code points so both platforms agree.
-function codePointCompare(left: string, right: string): number {
+export function compareTypeNames(left: string, right: string): number {
   const leftPoints = [...left].map((char) => char.codePointAt(0) as number);
   const rightPoints = [...right].map((char) => char.codePointAt(0) as number);
   const sharedLength = Math.min(leftPoints.length, rightPoints.length);
@@ -77,7 +77,7 @@ function codePointCompare(left: string, right: string): number {
 }
 
 function sortedNames(names: readonly string[]): string[] {
-  return [...names].sort(codePointCompare);
+  return [...names].sort(compareTypeNames);
 }
 
 function hasOwn(hierarchy: TypeHierarchy, type: string): boolean {
@@ -115,7 +115,7 @@ function cycleReason(hierarchy: TypeHierarchy): string | undefined {
       const cycle = path.slice(positions.get(current) as number);
       let smallestIndex = 0;
       cycle.forEach((name, index) => {
-        if (codePointCompare(name, cycle[smallestIndex]) < 0) {
+        if (compareTypeNames(name, cycle[smallestIndex]) < 0) {
           smallestIndex = index;
         }
       });
@@ -128,7 +128,7 @@ function cycleReason(hierarchy: TypeHierarchy): string | undefined {
   if (renderedCycles.length === 0) {
     return undefined;
   }
-  renderedCycles.sort(codePointCompare);
+  renderedCycles.sort(compareTypeNames);
   return `cycle ${renderedCycles[0]}`;
 }
 
@@ -317,6 +317,72 @@ export function rewriteHierarchyType(
   }
 }
 
+export function setHierarchyParent(
+  hierarchy: TypeHierarchy | undefined,
+  child: string,
+  parent: string | undefined,
+): TypeHierarchy | undefined {
+  const normalized = normalizeTypeHierarchy(hierarchy || {}) || {};
+  if (isBlankName(child)) {
+    throw new TypeHierarchyError('empty child');
+  }
+
+  const updated = new Map(Object.entries(normalized));
+  updated.delete(child);
+  if (parent !== undefined) {
+    updated.set(child, parent);
+  }
+  return normalizeTypeHierarchy(Object.fromEntries(updated));
+}
+
+export function removeHierarchyType(
+  hierarchy: TypeHierarchy,
+  type: string,
+): TypeHierarchy | undefined {
+  const normalized = normalizeTypeHierarchy(hierarchy) || {};
+  const parent = hasOwn(normalized, type) ? normalized[type] : undefined;
+  const updated = new Map<string, string>();
+
+  sortedNames(Object.keys(normalized)).forEach((child) => {
+    if (child === type) {
+      return;
+    }
+    const currentParent = normalized[child];
+    if (currentParent !== type) {
+      updated.set(child, currentParent);
+    } else if (parent !== undefined) {
+      updated.set(child, parent);
+    }
+  });
+  return normalizeTypeHierarchy(Object.fromEntries(updated));
+}
+
+/** Build the final hierarchy for an atomic type rename and parent edit. */
+export function updateHierarchyTypeDefinition(
+  hierarchy: TypeHierarchy | undefined,
+  currentType: string,
+  newType: string,
+  parent: string | undefined,
+): TypeHierarchy | undefined {
+  const normalized = normalizeTypeHierarchy(hierarchy || {}) || {};
+  if (isBlankName(currentType) || isBlankName(newType)) {
+    throw new TypeHierarchyError('empty child');
+  }
+
+  const updated = new Map<string, string>();
+  sortedNames(Object.keys(normalized)).forEach((child) => {
+    if (child === currentType || child === newType) {
+      return;
+    }
+    const currentParent = normalized[child];
+    updated.set(child, currentParent === currentType ? newType : currentParent);
+  });
+  if (parent !== undefined) {
+    updated.set(newType, parent);
+  }
+  return normalizeTypeHierarchy(Object.fromEntries(updated));
+}
+
 // Assignment replaces the selected claim's lineage while retaining unrelated claims and the
 // stored ancestors still implied by the new type. No missing hierarchy members are synthesized.
 export function reassignPairs(
@@ -381,7 +447,7 @@ export function mergePairs(
     });
   });
   return Array.from(confidenceByType.entries())
-    .sort((left, right) => (right[1] - left[1]) || codePointCompare(left[0], right[0]));
+    .sort((left, right) => (right[1] - left[1]) || compareTypeNames(left[0], right[0]));
 }
 
 export function selectPairIndex(

--- a/client/dive-common/typeHierarchy.ts
+++ b/client/dive-common/typeHierarchy.ts
@@ -317,24 +317,6 @@ export function rewriteHierarchyType(
   }
 }
 
-export function setHierarchyParent(
-  hierarchy: TypeHierarchy | undefined,
-  child: string,
-  parent: string | undefined,
-): TypeHierarchy | undefined {
-  const normalized = normalizeTypeHierarchy(hierarchy || {}) || {};
-  if (isBlankName(child)) {
-    throw new TypeHierarchyError('empty child');
-  }
-
-  const updated = new Map(Object.entries(normalized));
-  updated.delete(child);
-  if (parent !== undefined) {
-    updated.set(child, parent);
-  }
-  return normalizeTypeHierarchy(Object.fromEntries(updated));
-}
-
 export function removeHierarchyType(
   hierarchy: TypeHierarchy,
   type: string,

--- a/client/src/TrackFilterControls.spec.ts
+++ b/client/src/TrackFilterControls.spec.ts
@@ -801,6 +801,23 @@ describe('useAnnotationFilters', () => {
     expect(markPending).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps a hierarchy-only leaf when detaching its final parent edge', () => {
+    const { filters } = makePairFixture([[['used', 1]]]);
+    filters.setTypeHierarchy({ leaf: 'root' });
+
+    filters.updateTypeDefinition({
+      currentType: 'leaf',
+      newType: 'leaf',
+      parent: undefined,
+    });
+
+    expect(filters.typeHierarchy.value).toBeUndefined();
+    expect(filters.configuredTypes.value).toContain('leaf');
+    expect(filters.configuredTypes.value).toContain('root');
+    expect(filters.allTypes.value).toContain('leaf');
+    expect(filters.allTypes.value).toContain('root');
+  });
+
   it('renames and reparents through one validated update', () => {
     const markPending = vi.fn();
     const { cameraStore, filters } = makePairFixture([
@@ -1105,6 +1122,17 @@ describe('useAnnotationFilters', () => {
     expect(cameraStore.getTrack(0).confidencePairs).toEqual([['leaf', 1]]);
   });
 
+  it('keeps a hierarchy-only child when deleting its top-level parent', () => {
+    const { filters } = makePairFixture([[['used', 1]]]);
+    filters.setTypeHierarchy({ leaf: 'root' });
+
+    expect(filters.deleteType('root')).toBe(true);
+    expect(filters.typeHierarchy.value).toBeUndefined();
+    expect(filters.configuredTypes.value).toContain('leaf');
+    expect(filters.allTypes.value).toContain('leaf');
+    expect(filters.allTypes.value).not.toContain('root');
+  });
+
   it('keeps flat deletion behavior for a configured type outside the hierarchy', () => {
     const markPending = vi.fn();
     const { filters } = makePairFixture([[['leaf', 1]]], markPending);
@@ -1149,6 +1177,8 @@ describe('useAnnotationFilters', () => {
     expect(filters.deleteType('leaf')).toBe(true);
     expect(filters.hierarchyActive.value).toBe(false);
     expect(filters.typeHierarchy.value).toBeUndefined();
+    expect(filters.configuredTypes.value).toContain('root');
+    expect(filters.allTypes.value).toContain('root');
     expect(filters.typeHierarchySavePatch()).toEqual({ typeHierarchy: null });
   });
 });

--- a/client/src/TrackFilterControls.spec.ts
+++ b/client/src/TrackFilterControls.spec.ts
@@ -1058,6 +1058,50 @@ describe('useAnnotationFilters', () => {
     expect(markPending).not.toHaveBeenCalled();
   });
 
+  it('preflights all type-definition restrictions without changing state', () => {
+    const markPending = vi.fn();
+    const { cameraStore, filters } = makePairFixture([
+      [['leaf', 0.8], ['fin', 0.7]],
+    ], markPending);
+    filters.setTypeHierarchy({ leaf: 'root', child: 'leaf' });
+    markPending.mockClear();
+
+    expect(filters.validateTypeDefinition({
+      currentType: 'leaf', newType: 'leaf', parent: 'child',
+    })).toEqual({
+      field: 'parent', reason: 'cycle child -> leaf -> child',
+    });
+    expect(filters.validateTypeDefinition({
+      currentType: 'leaf', newType: 'fin', parent: 'root',
+    })).toEqual({
+      field: 'name', reason: 'track 0 already contains both "leaf" and "fin"',
+    });
+    expect(filters.validateTypeDefinition({
+      currentType: 'leaf', newType: 'renamed', parent: 'missing',
+    })).toEqual({
+      field: 'parent', reason: 'parent "missing" is not an existing type',
+    });
+    expect(filters.validateTypeDefinition({
+      currentType: 'leaf', newType: 'renamed', parent: 'leaf',
+    })).toEqual({
+      field: 'parent',
+      reason: 'the original type "leaf" cannot be its renamed type\'s parent',
+    });
+    expect(filters.validateTypeDefinition({
+      currentType: 'leaf', newType: 'root', parent: 'root',
+    })).toEqual({
+      field: 'name', reason: 'self edge "root -> root"',
+    });
+    expect(filters.validateTypeDefinition({
+      currentType: 'leaf', newType: 'leaf', parent: 'root',
+    })).toBeUndefined();
+
+    expect(cameraStore.getTrack(0).confidencePairs).toEqual([['leaf', 0.8], ['fin', 0.7]]);
+    expect(filters.typeHierarchy.value).toEqual({ child: 'leaf', leaf: 'root' });
+    expect(filters.typeHierarchySavePatch()).toEqual({});
+    expect(markPending).not.toHaveBeenCalled();
+  });
+
   it('rejects a rename when one track already has both names', () => {
     const markPending = vi.fn();
     const { cameraStore, filters } = makePairFixture([

--- a/client/src/TrackFilterControls.spec.ts
+++ b/client/src/TrackFilterControls.spec.ts
@@ -747,6 +747,145 @@ describe('useAnnotationFilters', () => {
     expect(groupFilters.configuredTypes.value).not.toContain('renamed group');
   });
 
+  it('creates the first parent edge without changing stored pairs', () => {
+    const markPending = vi.fn();
+    const { cameraStore, filters } = makePairFixture([
+      [['leaf', 0.8], ['root', 0.4]],
+    ], markPending);
+    markPending.mockClear();
+
+    filters.updateTypeDefinition({
+      currentType: 'leaf',
+      newType: 'leaf',
+      parent: 'root',
+    });
+
+    expect(filters.typeHierarchy.value).toEqual({ leaf: 'root' });
+    expect(cameraStore.getTrack(0).confidencePairs).toEqual([
+      ['leaf', 0.8], ['root', 0.4],
+    ]);
+    expect(filters.typeHierarchySavePatch()).toEqual({ typeHierarchy: { leaf: 'root' } });
+    expect(markPending).toHaveBeenCalledTimes(1);
+    expect(markPending).toHaveBeenCalledWith({ action: 'meta' });
+  });
+
+  it('reparents a used type without changing stored pairs and can detach the final edge', () => {
+    const markPending = vi.fn();
+    const { cameraStore, filters } = makePairFixture([
+      [['leaf', 0.8], ['root', 0.4], ['animal', 0.2]],
+    ], markPending);
+    filters.setTypeHierarchy({ leaf: 'root' });
+    markPending.mockClear();
+
+    filters.updateTypeDefinition({
+      currentType: 'leaf',
+      newType: 'leaf',
+      parent: 'animal',
+    });
+    expect(filters.typeHierarchy.value).toEqual({ leaf: 'animal' });
+    expect(cameraStore.getTrack(0).confidencePairs).toEqual([
+      ['leaf', 0.8], ['root', 0.4], ['animal', 0.2],
+    ]);
+
+    filters.updateTypeDefinition({
+      currentType: 'leaf',
+      newType: 'leaf',
+      parent: undefined,
+    });
+    expect(filters.typeHierarchy.value).toBeUndefined();
+    expect(filters.hierarchyActive.value).toBe(false);
+    expect(filters.typeHierarchySavePatch()).toEqual({ typeHierarchy: null });
+    expect(cameraStore.getTrack(0).confidencePairs).toEqual([
+      ['leaf', 0.8], ['root', 0.4], ['animal', 0.2],
+    ]);
+    expect(markPending).toHaveBeenCalledTimes(2);
+  });
+
+  it('renames and reparents through one validated update', () => {
+    const markPending = vi.fn();
+    const { cameraStore, filters } = makePairFixture([
+      [['leaf', 0.8], ['root', 0.4], ['animal', 0.2]],
+    ], markPending);
+    filters.importTypes(['leaf'], false);
+    filters.setConfidenceFilters({ leaf: 0.5, default: 0.1 });
+    filters.setTypeHierarchy({ leaf: 'root' });
+    markPending.mockClear();
+
+    filters.updateTypeDefinition({
+      currentType: 'leaf',
+      newType: 'fin',
+      parent: 'animal',
+    });
+
+    expect(filters.typeHierarchy.value).toEqual({ fin: 'animal' });
+    expect(cameraStore.getTrack(0).confidencePairs).toEqual([
+      ['fin', 0.8], ['root', 0.4], ['animal', 0.2],
+    ]);
+    expect(filters.configuredTypes.value).toEqual(['fin']);
+    expect(filters.confidenceFilters.value).toEqual({ fin: 0.5, default: 0.1 });
+    expect(filters.checkedTypes.value).toContain('fin');
+    expect(filters.typeHierarchySavePatch()).toEqual({ typeHierarchy: { fin: 'animal' } });
+    expect(markPending.mock.calls.filter(([data]) => data?.action === 'meta')).toHaveLength(1);
+  });
+
+  it('validates only the final map when a parent edit resolves a rename conflict', () => {
+    const { filters } = makePairFixture([
+      [['cod', 0.8], ['bird', 0.2]],
+      [['haddock', 0.7]],
+    ]);
+    filters.setTypeHierarchy({
+      cod: 'fish',
+      haddock: 'animal',
+      sole: 'cod',
+    });
+
+    filters.updateTypeDefinition({
+      currentType: 'cod',
+      newType: 'haddock',
+      parent: 'bird',
+    });
+
+    expect(filters.typeHierarchy.value).toEqual({
+      haddock: 'bird',
+      sole: 'haddock',
+    });
+  });
+
+  it('does nothing when the name and parent are unchanged', () => {
+    const markPending = vi.fn();
+    const { filters } = makePairFixture([[['leaf', 1], ['root', 0.8]]], markPending);
+    filters.setTypeHierarchy({ leaf: 'root' });
+    markPending.mockClear();
+
+    filters.updateTypeDefinition({
+      currentType: 'leaf',
+      newType: 'leaf',
+      parent: 'root',
+    });
+
+    expect(filters.typeHierarchySavePatch()).toEqual({});
+    expect(markPending).not.toHaveBeenCalled();
+  });
+
+  it('repairs invalid stored hierarchy by assigning an available parent', () => {
+    const markPending = vi.fn();
+    const { filters } = makePairFixture([[['leaf', 1], ['root', 0.8]]], markPending);
+    filters.setTypeHierarchy({ leaf: 'leaf' });
+    expect(filters.invalidHierarchyReason.value).not.toBeNull();
+    markPending.mockClear();
+
+    filters.updateTypeDefinition({
+      currentType: 'leaf',
+      newType: 'leaf',
+      parent: 'root',
+    });
+
+    expect(filters.invalidHierarchyReason.value).toBeNull();
+    expect(filters.typeHierarchy.value).toEqual({ leaf: 'root' });
+    expect(filters.typeHierarchySavePatch()).toEqual({ typeHierarchy: { leaf: 'root' } });
+    expect(markPending).toHaveBeenCalledTimes(1);
+  });
+
   it('renames assigned group pairs across camera replicas without collapsing the vector', () => {
     const cameraStore = new CameraStore({ markChangesPending });
     cameraStore.removeCamera('singleCam');
@@ -794,6 +933,35 @@ describe('useAnnotationFilters', () => {
     expect(filters.confidenceFilters.value).toEqual({ fin: 0.4, default: 0.1 });
     expect(filters.checkedTypes.value).toContain('fin');
     expect(filters.typeHierarchySavePatch()).toEqual({ typeHierarchy: { fin: 'root' } });
+  });
+
+  it('preserves an existing destination parent during a rename-only merge', () => {
+    const { filters } = makePairFixture([
+      [['heading', 0.8]],
+      [['animal', 0.7]],
+    ]);
+    filters.setTypeHierarchy({ leaf: 'heading', animal: 'root' });
+
+    filters.updateTypeName({ currentType: 'heading', newType: 'animal' });
+
+    expect(filters.typeHierarchy.value).toEqual({ animal: 'root', leaf: 'animal' });
+  });
+
+  it('preserves the landed conflicting-parent rejection for rename-only callers', () => {
+    const markPending = vi.fn();
+    const { cameraStore, filters } = makePairFixture([
+      [['cod', 0.8]],
+      [['haddock', 0.7]],
+    ], markPending);
+    filters.setTypeHierarchy({ cod: 'fish', haddock: 'animal' });
+    markPending.mockClear();
+
+    expect(() => filters.updateTypeName({ currentType: 'cod', newType: 'haddock' }))
+      .toThrow('conflicting parents for "haddock"');
+    expect(filters.typeHierarchy.value).toEqual({ cod: 'fish', haddock: 'animal' });
+    expect(cameraStore.getTrack(0).confidencePairs).toEqual([['cod', 0.8]]);
+    expect(cameraStore.getTrack(1).confidencePairs).toEqual([['haddock', 0.7]]);
+    expect(markPending).not.toHaveBeenCalled();
   });
 
   it('does not configure a hierarchy-only heading during a name-only rename', () => {
@@ -849,6 +1017,30 @@ describe('useAnnotationFilters', () => {
     expect(markPending).not.toHaveBeenCalled();
   });
 
+  it('rejects an invalid combined rename and parent before changing any state', () => {
+    const markPending = vi.fn();
+    const { cameraStore, filters } = makePairFixture([[['leaf', 0.8]]], markPending);
+    filters.importTypes(['leaf'], false);
+    filters.setConfidenceFilters({ leaf: 0.4, default: 0.1 });
+    filters.setTypeHierarchy({ leaf: 'root', child: 'leaf' });
+    const checkedBefore = [...filters.checkedTypes.value];
+    markPending.mockClear();
+
+    expect(() => filters.updateTypeDefinition({
+      currentType: 'leaf',
+      newType: 'fin',
+      parent: 'child',
+    })).toThrow(TypeHierarchyError);
+
+    expect(cameraStore.getTrack(0).confidencePairs).toEqual([['leaf', 0.8]]);
+    expect(filters.typeHierarchy.value).toEqual({ child: 'leaf', leaf: 'root' });
+    expect(filters.configuredTypes.value).toEqual(['leaf']);
+    expect(filters.confidenceFilters.value).toEqual({ leaf: 0.4, default: 0.1 });
+    expect(filters.checkedTypes.value).toEqual(checkedBefore);
+    expect(filters.typeHierarchySavePatch()).toEqual({});
+    expect(markPending).not.toHaveBeenCalled();
+  });
+
   it('rejects a rename when one track already has both names', () => {
     const markPending = vi.fn();
     const { cameraStore, filters } = makePairFixture([
@@ -887,22 +1079,44 @@ describe('useAnnotationFilters', () => {
     expect(markPending).not.toHaveBeenCalled();
   });
 
-  it('clears settings for unused parents and leaves hierarchy state unchanged', () => {
+  it('deletes an unused parent, promotes its child, and clears type settings', () => {
     const markPending = vi.fn();
     const { filters } = makePairFixture([[['used', 1]]], markPending);
-    filters.importTypes(['leaf'], false);
-    filters.setConfidenceFilters({ leaf: 0.4, default: 0.1 });
+    filters.importTypes(['parent'], false);
+    filters.setConfidenceFilters({ parent: 0.4, default: 0.1 });
     filters.setTypeHierarchy({ leaf: 'parent', parent: 'root' });
     markPending.mockClear();
-    const hierarchyBefore = { ...filters.typeHierarchy.value };
-    const checkedBefore = [...filters.checkedTypes.value];
+
     expect(filters.deleteType('parent')).toBe(true);
-    expect(filters.deleteType('leaf')).toBe(true);
-    expect(filters.typeHierarchy.value).toEqual(hierarchyBefore);
-    expect(filters.configuredTypes.value).not.toContain('leaf');
-    expect(filters.confidenceFilters.value).not.toHaveProperty('leaf');
-    expect(filters.checkedTypes.value).toEqual(checkedBefore);
-    expect(markPending).toHaveBeenCalledTimes(2);
+    expect(filters.typeHierarchy.value).toEqual({ leaf: 'root' });
+    expect(filters.typeHierarchySavePatch()).toEqual({ typeHierarchy: { leaf: 'root' } });
+    expect(filters.configuredTypes.value).not.toContain('parent');
+    expect(filters.confidenceFilters.value).not.toHaveProperty('parent');
+    expect(filters.checkedTypes.value).not.toContain('parent');
+    expect(markPending).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a used descendant when deleting its unused parent', () => {
+    const { cameraStore, filters } = makePairFixture([[['leaf', 1]]]);
+    filters.setTypeHierarchy({ leaf: 'parent', parent: 'root' });
+
+    expect(filters.deleteType('parent')).toBe(true);
+    expect(filters.typeHierarchy.value).toEqual({ leaf: 'root' });
+    expect(cameraStore.getTrack(0).confidencePairs).toEqual([['leaf', 1]]);
+  });
+
+  it('keeps flat deletion behavior for a configured type outside the hierarchy', () => {
+    const markPending = vi.fn();
+    const { filters } = makePairFixture([[['leaf', 1]]], markPending);
+    filters.setTypeHierarchy({ leaf: 'root' });
+    filters.importTypes(['configured'], false);
+    markPending.mockClear();
+
+    expect(filters.deleteType('configured')).toBe(true);
+    expect(filters.typeHierarchy.value).toEqual({ leaf: 'root' });
+    expect(filters.typeHierarchySavePatch()).toEqual({});
+    expect(filters.configuredTypes.value).not.toContain('configured');
+    expect(markPending).toHaveBeenCalledTimes(1);
   });
 
   it('blocks deleting a type that a divergent camera still uses', () => {
@@ -929,12 +1143,12 @@ describe('useAnnotationFilters', () => {
     expect(markPending).not.toHaveBeenCalled();
   });
 
-  it('keeps hierarchy active after clearing the final leaf settings', () => {
+  it('deletes the final edge and restores flat behavior', () => {
     const { filters } = makePairFixture([[['used', 1]]]);
     filters.setTypeHierarchy({ leaf: 'root' });
     expect(filters.deleteType('leaf')).toBe(true);
-    expect(filters.hierarchyActive.value).toBe(true);
-    expect(filters.typeHierarchy.value).toEqual({ leaf: 'root' });
-    expect(filters.typeHierarchySavePatch()).toEqual({});
+    expect(filters.hierarchyActive.value).toBe(false);
+    expect(filters.typeHierarchy.value).toBeUndefined();
+    expect(filters.typeHierarchySavePatch()).toEqual({ typeHierarchy: null });
   });
 });

--- a/client/src/TrackFilterControls.ts
+++ b/client/src/TrackFilterControls.ts
@@ -24,6 +24,29 @@ export interface TypeHierarchySavePatch {
   typeHierarchy?: Record<string, string> | null;
 }
 
+export interface TypeDefinitionParams {
+  currentType: string;
+  newType: string;
+  parent: string | undefined;
+}
+
+export interface TypeDefinitionValidationError {
+  field: 'name' | 'parent';
+  reason: string;
+}
+
+interface PreparedTypeDefinition {
+  nextHierarchy: TypeHierarchy | undefined;
+  nameChanged: boolean;
+  hierarchyChanged: boolean;
+  hierarchyInvolved: boolean;
+  survivingHierarchyTypes: Set<string>;
+}
+
+type TypeDefinitionPreflight =
+  | { prepared: PreparedTypeDefinition; error?: undefined }
+  | { prepared?: undefined; error: TypeDefinitionValidationError & { cause: TypeHierarchyError } };
+
 interface TrackFilterControlsParams extends FilterControlsParams<Track> {
   lookupGroups: (annotationId: AnnotationId) => Group[];
   groupFilterControls: BaseFilterControls<Group>;
@@ -291,50 +314,56 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
     });
   }
 
-  updateTypeDefinition({
+  private preflightTypeDefinition({
     currentType,
     newType,
     parent,
-  }: {
-    currentType: string;
-    newType: string;
-    parent: string | undefined;
-  }) {
-    if (parent === currentType && currentType !== newType) {
-      throw new TypeHierarchyError(
-        `the original type "${currentType}" cannot be its renamed type's parent`,
-        'conflict',
-      );
-    }
-    if (parent !== undefined && !this.allTypes.value.includes(parent)) {
-      throw new TypeHierarchyError(
-        `parent "${parent}" is not an existing type`,
-        'conflict',
-      );
+  }: TypeDefinitionParams): TypeDefinitionPreflight {
+    let prepared: PreparedTypeDefinition;
+    let structuralErrorField: TypeDefinitionValidationError['field'] = 'parent';
+    try {
+      if (parent === currentType && currentType !== newType) {
+        throw new TypeHierarchyError(
+          `the original type "${currentType}" cannot be its renamed type's parent`,
+          'conflict',
+        );
+      }
+      if (parent !== undefined && !this.allTypes.value.includes(parent)) {
+        throw new TypeHierarchyError(
+          `parent "${parent}" is not an existing type`,
+          'conflict',
+        );
+      }
+
+      const currentHierarchy = this.typeHierarchy.value;
+      const currentParent = currentHierarchy?.[currentType];
+      const nameChanged = currentType !== newType;
+      const parentChanged = parent !== currentParent;
+      structuralErrorField = nameChanged && !parentChanged ? 'name' : 'parent';
+      const survivingHierarchyTypes = hierarchyTypes(currentHierarchy);
+      if (nameChanged && survivingHierarchyTypes.delete(currentType)) {
+        survivingHierarchyTypes.add(newType);
+      }
+      const nextHierarchy = nameChanged && !parentChanged && currentHierarchy !== undefined
+        ? rewriteHierarchyType(currentHierarchy, currentType, newType)
+        : updateHierarchyTypeDefinition(currentHierarchy, currentType, newType, parent);
+      prepared = {
+        nextHierarchy,
+        nameChanged,
+        hierarchyChanged: !isEqual(currentHierarchy, nextHierarchy),
+        hierarchyInvolved: currentHierarchy !== undefined || nextHierarchy !== undefined,
+        survivingHierarchyTypes,
+      };
+    } catch (error) {
+      if (error instanceof TypeHierarchyError) {
+        return {
+          error: { field: structuralErrorField, reason: error.reason, cause: error },
+        };
+      }
+      throw error;
     }
 
-    const currentHierarchy = this.typeHierarchy.value;
-    const currentParent = currentHierarchy?.[currentType];
-    const nameChanged = currentType !== newType;
-    const parentChanged = parent !== currentParent;
-    const survivingHierarchyTypes = hierarchyTypes(currentHierarchy);
-    if (nameChanged && survivingHierarchyTypes.delete(currentType)) {
-      survivingHierarchyTypes.add(newType);
-    }
-    const nextHierarchy = nameChanged && !parentChanged && currentHierarchy !== undefined
-      ? rewriteHierarchyType(currentHierarchy, currentType, newType)
-      : updateHierarchyTypeDefinition(currentHierarchy, currentType, newType, parent);
-    const hierarchyChanged = !isEqual(currentHierarchy, nextHierarchy);
-    const hierarchyInvolved = currentHierarchy !== undefined || nextHierarchy !== undefined;
-    if (!nameChanged && !hierarchyChanged) {
-      return;
-    }
-    if (!hierarchyInvolved) {
-      this.updateTypeName({ currentType, newType });
-      return;
-    }
-
-    if (nameChanged) {
+    if (prepared.nameChanged && prepared.hierarchyInvolved) {
       const collision = this.sorted.value
         .flatMap((annotation) => this.getTracks(annotation.id))
         .find((track) => {
@@ -342,11 +371,42 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
           return names.has(currentType) && names.has(newType);
         });
       if (collision) {
-        throw new TypeHierarchyError(
+        const cause = new TypeHierarchyError(
           `track ${collision.id} already contains both "${currentType}" and "${newType}"`,
           'conflict',
         );
+        return {
+          error: { field: 'name', reason: cause.reason, cause },
+        };
       }
+    }
+    return { prepared };
+  }
+
+  validateTypeDefinition(params: TypeDefinitionParams): TypeDefinitionValidationError | undefined {
+    const { error } = this.preflightTypeDefinition(params);
+    return error && { field: error.field, reason: error.reason };
+  }
+
+  updateTypeDefinition(params: TypeDefinitionParams) {
+    const preflight = this.preflightTypeDefinition(params);
+    if (preflight.error) {
+      throw preflight.error.cause;
+    }
+    const {
+      nextHierarchy,
+      nameChanged,
+      hierarchyChanged,
+      hierarchyInvolved,
+      survivingHierarchyTypes,
+    } = preflight.prepared;
+    const { currentType, newType } = params;
+    if (!nameChanged && !hierarchyChanged) {
+      return;
+    }
+    if (!hierarchyInvolved) {
+      this.updateTypeName({ currentType, newType });
+      return;
     }
 
     const currentWasChecked = this.checkedTypes.value.includes(currentType);

--- a/client/src/TrackFilterControls.ts
+++ b/client/src/TrackFilterControls.ts
@@ -4,13 +4,14 @@ import { clientSettings } from 'dive-common/store/settings';
 import {
   compileHierarchy,
   normalizeTypeHierarchy,
+  removeHierarchyType,
   resolveConfidenceThreshold,
   selectFlatPairIndex,
-  rewriteHierarchyType,
   selectPairIndex,
   TypeHierarchy,
   TypeHierarchyError,
   TypeHierarchyIndex,
+  updateHierarchyTypeDefinition,
 } from 'dive-common/typeHierarchy';
 import { AnnotationId } from './BaseAnnotation';
 import BaseFilterControls, { AnnotationWithContext, FilterControlsParams } from './BaseFilterControls';
@@ -260,60 +261,141 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
       this.deleteType(currentType);
       return;
     }
-    const tracks = this.sorted.value.flatMap((annotation) => this.getTracks(annotation.id));
-    const collision = tracks.find((track) => {
-      const names = new Set(track.confidencePairs.map(([name]) => name));
-      return names.has(currentType) && names.has(newType);
+    this.updateTypeDefinition({
+      currentType,
+      newType,
+      parent: this.typeHierarchy.value?.[currentType],
     });
-    if (collision) {
+  }
+
+  updateTypeDefinition({
+    currentType,
+    newType,
+    parent,
+  }: {
+    currentType: string;
+    newType: string;
+    parent: string | undefined;
+  }) {
+    if (parent === currentType && currentType !== newType) {
       throw new TypeHierarchyError(
-        `track ${collision.id} already contains both "${currentType}" and "${newType}"`,
+        `the original type "${currentType}" cannot be its renamed type's parent`,
+        'conflict',
+      );
+    }
+    if (parent !== undefined && !this.allTypes.value.includes(parent)) {
+      throw new TypeHierarchyError(
+        `parent "${parent}" is not an existing type`,
         'conflict',
       );
     }
 
-    const currentHierarchy = this.typeHierarchy.value as TypeHierarchy;
-    const rewritten = rewriteHierarchyType(currentHierarchy, currentType, newType);
-    const hierarchyChanged = !isEqual(currentHierarchy, rewritten);
+    const currentHierarchy = this.typeHierarchy.value;
+    const currentHasParent = currentHierarchy !== undefined
+      && Object.prototype.hasOwnProperty.call(currentHierarchy, currentType);
+    const destinationHasParent = currentHierarchy !== undefined
+      && Object.prototype.hasOwnProperty.call(currentHierarchy, newType);
+    const currentParent = currentHasParent ? currentHierarchy?.[currentType] : undefined;
+    let destinationParent = destinationHasParent ? currentHierarchy?.[newType] : undefined;
+    if (destinationParent === currentType) {
+      destinationParent = newType;
+    }
+    const parentChanged = parent !== currentParent;
+    let finalParent = parent;
+    if (currentType !== newType && destinationHasParent && !parentChanged) {
+      if (currentHasParent && currentParent !== destinationParent) {
+        throw new TypeHierarchyError(
+          `conflicting parents for "${newType}": "${destinationParent}" and "${currentParent}"`,
+          'conflict',
+        );
+      }
+      if (!currentHasParent) {
+        finalParent = destinationParent;
+      }
+    }
+    const nextHierarchy = updateHierarchyTypeDefinition(
+      currentHierarchy,
+      currentType,
+      newType,
+      finalParent,
+    );
+    const nameChanged = currentType !== newType;
+    const hierarchyChanged = !isEqual(currentHierarchy, nextHierarchy)
+      || (this.invalidHierarchyReason.value !== null && finalParent !== undefined);
+    const hierarchyInvolved = currentHierarchy !== undefined || nextHierarchy !== undefined;
+    if (!nameChanged && !hierarchyChanged) {
+      return;
+    }
+    if (!hierarchyInvolved) {
+      this.updateTypeName({ currentType, newType });
+      return;
+    }
+
+    if (nameChanged) {
+      const collision = this.sorted.value
+        .flatMap((annotation) => this.getTracks(annotation.id))
+        .find((track) => {
+          const names = new Set(track.confidencePairs.map(([name]) => name));
+          return names.has(currentType) && names.has(newType);
+        });
+      if (collision) {
+        throw new TypeHierarchyError(
+          `track ${collision.id} already contains both "${currentType}" and "${newType}"`,
+          'conflict',
+        );
+      }
+    }
+
     const currentWasChecked = this.checkedTypes.value.includes(currentType);
     const newWasChecked = this.checkedTypes.value.includes(newType);
+    const currentWasConfigured = this.configuredTypes.value.includes(currentType);
 
-    this.sorted.value.forEach((annotation) => {
-      if (this.getTracks(annotation.id)
-        .some((track) => track.confidencePairs.some(([name]) => name === currentType))) {
-        this.renameTrackPair(annotation.id, currentType, newType);
+    if (nameChanged) {
+      this.sorted.value.forEach((annotation) => {
+        if (this.getTracks(annotation.id)
+          .some((track) => track.confidencePairs.some(([name]) => name === currentType))) {
+          this.renameTrackPair(annotation.id, currentType, newType);
+        }
+      });
+      this.carryConfidenceFilter(currentType, newType);
+      if (currentWasConfigured && !this.configuredTypes.value.includes(newType)) {
+        this.configuredTypes.value.push(newType);
       }
-    });
-    this.carryConfidenceFilter(currentType, newType);
-    if (this.configuredTypes.value.includes(currentType)
-      && !this.configuredTypes.value.includes(newType)) {
-      this.configuredTypes.value.push(newType);
+      this.deleteTypeConfiguration(currentType);
     }
-    this.deleteTypeConfiguration(currentType);
     if (hierarchyChanged) {
-      this.installTypeHierarchy(rewritten, true);
+      this.installTypeHierarchy(nextHierarchy, true);
     }
 
     const checked = new Set(this.checkedTypes.value);
-    if (!currentWasChecked && !newWasChecked) {
-      checked.delete(newType);
-    } else if (currentWasChecked) {
-      checked.add(newType);
-    }
-    if (!this.allTypes.value.includes(currentType)) {
-      checked.delete(currentType);
+    if (nameChanged) {
+      if (!currentWasChecked && !newWasChecked) {
+        checked.delete(newType);
+      } else if (currentWasChecked) {
+        checked.add(newType);
+      }
+      if (!this.allTypes.value.includes(currentType)) {
+        checked.delete(currentType);
+      }
     }
     this.checkedTypes.value = Array.from(checked);
     this.markChangesPending({ action: 'meta' });
   }
 
   deleteType(type: string): boolean {
-    if (!this.hierarchyActive.value) {
+    const currentHierarchy = this.typeHierarchy.value;
+    const hierarchyMember = currentHierarchy !== undefined
+      && (Object.prototype.hasOwnProperty.call(currentHierarchy, type)
+        || Object.values(currentHierarchy).includes(type));
+    if (!hierarchyMember) {
       return super.deleteType(type);
     }
     if (this.typeInUseOnAnyCamera(type)) {
       return false;
     }
+    const nextHierarchy = removeHierarchyType(currentHierarchy, type);
+    this.installTypeHierarchy(nextHierarchy, true);
+    this.checkedTypes.value = this.checkedTypes.value.filter((name) => name !== type);
     this.deleteTypeConfiguration(type);
     this.markChangesPending({ action: 'meta' });
     return true;

--- a/client/src/TrackFilterControls.ts
+++ b/client/src/TrackFilterControls.ts
@@ -6,6 +6,7 @@ import {
   normalizeTypeHierarchy,
   removeHierarchyType,
   resolveConfidenceThreshold,
+  rewriteHierarchyType,
   selectFlatPairIndex,
   selectPairIndex,
   TypeHierarchy,
@@ -32,6 +33,21 @@ interface TrackFilterControlsParams extends FilterControlsParams<Track> {
     currentType: string,
     newType: string,
   ) => [string, number][];
+}
+
+function hierarchyIncludesType(hierarchy: TypeHierarchy | undefined, type: string): boolean {
+  return hierarchy !== undefined
+    && (Object.prototype.hasOwnProperty.call(hierarchy, type)
+      || Object.values(hierarchy).includes(type));
+}
+
+function hierarchyTypes(hierarchy: TypeHierarchy | undefined): Set<string> {
+  const types = new Set<string>();
+  Object.entries(hierarchy || {}).forEach(([child, parent]) => {
+    types.add(child);
+    types.add(parent);
+  });
+  return types;
 }
 
 export default class TrackFilterControls extends BaseFilterControls<Track> {
@@ -73,14 +89,7 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
     this.typeHierarchy = ref(undefined);
     this.hierarchyIndex = ref(undefined);
     this.invalidHierarchyReason = ref(null);
-    this.hierarchyMembers = computed(() => {
-      const members = new Set<string>();
-      Object.entries(this.typeHierarchy.value || {}).forEach(([child, parent]) => {
-        members.add(child);
-        members.add(parent);
-      });
-      return Array.from(members);
-    });
+    this.hierarchyMembers = computed(() => Array.from(hierarchyTypes(this.typeHierarchy.value)));
     this.hierarchyActive = computed(() => this.hierarchyIndex.value !== undefined);
     this.allTypes = computed(() => Array.from(new Set([
       ...flatAllTypes.value,
@@ -249,6 +258,20 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
       .some((track) => track.confidencePairs.some(([name]) => name === type)));
   }
 
+  private configureStandaloneTypes(
+    types: ReadonlySet<string>,
+    hierarchy: TypeHierarchy | undefined,
+  ) {
+    const hierarchyMembers = hierarchyTypes(hierarchy);
+    const retainedTypes = new Set(this.usedPlusConfiguredTypes.value);
+    types.forEach((type) => {
+      if (!hierarchyMembers.has(type) && !retainedTypes.has(type)) {
+        this.configuredTypes.value.push(type);
+        retainedTypes.add(type);
+      }
+    });
+  }
+
   updateTypeName({ currentType, newType }: { currentType: string; newType: string }) {
     if (!this.hierarchyActive.value) {
       this.sorted.value.forEach((annotation) => {
@@ -291,37 +314,17 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
     }
 
     const currentHierarchy = this.typeHierarchy.value;
-    const currentHasParent = currentHierarchy !== undefined
-      && Object.prototype.hasOwnProperty.call(currentHierarchy, currentType);
-    const destinationHasParent = currentHierarchy !== undefined
-      && Object.prototype.hasOwnProperty.call(currentHierarchy, newType);
-    const currentParent = currentHasParent ? currentHierarchy?.[currentType] : undefined;
-    let destinationParent = destinationHasParent ? currentHierarchy?.[newType] : undefined;
-    if (destinationParent === currentType) {
-      destinationParent = newType;
-    }
-    const parentChanged = parent !== currentParent;
-    let finalParent = parent;
-    if (currentType !== newType && destinationHasParent && !parentChanged) {
-      if (currentHasParent && currentParent !== destinationParent) {
-        throw new TypeHierarchyError(
-          `conflicting parents for "${newType}": "${destinationParent}" and "${currentParent}"`,
-          'conflict',
-        );
-      }
-      if (!currentHasParent) {
-        finalParent = destinationParent;
-      }
-    }
-    const nextHierarchy = updateHierarchyTypeDefinition(
-      currentHierarchy,
-      currentType,
-      newType,
-      finalParent,
-    );
+    const currentParent = currentHierarchy?.[currentType];
     const nameChanged = currentType !== newType;
-    const hierarchyChanged = !isEqual(currentHierarchy, nextHierarchy)
-      || (this.invalidHierarchyReason.value !== null && finalParent !== undefined);
+    const parentChanged = parent !== currentParent;
+    const survivingHierarchyTypes = hierarchyTypes(currentHierarchy);
+    if (nameChanged && survivingHierarchyTypes.delete(currentType)) {
+      survivingHierarchyTypes.add(newType);
+    }
+    const nextHierarchy = nameChanged && !parentChanged && currentHierarchy !== undefined
+      ? rewriteHierarchyType(currentHierarchy, currentType, newType)
+      : updateHierarchyTypeDefinition(currentHierarchy, currentType, newType, parent);
+    const hierarchyChanged = !isEqual(currentHierarchy, nextHierarchy);
     const hierarchyInvolved = currentHierarchy !== undefined || nextHierarchy !== undefined;
     if (!nameChanged && !hierarchyChanged) {
       return;
@@ -363,6 +366,7 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
       }
       this.deleteTypeConfiguration(currentType);
     }
+    this.configureStandaloneTypes(survivingHierarchyTypes, nextHierarchy);
     if (hierarchyChanged) {
       this.installTypeHierarchy(nextHierarchy, true);
     }
@@ -384,16 +388,16 @@ export default class TrackFilterControls extends BaseFilterControls<Track> {
 
   deleteType(type: string): boolean {
     const currentHierarchy = this.typeHierarchy.value;
-    const hierarchyMember = currentHierarchy !== undefined
-      && (Object.prototype.hasOwnProperty.call(currentHierarchy, type)
-        || Object.values(currentHierarchy).includes(type));
-    if (!hierarchyMember) {
+    if (currentHierarchy === undefined || !hierarchyIncludesType(currentHierarchy, type)) {
       return super.deleteType(type);
     }
     if (this.typeInUseOnAnyCamera(type)) {
       return false;
     }
     const nextHierarchy = removeHierarchyType(currentHierarchy, type);
+    const survivingHierarchyTypes = hierarchyTypes(currentHierarchy);
+    survivingHierarchyTypes.delete(type);
+    this.configureStandaloneTypes(survivingHierarchyTypes, nextHierarchy);
     this.installTypeHierarchy(nextHierarchy, true);
     this.checkedTypes.value = this.checkedTypes.value.filter((name) => name !== type);
     this.deleteTypeConfiguration(type);

--- a/client/src/components/FilterList.spec.ts
+++ b/client/src/components/FilterList.spec.ts
@@ -9,6 +9,7 @@ import BaseFilterControls from '../BaseFilterControls';
 import Group from '../Group';
 import CameraStore from '../CameraStore';
 import FilterList from './FilterList.vue';
+import TypeEditor from './TypeEditor.vue';
 
 vi.mock('dive-common/vue-utilities/prompt-service', () => ({
   usePrompt: () => ({ prompt: vi.fn(), visible: () => false }),
@@ -21,6 +22,7 @@ const provideMocks = vi.hoisted(() => ({
   annotationMap: new Map<number, unknown>(),
   selectedCameraValue: 'singleCam',
   selectedCameraRef: undefined as { value: string } | undefined,
+  datasetIdRef: undefined as { value: string } | undefined,
 }));
 
 /**
@@ -64,6 +66,11 @@ vi.mock('../provides', () => ({
     }]])),
   }),
   useHandler: () => ({ seekFrame: provideMocks.seekFrame }),
+  useDatasetId: () => {
+    const datasetId = ref('dataset-a');
+    provideMocks.datasetIdRef = datasetId;
+    return datasetId;
+  },
   useReadOnlyMode: () => ref(false),
   useSelectedCamera: () => {
     const selectedCamera = ref(provideMocks.selectedCameraValue);
@@ -182,8 +189,33 @@ describe('FilterList hierarchy members', () => {
     provideMocks.annotationMap.clear();
     provideMocks.selectedCameraValue = 'singleCam';
     provideMocks.selectedCameraRef = undefined;
+    provideMocks.datasetIdRef = undefined;
     clientSettings.typeSettings.showTotalCount = true;
     clientSettings.typeSettings.showFrameCount = true;
+  });
+
+  it('discards an open Type Editor draft when the dataset changes', async () => {
+    const { filterControls, styleManager } = makeHierarchyFixture();
+    const { vm, wrapper } = mountFilterList({
+      filterControls,
+      styleManager,
+      showEmptyTypes: true,
+      height: 240,
+      headerHeight: 80,
+    });
+    vm.clickEdit('leaf');
+    await nextTick();
+    expect(vm.data.showPicker).toBe(true);
+    expect(wrapper.findComponent(TypeEditor).exists()).toBe(true);
+
+    if (!provideMocks.datasetIdRef) {
+      throw new Error('Dataset ID ref was not initialized');
+    }
+    provideMocks.datasetIdRef.value = 'dataset-b';
+    await nextTick();
+    expect(vm.data.showPicker).toBe(false);
+    expect(vm.data.selectedType).toBe('');
+    expect(wrapper.findComponent(TypeEditor).exists()).toBe(false);
   });
 
   it('keeps members as ordinary, independently checked flat rows', async () => {

--- a/client/src/components/FilterList.vue
+++ b/client/src/components/FilterList.vue
@@ -11,7 +11,7 @@ import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { clientSettings } from 'dive-common/store/settings';
 import { compileHierarchy } from 'dive-common/typeHierarchy';
 import {
-  useCameraStore, useHandler, useReadOnlyMode, useSelectedCamera, useTime,
+  useCameraStore, useDatasetId, useHandler, useReadOnlyMode, useSelectedCamera, useTime,
   usePendingSaveCount,
 } from '../provides';
 import TooltipBtn from './TooltipButton.vue';
@@ -109,6 +109,7 @@ export default defineComponent({
     const { prompt } = usePrompt();
     const handler = useHandler();
     const readOnlyMode = useReadOnlyMode();
+    const datasetId = useDatasetId();
     const cameraStore = useCameraStore();
     const selectedCamera = useSelectedCamera();
     const { frame } = useTime();
@@ -160,6 +161,10 @@ export default defineComponent({
         compactSharedLineage.value = true;
       });
     }
+    watch(datasetId, () => {
+      data.showPicker = false;
+      data.selectedType = '';
+    });
 
     function clickEdit(type: string) {
       data.selectedType = type;
@@ -738,6 +743,7 @@ export default defineComponent({
       width="350"
     >
       <TypeEditor
+        v-if="data.showPicker"
         :selected-type="data.selectedType"
         :filter-controls="filterControls"
         :style-manager="styleManager"

--- a/client/src/components/TypeEditor.spec.ts
+++ b/client/src/components/TypeEditor.spec.ts
@@ -129,9 +129,11 @@ describe('TypeEditor hierarchy editing', () => {
     const autocomplete = track.wrapper.find('v-autocomplete');
     expect(autocomplete.exists()).toBe(true);
     expect(autocomplete.attributes('auto-select-first')).toBe('');
+    expect(autocomplete.attributes('no-filter')).toBe('');
     expect(autocomplete.attributes('no-data-text')).toBe(
       'No matching type. Add it from Type Settings first.',
     );
+    expect(track.wrapper.find('v-text-field').attributes('hide-details')).toBe('auto');
 
     const group = mountEditor({ filters: makeGroupFilters(), group: true });
     expect(group.vm.showParentType).toBe(false);
@@ -193,14 +195,6 @@ describe('TypeEditor hierarchy editing', () => {
     expect(filters.updateTypeDefinition).not.toHaveBeenCalled();
     expect(styleManager.updateTypeStyle).not.toHaveBeenCalled();
     expect(closeEvents).toHaveLength(0);
-  });
-
-  it('accepts a cleared parent draft without pointer input', () => {
-    const { vm } = mountEditor();
-    vm.data.editingParent = null;
-    vm.data.parentSearch = null;
-    expect(vm.data.editingParent).toBeNull();
-    expect(vm.data.parentSearch).toBeNull();
   });
 
   it('saves name and parent through one atomic operation', () => {

--- a/client/src/components/TypeEditor.spec.ts
+++ b/client/src/components/TypeEditor.spec.ts
@@ -27,6 +27,7 @@ function makeFilters({
   filters.usedTypes = ref([]);
   filters.typeHierarchy = ref(hierarchy);
   filters.typeInUseOnAnyCamera = vi.fn(() => false);
+  filters.validateTypeDefinition = vi.fn(() => undefined);
   filters.updateTypeDefinition = vi.fn();
   filters.updateTypeName = vi.fn();
   filters.importTypes = vi.fn();
@@ -195,6 +196,49 @@ describe('TypeEditor hierarchy editing', () => {
     expect(filters.updateTypeDefinition).not.toHaveBeenCalled();
     expect(styleManager.updateTypeStyle).not.toHaveBeenCalled();
     expect(closeEvents).toHaveLength(0);
+  });
+
+  it('shows every known preflight restriction inline and disables Save', async () => {
+    const parent = mountEditor();
+    vi.mocked(parent.filters.validateTypeDefinition).mockReturnValue({
+      field: 'parent',
+      reason: 'cycle leaf -> branch -> leaf',
+    });
+    parent.vm.data.editingParent = 'branch';
+    parent.vm.data.parentSearch = 'branch';
+    await nextTick();
+    expect(parent.vm.parentDefinitionError).toBe(
+      'Type hierarchy is invalid: cycle leaf -> branch -> leaf.',
+    );
+    expect(parent.wrapper.find('v-autocomplete').attributes('error-messages')).toBe(
+      'Type hierarchy is invalid: cycle leaf -> branch -> leaf.',
+    );
+    expect(parent.vm.saveDisabled).toBe(true);
+    parent.vm.acceptChanges();
+    expect(parent.filters.updateTypeDefinition).not.toHaveBeenCalled();
+
+    const name = mountEditor();
+    vi.mocked(name.filters.validateTypeDefinition).mockReturnValue({
+      field: 'name',
+      reason: 'track 4 already contains both "leaf" and "root"',
+    });
+    name.vm.data.editingType = 'root';
+    await nextTick();
+    expect(name.vm.nameDefinitionError).toBe(
+      'Type hierarchy is invalid: track 4 already contains both "leaf" and "root".',
+    );
+    expect(name.wrapper.find('v-text-field').attributes('error-messages')).toBe(
+      'Type hierarchy is invalid: track 4 already contains both "leaf" and "root".',
+    );
+    expect(name.vm.saveDisabled).toBe(true);
+
+    const unresolved = mountEditor();
+    unresolved.vm.data.parentSearch = 'missing';
+    await nextTick();
+    expect(unresolved.vm.parentDefinitionError).toBe(
+      'Select an existing type from the list, or clear the field.',
+    );
+    expect(unresolved.vm.saveDisabled).toBe(true);
   });
 
   it('saves name and parent through one atomic operation', () => {

--- a/client/src/components/TypeEditor.spec.ts
+++ b/client/src/components/TypeEditor.spec.ts
@@ -1,25 +1,43 @@
-import { defineComponent, h, ref } from 'vue';
+import {
+  defineComponent, h, nextTick, ref, shallowReactive,
+} from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import { TypeHierarchyError } from 'dive-common/typeHierarchy';
+import BaseFilterControls from '../BaseFilterControls';
 import TrackFilterControls from '../TrackFilterControls';
 import TypeEditor from './TypeEditor.vue';
 
 const promptMock = vi.hoisted(() => vi.fn());
+const provideMocks = vi.hoisted(() => ({ readOnly: false }));
 
 vi.mock('dive-common/vue-utilities/prompt-service', () => ({
   usePrompt: () => ({ prompt: promptMock }),
 }));
 
 vi.mock('../provides', () => ({
-  useReadOnlyMode: () => ref(false),
+  useReadOnlyMode: () => ref(provideMocks.readOnly),
 }));
 
-function makeFilters() {
+function makeFilters({
+  allTypes = ['leaf', 'root'],
+  hierarchy = { leaf: 'root' } as Record<string, string> | undefined,
+} = {}) {
   const filters = Object.create(TrackFilterControls.prototype) as TrackFilterControls;
+  filters.allTypes = ref(allTypes);
   filters.usedTypes = ref([]);
+  filters.typeHierarchy = ref(hierarchy);
   filters.typeInUseOnAnyCamera = vi.fn(() => false);
+  filters.updateTypeDefinition = vi.fn();
   filters.updateTypeName = vi.fn();
   filters.importTypes = vi.fn();
+  filters.deleteType = vi.fn(() => true);
+  return filters;
+}
+
+function makeGroupFilters() {
+  const filters = Object.create(BaseFilterControls.prototype) as BaseFilterControls<never>;
+  filters.usedTypes = ref([]);
+  filters.updateTypeName = vi.fn();
   filters.deleteType = vi.fn(() => true);
   return filters;
 }
@@ -27,14 +45,24 @@ function makeFilters() {
 function makeStyleManager() {
   return Object.freeze({
     typeStyling: ref({
-      color: () => '#123456',
+      color: (type: string) => `color:${type}`,
       strokeWidth: () => 3,
       fill: () => false,
       opacity: () => 0.8,
       labelSettings: () => ({ showLabel: true, showConfidence: true }),
     }),
     updateTypeStyle: vi.fn(),
+    renameTypeStyle: vi.fn(),
+    deleteTypeStyle: vi.fn(),
   });
+}
+
+interface MountOptions {
+  selectedType?: string;
+  filters?: BaseFilterControls<never> | TrackFilterControls | null;
+  styleManager?: ReturnType<typeof makeStyleManager>;
+  group?: boolean;
+  styleOnly?: boolean;
 }
 
 /**
@@ -42,16 +70,26 @@ function makeStyleManager() {
  * SFC is not, so the editor is rendered from a host that captures the real instance and its
  * emitted events. It is left unstubbed to keep shallow semantics for its own children.
  */
-function mountEditor(filters = makeFilters(), styleManager = makeStyleManager()) {
+function mountEditor({
+  selectedType = 'leaf',
+  filters = makeFilters(),
+  styleManager = makeStyleManager(),
+  group = false,
+  styleOnly = false,
+}: MountOptions = {}) {
   const closeEvents: unknown[] = [];
+  const filterControls = filters ?? undefined;
+  const props = shallowReactive({
+    selectedType,
+    filterControls,
+    styleManager,
+    group,
+    styleOnly,
+  });
   let child: InstanceType<typeof TypeEditor> | undefined;
   const Host = defineComponent({
     setup: () => () => h(TypeEditor, {
-      props: {
-        selectedType: 'leaf',
-        filterControls: filters,
-        styleManager,
-      },
+      props,
       on: { close: () => closeEvents.push([]) },
       ref: (instance) => {
         if (instance && !(instance instanceof Element)) {
@@ -64,68 +102,265 @@ function mountEditor(filters = makeFilters(), styleManager = makeStyleManager())
   if (!child) {
     throw new Error('TypeEditor did not mount');
   }
+  const setProps = async (next: Partial<typeof props>) => {
+    Object.assign(props, next);
+    await nextTick();
+  };
   return {
-    filters, styleManager, wrapper, vm: child, closeEvents,
+    filters: filterControls as TrackFilterControls,
+    styleManager,
+    wrapper,
+    vm: child,
+    closeEvents,
+    setProps,
   };
 }
 
-describe('TypeEditor hierarchy safety', () => {
-  beforeEach(() => promptMock.mockReset());
-
-  it('allows clearing settings for an unused hierarchy parent', async () => {
-    const filters = makeFilters();
-    promptMock.mockResolvedValue(true);
-    const { vm } = mountEditor(filters);
-    await vm.clickDeleteType('leaf');
-    expect(promptMock).toHaveBeenCalled();
-    expect(filters.deleteType).toHaveBeenCalledWith('leaf');
+describe('TypeEditor hierarchy editing', () => {
+  beforeEach(() => {
+    promptMock.mockReset();
+    provideMocks.readOnly = false;
   });
 
-  it('disables deletion for a type used only by a camera the merged view hides', () => {
-    const filters = makeFilters();
-    vi.mocked(filters.typeInUseOnAnyCamera).mockReturnValue(true);
-    const { vm, wrapper } = mountEditor(filters);
-    expect(vm.deleteBlocked).toBe(true);
-    expect(wrapper.text()).toContain('Only types without any annotations can be deleted.');
+  it('shows Parent Type only for dataset track types and initializes its parent', () => {
+    const track = mountEditor();
+    expect(track.vm.showParentType).toBe(true);
+    expect(track.vm.data.editingParent).toBe('root');
+    const autocomplete = track.wrapper.find('v-autocomplete');
+    expect(autocomplete.exists()).toBe(true);
+    expect(autocomplete.attributes('auto-select-first')).toBe('');
+    expect(autocomplete.attributes('no-data-text')).toBe(
+      'No matching type. Add it from Type Settings first.',
+    );
+
+    const group = mountEditor({ filters: makeGroupFilters(), group: true });
+    expect(group.vm.showParentType).toBe(false);
+    expect(group.wrapper.find('v-autocomplete').exists()).toBe(false);
+
+    const savedStyle = mountEditor({ filters: null, styleOnly: true });
+    expect(savedStyle.vm.showParentType).toBe(false);
+    expect(savedStyle.wrapper.find('v-autocomplete').exists()).toBe(false);
   });
 
-  it('leaves an unused leaf unchanged when deletion is canceled', async () => {
-    promptMock.mockResolvedValue(false);
-    const { filters, vm, closeEvents } = mountEditor();
-    await vm.clickDeleteType('leaf');
-    expect(promptMock).toHaveBeenCalledTimes(1);
-    expect(filters.deleteType).not.toHaveBeenCalled();
-    expect(closeEvents).toHaveLength(0);
+  it('bounds empty-query choices with the selected parent first', () => {
+    const names = [
+      'leaf',
+      'current',
+      ...Array.from({ length: 100 }, (_, i) => `type${i.toString().padStart(3, '0')}`),
+    ];
+    const { vm } = mountEditor({
+      filters: makeFilters({ allTypes: names, hierarchy: { leaf: 'current' } }),
+    });
+    expect(vm.parentOptions).toHaveLength(50);
+    expect(vm.parentOptions[0]).toBe('current');
+    expect(vm.parentOptions.slice(1)).toEqual([...vm.parentOptions.slice(1)].sort());
   });
 
-  it('keeps the editor open for a rejected rename and allows a corrected retry', () => {
+  it('orders prefix matches before substring matches and excludes old and final names', async () => {
+    const { vm } = mountEditor({
+      filters: makeFilters({
+        allTypes: ['leaf', 'fin', 'current', 'alpine', 'alpha', 'coral'],
+        hierarchy: { leaf: 'current' },
+      }),
+    });
+    vm.data.editingType = 'fin';
+    vm.data.parentSearch = 'al';
+    await nextTick();
+    expect(vm.parentOptions).toEqual(['current', 'alpha', 'alpine', 'coral']);
+    expect(vm.parentOptions).not.toContain('leaf');
+    expect(vm.parentOptions).not.toContain('fin');
+  });
+
+  it('sorts parent choices by Unicode code point', () => {
+    const privateUse = '\uE000';
+    const astral = '\u{10000}';
+    const { vm } = mountEditor({
+      filters: makeFilters({
+        allTypes: ['leaf', 'current', astral, privateUse],
+        hierarchy: { leaf: 'current' },
+      }),
+    });
+    expect(vm.parentOptions).toEqual(['current', privateUse, astral]);
+  });
+
+  it('does not save free text that was not selected', () => {
     const {
       filters, styleManager, vm, closeEvents,
     } = mountEditor();
-    vi.mocked(filters.updateTypeName).mockImplementationOnce(() => {
-      throw new TypeHierarchyError('self edge "root -> root"', 'conflict');
-    });
-    vm.data.editingType = 'root';
+    vm.data.parentSearch = 'not an existing type';
     vm.acceptChanges();
-    expect(vm.data.renameError).toBe(
-      'Type hierarchy is invalid: self edge "root -> root". No types were changed.',
-    );
+    expect(vm.parentSearchUnresolved).toBe(true);
+    expect(filters.updateTypeDefinition).not.toHaveBeenCalled();
     expect(styleManager.updateTypeStyle).not.toHaveBeenCalled();
     expect(closeEvents).toHaveLength(0);
+  });
 
+  it('accepts a cleared parent draft without pointer input', () => {
+    const { vm } = mountEditor();
+    vm.data.editingParent = null;
+    vm.data.parentSearch = null;
+    expect(vm.data.editingParent).toBeNull();
+    expect(vm.data.parentSearch).toBeNull();
+  });
+
+  it('saves name and parent through one atomic operation', () => {
+    const { filters, vm, closeEvents } = mountEditor();
     vm.data.editingType = 'fin';
+    vm.data.editingParent = 'branch';
+    vm.data.parentSearch = 'branch';
     vm.acceptChanges();
-    expect(vm.data.renameError).toBe('');
-    expect(filters.updateTypeName).toHaveBeenLastCalledWith({
-      currentType: 'leaf', newType: 'fin',
+    expect(filters.updateTypeDefinition).toHaveBeenCalledTimes(1);
+    expect(filters.updateTypeDefinition).toHaveBeenCalledWith({
+      currentType: 'leaf', newType: 'fin', parent: 'branch',
     });
     expect(closeEvents).toHaveLength(1);
   });
 
-  it('promotes a hierarchy-only heading only after a style value changes', () => {
-    const { filters, vm } = mountEditor();
+  it('applies first-edge creation and final-edge clearing through the same operation', () => {
+    const first = mountEditor({
+      filters: makeFilters({ allTypes: ['leaf', 'root'], hierarchy: undefined }),
+    });
+    first.vm.data.editingParent = 'root';
+    first.vm.data.parentSearch = 'root';
+    first.vm.acceptChanges();
+    expect(first.filters.updateTypeDefinition).toHaveBeenCalledWith({
+      currentType: 'leaf', newType: 'leaf', parent: 'root',
+    });
+
+    const final = mountEditor();
+    final.vm.data.editingParent = null;
+    final.vm.data.parentSearch = null;
+    final.vm.acceptChanges();
+    expect(final.filters.updateTypeDefinition).toHaveBeenCalledWith({
+      currentType: 'leaf', newType: 'leaf', parent: undefined,
+    });
+  });
+
+  it('keeps all style changes staged when hierarchy preflight fails', () => {
+    const {
+      filters, styleManager, vm, closeEvents,
+    } = mountEditor();
+    vi.mocked(filters.updateTypeDefinition).mockImplementationOnce(() => {
+      throw new TypeHierarchyError('self edge "root -> root"', 'conflict');
+    });
+    vm.data.editingType = 'root';
+    vm.data.editingParent = 'root';
+    vm.data.parentSearch = 'root';
+    vm.data.editingColor = '#abcdef';
     vm.acceptChanges();
+    expect(vm.data.definitionError).toBe(
+      'Type hierarchy is invalid: self edge "root -> root". No type changes were applied.',
+    );
     expect(filters.importTypes).not.toHaveBeenCalled();
+    expect(styleManager.updateTypeStyle).not.toHaveBeenCalled();
+    expect(closeEvents).toHaveLength(0);
+  });
+
+  it('preserves group and Saved Styles rename paths', () => {
+    const groupFilters = makeGroupFilters();
+    const group = mountEditor({ filters: groupFilters, group: true });
+    group.vm.data.editingType = 'renamed-group';
+    group.vm.acceptChanges();
+    expect(groupFilters.updateTypeName).toHaveBeenCalledWith({
+      currentType: 'leaf', newType: 'renamed-group',
+    });
+
+    const style = mountEditor({ filters: null, styleOnly: true });
+    style.vm.data.editingType = 'renamed-style';
+    style.vm.acceptChanges();
+    expect(style.styleManager.renameTypeStyle).toHaveBeenCalledWith('leaf', 'renamed-style');
+  });
+
+  it('prompts truthfully when deleting hierarchy parents and leaves cancellation unchanged', async () => {
+    const middle = mountEditor({
+      selectedType: 'branch',
+      filters: makeFilters({
+        allTypes: ['root', 'branch', 'leaf'],
+        hierarchy: { branch: 'root', leaf: 'branch' },
+      }),
+    });
+    promptMock.mockResolvedValueOnce(false);
+    await middle.vm.clickDeleteType('branch');
+    expect(promptMock).toHaveBeenLastCalledWith({
+      title: 'Confirm',
+      text: 'Remove "branch" from the hierarchy? Its children will move under "root". Stored annotations will not be changed.',
+      confirm: true,
+    });
+    expect(middle.filters.deleteType).not.toHaveBeenCalled();
+
+    const root = mountEditor({
+      selectedType: 'root',
+      filters: makeFilters({
+        allTypes: ['root', 'leaf'], hierarchy: { leaf: 'root' },
+      }),
+    });
+    promptMock.mockResolvedValueOnce(true);
+    await root.vm.clickDeleteType('root');
+    expect(promptMock).toHaveBeenLastCalledWith({
+      title: 'Confirm',
+      text: 'Remove "root" from the hierarchy? Its children will become top-level types. Stored annotations will not be changed.',
+      confirm: true,
+    });
+    expect(root.filters.deleteType).toHaveBeenCalledWith('root');
+
+    const leaf = mountEditor();
+    promptMock.mockResolvedValueOnce(true);
+    await leaf.vm.clickDeleteType('leaf');
+    expect(promptMock).toHaveBeenLastCalledWith({
+      title: 'Confirm', text: 'Delete the unused type "leaf"?', confirm: true,
+    });
+  });
+
+  it('does not finish an asynchronous deletion after the editor unmounts', async () => {
+    let resolvePrompt: ((value: boolean) => void) | undefined;
+    promptMock.mockReturnValueOnce(new Promise<boolean>((resolve) => {
+      resolvePrompt = resolve;
+    }));
+    const {
+      filters, vm, wrapper, closeEvents,
+    } = mountEditor();
+    const deletion = vm.clickDeleteType('leaf');
+    wrapper.destroy();
+    if (!resolvePrompt) {
+      throw new Error('Prompt resolver was not initialized');
+    }
+    resolvePrompt(true);
+    await deletion;
+    expect(filters.deleteType).not.toHaveBeenCalled();
+    expect(closeEvents).toHaveLength(0);
+  });
+
+  it('blocks deletion for all-camera usage and disables both name fields in Read Only Mode', () => {
+    provideMocks.readOnly = true;
+    const filters = makeFilters();
+    vi.mocked(filters.typeInUseOnAnyCamera).mockReturnValue(true);
+    const { vm, wrapper } = mountEditor({ filters });
+    expect(vm.deleteBlocked).toBe(true);
+    expect(wrapper.text()).toContain('Only types without annotations can be deleted.');
+    expect(wrapper.find('v-autocomplete').attributes('disabled')).toBe('true');
+    expect(wrapper.find('v-text-field').attributes('disabled')).toBe('true');
+  });
+
+  it('reinitializes the complete draft when the selected type changes', async () => {
+    const filters = makeFilters({
+      allTypes: ['leaf', 'root', 'other', 'branch'],
+      hierarchy: { leaf: 'root', other: 'branch' },
+    });
+    const { vm, setProps } = mountEditor({ filters });
+    vm.data.editingParent = 'branch';
+    vm.data.editingColor = '#abcdef';
+    await setProps({ selectedType: 'other' });
+    expect(vm.data.selectedType).toBe('other');
+    expect(vm.data.editingType).toBe('other');
+    expect(vm.data.editingParent).toBe('branch');
+    expect(vm.data.parentSearch).toBe('branch');
+    expect(vm.data.editingColor).toBe('color:other');
+  });
+
+  it('promotes a hierarchy-only heading only after a style value changes', () => {
+    const unchanged = mountEditor();
+    unchanged.vm.acceptChanges();
+    expect(unchanged.filters.importTypes).not.toHaveBeenCalled();
 
     const changed = mountEditor();
     changed.vm.data.editingColor = '#abcdef';

--- a/client/src/components/TypeEditor.vue
+++ b/client/src/components/TypeEditor.vue
@@ -105,18 +105,13 @@ export default defineComponent({
       prefixMatches.sort(compareTypeNames);
       substringMatches.sort(compareTypeNames);
 
-      const options: string[] = [];
       const currentParent = data.editingParent;
+      const options = [...prefixMatches, ...substringMatches]
+        .filter((type) => type !== currentParent);
       if (currentParent !== null && !excluded.has(currentParent)) {
-        options.push(currentParent);
+        options.unshift(currentParent);
       }
-      [...prefixMatches, ...substringMatches].some((type) => {
-        if (!options.includes(type)) {
-          options.push(type);
-        }
-        return options.length >= MAX_PARENT_OPTIONS;
-      });
-      return options;
+      return options.slice(0, MAX_PARENT_OPTIONS);
     });
     const parentSearchUnresolved = computed(() => {
       const search = data.parentSearch;
@@ -297,7 +292,7 @@ export default defineComponent({
                 :label="readOnlyMode
                   ? 'Type Name (disabled in ReadOnly Mode)'
                   : (isStyleOnly ? 'Style Name' : 'Type Name')"
-                hide-details
+                hide-details="auto"
               />
             </v-col>
           </v-row>
@@ -307,6 +302,7 @@ export default defineComponent({
                 v-model="data.editingParent"
                 :search-input.sync="data.parentSearch"
                 :items="parentOptions"
+                no-filter
                 :disabled="readOnlyMode"
                 label="Parent Type"
                 placeholder="Top level"

--- a/client/src/components/TypeEditor.vue
+++ b/client/src/components/TypeEditor.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
 import {
-  computed, defineComponent, PropType, reactive, toRef, unref, watch,
+  computed, defineComponent, onBeforeUnmount, PropType, reactive, toRef, unref, watch,
 } from 'vue';
 
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
-import { TypeHierarchyError } from 'dive-common/typeHierarchy';
+import { compareTypeNames, TypeHierarchyError } from 'dive-common/typeHierarchy';
 
 import TrackFilterControls from '../TrackFilterControls';
 import BaseFilterControls from '../BaseFilterControls';
@@ -12,6 +12,8 @@ import type Group from '../Group';
 import type StyleManager from '../StyleManager';
 import type Track from '../track';
 import { useReadOnlyMode } from '../provides';
+
+const MAX_PARENT_OPTIONS = 50;
 
 export default defineComponent({
   name: 'TypeEditor',
@@ -45,17 +47,27 @@ export default defineComponent({
   },
 
   setup(props, { emit }) {
-    const typeStylingRef = props.styleManager.typeStyling;
-    const trackFilters = props.filterControls;
+    const trackFilters = computed(() => (
+      props.filterControls instanceof TrackFilterControls ? props.filterControls : undefined
+    ));
     const isStyleOnly = computed(() => props.styleOnly || !props.filterControls);
-    const usedTypesRef = computed(() => trackFilters?.usedTypes.value ?? []);
+    const showParentType = computed(() => (
+      !props.group && !isStyleOnly.value && trackFilters.value !== undefined
+    ));
+    const usedTypesRef = computed(() => props.filterControls?.usedTypes.value ?? []);
     const readOnlyMode = useReadOnlyMode();
     const { prompt } = usePrompt();
+    let active = true;
+    onBeforeUnmount(() => {
+      active = false;
+    });
 
     const data = reactive({
       selectedColor: '',
       selectedType: '',
       editingType: '',
+      editingParent: null as string | null,
+      parentSearch: null as string | null,
       editingColor: '',
       editingThickness: 5,
       editingFill: false,
@@ -63,7 +75,52 @@ export default defineComponent({
       editingShowLabel: true,
       editingShowConfidence: true,
       valid: true,
-      renameError: '',
+      definitionError: '',
+    });
+
+    const parentQuery = computed(() => {
+      const search = data.parentSearch ?? '';
+      return search === data.editingParent ? '' : search;
+    });
+    const parentOptions = computed(() => {
+      const controls = trackFilters.value;
+      if (!controls) {
+        return [];
+      }
+      const excluded = new Set([data.selectedType, data.editingType]);
+      const query = parentQuery.value.toLowerCase();
+      const prefixMatches: string[] = [];
+      const substringMatches: string[] = [];
+      controls.allTypes.value.forEach((type) => {
+        if (excluded.has(type)) {
+          return;
+        }
+        const candidate = type.toLowerCase();
+        if (candidate.startsWith(query)) {
+          prefixMatches.push(type);
+        } else if (candidate.includes(query)) {
+          substringMatches.push(type);
+        }
+      });
+      prefixMatches.sort(compareTypeNames);
+      substringMatches.sort(compareTypeNames);
+
+      const options: string[] = [];
+      const currentParent = data.editingParent;
+      if (currentParent !== null && !excluded.has(currentParent)) {
+        options.push(currentParent);
+      }
+      [...prefixMatches, ...substringMatches].some((type) => {
+        if (!options.includes(type)) {
+          options.push(type);
+        }
+        return options.length >= MAX_PARENT_OPTIONS;
+      });
+      return options;
+    });
+    const parentSearchUnresolved = computed(() => {
+      const search = data.parentSearch;
+      return search !== null && search !== '' && search !== data.editingParent;
     });
 
     const currentStyleValue = () => ({
@@ -77,32 +134,40 @@ export default defineComponent({
     let styleSnapshot = currentStyleValue();
 
     function acceptChanges() {
-      data.renameError = '';
-      if (data.editingType !== data.selectedType) {
-        if (isStyleOnly.value) {
+      if (!data.valid || parentSearchUnresolved.value) {
+        return;
+      }
+      data.definitionError = '';
+      if (isStyleOnly.value) {
+        if (data.editingType !== data.selectedType) {
           props.styleManager.renameTypeStyle(data.selectedType, data.editingType);
-        } else if (trackFilters) {
-          const updatedTypeObj = {
+        }
+      } else if (trackFilters.value) {
+        try {
+          trackFilters.value.updateTypeDefinition({
             currentType: data.selectedType,
             newType: data.editingType,
-          };
-          try {
-            trackFilters.updateTypeName(updatedTypeObj);
-          } catch (error) {
-            if (error instanceof TypeHierarchyError) {
-              data.renameError = `Type hierarchy is invalid: ${error.reason}. No types were changed.`;
-              return;
-            }
-            throw error;
+            parent: data.editingParent ?? undefined,
+          });
+        } catch (error) {
+          if (error instanceof TypeHierarchyError) {
+            data.definitionError = `Type hierarchy is invalid: ${error.reason}. No type changes were applied.`;
+            return;
           }
+          throw error;
         }
+      } else if (props.filterControls && data.editingType !== data.selectedType) {
+        props.filterControls.updateTypeName({
+          currentType: data.selectedType,
+          newType: data.editingType,
+        });
       }
       const styleValue = currentStyleValue();
       const styleChanged = Object.entries(styleValue).some(
         ([key, value]) => styleSnapshot[key as keyof typeof styleSnapshot] !== value,
       );
-      if (styleChanged && trackFilters instanceof TrackFilterControls) {
-        trackFilters.importTypes([data.editingType], false);
+      if (styleChanged && trackFilters.value) {
+        trackFilters.value.importTypes([data.editingType], false);
       }
       props.styleManager.updateTypeStyle({ type: data.editingType, value: styleValue });
       emit('close');
@@ -115,20 +180,30 @@ export default defineComponent({
           text: `Do you want to delete the saved style for "${type}"?`,
           confirm: true,
         });
-        if (result) {
+        if (result && active) {
           props.styleManager.deleteTypeStyle(type);
           emit('close');
         }
         return;
       }
-      const text = `Do you want to delete this empty Type: ${type}`;
+      const hierarchy = trackFilters.value?.typeHierarchy.value;
+      const hasChildren = hierarchy
+        ? Object.values(hierarchy).some((parent) => parent === type)
+        : false;
+      let text = `Delete the unused type "${type}"?`;
+      if (hasChildren) {
+        const parent = hierarchy?.[type];
+        text = parent
+          ? `Remove "${type}" from the hierarchy? Its children will move under "${parent}". Stored annotations will not be changed.`
+          : `Remove "${type}" from the hierarchy? Its children will become top-level types. Stored annotations will not be changed.`;
+      }
       const result = await prompt({
         title: 'Confirm',
         text,
         confirm: true,
       });
-      if (result && trackFilters) {
-        if (trackFilters.deleteType(type)) {
+      if (result && active && props.filterControls) {
+        if (props.filterControls.deleteType(type)) {
           emit('close');
         }
       }
@@ -137,32 +212,39 @@ export default defineComponent({
     function init() {
       data.selectedType = props.selectedType;
       data.editingType = props.selectedType;
-      data.editingColor = typeStylingRef.value.color(props.selectedType);
-      data.editingThickness = typeStylingRef.value.strokeWidth(props.selectedType);
-      data.editingFill = typeStylingRef.value.fill(props.selectedType);
-      data.editingOpacity = typeStylingRef.value.opacity(props.selectedType);
-      const labelSettings = typeStylingRef.value.labelSettings(props.selectedType);
+      data.editingParent = trackFilters.value?.typeHierarchy.value?.[props.selectedType] ?? null;
+      data.parentSearch = data.editingParent;
+      const typeStyling = props.styleManager.typeStyling.value;
+      data.editingColor = typeStyling.color(props.selectedType);
+      data.editingThickness = typeStyling.strokeWidth(props.selectedType);
+      data.editingFill = typeStyling.fill(props.selectedType);
+      data.editingOpacity = typeStyling.opacity(props.selectedType);
+      const labelSettings = typeStyling.labelSettings(props.selectedType);
       data.editingShowConfidence = labelSettings.showConfidence;
       data.editingShowLabel = labelSettings.showLabel;
-      data.renameError = '';
+      data.definitionError = '';
       styleSnapshot = currentStyleValue();
     }
     watch(toRef(props, 'selectedType'), init);
     init();
 
+    const nameRules = [(val: string) => !!val?.trim() || 'Name is required'];
     const thicknessRules = [(val: number) => val >= 0 || 'Must be >= 0'];
 
     return {
       data,
       isStyleOnly,
+      showParentType,
       readOnlyMode,
+      parentOptions,
+      parentSearchUnresolved,
       acceptChanges,
       clickDeleteType,
+      nameRules,
       thicknessRules,
       deleteBlocked: computed(() => (
         unref(usedTypesRef).includes(data.selectedType)
-        || (trackFilters instanceof TrackFilterControls
-          && trackFilters.typeInUseOnAnyCamera(data.selectedType))
+        || (trackFilters.value?.typeInUseOnAnyCamera(data.selectedType) ?? false)
       )),
     };
   },
@@ -199,11 +281,11 @@ export default defineComponent({
       </v-card-subtitle>
       <v-card-text>
         <v-alert
-          v-if="data.renameError"
+          v-if="data.definitionError"
           type="error"
           dense
         >
-          {{ data.renameError }}
+          {{ data.definitionError }}
         </v-alert>
         <v-form v-model="data.valid">
           <v-row>
@@ -211,10 +293,28 @@ export default defineComponent({
               <v-text-field
                 v-model="data.editingType"
                 :disabled="readOnlyMode"
+                :rules="nameRules"
                 :label="readOnlyMode
                   ? 'Type Name (disabled in ReadOnly Mode)'
                   : (isStyleOnly ? 'Style Name' : 'Type Name')"
                 hide-details
+              />
+            </v-col>
+          </v-row>
+          <v-row v-if="showParentType">
+            <v-col>
+              <v-autocomplete
+                v-model="data.editingParent"
+                :search-input.sync="data.parentSearch"
+                :items="parentOptions"
+                :disabled="readOnlyMode"
+                label="Parent Type"
+                placeholder="Top level"
+                hint="Select the immediate parent. Clear to make this type top-level."
+                no-data-text="No matching type. Add it from Type Settings first."
+                clearable
+                auto-select-first
+                persistent-hint
               />
             </v-col>
           </v-row>
@@ -312,7 +412,7 @@ export default defineComponent({
           >
             {{ isStyleOnly
               ? 'Remove this saved style override.'
-              : 'Only types without any annotations can be deleted.' }}
+              : 'Only types without annotations can be deleted.' }}
           </span>
         </v-tooltip>
         <v-spacer />
@@ -326,7 +426,7 @@ export default defineComponent({
         <v-btn
           color="primary"
           depressed
-          :disabled="!data.valid"
+          :disabled="!data.valid || parentSearchUnresolved"
           @click="acceptChanges"
         >
           Save

--- a/client/src/components/TypeEditor.vue
+++ b/client/src/components/TypeEditor.vue
@@ -117,6 +117,33 @@ export default defineComponent({
       const search = data.parentSearch;
       return search !== null && search !== '' && search !== data.editingParent;
     });
+    const definitionValidation = computed(() => {
+      const controls = trackFilters.value;
+      if (!controls || !data.editingType.trim() || parentSearchUnresolved.value) {
+        return undefined;
+      }
+      return controls.validateTypeDefinition({
+        currentType: data.selectedType,
+        newType: data.editingType,
+        parent: data.editingParent ?? undefined,
+      });
+    });
+    const nameDefinitionError = computed(() => (
+      definitionValidation.value?.field === 'name'
+        ? `Type hierarchy is invalid: ${definitionValidation.value.reason}.`
+        : ''
+    ));
+    const parentDefinitionError = computed(() => {
+      if (parentSearchUnresolved.value) {
+        return 'Select an existing type from the list, or clear the field.';
+      }
+      return definitionValidation.value?.field === 'parent'
+        ? `Type hierarchy is invalid: ${definitionValidation.value.reason}.`
+        : '';
+    });
+    const saveDisabled = computed(() => (
+      !data.valid || nameDefinitionError.value !== '' || parentDefinitionError.value !== ''
+    ));
 
     const currentStyleValue = () => ({
       color: data.editingColor,
@@ -129,7 +156,7 @@ export default defineComponent({
     let styleSnapshot = currentStyleValue();
 
     function acceptChanges() {
-      if (!data.valid || parentSearchUnresolved.value) {
+      if (saveDisabled.value) {
         return;
       }
       data.definitionError = '';
@@ -233,6 +260,9 @@ export default defineComponent({
       readOnlyMode,
       parentOptions,
       parentSearchUnresolved,
+      nameDefinitionError,
+      parentDefinitionError,
+      saveDisabled,
       acceptChanges,
       clickDeleteType,
       nameRules,
@@ -289,6 +319,7 @@ export default defineComponent({
                 v-model="data.editingType"
                 :disabled="readOnlyMode"
                 :rules="nameRules"
+                :error-messages="nameDefinitionError"
                 :label="readOnlyMode
                   ? 'Type Name (disabled in ReadOnly Mode)'
                   : (isStyleOnly ? 'Style Name' : 'Type Name')"
@@ -308,6 +339,7 @@ export default defineComponent({
                 placeholder="Top level"
                 hint="Select the immediate parent. Clear to make this type top-level."
                 no-data-text="No matching type. Add it from Type Settings first."
+                :error-messages="parentDefinitionError"
                 clearable
                 auto-select-first
                 persistent-hint
@@ -422,7 +454,7 @@ export default defineComponent({
         <v-btn
           color="primary"
           depressed
-          :disabled="!data.valid || parentSearchUnresolved"
+          :disabled="saveDisabled"
           @click="acceptChanges"
         >
           Save

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -49,6 +49,7 @@ A parent row's checkbox always toggles its complete subtree. The heading checkbo
 While a hierarchy is active, **Prevent Cascade Types** is disabled and shows: `Not applicable to hierarchical types; DIVE selects the deepest qualifying type.` Its saved value is preserved and becomes active again when the hierarchy is removed.
 
 Changes to **Type Name** and **Parent Type** are staged together and applied by one Save after the complete result passes validation. A rename involved in a hierarchy is rejected if one track already contains both the old and new type names. An invalid final hierarchy, such as a self-edge, conflicting parent, or cycle, is also rejected without applying either the name or parent change.
+Restrictions that can be determined from the draft are shown directly under the affected field as soon as they are known, and Save remains disabled until the draft is valid. Save still validates the complete result again before applying it.
 
 Deleting an unused hierarchy heading removes that heading while preserving its descendants. Its immediate children move under the deleted heading's parent, or become top-level when the deleted heading had no parent. This promotion does not rename descendants or rewrite their stored annotation confidence pairs.
 

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -40,7 +40,7 @@ highest-confidence pair, keeping the first stored pair when scores tie, because 
 have each viewer's checked types and confidence thresholds. Viewer counts and filtering use the
 hierarchy-resolved displayed type.
 
-Hierarchy members render as an expandable tree rather than ordinary flat rows. Parent checkboxes control their complete subtrees, and parent counts include descendants. The Type List does not offer hierarchy editing.
+Hierarchy members render as an expandable tree rather than ordinary flat rows. Parent checkboxes control their complete subtrees, and parent counts include descendants. To edit a type's hierarchy relationship, open its existing pencil editor and select its immediate **Parent Type**. The searchable list includes existing configured, used, and hierarchy-only track types. If the parent does not exist yet, add it through **+ Types** in Type Settings first. Clear **Parent Type** to make the edited type top-level.
 
 A parent row's checkbox always toggles its complete subtree. The heading checkbox is narrower: it skips a parent shown only as ancestor context for a match below it.
 
@@ -48,7 +48,9 @@ A parent row's checkbox always toggles its complete subtree. The heading checkbo
 
 While a hierarchy is active, **Prevent Cascade Types** is disabled and shows: `Not applicable to hierarchical types; DIVE selects the deepest qualifying type.` Its saved value is preserved and becomes active again when the hierarchy is removed.
 
-Renaming a hierarchy member updates exact hierarchy references only after the complete result passes validation. A rename that would create a self-edge, conflicting parent, cycle, or duplicate type pair on one track is rejected without changing types. Deleting an unused type clears only its optional filter and style settings. The hierarchy member, edges, checked state, and any children remain unchanged, so hierarchy-only rows stay available under **Show Empty** and use default styling and thresholds.
+Changes to **Type Name** and **Parent Type** are staged together and applied by one Save after the complete result passes validation. A rename involved in a hierarchy is rejected if one track already contains both the old and new type names. An invalid final hierarchy, such as a self-edge, conflicting parent, or cycle, is also rejected without applying either the name or parent change.
+
+Deleting an unused hierarchy heading removes that heading while preserving its descendants. Its immediate children move under the deleted heading's parent, or become top-level when the deleted heading had no parent. This promotion does not rename descendants or rewrite their stored annotation confidence pairs.
 
 ## Type Style Editor
 
@@ -58,6 +60,7 @@ The type style editor controls the visual appearance of annotations in all other
 
 
 * **Type Name** - You can change the name for the type and it will update all subsequent tracks that are using that Type.
+* **Parent Type** - Search for and select the type's immediate parent. Clear the field to make the type top-level. Add a missing parent through **+ Types** in Type Settings before selecting it.
 * **Show Label** - show the type name label in the text above each box.
 * **Show Confidence** - show the confidence value in the text above each box.
 * **Box Border Thickness** - the line thickness can be changed to make a type stand out more or less


### PR DESCRIPTION
# Edit type hierarchy relationships in the Type Editor

DIVE can display and import type hierarchies, but users currently have to edit configuration JSON
to create or change the relationships.

This PR adds **Parent Type** to the existing Type Editor opened from a Type List row's pencil. There
is no separate hierarchy mode: types remain ordinary types, and a type may optionally have a parent.

Parent-only edits change the dataset hierarchy without rewriting stored annotation confidence
pairs. A dataset with no parent edges keeps its existing flat behavior.

### Changes

- Add a searchable, clearable **Parent Type** field with up to 50 existing-type suggestions. Add
  missing parents through **+ Types** in Type Settings.
- Create, change, or clear parent relationships without rewriting annotation confidence pairs.
- Validate name and parent edits together, show errors inline, and disable invalid saves. Recheck
  the complete edit before applying any changes.
- Delete unused headings by promoting their children; block deletion if any camera uses the type.
- Preserve flat rename behavior and retain standalone types when the final parent edge is removed.
- Discard drafts on dataset changes, respect Read Only Mode, and keep parent controls out of group
  and Saved Styles editors.
- Add regression tests and update the Type List documentation.

### Validation

- Full non-integration gate passed on `1cfa6e0a`: 400 server tests, 1,346 client/Desktop tests,
  server and client lint, Web build, and Electron AppImage build.
- Client typecheck passed.
- Desktop and multicamera manual verification remain pending. Live integration tests were not run.

### Manual tests

Test data is available from
[PaulHax/dive-devkit](https://github.com/PaulHax/dive-devkit/tree/781274a).

From a workspace containing `dive/` and `dive-devkit/`:

```bash
dive-devkit/tools/up.sh <worktree>
cd dive/<worktree>/client
VITE_PORT=3000 VITE_API_PROXY_TARGET=http://localhost:8010 npm run serve
```

#### Create and remove a hierarchy edge

1. Open **Flat classification three tracks**.
2. Hover over `tuna` in the Type List, click its pencil, and select `fish` as Parent Type.
3. Save the Type Editor, then save the dataset and reload.
4. Reopen `tuna`, clear Parent Type, save the editor and dataset, and reload again.

Verify:

- `tuna` appears beneath `fish` after the first save and reload.
- Clearing the final edge returns the Type List to flat behavior.
- The `fish`, `tuna`, and `dolphin` annotations and confidence values are unchanged.
- Both `fish` and `tuna` remain available after the final edge is removed.

#### Reparent and validate atomically

1. Open **Hierarchical classification multipair**.
2. Change `bluefin-tuna` from parent `tuna` to parent `red-snapper`.
3. Confirm its tree position changes without changing the stored `bluefin-tuna`, `tuna`, and `fish`
   confidence values, then restore its original parent.
4. Edit `fish` and select `bluefin-tuna` as its parent.
5. Enter unmatched text in Parent Type without selecting a suggestion.
6. Make a valid parent edit and press Cancel.

Verify:

- Saving a valid reparent updates the tree immediately.
- Selecting the cyclic parent shows an error beneath Parent Type before saving.
- Save is disabled while the cycle exists, and no changes are applied.
- Unmatched text directs the user to add the type through Type Settings.
- Save is disabled while the parent text remains unresolved.
- Cancel leaves the tree unchanged.
- Cancel leaves the save badge unchanged.

#### Rename and reparent together

1. In **Hierarchical classification multipair**, edit the unused `unobserved-species` type.
2. Change its name and select `fish` as its new parent in the same editor session.
3. Save the Type Editor.

Verify:

- The old name disappears.
- The new name appears beneath `fish`.
- Both changes apply together, with no intermediate hierarchy or partial rename visible.

#### Delete unused hierarchy headings

1. Open a fresh **Hierarchical classification multipair** dataset.
2. Delete `unobserved-genus`.
3. Delete the unused top-level `eukaryota`.
4. Try to delete a used type such as `bluefin-tuna`.
5. Save the dataset and reload.

Verify:

- `unobserved-species` moves directly beneath `vertebrata`.
- `animalia` becomes top-level after `eukaryota` is removed.
- Descendant names and confidence pairs are unchanged.
- Deletion remains disabled for the used type.
- The promoted hierarchy persists after reload.

#### Parent search

1. Open **SEFSC-SEAMAP fish taxonomy**.
2. Edit `seriola_rivoliana` and search Parent Type by both prefix and substring.
3. Use the arrow keys and Enter to select a result, then clear the field and press Cancel.

Verify:

- Suggestions remain responsive and appear in a consistent order.
- Arrow keys and Enter select a result.
- The current parent remains available.
- Clearing the field represents a top-level type.
- No new type is created.

#### Multicamera persistence

1. Open **Hierarchical classification multicam divergent**.
2. Reparent a used type, save the Type Editor and dataset, then switch cameras and reload.
3. Attempt to delete a type that is present in stored confidence pairs.

Verify:

- Both camera views use the same edited hierarchy after reload.
- Reparenting does not rewrite either camera's confidence vector.
- Usage on any camera keeps deletion disabled.

This is a follow-up to
[Render hierarchical types as a tree](https://github.com/Kitware/dive/pull/1867).
