### PR TITLE
Fix Express 5 optional route params in the desktop backend

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -42,7 +42,7 @@
         "@types/cors": "^2.8.9",
         "@types/csv-parse": "^1.2.2",
         "@types/d3": "^7.4.3",
-        "@types/express": "^4.17.9",
+        "@types/express": "^5.0.6",
         "@types/geojson": "^7946.0.7",
         "@types/glob-to-regexp": "^0.4.0",
         "@types/js-yaml": "^4.0.5",
@@ -4495,22 +4495,21 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.0.tgz",
-      "integrity": "sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4552,9 +4551,9 @@
       "license": "MIT"
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4593,13 +4592,6 @@
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.1.tgz",
       "integrity": "sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4664,9 +4656,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.15",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4719,26 +4711,24 @@
       "license": "MIT"
     },
     "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
+        "@types/node": "*"
       }
     },
     "node_modules/@types/webxr": {

--- a/client/package.json
+++ b/client/package.json
@@ -62,7 +62,7 @@
     "@types/cors": "^2.8.9",
     "@types/csv-parse": "^1.2.2",
     "@types/d3": "^7.4.3",
-    "@types/express": "^4.17.9",
+    "@types/express": "^5.0.6",
     "@types/geojson": "^7946.0.7",
     "@types/glob-to-regexp": "^0.4.0",
     "@types/js-yaml": "^4.0.5",

--- a/client/platform/desktop/backend/server.spec.ts
+++ b/client/platform/desktop/backend/server.spec.ts
@@ -1,0 +1,60 @@
+import type { AddressInfo } from 'net';
+import type http from 'http';
+import {
+  afterAll, beforeAll, describe, expect, it, vi,
+} from 'vitest';
+
+import { close, listen } from './server';
+
+const mocks = vi.hoisted(() => ({ loadConfig: vi.fn() }));
+
+vi.mock('electron', () => ({ shell: { openPath: vi.fn(), showItemInFolder: vi.fn() } }));
+vi.mock('./state/settings', () => ({ default: { get: () => ({}) } }));
+vi.mock('./native/common', () => ({
+  loadConfig: mocks.loadConfig,
+  saveConfig: vi.fn(),
+  saveAttributes: vi.fn(),
+  saveAttributeTrackFilters: vi.fn(),
+  saveDetections: vi.fn(),
+  getDisplayImagePath: vi.fn(),
+}));
+vi.mock('./tiles/geotiffTiles', () => ({ getTilePng: vi.fn(), getTilesMetadata: vi.fn() }));
+vi.mock('./media/displayProcessing', () => ({ getDisplayPng: vi.fn(), getDisplayHistogram: vi.fn() }));
+vi.mock('./native/frameExtraction', () => ({
+  getVideoInfo: vi.fn(), extractFrame: vi.fn(), prefetchFrames: vi.fn(),
+}));
+
+/**
+ * The routes are declared at module scope, so a path pattern the router cannot
+ * parse takes down the whole main process at import time rather than failing a
+ * single request. Express 4 spelled the optional camera segment ':camera?';
+ * Express 5 spells it '{/:camera}' and throws on the old form.
+ */
+describe('desktop backend routes', () => {
+  let baseUrl = '';
+
+  beforeAll(async () => {
+    mocks.loadConfig.mockResolvedValue({ id: 'stub' });
+    await new Promise<void>((resolve) => {
+      listen((server: http.Server) => {
+        const { port } = server.address() as AddressInfo;
+        baseUrl = `http://localhost:${port}/api`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(() => close());
+
+  it('matches a dataset route without a camera segment', async () => {
+    const res = await fetch(`${baseUrl}/dataset/ds1/meta`);
+    expect(res.status).toBe(200);
+    expect(mocks.loadConfig).toHaveBeenLastCalledWith(expect.anything(), 'ds1', expect.any(Function));
+  });
+
+  it('matches a dataset route with a camera segment', async () => {
+    const res = await fetch(`${baseUrl}/dataset/ds1/left/meta`);
+    expect(res.status).toBe(200);
+    expect(mocks.loadConfig).toHaveBeenLastCalledWith(expect.anything(), 'ds1/left', expect.any(Function));
+  });
+});

--- a/client/platform/desktop/backend/server.ts
+++ b/client/platform/desktop/backend/server.ts
@@ -54,7 +54,7 @@ function makeMediaUrl(filepath: string): string {
 }
 
 /* LOAD dataset config */
-apirouter.get('/dataset/:id/:camera?/meta', async (req, res, next) => {
+apirouter.get('/dataset/:id{/:camera}/meta', async (req, res, next) => {
   try {
     let { id } = req.params;
     if (req.params.camera) {
@@ -69,7 +69,7 @@ apirouter.get('/dataset/:id/:camera?/meta', async (req, res, next) => {
 });
 
 /* SAVE dataset config */
-apirouter.post('/dataset/:id/:camera?/meta', async (req, res, next) => {
+apirouter.post('/dataset/:id{/:camera}/meta', async (req, res, next) => {
   try {
     let { id } = req.params;
     if (req.params.camera) {
@@ -84,7 +84,7 @@ apirouter.post('/dataset/:id/:camera?/meta', async (req, res, next) => {
 });
 
 /* SAVE attributes */
-apirouter.post('/dataset/:id/:camera?/attributes', async (req, res, next) => {
+apirouter.post('/dataset/:id{/:camera}/attributes', async (req, res, next) => {
   try {
     let { id } = req.params;
     if (req.params.camera) {
@@ -100,7 +100,7 @@ apirouter.post('/dataset/:id/:camera?/attributes', async (req, res, next) => {
   return null;
 });
 
-apirouter.post('/dataset/:id/:camera?/attribute_track_filters', async (req, res, next) => {
+apirouter.post('/dataset/:id{/:camera}/attribute_track_filters', async (req, res, next) => {
   try {
     let { id } = req.params;
     if (req.params.camera) {
@@ -117,7 +117,7 @@ apirouter.post('/dataset/:id/:camera?/attribute_track_filters', async (req, res,
 });
 
 /* SAVE detections */
-apirouter.post('/dataset/:id/:camera?/detections', async (req, res, next) => {
+apirouter.post('/dataset/:id{/:camera}/detections', async (req, res, next) => {
   try {
     let { id } = req.params;
     if (req.params.camera) {
@@ -134,7 +134,7 @@ apirouter.post('/dataset/:id/:camera?/detections', async (req, res, next) => {
 });
 
 /* Large image (GeoTIFF) tiles - compatible with LargeImageAnnotator getTiles/getTileURL */
-apirouter.get('/dataset/:id/:camera?/tiles/:level/:x/:y', async (req, res, next) => {
+apirouter.get('/dataset/:id{/:camera}/tiles/:level/:x/:y', async (req, res, next) => {
   try {
     const datasetId = req.params.camera
       ? `${req.params.id}/${req.params.camera}`
@@ -160,7 +160,7 @@ apirouter.get('/dataset/:id/:camera?/tiles/:level/:x/:y', async (req, res, next)
   return null;
 });
 
-apirouter.get('/dataset/:id/:camera?/tiles', async (req, res, next) => {
+apirouter.get('/dataset/:id{/:camera}/tiles', async (req, res, next) => {
   try {
     const datasetId = req.params.camera
       ? `${req.params.id}/${req.params.camera}`


### PR DESCRIPTION
## Problem

DIVE desktop does not start on `main`. It dies before the window opens:

```
A JavaScript error occurred in the main process
Uncaught Exception:
TypeError: Unexpected ? at index 20: /dataset/:id/:camera?/meta; visit https://git.new/pathToRegexpError for info
    at pathToRegexp (.../background.js:38722:5)
    at Router.<computed> [as get] (.../background.js:39368:27)
```

#1882 bumped `express` 4.22.2 → 5.2.1, which brings `path-to-regexp` 8. That release removed the `:param?` optional-parameter spelling, but the seven `/dataset/:id/:camera?/…` routes in `platform/desktop/backend/server.ts` were not migrated. The routes are registered at module scope, so the throw takes down the whole main process at import time rather than failing a single request.

## Fix

- `:id/:camera?/…` → `:id{/:camera}/…` on all seven routes. Handler bodies are unchanged: `req.params.camera` is still `undefined` when the segment is absent, and `/dataset/ds1/left/meta` still rejoins to the `ds1/left` dataset id.
- `@types/express` `^4.17.9` → `^5.0.6`. The runtime has been Express 5 since #1882 while the types stayed on 4; v4's `RouteParameters` parses `:id{` and `camera}` as parameter names and fails `npm run typecheck` on the corrected paths, whereas v5 models the `{…}` group as `Partial<…>`, which is exactly the optional-camera contract.

## Regression cover

`server.spec.ts` starts the backend and requests `/api/dataset/ds1/meta` and `/api/dataset/ds1/left/meta`, asserting both resolve and that the camera segment is folded into the dataset id.

CI builds the Electron main process but never loads it, and no spec imported `server.ts`, so a module-level throw passed lint, typecheck, tests and `build:electron` untouched. On the pre-fix route strings the new spec fails with the same `Unexpected ?` error users see at launch.

Verified locally on Node 22: `npm run lint`, `npm run typecheck`, `npm test` (112 files, 1492 tests) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZAPBnQ6uNU3vB67kc2Xg3
