### PR TITLE
reduce false positives for frame alignment

### DIFF
--- a/client/platform/desktop/backend/native/mediaJobs.ts
+++ b/client/platform/desktop/backend/native/mediaJobs.ts
@@ -84,6 +84,8 @@ function frameRateStringFromProbeStream(stream: {
 
 async function checkFrameMisalignment(file: string): Promise<boolean> {
   const args = [
+    '-select_streams',
+    'v:0',
     file,
     '-hide_banner',
     '-read_intervals',

--- a/samples/scripts/checkTranscoding/checkTranscodingNeeded.py
+++ b/samples/scripts/checkTranscoding/checkTranscodingNeeded.py
@@ -199,10 +199,12 @@ def probe_media(file_path: Path) -> tuple[dict, dict, str]:
 def is_frame_misaligned(file_path: Path) -> bool:
     """
     True when duplicate best_effort_timestamp_time values appear in the first
-    5 seconds of frames (audio/video misalignment indicator).
+    5 seconds of primary video frames (audio/video misalignment indicator).
     """
     frame_info = run_ffprobe(
         [
+            "-select_streams",
+            "v:0",
             str(file_path),
             "-hide_banner",
             "-read_intervals",

--- a/server/dive_tasks/frame_alignment.py
+++ b/server/dive_tasks/frame_alignment.py
@@ -37,7 +37,10 @@ def is_frame_misaligned(
     headers: Optional[str] = None,
 ) -> bool:
     """
-    Return True if the first ~5s of frames contain duplicate timestamps.
+    Return True if the first ~5s of video frames contain duplicate timestamps.
+
+    Only the primary video stream is checked so audio/timecode packets at the
+    same wall time (e.g. both at 0.0s) are not mistaken for duplicate frames.
 
     *input_source* may be a local Path or an HTTP(S) URL. Pass *headers* (e.g.
     ``girder_auth_headers(token)``) when probing a Girder download URL so ffprobe
@@ -45,6 +48,8 @@ def is_frame_misaligned(
     so the token is not in process argv on modern ffprobe.
     """
     probe_tail = [
+        '-select_streams',
+        'v:0',
         str(input_source),
         '-hide_banner',
         '-read_intervals',

--- a/server/tests/test_remote_ffprobe.py
+++ b/server/tests/test_remote_ffprobe.py
@@ -230,12 +230,45 @@ def test_is_frame_misaligned_accepts_url_and_headers():
 
     command = mock_run.call_args[0][3]['args']
     assert command[0] == 'ffprobe'
+    assert '-select_streams' in command
+    assert 'v:0' in command
     assert '-/headers' in command
     assert '-headers' not in command
     assert 'tok' not in command[command.index('-/headers') + 1]
     assert 'http://girder.example/api/v1/file/1/download' in command
     written = ''.join(str(c.args[0]) for c in manager.write.call_args_list)
     assert '8192' in written
+
+
+def test_is_frame_misaligned_ignores_cross_stream_timestamps():
+    """Audio at the same time as a video frame must not count as misalignment."""
+    task = MagicMock()
+    manager = MagicMock()
+    # ffprobe with -select_streams v:0 only returns video packets.
+    frame_json = (
+        '{"frames":[{"best_effort_timestamp_time":"0.0"},'
+        '{"best_effort_timestamp_time":"0.033"}]}'
+    )
+
+    with patch('dive_tasks.frame_alignment.stream_subprocess', return_value=frame_json) as mock_run:
+        assert is_frame_misaligned(task, '/tmp/clip.mp4', {}, manager) is False
+
+    command = mock_run.call_args[0][3]['args']
+    assert '-select_streams' in command
+    assert 'v:0' in command
+
+
+def test_is_frame_misaligned_detects_duplicate_video_timestamps():
+    task = MagicMock()
+    manager = MagicMock()
+    frame_json = (
+        '{"frames":[{"best_effort_timestamp_time":"0.0"},'
+        '{"best_effort_timestamp_time":"0.0"},'
+        '{"best_effort_timestamp_time":"0.033"}]}'
+    )
+
+    with patch('dive_tasks.frame_alignment.stream_subprocess', return_value=frame_json):
+        assert is_frame_misaligned(task, '/tmp/clip.mp4', {}, manager) is True
 
 
 def _run_convert_video(task, **kwargs):


### PR DESCRIPTION
The frame alignment would look at the audio timestamps as well and could create false postivies causing videos to be transcoded that really didn't need it.  I've updated it so it only checks the primary video stream and not other streams because DIVE should only care about the primary video stream.