### PR TITLE
Keep track confidence pairs when only some CSV rows carry them

### DIFF
--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -367,14 +367,6 @@ function _parseRow(row: string[]) {
     geoFeatureCollection.features.push(_createGeoJsonFeature('LineString', headTail, 'HeadTails'));
   }
 
-  // ensure confidence pairs list is not empty
-  if (confidencePairs.length === 0) {
-    // extract Detection or Length Confidence field
-    const confidence = parseFloat(row[7]) || 1.0;
-    // add a dummy pair with a default type
-    confidencePairs.push(['unknown', confidence] as ConfidencePair);
-  }
-
   return {
     attributes, trackAttributes, confidencePairs, geoFeatureCollection, notes,
   };
@@ -420,6 +412,7 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<[
   const dataMap = new Map<number, TrackData>();
   const missingImages: string[] = [];
   const foundImages: {image: string; frame: number; csvFrame: number}[] = [];
+  const fallbackConfidence: Record<TrackData['id'], number> = {};
   let error: Error | undefined;
   let multiFrameTracks = false;
   const warnings: string[] = [];
@@ -526,6 +519,12 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<[
           }
         }
       }
+      dataMap.forEach((track) => {
+        if (track.confidencePairs.length === 0) {
+          // eslint-disable-next-line no-param-reassign
+          track.confidencePairs = [['unknown', fallbackConfidence[track.id] ?? 1.0]];
+        }
+      });
       const tracks = Object.fromEntries(dataMap);
 
       if (error !== undefined) {
@@ -602,7 +601,13 @@ async function parse(input: Readable, imageMap?: Map<string, number>): Promise<[
           track.begin = Math.min(rowInfo.frame, track.begin);
           track.end = Math.max(rowInfo.frame, track.end);
           track.features.push(feature);
-          track.confidencePairs = confidencePairs;
+          // Pairs may be written on only one row of a track; rows without
+          // pairs must not clobber those already seen.
+          if (confidencePairs.length) {
+            track.confidencePairs = confidencePairs;
+          } else {
+            fallbackConfidence[track.id] = parseFloat(record[7]) || 1.0;
+          }
           Object.entries(trackAttributes).forEach(([key, val]) => {
             // "track is possibly undefined" seems like a bug
             if (track && track.attributes) {

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -245,18 +245,14 @@ def _parse_row(row: List[str]) -> Tuple[Dict, Dict, Dict, List, List]:
     if len(head_tail) == 2:
         create_geoJSONFeature(features, 'LineString', head_tail, 'HeadTails')
 
-    # ensure confidence pairs list is not empty
-    if len(sorted_confidence_pairs) == 0:
-        # extract Detection or Length Confidence field
-        try:
-            confidence = float(row[7])
-        except ValueError:  # in case field is empty
-            confidence = 1.0
-
-        # add a dummy pair with a default type
-        sorted_confidence_pairs.append(('unknown', confidence))
-
     return features, attributes, track_attributes, sorted_confidence_pairs, notes
+
+
+def _fallback_confidence(row: List[str]) -> float:
+    try:
+        return float(row[7])
+    except (ValueError, IndexError):
+        return 1.0
 
 
 def _parse_row_for_tracks(row: List[str]) -> Tuple[Feature, Dict, Dict, List]:
@@ -404,6 +400,7 @@ def load_csv_as_tracks_and_attributes(
     multiFrameTracks = False
     missingImages: List[str] = []
     foundImages: List[Dict[str, Any]] = []  # {image:str, frame: int, csvFrame: int}
+    fallbackConfidence: Dict[int, float] = {}
     sortedlist = sorted(reader, key=custom_sort)
     warnings: types.Warnings = []
     fps = None
@@ -465,13 +462,22 @@ def load_csv_as_tracks_and_attributes(
         track.begin = min(feature.frame, track.begin)
         track.end = max(track.end, feature.frame)
         track.features.append(feature)
-        track.confidencePairs = confidence_pairs
+        # Pairs may be written on only one row of a track; rows without
+        # pairs must not clobber those already seen.
+        if confidence_pairs:
+            track.confidencePairs = confidence_pairs
+        else:
+            fallbackConfidence[trackId] = _fallback_confidence(row)
 
         for key, val in track_attributes.items():
             track.attributes[key] = val
             create_attributes(metadata_attributes, test_vals, 'track', key, val)
         for key, val in attributes.items():
             create_attributes(metadata_attributes, test_vals, 'detection', key, val)
+
+    for track in tracks.values():
+        if not track.confidencePairs:
+            track.confidencePairs = [('unknown', fallbackConfidence.get(track.id, 1.0))]
 
     if imageMap and len(missingImages) and len(foundImages):
         minFrame = float('inf')

--- a/testutils/viame.spec.json
+++ b/testutils/viame.spec.json
@@ -872,5 +872,181 @@
             }
         },
         {}
+    ],
+    [
+        [
+            "0,1.png,0,10,10,20,20,0.5,-1,fish,0.9,scallop,0.1",
+            "0,2.png,1,10,10,20,20,0.5,-1",
+            "0,3.png,2,10,10,20,20,0.5,-1",
+            "1,1.png,0,10,10,20,20,0.5,-1",
+            "1,2.png,1,10,10,20,20,0.5,-1",
+            "1,3.png,2,10,10,20,20,0.5,-1,skate,0.7",
+            "2,1.png,0,10,10,20,20,0.5,-1",
+            "2,2.png,1,10,10,20,20,0.25,-1",
+            "3,1.png,0,10,10,20,20,0.5,-1,fish,0.9",
+            "3,2.png,1,10,10,20,20,0.5,-1,(trk-atr) booleanAttr true"
+        ],
+        {
+            "0": {
+                "id": 0,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "fish",
+                        0.9
+                    ],
+                    [
+                        "scallop",
+                        0.1
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ]
+                    },
+                    {
+                        "frame": 1,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ]
+                    },
+                    {
+                        "frame": 2,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ]
+                    }
+                ],
+                "begin": 0,
+                "end": 2
+            },
+            "1": {
+                "id": 1,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "skate",
+                        0.7
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ]
+                    },
+                    {
+                        "frame": 1,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ]
+                    },
+                    {
+                        "frame": 2,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ]
+                    }
+                ],
+                "begin": 0,
+                "end": 2
+            },
+            "2": {
+                "id": 2,
+                "attributes": {},
+                "confidencePairs": [
+                    [
+                        "unknown",
+                        0.25
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ]
+                    },
+                    {
+                        "frame": 1,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ]
+                    }
+                ],
+                "begin": 0,
+                "end": 1
+            },
+            "3": {
+                "id": 3,
+                "attributes": {
+                    "booleanAttr": true
+                },
+                "confidencePairs": [
+                    [
+                        "fish",
+                        0.9
+                    ]
+                ],
+                "features": [
+                    {
+                        "frame": 0,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ]
+                    },
+                    {
+                        "frame": 1,
+                        "bounds": [
+                            10,
+                            10,
+                            20,
+                            20
+                        ]
+                    }
+                ],
+                "begin": 0,
+                "end": 1
+            }
+        },
+        {
+            "track_booleanAttr": {
+                "belongs": "track",
+                "datatype": "boolean",
+                "key": "track_booleanAttr",
+                "name": "booleanAttr"
+            }
+        }
     ]
 ]


### PR DESCRIPTION
- VIAME's viame_csv track writer gained a `write_tot_once` option that writes species/confidence pairs on a track's first row only
- Both importers (desktop TS, server python) previously let the last row win, so such tracks imported as `unknown`
- Rows without pairs no longer overwrite pairs already seen; `unknown` fallback applied once per track after all rows are read
- Shared fixture case covers first-row-only, last-row-only, no pairs, and pairs followed by an attribute-only row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbxEphgC6zwbELWQk7qm5d