### PR TITLE
Follow the VIAME convert_cam_format to convert_cam tool rename

### DIFF
--- a/client/platform/desktop/backend/native/calibrationConvert.ts
+++ b/client/platform/desktop/backend/native/calibrationConvert.ts
@@ -1,7 +1,7 @@
 /**
  * Stereo camera calibration file handling for the desktop backend.
  *
- * VIAME ships a `convert_cam_format.py` tool (installed under
+ * VIAME ships a `convert_cam.py` tool (installed under
  * `<viamePath>/configs/`) that reads any supported stereo calibration format
  * (npz, opencv yml, matlab mat, zed, CamCAL, ...) and writes KWIVER's JSON
  * camera-rig format. We normalize every imported calibration to that JSON so the
@@ -15,7 +15,7 @@ import fs from 'fs-extra';
 import { Settings } from 'platform/desktop/constants';
 import { observeChild } from 'platform/desktop/backend/native/processManager';
 
-const ConvertToolRelativePath = npath.join('configs', 'convert_cam_format.py');
+const ConvertToolRelativePath = npath.join('configs', 'convert_cam.py');
 
 function shellQuote(value: string): string {
   if (process.platform === 'win32') {
@@ -25,7 +25,7 @@ function shellQuote(value: string): string {
 }
 
 /**
- * Run VIAME's convert_cam_format.py to convert a calibration file to the
+ * Run VIAME's convert_cam.py to convert a calibration file to the
  * KWIVER-compatible JSON camera-rig format.
  * @returns true if the JSON file was produced, false if conversion was
  *   unavailable (e.g. VIAME not configured) or failed.
@@ -107,7 +107,7 @@ async function prepareDatasetCalibration(
     return originalDest;
   }
   const base = npath.basename(originalDest, npath.extname(originalDest));
-  // convert_cam_format.py detects the input format by extension, so a binary
+  // convert_cam.py detects the input format by extension, so a binary
   // file mislabeled ".json" must be given its true extension first.
   let convertSource = originalDest;
   if (ext === '.json' && await looksLikeZip(originalDest)) {

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -2033,7 +2033,7 @@ def enqueue_calibration_conversion(
     jsonCalibrationFile JSON camera-rig item for display.
     """
     job_is_private = user.get(constants.UserPrivateQueueEnabledMarker, False)
-    # convert_cam_format.py lives on pipeline workers (VIAME image), not celery workers.
+    # convert_cam.py lives on pipeline workers (VIAME image), not celery workers.
     queue = f'{user["login"]}@private' if job_is_private else 'pipelines'
     token = Token().createToken(user=user, days=1)
     tasks.convert_calibration.apply_async(

--- a/server/dive_tasks/convert_images.py
+++ b/server/dive_tasks/convert_images.py
@@ -33,7 +33,7 @@ def convert_calibration(self: Task, itemId: str):
         manager.updateStatus(JobStatus.CANCELED)
         return
 
-    convert_tool = conf.viame_install_path / 'configs' / 'convert_cam_format.py'
+    convert_tool = conf.viame_install_path / 'configs' / 'convert_cam.py'
 
     with tempfile.TemporaryDirectory() as _working_directory, suppress(utils.CanceledError):
         _working_directory_path = Path(_working_directory)

--- a/server/dive_utils/calibration_format.py
+++ b/server/dive_utils/calibration_format.py
@@ -50,7 +50,7 @@ def prepare_conversion_input_path(
     """
     If a mislabeled .json is actually a ZIP/npz archive, return a .npz path for VIAME.
 
-    Returns the path to pass to convert_cam_format.py (may be input_path unchanged).
+    Returns the path to pass to convert_cam.py (may be input_path unchanged).
     """
     from pathlib import Path
 


### PR DESCRIPTION
- VIAME renamed `configs/convert_cam_format.py` to `configs/convert_cam.py`
- Desktop calibration import and the server calibration conversion task now run the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ii7jRztoYBSyCWKoGeHab