### PR TITLE
Let the collapsed Edit Types group expand while nothing is being edited

### DIFF
--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -460,15 +460,18 @@ export default defineComponent({
           <template #activator="{ on, attrs }">
             <v-btn
               v-bind="attrs"
-              :disabled="!editingMode || activeEditButton?.loading"
+              :disabled="!!activeEditButton?.loading"
               :loading="!!activeEditButton?.loading"
               :color="activeEditButton?.active ? editingHeader.color : ''"
               class="mx-1 mode-button toolbar-group-activator"
               small
-              v-on="on"
+              v-on="editingMode ? on : {}"
             >
-              <pre v-if="activeEditButton?.mousetrap">{{ activeEditButton.mousetrap[0].bind }}:</pre>
-              <v-icon>
+              <pre
+                v-if="activeEditButton?.mousetrap"
+                :class="{ 'edit-btn-unavailable': !editingMode }"
+              >{{ activeEditButton.mousetrap[0].bind }}:</pre>
+              <v-icon :class="{ 'edit-btn-unavailable': !editingMode }">
                 {{ activeEditButton?.icon }}
               </v-icon>
               <toolbar-expand-toggle


### PR DESCRIPTION
- Collapsed activator is no longer disabled outside edit mode, so its expand toggle works like the Visibility one
- Outside edit mode the icon is dimmed and the dropdown does not open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9QNsyzjQpPbUrWRtiwmrq