### PR TITLE
Desktop: list every trained pipe, not just the first

### DIFF
--- a/client/platform/desktop/backend/native/common.spec.ts
+++ b/client/platform/desktop/backend/native/common.spec.ts
@@ -497,6 +497,13 @@ beforeEach(() => {
             'trained_detector.zip': '',
           },
         },
+        detectorAndTrackerTrainingJob: {
+          category_models: {
+            'detector.pipe': '',
+            'tracker.pipe': '',
+            'trained_detector.zip': '',
+          },
+        },
       },
       DIVE_Pipelines: {
       /* Empty */
@@ -2602,6 +2609,28 @@ describe('native.common', () => {
     expect(pipes.tracker.pipes).toHaveLength(5);
     expect(pipes.utility.pipes).toHaveLength(4);
     expect(pipes.trained.pipes).toHaveLength(1);
+    expect(pipes.trained.pipes[0].name).toBe('trainedPipelineName detector');
+  });
+
+  it('getPipelineList lists both detector and tracker from one trained model', async () => {
+    const trainingArgs: RunTraining = {
+      type: JobType.RunTraining,
+      datasetIds: ['randomID'],
+      pipelineName: 'trainedPipelineName',
+      trainingConfig: 'trainingConfig',
+      annotatedFramesOnly: false,
+    };
+    await common.processTrainedPipeline(settings, trainingArgs, '/home/user/viamedata/DIVE_Jobs/detectorAndTrackerTrainingJob/');
+    const pipes = await common.getPipelineList(settings);
+    expect(pipes.trained.pipes).toHaveLength(2);
+    expect(pipes.trained.pipes.map((p) => p.name)).toEqual([
+      'trainedPipelineName detector',
+      'trainedPipelineName tracker',
+    ]);
+    expect(pipes.trained.pipes.map((p) => npath.basename(p.pipe))).toEqual([
+      'detector.pipe',
+      'tracker.pipe',
+    ]);
   });
 
   it('Full Annotation Loading and Attributes Testing', async () => {

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -1118,10 +1118,18 @@ async function getPipelineList(settings: Settings): Promise<Pipelines> {
       (p: string) => p.match(allowedTrainedPatterns) && !p.match(disallowedPatterns),
     );
     if (pipesInFolder.length >= 2) {
-      const pipeName = pipesInFolder.find((pipe) => pipe && pipe.indexOf('.pipe') !== -1);
-      if (pipeName) {
+      // A training run can emit both a detector and a tracker; list each one
+      // separately and disambiguate them the way web does.
+      const pipeNames = pipesInFolder.filter((p) => p.endsWith('.pipe')).sort();
+      pipeNames.forEach((pipeName) => {
+        let suffix = '';
+        if (pipeName.endsWith('tracker.pipe')) {
+          suffix = ' tracker';
+        } else if (pipeName.endsWith('detector.pipe')) {
+          suffix = ' detector';
+        }
         const pipeInfo = {
-          name: item,
+          name: `${item}${suffix}`,
           type: 'trained',
           pipe: npath.join(pipeFolder, pipeName),
         };
@@ -1133,7 +1141,7 @@ async function getPipelineList(settings: Settings): Promise<Pipelines> {
             description: 'trained pipes',
           };
         }
-      }
+      });
     }
     return true;
   }));


### PR DESCRIPTION
- VIAME training can emit both `category_models/detector.pipe` and `tracker.pipe`. `getPipelineList` used `find` to take the first `.pipe` in `readdir` order and dropped the rest, so the tracker was never runnable from desktop (which one won was FS-dependent: alphabetical on NTFS, hash order on ext4).
- Now emits one `trained` entry per `.pipe`, sorted for deterministic order, suffixed ` detector` / ` tracker` to match web (`crud_rpc.py:_load_dynamic_pipelines`).
- Single-pipe models still produce exactly one entry; their display name gains the ` detector` suffix, same as web.
- Deleting either entry still removes the whole model folder, unchanged and identical to web.
- Spec: new `detectorAndTrackerTrainingJob` fixture with both pipes + test asserting two entries; existing trained test now pins the name. 118 passed, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nzq6XQBXKUb1NRdaVpPYQZ