### PR TITLE
Follow VIAME stereo pipeline names and category

### DIFF
--- a/client/dive-common/constants.ts
+++ b/client/dive-common/constants.ts
@@ -222,15 +222,13 @@ const zipFileTypes = [
   'zip',
 ];
 
-const stereoPipelineMarker = 'measurement';
+const stereoPipelineMarker = 'stereo';
 /** Girder item meta key marking the original stereoscopic calibration upload (pipeline input). */
 const calibrationFileMarker = 'calibrationFile';
 /** Girder item meta key marking the JSON camera-rig used for calibration display. */
 const jsonCalibrationFileMarker = 'jsonCalibrationFile';
 /** Girder item meta key marking a frame-metadata attachment for Girder UI. */
 const frameMetadataFileMarker = 'frameMetadata';
-/** Legacy common_stereo category key; never shown in the run-pipeline menu. */
-const hiddenPipelineCategories = ['stereo'];
 /** Pipeline name/category substrings hidden from the web run-pipeline menu. */
 const webExcludedPipelineTerms = ['seagis'];
 const multiCamPipelineMarkers = ['2-cam', '3-cam'];
@@ -285,7 +283,6 @@ export {
   calibrationFileMarker,
   jsonCalibrationFileMarker,
   frameMetadataFileMarker,
-  hiddenPipelineCategories,
   webExcludedPipelineTerms,
   multiCamPipelineMarkers,
   pipelineCreatesDatasetMarkers,

--- a/client/dive-common/pipelineCalibration.spec.ts
+++ b/client/dive-common/pipelineCalibration.spec.ts
@@ -8,8 +8,8 @@ import type { Pipe } from './apispec';
 describe('pipelineCalibration', () => {
   const measurementPipe: Pipe = {
     name: 'gmm',
-    type: 'measurement',
-    pipe: 'measurement_gmm.pipe',
+    type: 'stereo',
+    pipe: 'stereo_gmm.pipe',
   };
 
   it('requires calibration when metadata flag is true', () => {

--- a/client/dive-common/pipelineCreatesDataset.spec.ts
+++ b/client/dive-common/pipelineCreatesDataset.spec.ts
@@ -28,8 +28,8 @@ describe('pipelineCreatesNewDataset', () => {
 
   it('matches the rectified disparity measurement pipe', () => {
     expect(pipelineCreatesNewDataset({
-      type: 'measurement',
-      pipe: 'measurement_compute_rectified_disparity.pipe',
+      type: 'stereo',
+      pipe: 'stereo_compute_rectified_disparity.pipe',
     })).toBe(true);
   });
 
@@ -37,8 +37,8 @@ describe('pipelineCreatesNewDataset', () => {
     expect(pipelineCreatesNewDataset({ type: '2-cam', pipe: 'detector_2-cam.pipe' })).toBe(false);
     expect(pipelineCreatesNewDataset({ type: 'detector', pipe: 'detector_default.pipe' })).toBe(false);
     expect(pipelineCreatesNewDataset({
-      type: 'measurement',
-      pipe: 'measurement_gmm_left_right_stereo.pipe',
+      type: 'stereo',
+      pipe: 'stereo_gmm_left_right_stereo.pipe',
     })).toBe(false);
   });
 });
@@ -75,10 +75,10 @@ describe('isTranscodePipeline', () => {
 describe('isDisparityImagePipeline', () => {
   it('matches only the rectified disparity pipe', () => {
     expect(isDisparityImagePipeline({
-      pipe: 'measurement_compute_rectified_disparity.pipe',
+      pipe: 'stereo_compute_rectified_disparity.pipe',
     })).toBe(true);
     expect(isDisparityImagePipeline({
-      pipe: 'measurement_gmm_left_right_stereo.pipe',
+      pipe: 'stereo_gmm_left_right_stereo.pipe',
     })).toBe(false);
   });
 });

--- a/client/dive-common/pipelineCreatesDataset.ts
+++ b/client/dive-common/pipelineCreatesDataset.ts
@@ -2,7 +2,7 @@ import type { Pipe } from 'dive-common/apispec';
 import { pipelineCreatesDatasetMarkers } from 'dive-common/constants';
 
 /** Stereo pipe that writes disparity/depth images as a new image-sequence dataset. */
-export const DISPARITY_IMAGE_PIPELINE = 'measurement_compute_rectified_disparity.pipe';
+export const DISPARITY_IMAGE_PIPELINE = 'stereo_compute_rectified_disparity.pipe';
 
 /**
  * True when a pipeline produces a new dataset (filter / transcode / disparity).
@@ -32,7 +32,7 @@ export function isTranscodePipeline(pipeline: Pick<Pipe, 'type' | 'pipe'>): bool
 }
 
 /**
- * True for measurement_compute_rectified_disparity.pipe — produces depth-map
+ * True for stereo_compute_rectified_disparity.pipe — produces depth-map
  * images that should become a new dataset (not CSV annotations).
  */
 export function isDisparityImagePipeline(pipeline: Pick<Pipe, 'pipe'>): boolean {

--- a/client/dive-common/pipelineMenuFilters.spec.ts
+++ b/client/dive-common/pipelineMenuFilters.spec.ts
@@ -7,11 +7,10 @@ import {
 import type { Pipelines } from './apispec';
 
 const samplePipelines: Pipelines = {
-  measurement: { description: '', pipes: [{ name: 'gmm', type: 'measurement', pipe: 'measurement_gmm.pipe' }] },
+  stereo: { description: '', pipes: [{ name: 'gmm', type: 'stereo', pipe: 'stereo_gmm.pipe' }] },
   '2-cam': { description: '', pipes: [{ name: 'detector', type: '2-cam', pipe: 'detector_2-cam.pipe' }] },
   '3-cam': { description: '', pipes: [{ name: 'detector', type: '3-cam', pipe: 'detector_3-cam.pipe' }] },
   detector: { description: '', pipes: [{ name: 'default', type: 'detector', pipe: 'detector_default.pipe' }] },
-  stereo: { description: '', pipes: [{ name: 'fish tracker', type: 'stereo', pipe: 'common_stereo_fish_tracker.pipe' }] },
 };
 
 describe('pipelineMenuFilters', () => {
@@ -27,24 +26,17 @@ describe('pipelineMenuFilters', () => {
     })).toBe(3);
   });
 
-  it('hides measurement and multicam categories when subTypeList is empty', () => {
+  it('hides stereo and multicam categories when subTypeList is empty', () => {
     const filtered = filterPipelinesForDatasets(samplePipelines, [], [1]);
-    expect(filtered.measurement).toBeUndefined();
     expect(filtered.stereo).toBeUndefined();
     expect(filtered['2-cam']).toBeUndefined();
     expect(filtered['3-cam']).toBeUndefined();
     expect(filtered.detector).toBeDefined();
   });
 
-  it('never shows legacy common_stereo category', () => {
+  it('shows stereo only for all-stereo selection', () => {
     const filtered = filterPipelinesForDatasets(samplePipelines, ['stereo'], [2]);
-    expect(filtered.stereo).toBeUndefined();
-    expect(filtered.measurement).toBeDefined();
-  });
-
-  it('shows measurement only for all-stereo selection', () => {
-    const filtered = filterPipelinesForDatasets(samplePipelines, ['stereo'], [2]);
-    expect(filtered.measurement).toBeDefined();
+    expect(filtered.stereo).toBeDefined();
     expect(filtered['2-cam']).toBeUndefined();
     expect(filtered.detector).toBeDefined();
   });
@@ -82,7 +74,7 @@ describe('pipelineMenuFilters', () => {
 
   it('hides special categories for non-multicam subtypes', () => {
     const filtered = filterPipelinesForDatasets(samplePipelines, [null], [1]);
-    expect(filtered.measurement).toBeUndefined();
+    expect(filtered.stereo).toBeUndefined();
     expect(filtered['2-cam']).toBeUndefined();
     expect(filtered.detector).toBeDefined();
   });
@@ -116,17 +108,17 @@ describe('pipelineMenuFilters', () => {
     expect(filtered.detector).toBeDefined();
   });
 
-  it('orders categories detector, tracker, measurement, filter, transcode, utility, trained', () => {
+  it('orders categories detector, tracker, stereo, filter, transcode, utility, trained', () => {
     const pipelines: Pipelines = {};
-    ['trained', 'utility', 'filter', 'zeta', 'transcode', 'tracker', 'measurement', 'alpha', 'detector']
+    ['trained', 'utility', 'filter', 'zeta', 'transcode', 'tracker', 'stereo', 'alpha', 'detector']
       .forEach((name) => { pipelines[name] = { description: '', pipes: [] }; });
     expect(Object.keys(orderPipelineCategories(pipelines))).toEqual([
-      'detector', 'tracker', 'measurement', 'filter', 'transcode', 'utility', 'trained', 'zeta', 'alpha',
+      'detector', 'tracker', 'stereo', 'filter', 'transcode', 'utility', 'trained', 'zeta', 'alpha',
     ]);
   });
 
   it('orders categories in filterPipelinesForDatasets', () => {
     const filtered = filterPipelinesForDatasets(samplePipelines, ['stereo'], [2]);
-    expect(Object.keys(filtered)).toEqual(['detector', 'measurement']);
+    expect(Object.keys(filtered)).toEqual(['detector', 'stereo']);
   });
 });

--- a/client/dive-common/pipelineMenuFilters.ts
+++ b/client/dive-common/pipelineMenuFilters.ts
@@ -1,7 +1,6 @@
 import type { Pipe, Pipelines, SubType } from 'dive-common/apispec';
 import {
   MultiType,
-  hiddenPipelineCategories,
   multiCamPipelineMarkers,
   stereoPipelineMarker,
 } from 'dive-common/constants';
@@ -51,7 +50,7 @@ function shouldShowMultiCamPipelineCategory(
   if (!cameraNumbers.every((count) => count === expectedCameras)) {
     return false;
   }
-  // Stereoscopic datasets use measurement pipelines, not X-cam categories.
+  // Stereoscopic datasets use stereo pipelines, not X-cam categories.
   if (subTypeList.some((item) => item === 'stereo')) {
     return false;
   }
@@ -97,7 +96,7 @@ export function excludePipelinesMatchingTerms(
 /**
  * Filter pipeline categories for the run-pipeline menu (matches desktop behavior).
  *
- * - measurement: only when every selected dataset is stereoscopic
+ * - stereo: only when every selected dataset is stereoscopic
  * - 2-cam / 3-cam: only when every selected dataset is multicam and all share that camera count
  * - other categories: always shown (except the special categories above when not applicable)
  */
@@ -126,8 +125,7 @@ export function filterPipelinesForDatasets(
       && shouldShowMultiCamPipelineCategory(name, subTypeList, cameraNumbers, datasetTypes)) {
       sortedPipelines[name] = category;
     }
-    if (!hiddenPipelineCategories.includes(name)
-      && name !== stereoPipelineMarker
+    if (name !== stereoPipelineMarker
       && !multiCamPipelineMarkers.includes(name)) {
       sortedPipelines[name] = category;
     }
@@ -140,7 +138,7 @@ export function filterPipelinesForDatasets(
 
 /** Menu order for known categories; anything else keeps its discovery order after them. */
 export const pipelineCategoryOrder = [
-  'detector', 'tracker', 'measurement', 'filter', 'transcode', 'utility', 'generate', 'trained',
+  'detector', 'tracker', 'stereo', 'filter', 'transcode', 'utility', 'generate', 'trained',
 ];
 
 export function orderPipelineCategories(pipelines: Pipelines): Pipelines {

--- a/client/dive-common/pipelineTypeDisplay.spec.ts
+++ b/client/dive-common/pipelineTypeDisplay.spec.ts
@@ -1,8 +1,8 @@
 import pipelineTypeDisplay from './pipelineTypeDisplay';
 
 describe('pipelineTypeDisplay', () => {
-  it('labels measurement category', () => {
-    expect(pipelineTypeDisplay('measurement')).toBe('Measurement');
+  it('labels stereo category', () => {
+    expect(pipelineTypeDisplay('stereo')).toBe('Stereo');
   });
 
   it('pluralizes other category keys', () => {

--- a/client/dive-common/pipelineTypeDisplay.ts
+++ b/client/dive-common/pipelineTypeDisplay.ts
@@ -8,8 +8,8 @@ export default function pipelineTypeDisplay(pipeType: string): string {
       return 'utilities';
     case 'transcode':
       return 'transcoders';
-    case 'measurement':
-      return 'Measurement';
+    case 'stereo':
+      return 'Stereo';
     default:
       return `${pipeType}s`;
   }

--- a/client/platform/desktop/backend/native/common.ts
+++ b/client/platform/desktop/backend/native/common.ts
@@ -1087,7 +1087,7 @@ async function autodiscoverData(settings: Settings): Promise<JsonConfig[]> {
  */
 async function getPipelineList(settings: Settings): Promise<Pipelines> {
   const pipelinePath = npath.join(settings.viamePath, 'configs/pipelines');
-  const allowedPatterns = /^filter_.+|^transcode_.+|^detector_.+|^tracker_.+|^generate_.+|^utility_|^measurement_.+|.*[2,3]-cam.+/;
+  const allowedPatterns = /^filter_.+|^transcode_.+|^detector_.+|^tracker_.+|^generate_.+|^utility_|^stereo_.+|.*[2,3]-cam.+/;
   const disallowedPatterns = /.*local.*|common_stereo_.*|detector_svm_models.pipe|tracker_svm_models.pipe/;
   const exists = await fs.pathExists(pipelinePath);
   if (!exists) return {};

--- a/client/platform/desktop/backend/native/viame.ts
+++ b/client/platform/desktop/backend/native/viame.ts
@@ -306,11 +306,11 @@ async function runPipeline(
   const joblog = npath.join(jobWorkDir, 'runlog.txt');
 
   //TODO: TEMPORARY FIX FOR DEMO PURPOSES
-  // Disparity image pipe is measurement_* but only needs stereo media + calibration.
+  // Disparity image pipe is stereo_* but only needs stereo media + calibration.
   let requiresInput = false;
   if (
     !isDisparityPipe
-    && (/utility_|filter_|transcode_|measurement_/g).test(pipeline.pipe)
+    && (/utility_|filter_|transcode_|stereo_/g).test(pipeline.pipe)
   ) {
     requiresInput = true;
   }

--- a/server/dive_tasks/multicam_pipeline.py
+++ b/server/dive_tasks/multicam_pipeline.py
@@ -13,7 +13,7 @@ from dive_tasks.pipeline_creates_dataset import is_disparity_image_pipeline
 from dive_utils import constants
 from dive_utils.types import MulticamCameraJob, MulticamRegistrationJob, PipelineDescription
 
-_PIPELINE_INPUT_PATTERN = re.compile(r'utility_|filter_|transcode_|measurement_')
+_PIPELINE_INPUT_PATTERN = re.compile(r'utility_|filter_|transcode_|stereo_')
 _PSEUDO_FRAME_PATTERN = re.compile(r'^frame://(\d+)$')
 
 
@@ -110,7 +110,7 @@ def extract_video_frames(
 
 def pipeline_requires_input(pipeline: PipelineDescription) -> bool:
     """True when the pipe needs existing detections/tracks as input (matches desktop)."""
-    # Disparity image pipe is measurement_* but only needs stereo media + calibration.
+    # Disparity image pipe is stereo_* but only needs stereo media + calibration.
     if is_disparity_image_pipeline(pipeline):
         return False
     return bool(_PIPELINE_INPUT_PATTERN.search(pipeline['pipe']))

--- a/server/dive_tasks/pipeline_creates_dataset.py
+++ b/server/dive_tasks/pipeline_creates_dataset.py
@@ -12,11 +12,11 @@ from dive_utils.types import PipelineDescription
 PIPELINE_CREATES_DATASET_MARKERS = ('transcode', 'filter')
 
 # Stereo pipe that writes disparity/depth images as a new image-sequence dataset.
-DISPARITY_IMAGE_PIPELINE = 'measurement_compute_rectified_disparity.pipe'
+DISPARITY_IMAGE_PIPELINE = 'stereo_compute_rectified_disparity.pipe'
 
 
 def is_disparity_image_pipeline(pipeline: PipelineDescription) -> bool:
-    """True for measurement_compute_rectified_disparity.pipe."""
+    """True for stereo_compute_rectified_disparity.pipe."""
     return pipeline.get('pipe') == DISPARITY_IMAGE_PIPELINE
 
 

--- a/server/dive_tasks/pipeline_discovery.py
+++ b/server/dive_tasks/pipeline_discovery.py
@@ -22,7 +22,7 @@ DisallowedTrainingConfigs = (
 # Align with desktop getPipelineList allow patterns (common.ts).
 AllowedStaticPipelines = (
     r"^filter_.+|^transcode_.+|^detector_.+|^tracker_.+|^generate_.+|^utility_.+|"
-    r"^measurement_.+|.*[23]-cam.+"
+    r"^stereo_.+|.*[23]-cam.+"
 )
 
 DisallowedStaticPipelines = (

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -154,7 +154,7 @@ AnnotationFileFutureProcessMarker = "importAnnotationFile"
 
 # Other constants
 TrainedPipelineCategory = "trained"
-StereoPipelineMarker = "measurement"
+StereoPipelineMarker = "stereo"
 MultiCamPipelineMarkers = ("2-cam", "3-cam")
 
 # The name of the folder where any user specific data should be stored

--- a/server/tests/test_create_multicam.py
+++ b/server/tests/test_create_multicam.py
@@ -435,7 +435,7 @@ def test_resolve_stereo_calibration_item_id_from_folder_root(item_cls):
     pipeline = {
         'name': 'Stereo',
         'type': constants.StereoPipelineMarker,
-        'pipe': 'measurement_foo.pipe',
+        'pipe': 'stereo_foo.pipe',
         'metadata': {'requiresCalibration': True},
     }
     cal_item = {
@@ -464,7 +464,7 @@ def test_resolve_stereo_calibration_item_id_legacy_multi_cam_id(item_cls):
     pipeline = {
         'name': 'Stereo',
         'type': constants.StereoPipelineMarker,
-        'pipe': 'measurement_foo.pipe',
+        'pipe': 'stereo_foo.pipe',
         'metadata': {'requiresCalibration': True},
     }
     cal_item = {

--- a/server/tests/test_multicam_pipeline.py
+++ b/server/tests/test_multicam_pipeline.py
@@ -32,14 +32,14 @@ def test_pipeline_requires_input():
         {
             'name': 'disparity',
             'type': constants.StereoPipelineMarker,
-            'pipe': 'measurement_compute_rectified_disparity.pipe',
+            'pipe': 'stereo_compute_rectified_disparity.pipe',
         }
     )
     assert pipeline_requires_input(
         {
             'name': 'meas',
             'type': constants.StereoPipelineMarker,
-            'pipe': 'measurement_gmm_left_right_stereo.pipe',
+            'pipe': 'stereo_gmm_left_right_stereo.pipe',
         }
     )
 
@@ -54,7 +54,7 @@ def test_is_stereo_or_multicam_pipeline():
 
 def test_is_stereo_measurement_pipeline():
     assert is_stereo_measurement_pipeline(
-        {'name': 'm', 'type': constants.StereoPipelineMarker, 'pipe': 'measurement_x.pipe'}
+        {'name': 'm', 'type': constants.StereoPipelineMarker, 'pipe': 'stereo_x.pipe'}
     )
     assert not is_stereo_measurement_pipeline({'name': '2', 'type': '2-cam', 'pipe': 'x.pipe'})
 
@@ -87,7 +87,7 @@ def test_append_stereo_calibration_kwiver_settings_declared_keys():
     pipeline = {
         'name': 'disparity',
         'type': constants.StereoPipelineMarker,
-        'pipe': 'measurement_compute_rectified_disparity.pipe',
+        'pipe': 'stereo_compute_rectified_disparity.pipe',
         'metadata': {
             'calibrationKeys': [
                 'depth_map:computer:ocv_stereo_disparity:calibration_file',

--- a/server/tests/test_pipeline_creates_dataset.py
+++ b/server/tests/test_pipeline_creates_dataset.py
@@ -39,14 +39,14 @@ def test_pipeline_creates_new_dataset_disparity():
         {
             'name': 'd',
             'type': constants.StereoPipelineMarker,
-            'pipe': 'measurement_compute_rectified_disparity.pipe',
+            'pipe': 'stereo_compute_rectified_disparity.pipe',
         }
     )
     assert not pipeline_creates_new_dataset(
         {
             'name': 'm',
             'type': constants.StereoPipelineMarker,
-            'pipe': 'measurement_gmm_left_right_stereo.pipe',
+            'pipe': 'stereo_gmm_left_right_stereo.pipe',
         }
     )
     assert not pipeline_creates_new_dataset(
@@ -65,13 +65,13 @@ def test_is_filter_transcode_disparity_helpers():
         {
             'name': 'd',
             'type': constants.StereoPipelineMarker,
-            'pipe': 'measurement_compute_rectified_disparity.pipe',
+            'pipe': 'stereo_compute_rectified_disparity.pipe',
         }
     )
     assert not is_disparity_image_pipeline(
         {
             'name': 'm',
             'type': constants.StereoPipelineMarker,
-            'pipe': 'measurement_other.pipe',
+            'pipe': 'stereo_other.pipe',
         }
     )

--- a/server/tests/test_pipeline_discovery.py
+++ b/server/tests/test_pipeline_discovery.py
@@ -7,10 +7,10 @@ from dive_tasks.pipeline_discovery import (
 )
 
 
-def test_parse_pipe_type_and_name_measurement():
-    assert parse_pipe_type_and_name('measurement_fully_auto_gmm_motion') == (
-        'measurement',
-        'fully auto gmm motion',
+def test_parse_pipe_type_and_name_stereo():
+    assert parse_pipe_type_and_name('stereo_measure_fully_auto_gmm_motion') == (
+        'stereo',
+        'measure fully auto gmm motion',
     )
 
 
@@ -42,15 +42,15 @@ def test_parse_pipe_type_and_name_one_cam_stays_detector():
     )
 
 
-def test_load_static_pipelines_includes_measurement_and_multicam(tmp_path: Path):
-    (tmp_path / 'measurement_fully_auto_gmm_motion.pipe').write_text('# Description: test\n')
+def test_load_static_pipelines_includes_stereo_and_multicam(tmp_path: Path):
+    (tmp_path / 'stereo_measure_fully_auto_gmm_motion.pipe').write_text('# Description: test\n')
     (tmp_path / 'utility_register_frames_2-cam.pipe').write_text('')
     (tmp_path / 'utility_register_frames_3-cam.pipe').write_text('')
     (tmp_path / 'detector_gmm_motion.pipe').write_text('')
 
     pipedict = load_static_pipelines(tmp_path)
-    assert 'measurement' in pipedict
-    assert pipedict['measurement']['pipes'][0]['type'] == 'measurement'
+    assert 'stereo' in pipedict
+    assert pipedict['stereo']['pipes'][0]['type'] == 'stereo'
     assert '2-cam' in pipedict
     assert '3-cam' in pipedict
     assert 'detector' in pipedict
@@ -76,7 +76,7 @@ def test_load_static_pipelines_excludes_common_stereo(tmp_path: Path):
 
 
 def test_extract_pipe_metadata_requires_calibration(tmp_path: Path):
-    pipe = tmp_path / 'measurement_foo.pipe'
+    pipe = tmp_path / 'stereo_foo.pipe'
     pipe.write_text(
         '\n'.join(
             [
@@ -98,7 +98,7 @@ def test_extract_pipe_metadata_requires_calibration(tmp_path: Path):
 
 
 def test_extract_pipe_metadata_calibration_keys(tmp_path: Path):
-    pipe = tmp_path / 'measurement_disparity.pipe'
+    pipe = tmp_path / 'stereo_disparity.pipe'
     pipe.write_text(
         '\n'.join(
             [

--- a/server/tests/test_pipeline_discovery.py
+++ b/server/tests/test_pipeline_discovery.py
@@ -8,9 +8,9 @@ from dive_tasks.pipeline_discovery import (
 
 
 def test_parse_pipe_type_and_name_stereo():
-    assert parse_pipe_type_and_name('stereo_measure_fully_auto_gmm_motion') == (
+    assert parse_pipe_type_and_name('stereo_detect_and_measure_gmm_motion') == (
         'stereo',
-        'measure fully auto gmm motion',
+        'detect and measure gmm motion',
     )
 
 
@@ -43,7 +43,7 @@ def test_parse_pipe_type_and_name_one_cam_stays_detector():
 
 
 def test_load_static_pipelines_includes_stereo_and_multicam(tmp_path: Path):
-    (tmp_path / 'stereo_measure_fully_auto_gmm_motion.pipe').write_text('# Description: test\n')
+    (tmp_path / 'stereo_detect_and_measure_gmm_motion.pipe').write_text('# Description: test\n')
     (tmp_path / 'utility_register_frames_2-cam.pipe').write_text('')
     (tmp_path / 'utility_register_frames_3-cam.pipe').write_text('')
     (tmp_path / 'detector_gmm_motion.pipe').write_text('')

--- a/server/tests/test_pipeline_media_writers.py
+++ b/server/tests/test_pipeline_media_writers.py
@@ -22,7 +22,7 @@ def test_append_new_dataset_media_writers_disparity(tmp_path: Path):
     pipeline = {
         'name': 'disparity',
         'type': constants.StereoPipelineMarker,
-        'pipe': 'measurement_compute_rectified_disparity.pipe',
+        'pipe': 'stereo_compute_rectified_disparity.pipe',
     }
     result = append_new_dataset_media_writers(command, pipeline, tmp_path)
     assert result is None
@@ -42,6 +42,6 @@ def test_append_new_dataset_media_writers_transcode(tmp_path: Path):
 def test_pipeline_renumbers_frames():
     assert pipeline_renumbers_frames('filter_enhance.pipe')
     assert pipeline_renumbers_frames('transcode_default.pipe')
-    assert pipeline_renumbers_frames('measurement_compute_rectified_disparity.pipe')
+    assert pipeline_renumbers_frames('stereo_compute_rectified_disparity.pipe')
     assert not pipeline_renumbers_frames('detector_default.pipe')
-    assert not pipeline_renumbers_frames('measurement_gmm_left_right_stereo.pipe')
+    assert not pipeline_renumbers_frames('stereo_gmm_left_right_stereo.pipe')


### PR DESCRIPTION
VIAME pipelines now use the `stereo_*` prefix, with measurement-producing pipelines named `stereo_measure_*`. Update desktop and server discovery, stereo category filtering and display, annotation input handling, and the rectified disparity dataset special case to follow these names. Remove the obsolete hidden stereo category rule.

Validation: 27 focused client tests passed; ESLint passed for all changed client files; rename/reference checks passed in VIAME. Updated server tests could not run locally because Girder and girder_worker are not installed.
