### PR TITLE
Stop passing --no-embedded-pipe to viame train

### DIFF
--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -920,7 +920,6 @@ async function train(
     `--config "${configFilePath}"`,
     '--no-query',
     '--no-adv-prints',
-    '--no-embedded-pipe',
   ];
 
   if (resumeDir) {

--- a/server/dive_tasks/run_training.py
+++ b/server/dive_tasks/run_training.py
@@ -152,7 +152,6 @@ def train_pipeline(self: Task, params: TrainingJob):
             "--config",
             shlex.quote(str(config_file)),
             "--no-query",
-            "--no-embedded-pipe",
         ]
 
         if annotated_frames_only:

--- a/server/tests/test_remote_ffprobe.py
+++ b/server/tests/test_remote_ffprobe.py
@@ -84,7 +84,7 @@ def test_sanitize_subprocess_args_keeps_header_file_path():
 def test_sanitize_subprocess_args_keeps_shell_command_string():
     cmd = (
         '. /opt/noaa/viame/setup_viame.sh && KWIVER_DEFAULT_LOG_LEVEL=warn '
-        '/opt/noaa/viame/bin/viame train --no-query --no-embedded-pipe'
+        '/opt/noaa/viame/bin/viame train --no-query'
     )
     assert utils.sanitize_subprocess_args_for_log(cmd) == cmd
 


### PR DESCRIPTION
- VIAME's training tool now produces runnable pipelines by default, with `--embedded-pipe` as the opt-in for fragments; the old flag is a deprecated no-op
- Drops it from the server and desktop training invocations and the arg-sanitizer test
- Pair with a VIAME build containing the inverted default; on older builds the flag is still required