### PR TITLE
Limit desktop library select-all to the current page

### DIFF
--- a/client/platform/desktop/frontend/components/Recent.vue
+++ b/client/platform/desktop/frontend/components/Recent.vue
@@ -236,17 +236,21 @@ export default defineComponent({
 
     const filteredRecents = computed(() => recents.value
       .filter((v) => v.name.toLowerCase().indexOf((searchText.value || '').toLowerCase()) >= 0));
-    const allSelected = computed(() => filteredRecents.value.length > 0
-      && filteredRecents.value.every((item) => selectedIds.value.has(item.id)));
-    const someSelected = computed(() => filteredRecents.value.some(
+    const visibleRecents = ref([] as JsonConfigCache[]);
+    const allSelected = computed(() => visibleRecents.value.length > 0
+      && visibleRecents.value.every((item) => selectedIds.value.has(item.id)));
+    const someSelected = computed(() => visibleRecents.value.some(
       (item) => selectedIds.value.has(item.id),
     ));
 
     function toggleSelectAll() {
       if (allSelected.value) {
-        selectedRecents.value = [];
+        const visibleIds = new Set(visibleRecents.value.map((item) => item.id));
+        selectedRecents.value = selectedRecents.value.filter((item) => !visibleIds.has(item.id));
       } else {
-        selectedRecents.value = filteredRecents.value.slice();
+        selectedRecents.value = selectedRecents.value.concat(
+          visibleRecents.value.filter((item) => !selectedIds.value.has(item.id)),
+        );
       }
     }
 
@@ -370,6 +374,7 @@ export default defineComponent({
       multiCamOpenType,
       stereo,
       filteredRecents,
+      visibleRecents,
       selectedRecents,
       allSelected,
       someSelected,
@@ -387,7 +392,7 @@ export default defineComponent({
       knownVersion,
       checkingMedia,
       clientSettings,
-      itemsPerPageOptions,
+      itemsPerPageOptions: [...itemsPerPageOptions, 1000, -1],
       queuedConversionDatasetIds,
     };
   },
@@ -704,6 +709,7 @@ export default defineComponent({
               :footer-props="{ itemsPerPageOptions }"
               :items-per-page.sync="clientSettings.rowsPerPage"
               no-data-text="No data loaded"
+              @current-items="visibleRecents = $event"
             >
               <template #[`header.select`]>
                 <v-simple-checkbox


### PR DESCRIPTION
The desktop library's header checkbox selected every matching dataset across multiple pages. It now checks or unchecks only the rows displayed on the current page after sorting and filtering, and its checked/indeterminate state reflects those rows. Existing selections on other pages are preserved.

Add 1000 and All after the existing 20, 50, and 100 page-size options in the desktop library. All displays every dataset matching the current search, allowing the header checkbox to select all displayed matches intentionally.

Validation: ESLint for Recent.vue and full client type checking passed. Existing desktop frontend query tests passed (5 tests).
