### PR TITLE
Fix stale annotation indices and redraw watchers after reload

### DIFF
--- a/client/src/BaseAnnotationStore.ts
+++ b/client/src/BaseAnnotationStore.ts
@@ -206,9 +206,7 @@ export default abstract class BaseAnnotationStore<T extends Track | Group> {
 
   clearAll() {
     this.annotationMap.clear();
-    this.intervalTree.items.forEach((item) => {
-      this.intervalTree.remove(item.key);
-    });
+    this.intervalTree.clear();
     this.annotationIds.value = [];
   }
 }

--- a/client/src/TrackStore.spec.ts
+++ b/client/src/TrackStore.spec.ts
@@ -84,3 +84,17 @@ describe('TrackStore', () => {
     called = false;
   });
 });
+
+describe('TrackStore pipeline reload', () => {
+  it('clears every indexed detection before loading replacement results', () => {
+    const store = new TrackStore({ markChangesPending: () => null, cameraName: 'left' });
+    store.add(4, 'fish', undefined, 7);
+    store.add(4, 'fish', undefined, 8);
+    store.add(9, 'fish', undefined, 9);
+    store.clearAll();
+    expect(store.intervalTree.search([0, 20])).toEqual([]);
+    store.add(4, 'fish', undefined, 7);
+    expect(store.intervalTree.search([4, 4])).toEqual(['7']);
+    expect(store.intervalTree.search([9, 9])).toEqual([]);
+  });
+});

--- a/client/src/components/LayerManager.spec.ts
+++ b/client/src/components/LayerManager.spec.ts
@@ -1,7 +1,8 @@
 /* eslint-disable max-classes-per-file -- lightweight layer doubles */
-import {
-  defineComponent, h, ref,
+import Vue, {
+  defineComponent, h, ref, nextTick,
 } from 'vue';
+import type { Ref } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import Track, { Feature } from '../track';
 import CameraStore from '../CameraStore';
@@ -12,6 +13,7 @@ import LayerManager from './LayerManager.vue';
 
 const layerMocks = vi.hoisted(() => {
   const rectangleChangeData = vi.fn();
+  const mountWidget = vi.fn();
 
   class MockLayer {
     bus = { $on: vi.fn() };
@@ -44,7 +46,7 @@ const layerMocks = vi.hoisted(() => {
 
     update = vi.fn();
 
-    addDOMWidget = vi.fn();
+    addDOMWidget = mountWidget;
 
     setToolTipWidget = vi.fn();
 
@@ -55,7 +57,9 @@ const layerMocks = vi.hoisted(() => {
     changeData = rectangleChangeData;
   }
 
-  return { MockLayer, MockRectangleLayer, rectangleChangeData };
+  return {
+    MockLayer, MockRectangleLayer, rectangleChangeData, mountWidget,
+  };
 });
 
 const provided = vi.hoisted(() => ({
@@ -316,9 +320,11 @@ function renderCamera(
     pendingSaveCount: ref(0),
   };
   layerMocks.rectangleChangeData.mockClear();
-  mountLayerManager({ camera });
+  const wrapper = mountLayerManager({ camera });
   const { calls } = layerMocks.rectangleChangeData.mock;
-  return calls[calls.length - 1][0] as { styleType: [string, number] }[];
+  const frameData = calls[calls.length - 1][0] as { styleType: [string, number] }[];
+  wrapper.destroy();
+  return frameData;
 }
 
 describe('LayerManager multicamera hierarchy selection', () => {
@@ -350,5 +356,36 @@ describe('LayerManager multicamera hierarchy selection', () => {
     trackFilters.setConfidenceFilters({ default: 0.5 });
     expect(renderCamera(cameraStore, trackFilters, 'left')[0].styleType).toEqual(['leaf', 0.8]);
     expect(renderCamera(cameraStore, trackFilters, 'right')).toHaveLength(0);
+  });
+});
+
+describe('LayerManager pipeline reload lifecycle', () => {
+  it('stops redraw watchers when the old viewer unmounts, including after mounting a tooltip', async () => {
+    // GeoJS tooltips mount their own Vue root. Exercise that real Vue lifecycle:
+    // mounting it during setup detaches subsequent watches from LayerManager.
+    const widgets: Vue[] = [];
+    layerMocks.mountWidget.mockImplementation(() => {
+      const Tooltip = defineComponent({ setup: () => () => h('span') });
+      widgets.push(new Vue({ render: (createElement) => createElement(Tooltip) }).$mount());
+    });
+    const { cameraStore, trackFilters } = makeMultiCamFixture([['fish', 1]], [['fish', 1]], {});
+    try {
+      renderCamera(cameraStore, trackFilters, 'left'); // mounts and destroys the old manager
+      const selectedKey = provided.values?.selectedKey as Ref<string>;
+      layerMocks.rectangleChangeData.mockClear();
+      selectedKey.value = '1';
+      await nextTick();
+      expect(layerMocks.rectangleChangeData).not.toHaveBeenCalled();
+
+      const replacement = mountLayerManager({ camera: 'left' });
+      layerMocks.rectangleChangeData.mockClear();
+      selectedKey.value = '';
+      await nextTick();
+      expect(layerMocks.rectangleChangeData).toHaveBeenCalledTimes(1);
+      replacement.destroy();
+    } finally {
+      widgets.forEach((widget) => widget.$destroy());
+      layerMocks.mountWidget.mockReset();
+    }
   });
 });

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  defineComponent, watch, PropType, Ref, ref, computed, toRef,
+  defineComponent, watch, PropType, Ref, ref, computed, toRef, onMounted,
 } from 'vue';
 
 import { clientSettings } from 'dive-common/store/settings';
@@ -319,7 +319,12 @@ export default defineComponent({
       selected: selectedTrackIdRef,
       stateStyling: trackStyleManager.stateStyles,
     };
-    uiLayer.addDOMWidget('customToolTip', ToolTipWidget, toolTipWidgetProps, { x: 10, y: 10 });
+    // Mounting the tooltip's separate Vue root during setup clears Vue's
+    // current component scope. Later watches then survive a dataset reload
+    // and redraw the old, destroyed map. Finish setup before mounting it.
+    onMounted(() => {
+      uiLayer.addDOMWidget('customToolTip', ToolTipWidget, toolTipWidgetProps, { x: 10, y: 10 });
+    });
 
     useSegmentationPointsLayer({
       camera: props.camera,


### PR DESCRIPTION
Reloading pipeline annotations could leave stale detections in the frame index and redraw watchers attached to a destroyed viewer. Clear the interval tree directly when replacing annotations, and mount the tooltip after LayerManager setup so its redraw watchers are disposed with the component.

Regression tests cover clearing and repopulating the frame index, stopping redraws after the old viewer unmounts, and updating the replacement viewer once.

Validation:
- 58 tests passed across LayerManager, TrackStore, CameraStore, and desktop VIAME CSV serialization.
- Type checking passed.
- ESLint: no errors; two component-count warnings in the test file.
- `git diff --check` passed.
