### PR TITLE
Add breathing room between toolbar group legends and their buttons

### DIFF
--- a/client/dive-common/components/AnnotationVisibilityMenu.vue
+++ b/client/dive-common/components/AnnotationVisibilityMenu.vue
@@ -213,7 +213,6 @@ export default defineComponent({
 <template>
   <span
     class="toolbar-group-host"
-    :class="{ 'toolbar-group-host--expanded': isExpanded }"
   >
     <!-- Dropdown mode when collapsed -->
     <v-menu

--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -449,7 +449,6 @@ export default defineComponent({
       <!-- Collapsed mode for edit buttons -->
       <span
         class="toolbar-group-host"
-        :class="{ 'toolbar-group-host--expanded': isEditButtonsExpanded }"
       >
         <v-menu
           v-if="!isEditButtonsExpanded"

--- a/client/dive-common/components/MultiCamToolbar.vue
+++ b/client/dive-common/components/MultiCamToolbar.vue
@@ -306,7 +306,6 @@ export default defineComponent({
     v-if="selectedTrackId !== null && cameras.length > 1"
     v-mousetrap="mousetrap"
     class="toolbar-group-host"
-    :class="{ 'toolbar-group-host--expanded': isExpanded }"
   >
     <!-- Dropdown mode when collapsed -->
     <v-menu

--- a/client/dive-common/components/OutlinedLabeledGroup.vue
+++ b/client/dive-common/components/OutlinedLabeledGroup.vue
@@ -21,15 +21,15 @@ export default defineComponent({
 .outlined-labeled-group {
   border: 1px solid rgba(255, 255, 255, 0.24);
   border-radius: 4px;
-  margin: -9px 4px 0;
-  padding: 6px 6px 4px;
+  margin: 0 4px;
+  padding: 4px 6px 2px;
   min-inline-size: min-content;
 }
 
 .outlined-labeled-group__legend {
   color: rgba(255, 255, 255, 0.6);
   font-size: 12px;
-  line-height: 1.25;
+  line-height: 1;
   padding: 0 4px;
   width: auto;
 }

--- a/client/dive-common/components/OutlinedLabeledGroup.vue
+++ b/client/dive-common/components/OutlinedLabeledGroup.vue
@@ -21,7 +21,7 @@ export default defineComponent({
 .outlined-labeled-group {
   border: 1px solid rgba(255, 255, 255, 0.24);
   border-radius: 4px;
-  margin: 0 4px;
+  margin: -4px 4px 0;
   padding: 4px 6px 2px;
   min-inline-size: min-content;
 }

--- a/client/dive-common/components/OutlinedLabeledGroup.vue
+++ b/client/dive-common/components/OutlinedLabeledGroup.vue
@@ -21,7 +21,7 @@ export default defineComponent({
 .outlined-labeled-group {
   border: 1px solid rgba(255, 255, 255, 0.24);
   border-radius: 4px;
-  margin: -4px 4px 0;
+  margin: -8px 4px 0;
   padding: 4px 6px 2px;
   min-inline-size: min-content;
 }

--- a/client/dive-common/components/OutlinedLabeledGroup.vue
+++ b/client/dive-common/components/OutlinedLabeledGroup.vue
@@ -22,7 +22,7 @@ export default defineComponent({
   border: 1px solid rgba(255, 255, 255, 0.24);
   border-radius: 4px;
   margin: -9px 4px 0;
-  padding: 2px 6px 4px;
+  padding: 6px 6px 4px;
   min-inline-size: min-content;
 }
 

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -2478,7 +2478,7 @@ export default defineComponent({
   <v-main class="viewer">
     <v-app-bar
       app
-      extension-height="56"
+      extension-height="52"
     >
       <slot name="title" />
       <span

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -2478,7 +2478,7 @@ export default defineComponent({
   <v-main class="viewer">
     <v-app-bar
       app
-      extension-height="52"
+      extension-height="56"
     >
       <slot name="title" />
       <span

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -2476,7 +2476,10 @@ export default defineComponent({
 
 <template>
   <v-main class="viewer">
-    <v-app-bar app>
+    <v-app-bar
+      app
+      extension-height="56"
+    >
       <slot name="title" />
       <span
         class="title pl-3 flex-row"

--- a/client/dive-common/components/toolbarGroup.scss
+++ b/client/dive-common/components/toolbarGroup.scss
@@ -4,15 +4,6 @@
   vertical-align: middle;
 }
 
-/*
- * Only shift the group up when expanded, to compensate for the fieldset legend
- * that pokes above the toolbar. In collapsed mode there is no legend, so the
- * shift would misalign the activator button with the rest of the toolbar.
- */
-.toolbar-group-host--expanded {
-  margin-top: -9px;
-}
-
 .toolbar-group-activator.v-btn.v-size--small {
   height: 28px !important;
   min-height: 28px !important;


### PR DESCRIPTION
- Edit Types / Visibility legends were 2px above the button row; now 6px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9QNsyzjQpPbUrWRtiwmrq