### PR TITLE
Ignore nonpositive detection lengths when importing VIAME CSV

### DIFF
--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -246,6 +246,35 @@ describe('VIAME Python Compatibility Check', () => {
   });
 });
 
+describe('Detection length import', () => {
+  [0, -1, -2.5, 12.5].forEach((columnLength) => {
+    [undefined, 0, -1, -2.5, 7.5].forEach((attributeLength) => {
+      it(`imports positive lengths from column ${columnLength} and attribute ${attributeLength}`, async () => {
+        let csv = `0,1.png,0,10,10,20,20,1,${columnLength},fish,0.9,(atr) other 3`;
+        if (attributeLength !== undefined) {
+          csv += `,(atr) length ${attributeLength}`;
+        }
+        const [data] = await parse(Readable.from([csv]));
+        const track = Object.values(data.tracks)[0];
+        const feature = track.features[0];
+        const expected = attributeLength !== undefined && attributeLength > 0
+          ? attributeLength : columnLength;
+        expect(feature.attributes?.other).toBe(3);
+        const { attributes } = processTrackAttributes([track]);
+        if (expected > 0) {
+          expect(feature.attributes?.length).toBe(expected);
+          expect(feature.fishLength).toBe(expected);
+          expect(attributes).toHaveProperty('detection_length');
+        } else {
+          expect(feature.attributes).not.toHaveProperty('length');
+          expect(feature).not.toHaveProperty('fishLength');
+          expect(attributes).not.toHaveProperty('detection_length');
+        }
+      });
+    });
+  });
+});
+
 describe('Attribute value parsing', () => {
   it('keeps filename-like attribute values as full strings', async () => {
     const csv = [

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -379,11 +379,14 @@ function _parseFeature(row: string[]) {
     frame: rowInfo.frame,
     bounds: rowInfo.bounds,
   };
-  if (rowInfo.fishLength !== -1 && Number.isFinite(rowInfo.fishLength)) {
+  if (rowInfo.fishLength > 0 && Number.isFinite(rowInfo.fishLength)) {
     feature.fishLength = rowInfo.fishLength;
   }
   if (rowData.attributes) {
     feature.attributes = rowData.attributes;
+  }
+  if (feature.attributes?.length !== undefined && Number(feature.attributes.length) <= 0) {
+    delete feature.attributes.length;
   }
   const syncedFeature = syncDetectionLengthFields(feature);
   if (rowData.geoFeatureCollection.features.length > 0) {

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -68,12 +68,15 @@ def _resolve_detection_length(
     fish_length_from_column: float,
 ) -> Tuple[Dict[str, Any], Optional[float]]:
     """Resolve length from attributes.length or the VIAME length column."""
+    attributes = dict(attributes or {})
     attr_length: Optional[float] = None
     if attributes and 'length' in attributes:
         try:
             candidate = float(attributes['length'])
-            if candidate == candidate:  # not NaN
+            if candidate > 0:
                 attr_length = candidate
+            elif candidate <= 0:
+                attributes.pop('length')
         except (TypeError, ValueError):
             attr_length = None
 

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -22,3 +22,25 @@ def test_read_viame_csv(
         expected_tracks, sort_keys=True
     )
     assert json.dumps(attributes, sort_keys=True) == json.dumps(expected_attributes, sort_keys=True)
+
+
+@pytest.mark.parametrize("column_length", [0, -1, -2.5, 12.5])
+@pytest.mark.parametrize("attribute_length", [None, 0, -1, -2.5, 7.5])
+def test_import_detection_length(column_length, attribute_length):
+    row = f"0,1.png,0,10,10,20,20,1,{column_length},fish,0.9,(atr) other 3"
+    if attribute_length is not None:
+        row += f",(atr) length {attribute_length}"
+    converted, attributes, *_ = viame.load_csv_as_tracks_and_attributes([row])
+    feature = converted['tracks']['0']['features'][0]
+    expected = (
+        attribute_length if attribute_length is not None and attribute_length > 0 else column_length
+    )
+    assert feature['attributes']['other'] == 3
+    if expected > 0:
+        assert feature['attributes']['length'] == expected
+        assert feature['fishLength'] == expected
+        assert 'detection_length' in attributes
+    else:
+        assert 'length' not in feature['attributes']
+        assert 'fishLength' not in feature
+        assert 'detection_length' not in attributes


### PR DESCRIPTION
VIAME CSV imports could create zero or negative detection length attributes. Ignore nonpositive lengths from the dedicated length column and explicit `(atr) length` fields in the desktop and Python importers. Positive attribute lengths retain precedence, with a positive column length used as fallback, and unrelated attributes are preserved.

Added 20 regression cases per importer covering absent, zero, negative, and positive attribute lengths against zero, negative, and positive column lengths, including generated attribute definitions.

Validation: 48 Python CSV import/export tests and 34 desktop CSV tests passed; ESLint on both changed TypeScript files and Black checks on both changed Python files passed.
