### PR TITLE
Launch pipelines with viame run instead of viame runner

### DIFF
--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -349,9 +349,8 @@ async function runPipeline(
     }
     command = [
       `${viameConstants.setupScriptAbs} &&`,
-      `"${viameConstants.viameExe}" runner`,
+      `"${viameConstants.viameExe}" run "${pipelinePath}"`,
       ...(feedsVideoReader ? ['-s "input:video_reader:type=vidl_ffmpeg"'] : []),
-      `-p "${pipelinePath}"`,
       ...(feedsVideoReader ? [`-s downsampler:target_frame_rate=${meta.fps}`] : []),
     ];
     if (frameRange && feedsVideoReader) {
@@ -389,8 +388,7 @@ async function runPipeline(
     await fs.writeFile(manifestFile, fileData);
     command = [
       `${viameConstants.setupScriptAbs} &&`,
-      `"${viameConstants.viameExe}" runner`,
-      `-p "${pipelinePath}"`,
+      `"${viameConstants.viameExe}" run "${pipelinePath}"`,
     ];
     if (!stereoOrMultiCam) {
       command.push(`-s input:video_filename="${manifestFile}"`);
@@ -778,8 +776,7 @@ async function exportTrainedPipeline(
 
   const command = [
     `${viameConstants.setupScriptAbs} &&`,
-    `"${viameConstants.viameExe}" runner`,
-    `-p "${exportPipelinePath}"`,
+    `"${viameConstants.viameExe}" run "${exportPipelinePath}"`,
     `-s "onnx_convert:model_path=${weightsPath}"`,
     `-s "onnx_convert:onnx_model_prefix=${converterOutput}"`,
   ];

--- a/docs/Deployment-Provision.md
+++ b/docs/Deployment-Provision.md
@@ -159,7 +159,7 @@ docker run --gpus=all --rm nvidia/cuda:11.0-base nvidia-smi
 # Test regular nvidia runtime
 nvidia-smi
 
-# For Scenario 2 and 3, check that the VIAME CLI is available (DIVE jobs use `viame runner` / `viame train`)
+# For Scenario 2 and 3, check that the VIAME CLI is available (DIVE jobs use `viame run` / `viame train`)
 cd /opt/noaa/viame
 source setup_viame.sh
 viame --help

--- a/server/dive_tasks/run_pipeline.py
+++ b/server/dive_tasks/run_pipeline.py
@@ -340,8 +340,7 @@ def run_pipeline(self: Task, params: PipelineJob):
             command = [
                 f". {shlex.quote(str(conf.viame_setup_script))} &&",
                 f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
-                "viame runner",
-                f"-p {shlex.quote(str(pipeline_path))}",
+                f"viame run {shlex.quote(str(pipeline_path))}",
             ]
             # An extracted subset replaced every video input with an image list;
             # leaving the video reader type (or the downsampler) bound would
@@ -543,9 +542,8 @@ def run_pipeline(self: Task, params: PipelineJob):
             command = [
                 f". {shlex.quote(str(conf.viame_setup_script))} &&",
                 f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
-                "viame runner",
+                f"viame run {shlex.quote(str(pipeline_path))}",
                 "-s input:video_reader:type=vidl_ffmpeg",
-                f"-p {shlex.quote(str(pipeline_path))}",
                 f"-s input:video_filename={shlex.quote(input_media_list[0])}",
                 f"-s downsampler:target_frame_rate={shlex.quote(str(input_fps))}",
                 f"-s detector_writer:file_name={shlex.quote(detector_output_file)}",
@@ -567,8 +565,7 @@ def run_pipeline(self: Task, params: PipelineJob):
             command = [
                 f". {shlex.quote(str(conf.viame_setup_script))} &&",
                 f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
-                "viame runner",
-                f"-p {shlex.quote(str(pipeline_path))}",
+                f"viame run {shlex.quote(str(pipeline_path))}",
                 f"-s input:video_filename={shlex.quote(str(img_list_path))}",
                 f"-s detector_writer:file_name={shlex.quote(detector_output_file)}",
                 f"-s track_writer:file_name={shlex.quote(track_output_file)}",

--- a/server/dive_tasks/run_training.py
+++ b/server/dive_tasks/run_training.py
@@ -59,8 +59,7 @@ def export_trained_pipeline(self: Task, params: ExportTrainedPipelineJob):
         command = [
             f". {shlex.quote(str(conf.viame_setup_script))} &&",
             f"KWIVER_DEFAULT_LOG_LEVEL={shlex.quote(conf.kwiver_log_level)}",
-            "viame runner",
-            f"-p {shlex.quote(str(convert_to_onnx_pipeline_path))}",
+            f"viame run {shlex.quote(str(convert_to_onnx_pipeline_path))}",
             f"-s onnx_convert:model_path={shlex.quote(str(model_file))}",
             f"-s onnx_convert:onnx_model_prefix={shlex.quote(str(onnx_path))}",
         ]


### PR DESCRIPTION
- All desktop and server pipeline launches call `viame run <pipe>` instead of `viame runner -p <pipe>`
- The pipe file is positional because `viame run` only forwards to the pipeline runner when it sees a bare `.pipe` argument; `-p` would route to the batch driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ii7jRztoYBSyCWKoGeHab