### PR TITLE
Find VIAME's calibration converter as convert.py, falling back to convert_cam.py

### DIFF
--- a/client/platform/desktop/backend/native/calibrationConvert.ts
+++ b/client/platform/desktop/backend/native/calibrationConvert.ts
@@ -1,7 +1,7 @@
 /**
  * Stereo camera calibration file handling for the desktop backend.
  *
- * VIAME ships a `convert_cam.py` tool (installed under
+ * VIAME ships a calibration converter, `viame convert` (convert.py, installed under
  * `<viamePath>/configs/`) that reads any supported stereo calibration format
  * (npz, opencv yml, matlab mat, zed, CamCAL, ...) and writes KWIVER's JSON
  * camera-rig format. We normalize every imported calibration to that JSON so the
@@ -15,7 +15,18 @@ import fs from 'fs-extra';
 import { Settings } from 'platform/desktop/constants';
 import { observeChild } from 'platform/desktop/backend/native/processManager';
 
-const ConvertToolRelativePath = npath.join('configs', 'convert_cam.py');
+/** The calibration converter: `viame convert` (convert.py), or the older convert_cam.py. */
+const ConvertToolCandidates = [
+  npath.join('configs', 'convert.py'),
+  npath.join('configs', 'convert_cam.py'),
+];
+
+async function findConvertTool(viamePath: string): Promise<string | null> {
+  const candidates = ConvertToolCandidates.map((relative) => npath.join(viamePath, relative));
+  const present = await Promise.all(candidates.map((candidate) => fs.pathExists(candidate)));
+  const index = present.findIndex((exists) => exists);
+  return index >= 0 ? candidates[index] : null;
+}
 
 function shellQuote(value: string): string {
   if (process.platform === 'win32') {
@@ -25,7 +36,7 @@ function shellQuote(value: string): string {
 }
 
 /**
- * Run VIAME's convert_cam.py to convert a calibration file to the
+ * Run VIAME's convert tool to convert a calibration file to the
  * KWIVER-compatible JSON camera-rig format.
  * @returns true if the JSON file was produced, false if conversion was
  *   unavailable (e.g. VIAME not configured) or failed.
@@ -37,8 +48,8 @@ async function convertCalibrationToJson(
 ): Promise<boolean> {
   const isWin = process.platform === 'win32';
   const setupScript = npath.join(settings.viamePath, isWin ? 'setup_viame.bat' : 'setup_viame.sh');
-  const toolPath = npath.join(settings.viamePath, ConvertToolRelativePath);
-  if (!(await fs.pathExists(setupScript)) || !(await fs.pathExists(toolPath))) {
+  const toolPath = await findConvertTool(settings.viamePath);
+  if (!(await fs.pathExists(setupScript)) || toolPath === null) {
     return false;
   }
   const sourceCmd = isWin ? `call ${shellQuote(setupScript)}` : `. ${shellQuote(setupScript)}`;
@@ -107,7 +118,7 @@ async function prepareDatasetCalibration(
     return originalDest;
   }
   const base = npath.basename(originalDest, npath.extname(originalDest));
-  // convert_cam.py detects the input format by extension, so a binary
+  // The converter detects the input format by extension, so a binary
   // file mislabeled ".json" must be given its true extension first.
   let convertSource = originalDest;
   if (ext === '.json' && await looksLikeZip(originalDest)) {

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -2033,7 +2033,7 @@ def enqueue_calibration_conversion(
     jsonCalibrationFile JSON camera-rig item for display.
     """
     job_is_private = user.get(constants.UserPrivateQueueEnabledMarker, False)
-    # convert_cam.py lives on pipeline workers (VIAME image), not celery workers.
+    # the VIAME convert tool lives on pipeline workers (VIAME image), not celery workers.
     queue = f'{user["login"]}@private' if job_is_private else 'pipelines'
     token = Token().createToken(user=user, days=1)
     tasks.convert_calibration.apply_async(

--- a/server/dive_tasks/convert_images.py
+++ b/server/dive_tasks/convert_images.py
@@ -33,7 +33,10 @@ def convert_calibration(self: Task, itemId: str):
         manager.updateStatus(JobStatus.CANCELED)
         return
 
-    convert_tool = conf.viame_install_path / 'configs' / 'convert_cam.py'
+    # viame convert (convert.py); older installs ship it as convert_cam.py
+    convert_tool = conf.viame_install_path / 'configs' / 'convert.py'
+    if not convert_tool.exists():
+        convert_tool = conf.viame_install_path / 'configs' / 'convert_cam.py'
 
     with tempfile.TemporaryDirectory() as _working_directory, suppress(utils.CanceledError):
         _working_directory_path = Path(_working_directory)

--- a/server/dive_utils/calibration_format.py
+++ b/server/dive_utils/calibration_format.py
@@ -50,7 +50,7 @@ def prepare_conversion_input_path(
     """
     If a mislabeled .json is actually a ZIP/npz archive, return a .npz path for VIAME.
 
-    Returns the path to pass to convert_cam.py (may be input_path unchanged).
+    Returns the path to pass to the VIAME convert tool (may be input_path unchanged).
     """
     from pathlib import Path
 


### PR DESCRIPTION
VIAME renamed `convert_cam.py` to `convert.py` (the `viame convert` applet, VIAME/VIAME main 9f44a8e70 and later). Desktop and the pipeline worker now look for `convert.py` first and keep working with installs that still ship `convert_cam.py`.

Verified with lint and typecheck on the desktop client and a syntax check on the worker task. The same change is already on the VIAME fork's `viame/main` (0043ceef), which VIAME pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1C4QY6hxjHaUPJfWPfQuu