### PR TITLE
Add Resume button to desktop navigation

### DIFF
--- a/client/platform/desktop/frontend/components/NavigationBar.vue
+++ b/client/platform/desktop/frontend/components/NavigationBar.vue
@@ -26,11 +26,11 @@ export default defineComponent({
       color="accent"
     >
       <v-tab
-        :to="lastAnnotation ? { name: 'viewer', params: { id: lastAnnotation.id } } : undefined"
-        :disabled="!lastAnnotation"
-        :title="lastAnnotation ? `Resume editing ${lastAnnotation.name}` : 'Open a sequence to resume editing'"
+        v-if="lastAnnotation"
+        :to="{ name: 'viewer', params: { id: lastAnnotation.id } }"
+        :title="`Resume editing ${lastAnnotation.name}`"
       >
-        Resume Last<v-icon>mdi-history</v-icon>
+        Resume<v-icon>mdi-history</v-icon>
       </v-tab>
       <v-tab :to="{ name: 'recent' }">
         Library<v-icon>mdi-folder-open</v-icon>

--- a/client/platform/desktop/frontend/components/NavigationBar.vue
+++ b/client/platform/desktop/frontend/components/NavigationBar.vue
@@ -1,6 +1,7 @@
 <script>
 import { defineComponent } from 'vue';
 import JobTab from './JobTab.vue';
+import { lastAnnotation } from '../store/dataset';
 
 export default defineComponent({
   components: { JobTab },
@@ -9,6 +10,9 @@ export default defineComponent({
       type: String,
       default: 'DIVE',
     },
+  },
+  setup() {
+    return { lastAnnotation };
   },
 });
 </script>
@@ -21,6 +25,13 @@ export default defineComponent({
       style="flex-basis:0; flex-grow:0;"
       color="accent"
     >
+      <v-tab
+        :to="lastAnnotation ? { name: 'viewer', params: { id: lastAnnotation.id } } : undefined"
+        :disabled="!lastAnnotation"
+        :title="lastAnnotation ? `Resume editing ${lastAnnotation.name}` : 'Open a sequence to resume editing'"
+      >
+        Resume Last<v-icon>mdi-history</v-icon>
+      </v-tab>
       <v-tab :to="{ name: 'recent' }">
         Library<v-icon>mdi-folder-open</v-icon>
       </v-tab>

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -41,7 +41,7 @@ import {
 import Export from './Export.vue';
 import JobTab from './JobTab.vue';
 import DatasetSourceInfo from './DatasetSourceInfo.vue';
-import { datasets } from '../store/dataset';
+import { datasets, rememberAnnotation } from '../store/dataset';
 import { settings } from '../store/settings';
 import { runningJobs } from '../store/jobs';
 import { setCloseGuard } from '../store/closeGuard';
@@ -934,6 +934,17 @@ export default defineComponent({
     // until the toggle was flipped off and on again. The load-time auto-enable
     // is deferred to the viewer-ready watcher below instead.
     watch(stereoServiceWanted, (enabled) => requestStereoServiceState(enabled, true));
+
+    watch(
+      () => viewerRef.value?.progress?.loaded === true,
+      (loaded) => {
+        // Read-only scoring previews should not replace the last editing sequence.
+        if (loaded && !scoringPreviewFile.value) {
+          rememberAnnotation(props.id);
+        }
+      },
+      { immediate: true },
+    );
 
     // Load-time auto-enable of a remembered setting: run once the viewer has
     // actually finished loading the dataset (progress.loaded), so the metadata

--- a/client/platform/desktop/frontend/store/dataset.ts
+++ b/client/platform/desktop/frontend/store/dataset.ts
@@ -45,6 +45,16 @@ function hydrateJsonConfigCacheValue(input: any): JsonConfigCache {
 
 const datasets = ref({} as Record<string, JsonConfigCache>);
 
+// Remember annotation navigation separately from library selections and jobs.
+const lastAnnotationId = ref<string | null>(null);
+const lastAnnotation = computed(() => (
+  lastAnnotationId.value ? datasets.value[lastAnnotationId.value] : undefined
+));
+
+function rememberAnnotation(datasetId: string) {
+  lastAnnotationId.value = datasetId;
+}
+
 const recents = computed(() => (Object.values(datasets.value)));
 
 function setRecents(meta: JsonConfig, accessTime?: string) {
@@ -70,6 +80,7 @@ function setRecents(meta: JsonConfig, accessTime?: string) {
 }
 
 function clearRecents() {
+  lastAnnotationId.value = null;
   datasets.value = {};
   window.localStorage.setItem(RecentsKey, JSON.stringify([]));
 }
@@ -136,6 +147,9 @@ function locateDuplicates(meta: JsonConfig) {
 }
 
 function removeRecents(datasetId: string) {
+  if (lastAnnotationId.value === datasetId) {
+    lastAnnotationId.value = null;
+  }
   if (datasets.value[datasetId]) {
     Vue.delete(datasets.value, datasetId);
   }
@@ -144,6 +158,8 @@ function removeRecents(datasetId: string) {
 }
 
 export {
+  lastAnnotation,
+  rememberAnnotation,
   datasets,
   recents,
   autoDiscover,


### PR DESCRIPTION
Add Resume to the left of Library to reopen the last successfully loaded annotation sequence after navigating to Training, Review, or another menu page. The button is hidden until a sequence is available. The target is remembered for the app session, excludes scoring previews, and clears when the dataset is removed.

Validation: targeted ESLint passed; TypeScript checks passed for the navigation implementation before the label and visibility adjustment.
