### PR TITLE
Order run-pipeline categories and pad the list below the docs blurb

### DIFF
--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -575,7 +575,9 @@ export default defineComponent({
           v-else-if="pipelines"
           outlined
         >
-          <v-card-title> VIAME Pipelines </v-card-title>
+          <v-card-title class="pb-2">
+            VIAME Pipelines
+          </v-card-title>
 
           <v-card-text class="pb-0">
             Choose a pipeline type. Check the
@@ -760,7 +762,7 @@ export default defineComponent({
 }
 
 .pipeline-categories-row {
-  margin-top: -6px;
+  margin-top: -2px;
 }
 
 .pipeline-category-col--last {

--- a/client/dive-common/components/RunPipelineMenu.vue
+++ b/client/dive-common/components/RunPipelineMenu.vue
@@ -759,6 +759,10 @@ export default defineComponent({
   margin-left: 8px;
 }
 
+.pipeline-categories-row {
+  margin-top: -6px;
+}
+
 .pipeline-category-col--last {
   padding-bottom: 12px;
   margin-bottom: 12px;

--- a/client/dive-common/pipelineMenuFilters.spec.ts
+++ b/client/dive-common/pipelineMenuFilters.spec.ts
@@ -2,6 +2,7 @@ import {
   excludePipelinesMatchingTerms,
   filterPipelinesForDatasets,
   getMultiCamCameraCount,
+  orderPipelineCategories,
 } from './pipelineMenuFilters';
 import type { Pipelines } from './apispec';
 
@@ -113,5 +114,19 @@ describe('pipelineMenuFilters', () => {
     const filtered = filterPipelinesForDatasets(withSeagis, [null], [1], undefined, ['seagis']);
     expect(filtered.utility).toBeUndefined();
     expect(filtered.detector).toBeDefined();
+  });
+
+  it('orders categories detector, tracker, measurement, filter, transcode, utility, trained', () => {
+    const pipelines: Pipelines = {};
+    ['trained', 'utility', 'filter', 'zeta', 'transcode', 'tracker', 'measurement', 'alpha', 'detector']
+      .forEach((name) => { pipelines[name] = { description: '', pipes: [] }; });
+    expect(Object.keys(orderPipelineCategories(pipelines))).toEqual([
+      'detector', 'tracker', 'measurement', 'filter', 'transcode', 'utility', 'trained', 'zeta', 'alpha',
+    ]);
+  });
+
+  it('orders categories in filterPipelinesForDatasets', () => {
+    const filtered = filterPipelinesForDatasets(samplePipelines, ['stereo'], [2]);
+    expect(Object.keys(filtered)).toEqual(['detector', 'measurement']);
   });
 });

--- a/client/dive-common/pipelineMenuFilters.ts
+++ b/client/dive-common/pipelineMenuFilters.ts
@@ -133,5 +133,25 @@ export function filterPipelinesForDatasets(
     }
   });
 
-  return excludePipelinesMatchingTerms(sortedPipelines, excludePipelineTerms);
+  return orderPipelineCategories(
+    excludePipelinesMatchingTerms(sortedPipelines, excludePipelineTerms),
+  );
+}
+
+/** Menu order for known categories; anything else keeps its discovery order after them. */
+export const pipelineCategoryOrder = [
+  'detector', 'tracker', 'measurement', 'filter', 'transcode', 'utility', 'generate', 'trained',
+];
+
+export function orderPipelineCategories(pipelines: Pipelines): Pipelines {
+  const rank = (name: string) => {
+    const index = pipelineCategoryOrder.indexOf(name);
+    return index === -1 ? pipelineCategoryOrder.length : index;
+  };
+  const ordered = {} as Pipelines;
+  Object.keys(pipelines)
+    .map((name, index) => ({ name, index }))
+    .sort((a, b) => rank(a.name) - rank(b.name) || a.index - b.index)
+    .forEach(({ name }) => { ordered[name] = pipelines[name]; });
+  return ordered;
 }


### PR DESCRIPTION
- Categories shown as Detectors, Trackers, Measurement, Filters, Transcoders, Utilities, Trained; hidden ones just drop out, unknown ones follow in discovery order
- A few px of space between "...about these options." and the first category button
- Unit tests for the ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9QNsyzjQpPbUrWRtiwmrq