### PR TITLE
Rename the Pipeline tab to Pipelines and move it next to Library

### DIFF
--- a/client/platform/desktop/frontend/components/NavigationBar.vue
+++ b/client/platform/desktop/frontend/components/NavigationBar.vue
@@ -17,12 +17,12 @@ export default defineComponent({
   <v-app-bar app>
     <v-tabs
       icons-and-text
+      class="desktop-nav-tabs"
       style="flex-basis:0; flex-grow:0;"
       color="accent"
     >
       <v-tab :to="{ name: 'recent' }">
-        Library
-        <v-icon>mdi-folder-open</v-icon>
+        Library<v-icon>mdi-folder-open</v-icon>
       </v-tab>
       <v-tab :to="{ name: 'pipeline' }">
         Pipelines<v-icon>mdi-pipe</v-icon>
@@ -41,3 +41,7 @@ export default defineComponent({
     <v-spacer />
   </v-app-bar>
 </template>
+
+<style lang="scss">
+@import './navTabs.scss';
+</style>

--- a/client/platform/desktop/frontend/components/NavigationBar.vue
+++ b/client/platform/desktop/frontend/components/NavigationBar.vue
@@ -24,12 +24,12 @@ export default defineComponent({
         Library
         <v-icon>mdi-folder-open</v-icon>
       </v-tab>
+      <v-tab :to="{ name: 'pipeline' }">
+        Pipelines<v-icon>mdi-pipe</v-icon>
+      </v-tab>
       <job-tab />
       <v-tab :to="{ name: 'training' }">
         Training<v-icon>mdi-brain</v-icon>
-      </v-tab>
-      <v-tab :to="{ name: 'pipeline' }">
-        Pipeline<v-icon>mdi-pipe</v-icon>
       </v-tab>
       <v-tab :to="{ name: 'scoring' }">
         Scoring<v-icon>mdi-chart-box-outline</v-icon>

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -2067,11 +2067,11 @@ export default defineComponent({
         <v-tabs
           icons-and-text
           hide-slider
+          class="desktop-nav-tabs"
           style="flex-basis:0; flex-grow:0;"
         >
           <v-tab :to="{ name: 'recent' }">
-            Library
-            <v-icon>mdi-folder-open</v-icon>
+            Library<v-icon>mdi-folder-open</v-icon>
           </v-tab>
           <job-tab />
           <v-tab :to="{ name: 'training' }">
@@ -2198,6 +2198,10 @@ export default defineComponent({
     </v-snackbar>
   </div>
 </template>
+
+<style lang="scss">
+@import './navTabs.scss';
+</style>
 
 <style scoped>
 .viewer-loader-wrapper {

--- a/client/platform/desktop/frontend/components/navTabs.scss
+++ b/client/platform/desktop/frontend/components/navTabs.scss
@@ -1,0 +1,6 @@
+/* Equal tab widths so the icon spacing does not follow the label length. */
+.desktop-nav-tabs .v-tab {
+  min-width: 116px;
+  max-width: 116px;
+  padding: 0 8px;
+}

--- a/client/platform/desktop/frontend/components/navTabs.scss
+++ b/client/platform/desktop/frontend/components/navTabs.scss
@@ -1,6 +1,7 @@
 /* Equal tab widths so the icon spacing does not follow the label length. */
 .desktop-nav-tabs .v-tab {
-  min-width: 116px;
-  max-width: 116px;
-  padding: 0 8px;
+  min-width: 100px;
+  max-width: 100px;
+  padding: 0 6px;
+  white-space: nowrap;
 }


### PR DESCRIPTION
- Desktop nav tab reads **Pipelines** and sits directly right of Library

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9QNsyzjQpPbUrWRtiwmrq