### PR TITLE
Add a select-all button to the Pipelines page dataset list

### DIFF
--- a/client/platform/desktop/frontend/components/MultiPipeline.vue
+++ b/client/platform/desktop/frontend/components/MultiPipeline.vue
@@ -180,13 +180,23 @@ function toggleStaged(item: JsonConfigCache) {
     stagedDatasetIds.value.push(item.id);
   }
 }
+function datasetMatchesSearch(item: JsonConfigCache, search: string) {
+  if (!search) {
+    return true;
+  }
+  const record = item as unknown as Record<string, unknown>;
+  return headersTmpl.some((header) => {
+    const value = String(record[header.value] ?? '').toLowerCase();
+    return value.includes(search);
+  });
+}
 /* Mirrors the table's default search so "select all" only stages what is listed. */
 const unstagedSearchMatches = computed(() => {
-  const needle = availableDatasetSearch.value.trim().toLowerCase();
-  return availableItems.value.filter((item) => !stagedDatasetIds.value.includes(item.id)
-    && (!needle || headersTmpl.some((header) => String(
-      (item as unknown as Record<string, unknown>)[header.value] ?? '',
-    ).toLowerCase().includes(needle))));
+  const search = availableDatasetSearch.value.trim().toLowerCase();
+  return availableItems.value.filter((item) => (
+    !stagedDatasetIds.value.includes(item.id)
+    && datasetMatchesSearch(item, search)
+  ));
 });
 function stageAllAvailable() {
   stagedDatasetIds.value = stagedDatasetIds.value.concat(

--- a/client/platform/desktop/frontend/components/MultiPipeline.vue
+++ b/client/platform/desktop/frontend/components/MultiPipeline.vue
@@ -180,6 +180,19 @@ function toggleStaged(item: JsonConfigCache) {
     stagedDatasetIds.value.push(item.id);
   }
 }
+/* Mirrors the table's default search so "select all" only stages what is listed. */
+const unstagedSearchMatches = computed(() => {
+  const needle = availableDatasetSearch.value.trim().toLowerCase();
+  return availableItems.value.filter((item) => !stagedDatasetIds.value.includes(item.id)
+    && (!needle || headersTmpl.some((header) => String(
+      (item as unknown as Record<string, unknown>)[header.value] ?? '',
+    ).toLowerCase().includes(needle))));
+});
+function stageAllAvailable() {
+  stagedDatasetIds.value = stagedDatasetIds.value.concat(
+    unstagedSearchMatches.value.map((item) => item.id),
+  );
+}
 
 async function runPipelineForDatasets() {
   const pipeline = selectedPipeline.value;
@@ -356,6 +369,23 @@ onBeforeMount(async () => {
             single-line
             hide-details
           />
+        </v-col>
+        <v-spacer />
+        <v-col
+          cols="auto"
+          class="align-self-end"
+        >
+          <v-btn
+            :disabled="unstagedSearchMatches.length === 0"
+            color="success"
+            small
+            @click="stageAllAvailable"
+          >
+            <v-icon left>
+              mdi-check-all
+            </v-icon>
+            Select all
+          </v-btn>
         </v-col>
       </v-row>
       <v-data-table


### PR DESCRIPTION
- Select all button at the top right of Available datasets; stages every unstaged dataset matching the current search

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9QNsyzjQpPbUrWRtiwmrq