### PR TITLE
Support editable curved centerlines and stereo keypoint mapping

### DIFF
--- a/client/dive-common/components/EditorMenu.vue
+++ b/client/dive-common/components/EditorMenu.vue
@@ -214,12 +214,12 @@ export default defineComponent({
       Creating: {
         rectangle: 'Drag to draw rectangle. Press ESC to exit.',
         Polygon: 'Click to place vertices. Right click to close.',
-        LineString: 'Click to place head/tail points.',
+        LineString: 'Place head/tail points, then drag segment midpoints to add vertices.',
       },
       Editing: {
         rectangle: 'Drag vertices to resize the rectangle',
         Polygon: 'Drag midpoints to create new vertices. Click vertices to select for deletion.',
-        LineString: 'Click endpoints to select for deletion.',
+        LineString: 'Click a vertex to select it for deletion.',
       },
     };
 

--- a/client/dive-common/recipes/headtail.ts
+++ b/client/dive-common/recipes/headtail.ts
@@ -1,6 +1,7 @@
 import Vue, { ref, Ref } from 'vue';
 
 import Track from 'vue-media-annotator/track';
+import { headTailFeatures, isHeadTailPoint } from 'vue-media-annotator/headTail';
 import Recipe, { UpdateResponse } from 'vue-media-annotator/recipe';
 import { EditAnnotationTypes } from 'vue-media-annotator/layers';
 import { Mousetrap } from 'vue-media-annotator/types';
@@ -88,6 +89,7 @@ export default class HeadTail implements Recipe {
         ],
       }];
     }
+    if (coords.length > 2) return HeadTail.tightBoundsExpanded(coords, 0);
     // If only 1 point is available so far
     return [{
       type: 'Polygon',
@@ -161,45 +163,20 @@ export default class HeadTail implements Recipe {
   }
 
   private static makeGeom(ls: GeoJSON.LineString, startWithHead: boolean) {
-    const firstFeature: GeoJSON.Feature<GeoJSON.Point> = {
-      type: 'Feature',
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          ls.coordinates[0][0],
-          ls.coordinates[0][1],
-        ],
-      },
-      properties: {},
-    };
-    const ret: Record<string,
-      GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon>[]> = {
-        [startWithHead ? HeadPointKey : TailPointKey]: [firstFeature],
+    const coordinates = ls.coordinates.map((p) => [...p]);
+    if (coordinates.length < 2) {
+      return {
+        [startWithHead ? HeadPointKey : TailPointKey]: [{
+          type: 'Feature' as const,
+          properties: {},
+          geometry: { type: 'Point' as const, coordinates: coordinates[0] },
+        }],
       };
-    if (ls.coordinates.length === 2) {
-      const secondFeature: GeoJSON.Feature<GeoJSON.Point> = {
-        type: 'Feature',
-        geometry: {
-          type: 'Point',
-          coordinates: [
-            ls.coordinates[1][0],
-            ls.coordinates[1][1],
-          ],
-        },
-        properties: {},
-      };
-      if (!startWithHead) {
-        ls.coordinates.reverse();
-      }
-      const headTailLine: GeoJSON.Feature<GeoJSON.LineString> = {
-        type: 'Feature',
-        geometry: ls,
-        properties: {},
-      };
-      ret[startWithHead ? TailPointKey : HeadPointKey] = [secondFeature];
-      ret[HeadTailLineKey] = [headTailLine];
     }
-    return ret;
+    if (!startWithHead) coordinates.reverse();
+    const result: Record<string, GeoJSON.Feature<GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon>[]> = {};
+    headTailFeatures(coordinates).forEach((f) => { result[f.properties?.key] = [f]; });
+    return result;
   }
 
   update(
@@ -314,20 +291,31 @@ export default class HeadTail implements Recipe {
   // eslint-disable-next-line class-methods-use-this
   delete(frame: number, track: Track, key: string, type: EditAnnotationTypes) {
     if (key === HeadTailLineKey && type === 'LineString') {
-      track.removeFeatureGeometry(frame, { type: 'Point', key: HeadPointKey });
+      track.getFeatureGeometry(frame, { type: 'Point' }).forEach((f) => {
+        if (isHeadTailPoint(f.properties?.key || '')) track.removeFeatureGeometry(frame, { type: 'Point', key: f.properties?.key });
+      });
       track.removeFeatureGeometry(frame, { type: 'Point', key: TailPointKey });
       track.removeFeatureGeometry(frame, { type: 'LineString', key: HeadTailLineKey });
+      track.setFeature({ frame, head: undefined, tail: undefined });
+      track.invalidateMeasurement(frame);
     }
   }
 
   // eslint-disable-next-line class-methods-use-this
   deletePoint(frame: number, track: Track, idx: number, key: string, type: EditAnnotationTypes) {
     if (key === HeadTailLineKey && type === 'LineString') {
-      track.removeFeatureGeometry(frame, { type: 'LineString', key: HeadTailLineKey });
-      if (idx === 0) {
-        track.removeFeatureGeometry(frame, { type: 'Point', key: HeadPointKey });
+      const line = track.getFeatureGeometry(frame, { type: 'LineString', key: HeadTailLineKey })[0];
+      if (!line || line.geometry.type !== 'LineString') return;
+      const coordinates = line.geometry.coordinates.map((p) => [...p]);
+      if (idx < 0 || idx >= coordinates.length) return;
+      if (coordinates.length > 2) {
+        coordinates.splice(idx, 1);
+        track.setFeature({ frame }, headTailFeatures(coordinates));
       } else {
-        track.removeFeatureGeometry(frame, { type: 'Point', key: TailPointKey });
+        track.removeFeatureGeometry(frame, { type: 'LineString', key: HeadTailLineKey });
+        track.removeFeatureGeometry(frame, { type: 'Point', key: idx === 0 ? HeadPointKey : TailPointKey });
+        track.setFeature({ frame, [idx === 0 ? 'head' : 'tail']: undefined });
+        track.invalidateMeasurement(frame);
       }
     }
   }

--- a/client/dive-common/recipes/headtail.ts
+++ b/client/dive-common/recipes/headtail.ts
@@ -20,14 +20,6 @@ const PaddingVector: [number, number][] = [
   [1.10, 0.10],
   [-0.10, -0.10],
 ];
-/* No padding */
-const PaddingVectorZero: [number, number][] = [
-  [0, 0],
-  [0, 0],
-  [1, 0],
-  [1, 0],
-  [0, 0],
-];
 /* Cap how skinny a line's box may get: longer side at most this x the shorter. */
 const MAX_BOX_ASPECT_RATIO = 6;
 
@@ -38,8 +30,8 @@ export default class HeadTail implements Recipe {
 
   private startWithHead: boolean;
 
-  /* Whether the track had bounds before line creation started */
-  private hadBoundsOnCreate: boolean;
+  /* Only the initial completion of a newly boxed line may replace its interim box. */
+  private initialBoundsTarget: { track: Track; frame: number } | null;
 
   bus: Vue;
 
@@ -50,7 +42,7 @@ export default class HeadTail implements Recipe {
   constructor() {
     this.bus = new Vue();
     this.startWithHead = true;
-    this.hadBoundsOnCreate = false;
+    this.initialBoundsTarget = null;
     this.active = ref(false);
     this.name = 'HeadTail';
     this.toggleable = ref(true);
@@ -108,6 +100,17 @@ export default class HeadTail implements Recipe {
       results.push(withinBounds([x, y], bounds));
     }
     return (results.filter((item) => item).length === coords.length);
+  }
+
+  /** Expand an existing box only enough to enclose outlying vertices. */
+  private static encloseVertices(bounds: RectBounds, coordinates: GeoJSON.Position[]): GeoJSON.Polygon[] {
+    if (HeadTail.coordsInBounds(bounds, coordinates)) return [];
+    const xs = coordinates.map((p) => p[0]);
+    const ys = coordinates.map((p) => p[1]);
+    // Track stores integer boxes; round outward so fractional points stay inside.
+    const x0 = Math.floor(Math.min(...xs)); const x1 = Math.ceil(Math.max(...xs));
+    const y0 = Math.floor(Math.min(...ys)); const y1 = Math.ceil(Math.max(...ys));
+    return [{ type: 'Polygon', coordinates: [[[x0, y0], [x1, y0], [x1, y1], [x0, y1], [x0, y0]]] }];
   }
 
   /**
@@ -222,20 +225,9 @@ export default class HeadTail implements Recipe {
           } as GeoJSON.LineString;
         }
         if (geom.coordinates.length === 2) {
-          let union: GeoJSON.Polygon[];
-          if (bounds !== null) {
-            // If both are inside of the bbox don't adjust the union
-            if (HeadTail.coordsInBounds(bounds, geom.coordinates)) {
-              union = [];
-            } else if (tail.length > 0) { // If creating new box add padding
-              union = HeadTail.findBounds(geom, PaddingVectorZero);
-            } else {
-              union = HeadTail.findBounds(geom, PaddingVector);
-            }
-          } else {
-            // No existing box: make box 10% larger than tight box around vertices
-            union = HeadTail.tightBoundsExpanded(geom.coordinates, 0.10);
-          }
+          const initialBounds = (this.initialBoundsTarget?.track === track && this.initialBoundsTarget.frame === frameNum) || bounds === null;
+          this.initialBoundsTarget = null;
+          const union = initialBounds ? [] : HeadTail.encloseVertices(bounds!, geom.coordinates);
           // Both head and tail placed, replace them.
           return {
             ...EmptyResponse,
@@ -243,17 +235,14 @@ export default class HeadTail implements Recipe {
             newSelectedKey: HeadTailLineKey,
             done: true,
             union,
+            unionWithoutBounds: initialBounds ? HeadTail.tightBoundsExpanded(geom.coordinates, 0.10) : [],
           } as UpdateResponse;
         }
         if (geom.coordinates.length === 1) {
           // Only the head placed so far — record if the track already had bounds
-          this.hadBoundsOnCreate = bounds !== null;
+          this.initialBoundsTarget = bounds === null ? { track, frame: frameNum } : null;
           let union = HeadTail.findBounds(geom, PaddingVector);
-          if (bounds !== null) {
-            if (HeadTail.coordsInBounds(bounds, geom.coordinates)) {
-              union = [];
-            }
-          }
+          if (bounds !== null) union = HeadTail.encloseVertices(bounds, geom.coordinates);
 
           return {
             ...EmptyResponse,
@@ -267,9 +256,12 @@ export default class HeadTail implements Recipe {
       /**
        * IF recipe isn't active, but the key matches, we are editing
        */
-        if (this.active.value && !this.hadBoundsOnCreate) {
+        const bounds = track.getFeature(frameNum)[0]?.bounds;
+        const initialBounds = (this.initialBoundsTarget?.track === track && this.initialBoundsTarget.frame === frameNum) || !bounds;
+        this.initialBoundsTarget = null;
+        if (initialBounds) {
           // Creating a new line on a track without a pre-existing box:
-          // use unionWithoutBounds to replace interim bounds with 10% expanded box
+          // use unionWithoutBounds to replace interim bounds with 20% expanded box
           return {
             ...EmptyResponse,
             data: HeadTail.makeGeom(linestring.geometry, true),
@@ -280,7 +272,7 @@ export default class HeadTail implements Recipe {
         return {
           ...EmptyResponse,
           data: HeadTail.makeGeom(linestring.geometry, true),
-          union: HeadTail.findBounds(linestring.geometry, PaddingVectorZero),
+          union: HeadTail.encloseVertices(bounds!, linestring.geometry.coordinates),
           done: true,
         };
       }
@@ -333,6 +325,7 @@ export default class HeadTail implements Recipe {
 
   deactivate() {
     this.active.value = false;
+    this.initialBoundsTarget = null;
   }
 
   private headfirst() {

--- a/client/dive-common/use/stereo/keypointTransfer.ts
+++ b/client/dive-common/use/stereo/keypointTransfer.ts
@@ -1,0 +1,109 @@
+import Track, { TrackSupportedFeature } from 'vue-media-annotator/track';
+import {
+  headTailFeatures, isHeadTailPoint, spineIndex, spineName,
+} from 'vue-media-annotator/headTail';
+
+export function namedPoint(track: Track | undefined, frame: number, key: string) {
+  const [feature] = track ? track.getFeature(frame) : [null];
+  return feature?.geometry?.features.find((g) => g.geometry.type === 'Point' && g.properties?.key === key);
+}
+
+function mappedPoint(track: Track | undefined, frame: number, key: string, camera: string) {
+  const [feature] = track ? track.getFeature(frame) : [null];
+  return feature?.geometry?.features.find((g) => g.geometry.type === 'Point'
+    && g.properties?.stereoSource === camera && g.properties?.stereoKey === key);
+}
+
+/** A missing point can be added even when the target detection already exists. */
+export function canMapPoint(track: Track | undefined, frame: number, key: string, sourceCamera: string) {
+  const point = mappedPoint(track, frame, key, sourceCamera) ?? namedPoint(track, frame, key);
+  return !point || point.properties?.stereoSource === sourceCamera;
+}
+
+export function pointUnchanged(track: Track | undefined, frame: number, key: string, point: [number, number]) {
+  const current = namedPoint(track, frame, key);
+  return current?.geometry.type === 'Point' && JSON.stringify(current.geometry.coordinates) === JSON.stringify(point);
+}
+
+export function applyMappedPoint(track: Track, frame: number, key: string, point: [number, number], sourceCamera: string, insert = false) {
+  if (!key || !point.every(Number.isFinite)) throw new Error('Invalid mapped keypoint');
+  const [feature] = track.getFeature(frame);
+  const targetKey = (!insert && mappedPoint(track, frame, key, sourceCamera)?.properties?.key) || key;
+  const marker: GeoJSON.Feature<GeoJSON.Point> = {
+    type: 'Feature',
+    properties: { key: targetKey, stereoSource: sourceCamera, stereoKey: key },
+    geometry: { type: 'Point', coordinates: [...point] },
+  };
+  let geometry: GeoJSON.Feature<TrackSupportedFeature>[] = [marker];
+  const line = feature?.geometry?.features.find((g) => g.geometry.type === 'LineString' && g.properties?.key === 'HeadTails');
+  if (line?.geometry.type === 'LineString' && isHeadTailPoint(key)) {
+    const coordinates = line.geometry.coordinates.map((p) => [...p]);
+    const index = targetKey === 'head' ? 0 : spineIndex(targetKey);
+    if (insert && spineIndex(key) !== null) {
+      let best = Infinity; let segment = 0;
+      for (let i = 0; i < coordinates.length - 1; i += 1) {
+        const a = coordinates[i]; const b = coordinates[i + 1];
+        const dx = b[0] - a[0]; const dy = b[1] - a[1];
+        const t = Math.max(0, Math.min(1, ((point[0] - a[0]) * dx + (point[1] - a[1]) * dy) / (dx * dx + dy * dy || 1)));
+        const distance = Math.hypot(point[0] - a[0] - t * dx, point[1] - a[1] - t * dy);
+        if (distance < best) { best = distance; segment = i; }
+      }
+      coordinates.splice(segment + 1, 0, point);
+      marker.properties = { ...marker.properties, key: spineName(segment + 1) };
+    } else if (targetKey === 'tail') coordinates[coordinates.length - 1] = point;
+    else if (index !== null && index < coordinates.length - 1) coordinates[index] = point;
+    else if (index === coordinates.length - 1) coordinates.splice(index, 0, point);
+    else throw new Error('Cannot insert a centerline point with a missing predecessor');
+    geometry = [...headTailFeatures(coordinates).map((generated) => {
+      // Preserve ownership of untouched vertices even when insertion renumbers them.
+      const old = feature?.geometry?.features.find((g) => g.geometry.type === 'Point'
+        && generated.geometry.type === 'Point'
+        && JSON.stringify(g.geometry.coordinates) === JSON.stringify(generated.geometry.coordinates));
+      const properties = { ...old?.properties, ...generated.properties };
+      const sourceIndex = spineIndex(properties.stereoKey || '');
+      const insertedIndex = spineIndex(key);
+      if (insert && properties.stereoSource === sourceCamera && sourceIndex !== null
+          && insertedIndex !== null && sourceIndex >= insertedIndex) {
+        properties.stereoKey = spineName(sourceIndex + 1);
+      }
+      return { ...generated, properties };
+    }), marker];
+  }
+  track.setFeature({
+    frame,
+    keyframe: true,
+    interpolate: feature?.interpolate ?? false,
+    bounds: feature?.bounds ?? [point[0] - 5, point[1] - 5, point[0] + 5, point[1] + 5],
+  }, geometry);
+  if (isHeadTailPoint(key)) track.invalidateMeasurement(frame);
+}
+
+/** Identify one inserted or moved vertex without guessing stereo correspondence. */
+export function linePointEdit(before: GeoJSON.Position[] | undefined, after: GeoJSON.Position[]) {
+  if (!before) return null;
+  const same = (a: GeoJSON.Position, b: GeoJSON.Position) => JSON.stringify(a) === JSON.stringify(b);
+  if (after.length === before.length + 1) {
+    const index = after.findIndex((p, i) => !before[i] || !same(p, before[i]));
+    if (index > 0 && index < after.length - 1
+        && before.every((p, i) => same(p, after[i < index ? i : i + 1]))) {
+      return { key: spineName(index), point: after[index] as [number, number], insert: true };
+    }
+  }
+  if (before.length === after.length) {
+    const changed = after.map((p, i) => (!same(p, before[i]) ? i : -1)).filter((i) => i >= 0);
+    if (changed.length === 1) {
+      const index = changed[0];
+      let key = spineName(index);
+      if (index === 0) key = 'head';
+      if (index === after.length - 1) key = 'tail';
+      return { key, point: after[index] as [number, number], insert: false };
+    }
+  }
+  return null;
+}
+
+export function pointTargetState(track: Track | undefined, frame: number, key: string, insert = false, camera = '') {
+  if (!insert) return JSON.stringify(mappedPoint(track, frame, key, camera) ?? namedPoint(track, frame, key));
+  const [feature] = track ? track.getFeature(frame) : [null];
+  return JSON.stringify(feature?.geometry);
+}

--- a/client/dive-common/use/stereo/tests/keypointTransfer.spec.ts
+++ b/client/dive-common/use/stereo/tests/keypointTransfer.spec.ts
@@ -1,0 +1,164 @@
+import {
+  it, expect, vi,
+} from 'vitest';
+import { ref } from 'vue';
+import Track from 'vue-media-annotator/track';
+import { headTailFeatures } from 'vue-media-annotator/headTail';
+import {
+  applyMappedPoint, namedPoint, canMapPoint, linePointEdit,
+} from '../keypointTransfer';
+import useStereoOnnxTransfer from '../useStereoOnnxTransfer';
+import { StereoRig } from '../calibration';
+
+const pointFeature = (key: string, point: [number, number]): GeoJSON.Feature<GeoJSON.Point> => ({
+  type: 'Feature', properties: { key }, geometry: { type: 'Point', coordinates: point },
+});
+function makeTrack() {
+  const track = new Track(1, { begin: 0, end: 0, meta: {} });
+  track.setFeature({
+    frame: 0, keyframe: true, bounds: [10, 10, 100, 100], attributes: { species: 'fish' },
+  });
+  return track;
+}
+function harness(enabled = true) {
+  const tracks = new Map([['left', makeTrack()], ['right', makeTrack()]]);
+  const k = Float32Array.from([100, 0, 100, 0, 100, 100, 0, 0, 1]);
+  const rig: StereoRig = {
+    Kl: k,
+    Kr: k,
+    distl: new Float32Array(8),
+    distr: new Float32Array(8),
+    R: Float32Array.from([1, 0, 0, 0, 1, 0, 0, 0, 1]),
+    T: Float32Array.from([-1, 0, 0]),
+  };
+  const warpPoints = vi.fn(async (points: [number, number][], _a: unknown, _b: unknown, r: StereoRig) => points.map(([x, y]) => ({ x: x + (r.T[0] < 0 ? -10 : 10), y, accepted: true })));
+  const onChange = vi.fn();
+  const onError = vi.fn();
+  const cameraStore = {
+    getPossibleTrack: (_id: number, camera: string) => tracks.get(camera),
+    camMap: ref(new Map(['left', 'right'].map((camera) => [camera, {
+      trackStore: {
+        add: () => {
+          const t = makeTrack(); tracks.set(camera, t); return t;
+        },
+      },
+    }]))),
+  };
+  const transfer = useStereoOnnxTransfer({
+    cameraStore: cameraStore as never,
+    getMultiCamList: () => ['left', 'right'],
+    getLeftCameraName: () => 'left',
+    getRig: async () => rig,
+    getMatcher: async () => ({ warpPoints }) as never,
+    getFrame: async () => ({ width: 200, height: 200, data: new Uint8ClampedArray(200 * 200 * 4) }),
+    getRange: () => ({ minDisparity: 1, maxDisparity: 100 }),
+    autoCompute: () => enabled,
+    onChange,
+    onError,
+  });
+  return {
+    tracks, transfer, warpPoints, onChange, onError,
+  };
+}
+const request = (camera = 'left', key = 'eye', point: [number, number] = [50.5, 60.25]) => ({
+  type: 'point' as const, camera, key, point, trackId: 1, frameNum: 0,
+});
+
+it.each(['left', 'right'])('maps a named point from %s into an existing detection', async (camera) => {
+  const h = harness();
+  const other = camera === 'left' ? 'right' : 'left';
+  h.tracks.get(camera)!.setFeature({ frame: 0 }, [pointFeature('eye', [50.5, 60.25])]);
+  h.tracks.get(other)!.setFeature({ frame: 0 }, [pointFeature('fin', [40, 30])]);
+  expect(await h.transfer.handleStereoAnnotationComplete(request(camera))).toBe('transferred');
+  const mapped = namedPoint(h.tracks.get(other), 0, 'eye');
+  expect(mapped?.geometry.coordinates).toEqual([camera === 'left' ? 40.5 : 60.5, 60.25]);
+  expect(namedPoint(h.tracks.get(other), 0, 'fin')?.geometry.coordinates).toEqual([40, 30]);
+  expect(h.tracks.get(other)!.features[0].bounds).toEqual([10, 10, 100, 100]);
+  expect(h.tracks.get(other)!.features[0].attributes?.species).toBe('fish');
+});
+it('obeys the auto-map option', async () => {
+  const h = harness(false);
+  expect(await h.transfer.handleStereoAnnotationComplete(request())).toBe('skipped');
+  expect(h.warpPoints).not.toHaveBeenCalled();
+});
+it('creates a target detection when necessary', async () => {
+  const h = harness(); h.tracks.delete('right');
+  h.tracks.get('left')!.setFeature({ frame: 0 }, [pointFeature('eye', [50.5, 60.25])]);
+  expect(await h.transfer.handleStereoAnnotationComplete(request())).toBe('transferred');
+  expect(namedPoint(h.tracks.get('right'), 0, 'eye')).toBeDefined();
+});
+it('preserves a manually edited target point', async () => {
+  const h = harness();
+  h.tracks.get('right')!.setFeature({ frame: 0 }, [pointFeature('eye', [20, 30])]);
+  expect(await h.transfer.handleStereoAnnotationComplete(request())).toBe('skipped');
+  expect(h.warpPoints).not.toHaveBeenCalled();
+});
+it('updates a previously generated point', async () => {
+  const h = harness();
+  applyMappedPoint(h.tracks.get('right')!, 0, 'eye', [20, 30], 'left');
+  h.tracks.get('left')!.setFeature({ frame: 0 }, [pointFeature('eye', [50.5, 60.25])]);
+  expect(await h.transfer.handleStereoAnnotationComplete(request())).toBe('transferred');
+  expect(namedPoint(h.tracks.get('right'), 0, 'eye')?.geometry.coordinates).toEqual([40.5, 60.25]);
+});
+it('rejects an unmatched point without changing the target', async () => {
+  const h = harness();
+  h.warpPoints.mockResolvedValue([{ x: 0, y: 0, accepted: false }]);
+  expect(await h.transfer.handleStereoAnnotationComplete(request())).toBe('failed');
+  expect(namedPoint(h.tracks.get('right'), 0, 'eye')).toBeUndefined();
+});
+it.each(['source', 'target'])('discards a reply after the %s point changes', async (side) => {
+  const h = harness();
+  h.tracks.get('left')!.setFeature({ frame: 0 }, [pointFeature('eye', [50.5, 60.25])]);
+  h.warpPoints.mockImplementation(async () => {
+    h.tracks.get(side === 'source' ? 'left' : 'right')!.setFeature({ frame: 0 }, [pointFeature('eye', [75, 75])]);
+    return [{ x: 40.5, y: 60.25, accepted: true }];
+  });
+  expect(await h.transfer.handleStereoAnnotationComplete(request())).toBe('skipped');
+});
+it('keeps generated spine points synchronized and editable', () => {
+  const track = makeTrack();
+  track.setFeature({ frame: 0 }, headTailFeatures([[20, 30], [40, 50], [80, 30]]));
+  applyMappedPoint(track, 0, 'spine_001', [45, 55], 'left');
+  expect(canMapPoint(track, 0, 'spine_001', 'left')).toBe(true);
+  expect(track.getFeatureGeometry(0, { key: 'HeadTails' })[0].geometry.coordinates).toEqual([[20, 30], [45, 55], [80, 30]]);
+  track.setFeature({ frame: 0 }, headTailFeatures([[20, 30], [46, 56], [80, 30]]));
+  expect(canMapPoint(track, 0, 'spine_001', 'left')).toBe(false);
+});
+
+it('detects a new interior vertex as one point transfer', () => {
+  expect(linePointEdit([[10, 20], [80, 20]], [[10, 20], [40, 35], [80, 20]])).toEqual({
+    key: 'spine_001', point: [40, 35], insert: true,
+  });
+  expect(linePointEdit([[10, 20], [40, 35], [80, 20]], [[10, 20], [45, 40], [80, 20]])).toEqual({
+    key: 'spine_001', point: [45, 40], insert: false,
+  });
+});
+it('inserts a matched vertex into the nearest target segment, retaining its existing vertices', async () => {
+  const h = harness();
+  h.tracks.get('left')!.setFeature({ frame: 0 }, headTailFeatures([[10, 20], [70, 40], [100, 20]]));
+  h.tracks.get('right')!.setFeature({ frame: 0 }, headTailFeatures([[0, 20], [30, 40], [90, 20]]));
+  const outcome = await h.transfer.handleStereoAnnotationComplete({ ...request('left', 'spine_001', [70, 40]), insert: true });
+  expect(outcome).toBe('transferred');
+  expect(h.tracks.get('right')!.getFeatureGeometry(0, { key: 'HeadTails' })[0].geometry.coordinates).toEqual([[0, 20], [30, 40], [60, 40], [90, 20]]);
+  // The two views have different vertex counts: remember the mapped marker's
+  // origin instead of treating equal spine indices as matched physical points.
+  h.tracks.get('left')!.setFeature({ frame: 0 }, headTailFeatures([[10, 20], [75, 45], [100, 20]]));
+  expect(await h.transfer.handleStereoAnnotationComplete(request('left', 'spine_001', [75, 45]))).toBe('transferred');
+  expect(h.tracks.get('right')!.getFeatureGeometry(0, { key: 'HeadTails' })[0].geometry.coordinates).toEqual([[0, 20], [30, 40], [65, 45], [90, 20]]);
+});
+
+it('keeps mapped vertices updateable after inserting an earlier vertex', async () => {
+  const h = harness();
+  const line: [number, number][] = [[20, 20], [70, 35], [100, 20]];
+  h.tracks.get('left')!.setFeature({ frame: 0 }, headTailFeatures(line));
+  expect(await h.transfer.handleStereoAnnotationComplete({
+    type: 'line', camera: 'left', trackId: 1, frameNum: 0, key: 'HeadTails', line,
+  })).toBe('transferred');
+  expect(canMapPoint(h.tracks.get('right'), 0, 'spine_001', 'left')).toBe(true);
+  h.tracks.get('left')!.setFeature({ frame: 0 }, headTailFeatures([[20, 20], [40, 30], [70, 35], [100, 20]]));
+  expect(await h.transfer.handleStereoAnnotationComplete({ ...request('left', 'spine_001', [40, 30]), insert: true })).toBe('transferred');
+  expect(canMapPoint(h.tracks.get('right'), 0, 'spine_002', 'left')).toBe(true);
+  h.tracks.get('left')!.setFeature({ frame: 0 }, headTailFeatures([[20, 20], [40, 30], [75, 40], [100, 20]]));
+  expect(await h.transfer.handleStereoAnnotationComplete(request('left', 'spine_002', [75, 40]))).toBe('transferred');
+  expect(h.tracks.get('right')!.getFeatureGeometry(0, { key: 'HeadTails' })[0].geometry.coordinates).toEqual([[10, 20], [30, 30], [65, 40], [90, 20]]);
+});

--- a/client/dive-common/use/stereo/tests/stereoTransfer.spec.ts
+++ b/client/dive-common/use/stereo/tests/stereoTransfer.spec.ts
@@ -103,6 +103,14 @@ function makeTrack(id: number) {
       const f = features.get(frame);
       if (f) f.attributes[key] = value;
     },
+    invalidateMeasurement: (frame: number) => {
+      const f = features.get(frame);
+      if (f) {
+        delete f.fishLength;
+        delete f.attributes.length;
+        f.attributes.measurement_stale = true;
+      }
+    },
     setAttribute: (key: string, value: unknown) => { attributes[key] = value; },
   };
   return track;
@@ -117,7 +125,7 @@ function setLine(track: ReturnType<typeof makeTrack>, frame: number, line: [numb
   }] as GeoJSON.Feature[]);
 }
 
-function makeHarness(rig: StereoRig) {
+function makeHarness(rig: StereoRig, matcher: unknown = null) {
   const tracks: Record<string, Map<number, ReturnType<typeof makeTrack>>> = {
     left: new Map(), right: new Map(),
   };
@@ -136,8 +144,8 @@ function makeHarness(rig: StereoRig) {
     getLeftCameraName: () => 'left',
     getRig: async () => rig,
     // Both cameras already carry a human line, so no warp runs in these cases.
-    getMatcher: async () => null,
-    getFrame: async () => null,
+    getMatcher: async () => matcher as never,
+    getFrame: async () => (matcher ? { width: 200, height: 200, data: new Uint8ClampedArray(200 * 200 * 4) } : null),
     getRange: () => ({ minDisparity: 2, maxDisparity: 300 }),
     autoCompute: () => false,
     measureLengths: () => true,
@@ -231,4 +239,31 @@ describe('useStereoOnnxTransfer measurement', () => {
     });
     expect(onError).toHaveBeenCalledWith(expect.stringContaining('calibration'));
   });
+});
+
+it('remeasures a curved line without pairing vertex indices across views', async () => {
+  const k = Float32Array.from([100, 0, 100, 0, 100, 100, 0, 0, 1]);
+  const rig: StereoRig = {
+    Kl: k,
+    Kr: k,
+    distl: new Float32Array(8),
+    distr: new Float32Array(8),
+    R: Float32Array.from(IDENTITY),
+    T: Float32Array.from([-1, 0, 0]),
+  };
+  const matcher = { warpPoints: vi.fn(async (points: [number, number][]) => points.map(([x, y]) => ({ x: x - 10, y, accepted: true }))) };
+  const { tracks, transfer, onMeasurement } = makeHarness(rig, matcher);
+  const left = makeTrack(1); const right = makeTrack(1);
+  tracks.left.set(1, left); tracks.right.set(1, right);
+  const line: [number, number][] = [[80, 80], [110, 110], [140, 80]];
+  setLine(left, 0, line);
+  setLine(right, 0, [[70, 80], [85, 95], [100, 110], [130, 80]]);
+  await transfer.handleStereoAnnotationComplete({
+    type: 'line', camera: 'left', trackId: 1, frameNum: 0, line, key: 'HeadTails',
+  });
+  const result = onMeasurement.mock.calls[0][0];
+  expect(result.curved_length).toBeCloseTo(6 * Math.sqrt(2), 4);
+  expect(result.straight_length).toBeCloseTo(6, 4);
+  expect(left.features[0].attributes.measurement_stale).toBe(false);
+  expect(matcher.warpPoints.mock.calls[0][0].length).toBeGreaterThan(line.length);
 });

--- a/client/dive-common/use/stereo/triangulate.ts
+++ b/client/dive-common/use/stereo/triangulate.ts
@@ -15,6 +15,9 @@
 import { StereoRig } from './calibration';
 
 export interface StereoMeasurement {
+  curved_length?: number;
+  straight_length?: number;
+  curvature_ratio?: number;
   length: number;
   midpoint_x: number;
   midpoint_y: number;

--- a/client/dive-common/use/stereo/useStereoOnnxTransfer.ts
+++ b/client/dive-common/use/stereo/useStereoOnnxTransfer.ts
@@ -16,10 +16,15 @@
 
 import CameraStore from 'vue-media-annotator/CameraStore';
 import Track from 'vue-media-annotator/track';
-import { headTailFeatures, sampleHeadTail, distanceToHeadTail } from 'vue-media-annotator/headTail';
+import {
+  headTailFeatures, sampleHeadTail, distanceToHeadTail, isHeadTailPoint,
+} from 'vue-media-annotator/headTail';
 import { RectBounds } from 'vue-media-annotator/utils';
 import { HeadTailLineKey } from 'dive-common/recipes/headtail';
 import type { StereoAnnotationCompleteParams } from '../useModeManager';
+import {
+  canMapPoint, pointUnchanged, applyMappedPoint, pointTargetState,
+} from './keypointTransfer';
 import { StereoOnnxMatcher, SearchRange } from './StereoOnnxMatcher';
 import { StereoRig, invertRig } from './calibration';
 import { rgbaToGray, RgbaImage } from './image';
@@ -144,9 +149,13 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
   }
 
   /** Replace a track feature's head/tail line, preserving any other geometry. */
-  function applyLine(track: Track | undefined, frameNum: number, line: Line) {
+  function applyLine(track: Track | undefined, frameNum: number, line: Line, sourceCamera: string) {
     if (!track) return;
-    const geometry = headTailFeatures(line);
+    const geometry = headTailFeatures(line).map((g) => ({
+      ...g,
+      properties: g.geometry.type === 'Point'
+        ? { ...g.properties, stereoSource: sourceCamera, stereoKey: g.properties?.key } : g.properties,
+    }));
     track.setFeature({
       frame: frameNum,
       flick: 0,
@@ -303,10 +312,13 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
     quiet = false,
   ): Promise<'transferred' | 'skipped' | 'failed'> {
     if (params.type === 'segmentation') return 'skipped';
+    if (params.type === 'point' && isHeadTailPoint(params.key)) {
+      getMultiCamList().forEach((camera) => cameraStore.getPossibleTrack(params.trackId, camera)?.invalidateMeasurement(params.frameNum));
+    }
 
     // The warp writes geometry directly rather than re-emitting this event, so
     // reaching here means the user authored this camera's line.
-    if (params.type === 'line') {
+    if (params.type === 'line' || (params.type === 'point' && isHeadTailPoint(params.key))) {
       getMultiCamList().forEach((camera) => cameraStore.getPossibleTrack(params.trackId, camera)?.invalidateMeasurement(params.frameNum));
       cameraStore.getPossibleTrack(params.trackId, params.camera)
         ?.setFeatureAttribute(params.frameNum, STEREO_USER_LINE_ATTR, true);
@@ -337,13 +349,37 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
         }
         return 'skipped';
       }
+    } else if (params.type === 'point') {
+      if (!shouldWarp || (!params.insert && !canMapPoint(otherTrack, params.frameNum, params.key, params.camera))) {
+        if (isHeadTailPoint(params.key) && measureLengths() && otherHasFeature) {
+          try { await measureAndReport(params.trackId, params.frameNum); } catch (err) { config.onError?.(`Stereo measurement failed. ${(err as Error).message}`); }
+        }
+        return 'skipped';
+      }
     } else if (otherHasFeature || !shouldWarp) {
       return 'skipped';
     }
 
     if (!quiet) config.onStatus?.('Computing stereo correspondence...');
     try {
-      if (params.type === 'box') {
+      if (params.type === 'point') {
+        const source = cameraStore.getPossibleTrack(params.trackId, params.camera);
+        const targetBefore = pointTargetState(otherTrack, params.frameNum, params.key, params.insert, params.camera);
+        const result = await warp([params.point], params.camera, otherCamera, params.frameNum);
+        if (result.length !== 1 || !result[0].accepted || !Number.isFinite(result[0].x) || !Number.isFinite(result[0].y)) {
+          throw new Error('No confident stereo match for this keypoint.');
+        }
+        const currentTarget = cameraStore.getPossibleTrack(params.trackId, otherCamera);
+        if (!pointUnchanged(source, params.frameNum, params.key, params.point)
+            || pointTargetState(currentTarget, params.frameNum, params.key, params.insert, params.camera) !== targetBefore) return 'skipped';
+        const track = getOrCreateTrack(params.trackId, params.camera, otherCamera, params.frameNum);
+        if (!track) throw new Error('Could not create the target detection.');
+        applyMappedPoint(track, params.frameNum, params.key, [result[0].x, result[0].y], params.camera, params.insert);
+        config.onChange?.(otherCamera, track);
+        if (isHeadTailPoint(params.key) && measureLengths()) {
+          try { await measureAndReport(params.trackId, params.frameNum); } catch (err) { config.onError?.(`Point transferred; stereo measurement failed. ${(err as Error).message}`); }
+        }
+      } else if (params.type === 'box') {
         const [x1, y1, x2, y2] = params.bounds;
         const corners: Point[] = [[x1, y1], [x2, y1], [x2, y2], [x1, y2]];
         const res = await warp(corners, params.camera, otherCamera, params.frameNum);
@@ -390,7 +426,7 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
         }
         const track = getOrCreateTrack(params.trackId, params.camera, otherCamera, params.frameNum);
         if (!track) throw new Error('Could not create the track on the other camera.');
-        applyLine(track, params.frameNum, res.map((r): Point => [r.x, r.y]));
+        applyLine(track, params.frameNum, res.map((r): Point => [r.x, r.y]), params.camera);
         config.onChange?.(otherCamera, track);
         if (measureLengths()) await measureAndReport(params.trackId, params.frameNum);
       }

--- a/client/dive-common/use/stereo/useStereoOnnxTransfer.ts
+++ b/client/dive-common/use/stereo/useStereoOnnxTransfer.ts
@@ -16,8 +16,9 @@
 
 import CameraStore from 'vue-media-annotator/CameraStore';
 import Track from 'vue-media-annotator/track';
+import { headTailFeatures, sampleHeadTail, distanceToHeadTail } from 'vue-media-annotator/headTail';
 import { RectBounds } from 'vue-media-annotator/utils';
-import { HeadPointKey, TailPointKey, HeadTailLineKey } from 'dive-common/recipes/headtail';
+import { HeadTailLineKey } from 'dive-common/recipes/headtail';
 import type { StereoAnnotationCompleteParams } from '../useModeManager';
 import { StereoOnnxMatcher, SearchRange } from './StereoOnnxMatcher';
 import { StereoRig, invertRig } from './calibration';
@@ -67,11 +68,11 @@ export const STEREO_USER_LINE_ATTR = 'stereo_user_line';
 /** 'stereo' = auto-computed from the warped lines, 'user_set' = locked by the user. */
 export const STEREO_LENGTH_METHOD_ATTR = 'length_method';
 export const STEREO_MEASUREMENT_ATTRS = [
-  'length', 'midpoint_x', 'midpoint_y', 'midpoint_z', 'midpoint_range', 'stereo_rms',
+  'length', 'curved_length', 'straight_length', 'curvature_ratio', 'midpoint_x', 'midpoint_y', 'midpoint_z', 'midpoint_range', 'stereo_rms',
 ] as const;
 
 type Point = [number, number];
-type Line = [Point, Point];
+type Line = Point[];
 
 const round2 = (v: number) => Math.round(v * 100) / 100;
 
@@ -135,39 +136,23 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
     if (!features) return null;
     const lineFeat = features.find(
       (f) => f.geometry.type === 'LineString'
-        && (f.geometry.coordinates as Point[]).length === 2,
+        && (f.geometry.coordinates as Point[]).length >= 2,
     );
     if (!lineFeat) return null;
     const c = lineFeat.geometry.coordinates as unknown as Point[];
-    return [c[0], c[1]];
+    return c;
   }
 
   /** Replace a track feature's head/tail line, preserving any other geometry. */
-  function applyLine(track: Track | undefined, frameNum: number, line: Line, key?: string) {
+  function applyLine(track: Track | undefined, frameNum: number, line: Line) {
     if (!track) return;
-    const [feature] = track.getFeature(frameNum);
-    const [p1, p2] = line;
-    const preserved = (feature?.geometry?.features ?? []).filter((f) => {
-      if (f.geometry.type === 'LineString') return false;
-      const k = f.properties?.key;
-      return k !== HeadPointKey && k !== TailPointKey;
-    });
-    const geometry: GeoJSON.Feature[] = [
-      ...preserved,
-      {
-        type: 'Feature',
-        geometry: { type: 'LineString', coordinates: line },
-        properties: { key: key ?? HeadTailLineKey },
-      },
-      { type: 'Feature', geometry: { type: 'Point', coordinates: p1 }, properties: { key: HeadPointKey } },
-      { type: 'Feature', geometry: { type: 'Point', coordinates: p2 }, properties: { key: TailPointKey } },
-    ];
+    const geometry = headTailFeatures(line);
     track.setFeature({
       frame: frameNum,
       flick: 0,
       keyframe: true,
       interpolate: false,
-      bounds: boundsFromPoints([p1, p2], BOX_PAD, true),
+      bounds: boundsFromPoints(line, BOX_PAD, true),
     }, geometry as GeoJSON.Feature<GeoJSON.Geometry>[] as never);
   }
 
@@ -179,6 +164,7 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
   function applyMeasurement(track: Track | undefined, frameNum: number, m: StereoMeasurement) {
     if (!track) return;
     const [feature] = track.getFeature(frameNum);
+    track.setFeatureAttribute(frameNum, 'measurement_stale', false);
     const lengthLocked = feature?.attributes?.[STEREO_LENGTH_METHOD_ATTR] === 'user_set';
     if (!lengthLocked && Number.isFinite(m.length) && feature?.keyframe) {
       track.setFeature({ frame: frameNum, fishLength: round2(m.length) });
@@ -187,7 +173,7 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
     STEREO_MEASUREMENT_ATTRS.forEach((name) => {
       if (name === 'length' && lengthLocked) return;
       const v = m[name as keyof StereoMeasurement];
-      if (Number.isFinite(v)) track.setFeatureAttribute(frameNum, name, round2(v));
+      if (typeof v === 'number' && Number.isFinite(v)) track.setFeatureAttribute(frameNum, name, round2(v));
     });
   }
 
@@ -235,10 +221,36 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
     const rig = await getRig();
     if (!rig) throw new Error('No stereo calibration is available for this dataset.');
 
-    const measurement = measureLine(rig, leftLine, rightLine);
+    let measurement: StereoMeasurement | null;
+    if (leftLine.length > 2 || rightLine.length > 2) {
+      const samples = sampleHeadTail(leftLine);
+      const matches = await warp(samples, leftCamera, rightCamera, frameNum);
+      if (!matches.every((m) => m.accepted && distanceToHeadTail([m.x, m.y], rightLine) <= 5)) {
+        throw new Error('Incomplete or inconsistent centerline correspondence.');
+      }
+      const target = matches.map((m): Point => [m.x, m.y]);
+      const pieces = samples.slice(1).map((p, i) => measureLine(rig, [samples[i], p], [target[i], target[i + 1]]));
+      const chord = measureLine(rig, [samples[0], samples[samples.length - 1]], [target[0], target[target.length - 1]]);
+      if (!chord || chord.length <= 0 || pieces.some((p) => !p || !Number.isFinite(p.length) || p.length <= 0 || p.stereo_rms > 5)) {
+        throw new Error('Invalid reconstructed centerline.');
+      }
+      const length = pieces.reduce((sum, p) => sum + (p as StereoMeasurement).length, 0);
+      measurement = {
+        ...chord,
+        length,
+        curved_length: length,
+        straight_length: chord.length,
+        curvature_ratio: length / chord.length,
+        stereo_rms: Math.max(...pieces.map((p) => (p as StereoMeasurement).stereo_rms)),
+      };
+    } else {
+      measurement = measureLine(rig, [leftLine[0], leftLine[1]], [rightLine[0], rightLine[1]]);
+    }
     if (!measurement) {
       throw new Error('The two lines could not be triangulated; check that the calibration matches these cameras.');
     }
+    if (JSON.stringify(lineEndpoints(leftTrack, frameNum)) !== JSON.stringify(leftLine)
+        || JSON.stringify(lineEndpoints(rightTrack, frameNum)) !== JSON.stringify(rightLine)) return null;
     config.ensureMeasurementAttributes?.();
     applyMeasurement(leftTrack, frameNum, measurement);
     applyMeasurement(rightTrack, frameNum, measurement);
@@ -295,6 +307,7 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
     // The warp writes geometry directly rather than re-emitting this event, so
     // reaching here means the user authored this camera's line.
     if (params.type === 'line') {
+      getMultiCamList().forEach((camera) => cameraStore.getPossibleTrack(params.trackId, camera)?.invalidateMeasurement(params.frameNum));
       cameraStore.getPossibleTrack(params.trackId, params.camera)
         ?.setFeatureAttribute(params.frameNum, STEREO_USER_LINE_ATTR, true);
     }
@@ -372,12 +385,12 @@ export default function useStereoOnnxTransfer(config: StereoOnnxTransferConfig) 
         config.onChange?.(otherCamera, track);
       } else {
         const res = await warp(params.line, params.camera, otherCamera, params.frameNum);
-        if (!res[0].accepted || !res[1].accepted) {
+        if (!res.every((r) => r.accepted)) {
           throw new Error('No confident stereo match for the line endpoints.');
         }
         const track = getOrCreateTrack(params.trackId, params.camera, otherCamera, params.frameNum);
         if (!track) throw new Error('Could not create the track on the other camera.');
-        applyLine(track, params.frameNum, [[res[0].x, res[0].y], [res[1].x, res[1].y]], params.key);
+        applyLine(track, params.frameNum, res.map((r): Point => [r.x, r.y]));
         config.onChange?.(otherCamera, track);
         if (measureLengths()) await measureAndReport(params.trackId, params.frameNum);
       }

--- a/client/dive-common/use/useModeManager.spec.ts
+++ b/client/dive-common/use/useModeManager.spec.ts
@@ -16,12 +16,15 @@ import type { MarkChangesPending } from 'vue-media-annotator/BaseAnnotationStore
 import Track from 'vue-media-annotator/track';
 import { ROTATION_ATTRIBUTE_NAME } from 'vue-media-annotator/utils';
 import useModeManager from './useModeManager';
+import HeadTail from '../recipes/headtail';
+import { headTailFeatures } from '../../src/headTail';
+import type Recipe from '../../src/recipe';
 
 function translation(tx: number, ty: number): Matrix3 {
   return [[1, 0, tx], [0, 1, ty], [0, 0, 1]];
 }
 
-function makeHarness(markChangesPending: MarkChangesPending = () => undefined) {
+function makeHarness(markChangesPending: MarkChangesPending = () => undefined, recipes: Recipe[] = []) {
   const cameraStore = new CameraStore({ markChangesPending });
   cameraStore.removeCamera('singleCam');
   cameraStore.addCamera('left');
@@ -72,7 +75,7 @@ function makeHarness(markChangesPending: MarkChangesPending = () => undefined) {
     groupFilterControls,
     aggregateController,
     readonlyState: ref(false),
-    recipes: [],
+    recipes,
     alignedView,
   });
   modeManager.selectedCamera.value = 'left';
@@ -427,5 +430,29 @@ describe('useModeManager polygon clip on box resize', () => {
       type: 'Polygon',
       coordinates: [[[0, 0], [20, 0], [20, 20], [0, 40], [0, 0]]],
     });
+  });
+});
+
+describe('centerline editing continuity', () => {
+  it('keeps the saved line editable after deleting an interior vertex', () => {
+    const recipe = new HeadTail();
+    const { cameraStore, modeManager: manager } = makeHarness(undefined, [recipe]);
+    const id = manager.handler.trackAdd();
+    const track = cameraStore.getTrack(id, 'left');
+    track.setFeature({ frame: 0, keyframe: true, bounds: [0, 0, 100, 100] }, headTailFeatures([[10, 10], [50, 50], [90, 10]]));
+    recipe.activate();
+    manager.handler.selectFeatureHandle(1, 'HeadTails');
+    manager.handler.removePoint();
+    expect(manager.selectedKey.value).toBe('HeadTails');
+    expect(manager.editingMode.value).toBe('LineString');
+    expect(manager.editingDetails.value).toBe('Editing');
+    expect(manager.selectedFeatureHandle.value).toBe(-1);
+    expect(track.getFeatureGeometry(0, { key: 'HeadTails' })[0].geometry.coordinates).toEqual([[10, 10], [90, 10]]);
+    // Move an endpoint through the same update path, without reactivating a tool.
+    manager.handler.updateGeoJSON('editing', 0, 0, {
+      type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates: [[20, 20], [90, 10]] },
+    }, manager.selectedKey.value);
+    expect(track.getFeatureGeometry(0, { key: 'HeadTails' })[0].geometry.coordinates).toEqual([[20, 20], [90, 10]]);
+    expect(track.features[0].bounds).toEqual([0, 0, 100, 100]);
   });
 });

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -40,6 +40,7 @@ import SegmentationPointClick, {
   MultiFrameSegmentationResult,
 } from 'dive-common/recipes/segmentationpointclick';
 import { HeadPointKey, TailPointKey } from 'dive-common/recipes/headtail';
+import { linePointEdit } from './stereo/keypointTransfer';
 
 type SupportedFeature = GeoJSON.Feature<GeoJSON.Point | GeoJSON.Polygon | GeoJSON.LineString>;
 
@@ -76,6 +77,7 @@ interface SetAnnotationStateArgs {
 }
 
 export type StereoAnnotationCompleteParams =
+  | { type: 'point'; camera: string; trackId: number; frameNum: number; point: [number, number]; key: string; insert?: boolean; }
   | { type: 'line'; camera: string; trackId: number; frameNum: number;
       line: [number, number][]; key: string; }
   | { type: 'box'; camera: string; trackId: number; frameNum: number;
@@ -880,6 +882,9 @@ export default function useModeManager({
         // newDetectionMode is true if there's no keyframe on frameNum
         const { features, interpolate } = track.canInterpolate(frameNum);
         const [real] = features;
+        const previousLine = real?.geometry?.features.find((g) => g.geometry.type === 'LineString' && g.properties?.key === key);
+        const previousCoordinates = previousLine?.geometry.type === 'LineString'
+          ? previousLine.geometry.coordinates.map((p) => [...p]) : undefined;
 
         // Give each recipe the opportunity to make changes
         recipes.forEach((recipe) => {
@@ -967,6 +972,26 @@ export default function useModeManager({
 
           mirrorFeatureToAlignedCameras(track.id, frameNum);
 
+          // Emit persisted named points, including a head placed before its tail.
+          // Completed lines use their existing whole-line transfer event instead.
+          if (onStereoAnnotationComplete && stereoInteractiveActive()
+              && !(data.geometry.type === 'LineString' && data.geometry.coordinates.length >= 2)) {
+            Object.entries(update.geoJsonFeatureRecord).forEach(([pointKey, geoms]) => {
+              geoms.forEach((geom) => {
+                if (geom.geometry.type === 'Point' && pointKey) {
+                  onStereoAnnotationComplete({
+                    type: 'point',
+                    camera: selectedCamera.value,
+                    trackId: track.id as number,
+                    frameNum,
+                    point: geom.geometry.coordinates as [number, number],
+                    key: pointKey,
+                  });
+                }
+              });
+            });
+          }
+
           // Only perform "initialization" after the first shape.
           // Treat this as a completed annotation if eventType is editing
           // Or none of the recieps reported that they were unfinished.
@@ -984,14 +1009,25 @@ export default function useModeManager({
               if (data.geometry.type === 'LineString'
                   && data.geometry.coordinates.length >= 2) {
                 const coords = data.geometry.coordinates as [number, number][];
-                onStereoAnnotationComplete({
-                  type: 'line',
-                  camera: selectedCamera.value,
-                  trackId: completedTrackId as number,
-                  frameNum,
-                  line: coords,
-                  key: selectedKey.value,
-                });
+                const editedPoint = linePointEdit(previousCoordinates, coords);
+                if (editedPoint) {
+                  onStereoAnnotationComplete({
+                    type: 'point',
+                    camera: selectedCamera.value,
+                    trackId: completedTrackId as number,
+                    frameNum,
+                    ...editedPoint,
+                  });
+                } else {
+                  onStereoAnnotationComplete({
+                    type: 'line',
+                    camera: selectedCamera.value,
+                    trackId: completedTrackId as number,
+                    frameNum,
+                    line: coords,
+                    key: selectedKey.value,
+                  });
+                }
               }
               // Check for completed Polygon (done=true from recipes)
               if (update.done.some((v) => v === true)) {

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -1091,7 +1091,10 @@ export default function useModeManager({
         }
       }
     }
-    handleSelectFeatureHandle(-1);
+    // Clear the deleted handle, not the geometry key that keeps the editor on
+    // the remaining line (or on its surviving endpoint when only one remains).
+    handleSelectFeatureHandle(-1, selectedKey.value);
+    _nudgeEditingCanary();
   }
 
   /* If any recipes are active, remove the geometry they added */

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -77,7 +77,7 @@ interface SetAnnotationStateArgs {
 
 export type StereoAnnotationCompleteParams =
   | { type: 'line'; camera: string; trackId: number; frameNum: number;
-      line: [[number, number], [number, number]]; key: string; }
+      line: [number, number][]; key: string; }
   | { type: 'box'; camera: string; trackId: number; frameNum: number;
       bounds: [number, number, number, number]; }
   | { type: 'polygon'; camera: string; trackId: number; frameNum: number;
@@ -982,14 +982,14 @@ export default function useModeManager({
                 && completedTrackId !== null) {
               // Check for LineString with exactly 2 points (line annotation)
               if (data.geometry.type === 'LineString'
-                  && data.geometry.coordinates.length === 2) {
+                  && data.geometry.coordinates.length >= 2) {
                 const coords = data.geometry.coordinates as [number, number][];
                 onStereoAnnotationComplete({
                   type: 'line',
                   camera: selectedCamera.value,
                   trackId: completedTrackId as number,
                   frameNum,
-                  line: [coords[0], coords[1]],
+                  line: coords,
                   key: selectedKey.value,
                 });
               }
@@ -1042,6 +1042,17 @@ export default function useModeManager({
           }
         });
         mirrorFeatureToAlignedCameras(track.id, selectedCameraFrame());
+        const line = track.getFeatureGeometry(selectedCameraFrame(), { type: 'LineString', key: selectedKey.value })[0];
+        if (line?.geometry.type === 'LineString' && onStereoAnnotationComplete && stereoInteractiveActive()) {
+          onStereoAnnotationComplete({
+            type: 'line',
+            camera: selectedCamera.value,
+            trackId: track.id as number,
+            frameNum: selectedCameraFrame(),
+            line: line.geometry.coordinates as [number, number][],
+            key: selectedKey.value,
+          });
+        }
       }
     }
     handleSelectFeatureHandle(-1);

--- a/client/dive-common/use/useReview.ts
+++ b/client/dive-common/use/useReview.ts
@@ -1,3 +1,4 @@
+import { orderedHeadTail } from 'vue-media-annotator/headTail';
 /**
  * State behind the Review page: the datasets under review (with their
  * tracks held in memory), the query, the grid settings, the rendered
@@ -180,7 +181,7 @@ function syncHeadTailLine(feature: Feature) {
     collection.features.push({
       type: 'Feature',
       properties: { key: 'HeadTails' },
-      geometry: { type: 'LineString', coordinates: [head.geometry.coordinates, tail.geometry.coordinates] },
+      geometry: { type: 'LineString', coordinates: orderedHeadTail(collection.features) || [head.geometry.coordinates, tail.geometry.coordinates] },
     });
   }
 }

--- a/client/platform/desktop/backend/native/interactive.ts
+++ b/client/platform/desktop/backend/native/interactive.ts
@@ -631,7 +631,15 @@ export class InteractiveServiceManager extends EventEmitter {
     if (!this.isEnabled()) {
       return { id: '', success: false, error: 'Stereo service is not enabled' };
     }
-    const r = await this.sendRequest({ command: 'transfer_points', points: request.points }, 'transfer_points');
+    const r = await this.sendRequest({
+      command: 'transfer_points',
+      points: request.points,
+      source_camera: request.sourceCamera,
+      strict: request.strict,
+      left_image_path: request.leftImagePath,
+      right_image_path: request.rightImagePath,
+      frame_time: request.frameTime,
+    }, 'transfer_points');
     return {
       id: r.id,
       success: r.success ?? false,
@@ -639,6 +647,7 @@ export class InteractiveServiceManager extends EventEmitter {
       transferredPoints: r.transferred_points,
       originalPoints: r.original_points,
       disparityValues: r.disparity_values,
+      validMatches: r.valid_matches,
     };
   }
 

--- a/client/platform/desktop/backend/native/stereo.ts
+++ b/client/platform/desktop/backend/native/stereo.ts
@@ -45,6 +45,9 @@ export interface StereoTransferLineRequest {
  * All values are in calibration units (e.g. mm). Keys match VIAME's attribute names.
  */
 export interface StereoMeasurement {
+  curved_length?: number;
+  straight_length?: number;
+  curvature_ratio?: number;
   length: number;
   midpoint_x: number;
   midpoint_y: number;
@@ -74,8 +77,8 @@ export interface StereoTransferLineResponse {
 
 /** Request to triangulate the length of a line already corresponded on both images */
 export interface StereoMeasureLineRequest {
-  leftLine: [[number, number], [number, number]];
-  rightLine: [[number, number], [number, number]];
+  leftLine: [number, number][];
+  rightLine: [number, number][];
 }
 
 /** Response from a measure-line request */

--- a/client/platform/desktop/backend/native/stereo.ts
+++ b/client/platform/desktop/backend/native/stereo.ts
@@ -110,6 +110,11 @@ export interface StereoAggregateLengthsResponse {
 
 /** Request to transfer multiple points */
 export interface StereoTransferPointsRequest {
+  sourceCamera?: 'left' | 'right';
+  strict?: boolean;
+  leftImagePath?: string;
+  rightImagePath?: string;
+  frameTime?: number;
   points: [number, number][];
 }
 
@@ -121,6 +126,7 @@ export interface StereoTransferPointsResponse {
   transferredPoints?: [number, number][];
   originalPoints?: [number, number][];
   disparityValues?: number[];
+  validMatches?: boolean[];
 }
 
 /** Status response from the stereo service */

--- a/client/platform/desktop/backend/serializers/coco.spec.ts
+++ b/client/platform/desktop/backend/serializers/coco.spec.ts
@@ -826,3 +826,58 @@ describe('KWCOCO species list', () => {
 afterEach(() => {
   mockfs.restore();
 });
+
+it.each([false, true])('round-trips ordered centerlines from COCO and KWCOCO (named=%s)', async (named) => {
+  const labels = ['tail', 'spine_010', 'head', 'spine_002', 'spine_003', 'eye'];
+  const triples = [[90.5, 20.25, 2], [60.1, 35.2, 2], [10.25, 20.5, 2], [30.75, 40.125, 1], [0, 0, 0], [12.5, 18.5, 2]];
+  const doc = {
+    images: [{ id: 1, file_name: 'fish.png', frame_index: 0 }],
+    categories: [{ id: 7, name: 'fish', keypoints: labels }],
+    keypoint_categories: labels.map((name, i) => ({ id: 10 + i * 3, name })),
+    annotations: [{
+      id: 1,
+      image_id: 1,
+      category_id: 7,
+      bbox: [0, 0, 100, 50],
+      keypoints: named ? triples.map((p, i) => ({ keypoint_category_id: 10 + i * 3, xy: p.slice(0, 2), visible: p[2] })) : triples.flat(),
+    }],
+  };
+  await fs.writeJSON('/input/curve.json', doc);
+  const [parsed] = await parseFile('/input/curve.json');
+  const feature = Object.values(parsed.tracks)[0].features[0];
+  const geometry = feature.geometry!.features;
+  const expected = [2, 3, 1, 0].map((i) => triples[i].slice(0, 2));
+  expect(geometry.find((g) => g.geometry.type === 'LineString')!.geometry.coordinates).toEqual(expected);
+  expect(geometry.some((g) => g.properties?.key === 'spine_003')).toBe(false);
+  feature.geometry!.features = geometry.filter((g) => g.geometry.type === 'LineString');
+  await serializeFile('/output/curve.json', parsed, imageMeta);
+  const out = await fs.readJSON('/output/curve.json');
+  expect(out.categories[0].keypoints).toEqual(['head', 'spine_001', 'spine_002', 'tail']);
+  expect(out.categories[0].skeleton).toEqual([[1, 2], [2, 3], [3, 4]]);
+  expect(out.annotations[0].num_keypoints).toBe(4);
+  const [again] = await parseFile('/output/curve.json');
+  expect(Object.values(again.tracks)[0].features[0].geometry!.features.find((g) => g.geometry.type === 'LineString')!.geometry.coordinates).toEqual(expected);
+});
+
+it('pads shorter centerlines without inventing vertices or missing endpoints', async () => {
+  const source = JSON.parse(JSON.stringify(annotationSchema)) as AnnotationSchema;
+  const lines = [[[1.25, 2.5], [4.5, 6.25], [9.5, 3.25]], [[2.5, 3.5], [8.5, 4.5]]];
+  source.tracks[3].end = 1;
+  source.tracks[3].features = lines.map((coordinates, frame) => ({
+    frame,
+    bounds: [0, 0, 10, 10],
+    geometry: { type: 'FeatureCollection', features: [{ type: 'Feature', properties: { key: 'HeadTails' }, geometry: { type: 'LineString', coordinates } }] },
+  }));
+  await serializeFile('/output/curves.json', source, imageMeta);
+  const out = await fs.readJSON('/output/curves.json');
+  expect(out.annotations[1].keypoints).toEqual([2.5, 3.5, 2, 0, 0, 0, 8.5, 4.5, 2]);
+  expect(out.annotations[1].num_keypoints).toBe(2);
+  const [again] = await parseFile('/output/curves.json');
+  again.tracks[3].features.forEach((f, i) => {
+    expect(f.geometry!.features.find((g) => g.geometry.type === 'LineString')!.geometry.coordinates).toEqual(lines[i]);
+  });
+  out.annotations[0].keypoints[out.annotations[0].keypoints.length - 1] = 0;
+  await fs.writeJSON('/output/missing.json', out);
+  const [missing] = await parseFile('/output/missing.json');
+  expect(missing.tracks[3].features[0].geometry!.features.some((g) => g.geometry.type === 'LineString')).toBe(false);
+});

--- a/client/platform/desktop/backend/serializers/coco.ts
+++ b/client/platform/desktop/backend/serializers/coco.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { orderedHeadTail, spineIndex, syncHeadTail } from 'vue-media-annotator/headTail';
 import { isEmpty } from 'lodash';
 import { AnnotationSchema } from 'dive-common/apispec';
 import { JsonConfig } from 'platform/desktop/constants';
@@ -17,6 +18,7 @@ type CocoCategory = {
   id: number;
   name?: string;
   keypoints?: string[];
+  skeleton?: number[][];
   supercategory?: string | null;
   parents?: unknown;
 };
@@ -221,7 +223,8 @@ type CocoAnnotation = {
    * a dict, polygon/mask geometry is skipped (bbox and other fields still import).
    */
   iscrowd?: number;
-  keypoints?: number[];
+  keypoints?: number[] | { xy: number[]; keypoint_category?: string; keypoint_category_id?: number; visible?: number }[];
+  num_keypoints?: number;
   segmentation?: number[] | number[][] | Record<string, unknown>;
   dive_detection_attributes?: Record<string, unknown>;
   dive_track_attributes?: Record<string, unknown>;
@@ -247,6 +250,7 @@ type CocoDocument = CocoCategoryDocument & {
   images: CocoImage[];
   annotations: CocoAnnotation[];
   videos?: CocoVideo[];
+  keypoint_categories?: { id: number; name: string }[];
 };
 
 /**
@@ -278,13 +282,12 @@ function hasRleSegmentation(annotation: CocoAnnotation): boolean {
 function buildFeatureGeometry(
   annotation: CocoAnnotation,
   category?: CocoCategory,
+  keypointCategories: { id: number; name: string }[] = [],
 ): { geometry?: GeoJSON.FeatureCollection<TrackSupportedFeature, GeoJSON.GeoJsonProperties>; rleSkipped: boolean } {
-  if (hasRleSegmentation(annotation)) {
-    return { rleSkipped: true };
-  }
+  const rleSkipped = hasRleSegmentation(annotation);
   const geometryFeatures:
     GeoJSON.Feature<TrackSupportedFeature, GeoJSON.GeoJsonProperties>[] = [];
-  const coordLists = extractPolygonCoordsLists(annotation.segmentation);
+  const coordLists = rleSkipped ? [] : extractPolygonCoordsLists(annotation.segmentation);
   coordLists.forEach((coords) => {
     geometryFeatures.push({
       type: 'Feature',
@@ -297,50 +300,35 @@ function buildFeatureGeometry(
   });
 
   const keypoints = annotation.keypoints || [];
-  if (Array.isArray(keypoints) && keypoints.length >= 3) {
-    const labels = category?.keypoints || [];
-    const headTail: [number, number][] = [];
-    for (let i = 0; i + 2 < keypoints.length; i += 3) {
-      const label = labels[Math.floor(i / 3)];
-      if (label === 'head' || label === 'tail') {
-        const x = keypoints[i];
-        const y = keypoints[i + 1];
-        const visible = keypoints[i + 2] > 0;
-        if (visible) {
-          const point: [number, number] = [x, y];
-          headTail.push(point);
-          geometryFeatures.push({
-            type: 'Feature',
-            properties: { key: label },
-            geometry: {
-              type: 'Point',
-              coordinates: point,
-            },
-          });
-        }
-      }
-    }
-    if (headTail.length === 2) {
-      geometryFeatures.push({
-        type: 'Feature',
-        properties: { key: 'HeadTails' },
-        geometry: {
-          type: 'LineString',
-          coordinates: headTail,
-        },
-      });
-    }
+  const points = new Map<string, number[]>();
+  if (keypoints.length && typeof keypoints[0] === 'number') {
+    const flat = keypoints as number[];
+    (category?.keypoints || []).forEach((label, i) => {
+      if (i * 3 + 2 < flat.length && flat[i * 3 + 2] > 0) points.set(label, flat.slice(i * 3, i * 3 + 2));
+    });
+  } else {
+    keypoints.forEach((kp) => {
+      if (typeof kp === 'number') return;
+      const label = kp.keypoint_category || keypointCategories.find((k) => k.id === kp.keypoint_category_id)?.name;
+      if (label && (kp.visible ?? 2) > 0) points.set(label, kp.xy);
+    });
   }
+  points.forEach((point, label) => {
+    if (!Array.isArray(point) || point.length < 2 || !point.slice(0, 2).every(Number.isFinite)) return;
+    geometryFeatures.push({ type: 'Feature', properties: { key: label }, geometry: { type: 'Point', coordinates: point.slice(0, 2) } });
+  });
+  const line = orderedHeadTail(geometryFeatures);
+  if (line) geometryFeatures.push({ type: 'Feature', properties: { key: 'HeadTails' }, geometry: { type: 'LineString', coordinates: line } });
 
   if (!geometryFeatures.length) {
-    return { rleSkipped: false };
+    return { rleSkipped };
   }
   return {
     geometry: {
       type: 'FeatureCollection' as const,
       features: geometryFeatures,
     },
-    rleSkipped: false,
+    rleSkipped,
   };
 }
 
@@ -540,7 +528,7 @@ async function parseFile(path: string): Promise<[AnnotationSchema, Record<string
     } else if (typeof noteField === 'string' && noteField.trim()) {
       feature.notes = [noteField.trim()];
     }
-    const { geometry, rleSkipped } = buildFeatureGeometry(annotation, category);
+    const { geometry, rleSkipped } = buildFeatureGeometry(annotation, category, parsed.keypoint_categories);
     if (rleSkipped) {
       skippedRleMasks = true;
     }
@@ -597,6 +585,16 @@ async function serializeFile(
     excludeBelowThreshold: false,
   },
 ) {
+  const featurePoints = (feature: AnnotationSchema['tracks'][number]['features'][number]) => {
+    const geometry = feature.geometry?.features || [];
+    const hasLine = geometry.some((f) => f.geometry.type === 'LineString' && f.properties?.key === 'HeadTails');
+    return new Map((hasLine ? syncHeadTail(geometry) : geometry)
+      .filter((f) => f.geometry.type === 'Point' && f.properties?.key)
+      .map((f) => [f.properties?.key as string, (f.geometry as GeoJSON.Point).coordinates.slice(0, 2)]));
+  };
+  const names = new Set(Object.values(data.tracks).flatMap((t) => t.features.flatMap((f) => [...featurePoints(f).keys()])));
+  const spine = [...names].filter((k) => spineIndex(k) !== null).sort((a, b) => (spineIndex(a) as number) - (spineIndex(b) as number));
+  const labels = ['head', ...spine, 'tail', ...[...names].filter((k) => k !== 'head' && k !== 'tail' && spineIndex(k) === null).sort()];
   const images = new Map<number, CocoImage>();
   const annotations: CocoAnnotation[] = [];
   let annotationId = 1;
@@ -656,6 +654,7 @@ async function serializeFile(
           ...(emitVideo ? { video_id: 1 } : {}),
         });
       }
+      const points = featurePoints(feature);
       annotations.push({
         id: annotationId,
         image_id: imageId,
@@ -664,6 +663,7 @@ async function serializeFile(
         bbox: [x1, y1, Math.max(0, x2 - x1), Math.max(0, y2 - y1)],
         score,
         prob,
+        ...(points.size ? { keypoints: labels.flatMap((k) => (points.has(k) ? [...points.get(k)!, 2] : [0, 0, 0])), num_keypoints: points.size } : {}),
         dive_confidence_pairs: pairs.map(([name, confidence]) => [name, confidence]),
         ...(feature.attributes ? { dive_detection_attributes: feature.attributes } : {}),
         ...(track.attributes ? { dive_track_attributes: track.attributes } : {}),
@@ -676,7 +676,8 @@ async function serializeFile(
   const categoryDocs: CocoCategory[] = Array.from(categories.entries()).map(([name, id]) => ({
     id,
     name,
-    keypoints: ['head', 'tail'],
+    keypoints: labels,
+    skeleton: Array.from({ length: labels.indexOf('tail') }, (_, i) => [i + 1, i + 2]),
     ...(hierarchy[name] ? { supercategory: hierarchy[name] } : {}),
   }));
   // datasetInfo rides in the `info` block + dive_extensions; omitted entirely when empty.

--- a/client/platform/desktop/backend/serializers/viame.spec.ts
+++ b/client/platform/desktop/backend/serializers/viame.spec.ts
@@ -3,7 +3,7 @@ import { AnnotationSchema, MultiTrackRecord } from 'dive-common/apispec';
 import { parse as parseSync } from 'csv-parse/sync';
 import fs from 'fs-extra';
 import mockfs from 'mock-fs';
-import { Readable } from 'stream';
+import { Readable, Writable } from 'stream';
 import { AnnotationsCurrentVersion, JsonConfig } from 'platform/desktop/constants';
 import { serialize, parse, parseFile } from 'platform/desktop/backend/serializers/viame';
 import { Attribute } from 'vue-media-annotator/use/AttributeTypes';
@@ -469,4 +469,48 @@ describe('Test Image Filenames', () => {
 
 afterEach(() => {
   mockfs.restore();
+});
+
+it('imports ordered subpixel centerlines and unrelated keypoints', async () => {
+  const csv = '1,img.png,0,0,0,100,100,1,-1,fish,1,(kp) tail 90 10,(kp) spine_010 60.123456789 40,(kp) head 10 10,(kp) spine_002 40 30,(kp) eye 12 11';
+  const [data] = await parse(Readable.from([csv]));
+  const feature = Object.values(data.tracks)[0].features[0];
+  const line = feature.geometry!.features.find((g) => g.geometry.type === 'LineString');
+  expect(line?.geometry.coordinates).toEqual([[10, 10], [40, 30], [60.123456789, 40], [90, 10]]);
+  expect(feature.geometry!.features.some((g) => g.properties?.key === 'eye')).toBe(true);
+});
+
+it('round-trips line-only JSON through CSV without rounding vertices', async () => {
+  const coordinates = [[10.123456789, 20], [20, 30.987654321], [30, 20]];
+  const annotation = {
+    ...data,
+    tracks: {
+      1: {
+        ...Object.values(data.tracks)[0],
+        id: 1,
+        begin: 0,
+        end: 0,
+        features: [{
+          frame: 0,
+          keyframe: true,
+          bounds: [0, 0, 100, 100],
+          geometry: {
+            type: 'FeatureCollection',
+            features: [{
+              type: 'Feature',
+              properties: { key: 'HeadTails' },
+              geometry: { type: 'LineString', coordinates },
+            }],
+          },
+        }],
+      },
+    },
+  } as AnnotationSchema;
+  let output = '';
+  const stream = new Writable({ write(chunk, encoding, callback) { output += chunk.toString(); callback(); } });
+  await serialize(stream, annotation, meta, new Set(), { excludeBelowThreshold: false, header: false });
+  const [loaded] = await parse(Readable.from([output]));
+  const geometry = Object.values(loaded.tracks)[0].features[0].geometry!;
+  expect(geometry.features.find((f) => f.geometry.type === 'LineString')?.geometry.coordinates).toEqual(coordinates);
+  expect(output).toContain('(kp) spine_001 20 30.987654321');
 });

--- a/client/platform/desktop/backend/serializers/viame.ts
+++ b/client/platform/desktop/backend/serializers/viame.ts
@@ -20,11 +20,10 @@ import { splitExt } from 'platform/desktop/backend/native/utils';
 import Track, {
   TrackData, Feature, TrackSupportedFeature,
 } from 'vue-media-annotator/track';
+import { orderedHeadTail, syncHeadTail } from 'vue-media-annotator/headTail';
 import { ConfidencePair, StringKeyObject } from 'vue-media-annotator/BaseAnnotation';
 
 const CommentRegex = /^\s*#/g;
-const HeadRegex = /^\(kp\) head (-?[0-9]+\.*-?[0-9]*) (-?[0-9]+\.*-?[0-9]*)/g;
-const TailRegex = /^\(kp\) tail (-?[0-9]+\.*-?[0-9]*) (-?[0-9]+\.*-?[0-9]*)/g;
 const AttrRegex = /^\(atr\) (.*?)\s(.+)/g;
 const TrackAttrRegex = /^\(trk-atr\) (.*?)\s(.+)/g;
 // Polygon format: (poly) coordinates
@@ -283,21 +282,12 @@ function _parseRow(row: string[]) {
     })
     .filter((val) => val[0] !== '')
     .sort((a, b) => b[1] - a[1]);
-  const headTail: [number, number][] = [];
+
   const start = 9 + (confidencePairs.length * 2);
   row.slice(start).forEach((value) => {
-    /* Head */
-    const head = getCaptureGroups(HeadRegex, value);
-    if (head !== null) {
-      headTail[0] = [parseFloat(head[1]), parseFloat(head[2])];
-      geoFeatureCollection.features.push(_createGeoJsonFeature('Point', [headTail[0]], 'head'));
-    }
-
-    /* Tail */
-    const tail = getCaptureGroups(TailRegex, value);
-    if (tail !== null) {
-      headTail[1] = [parseFloat(tail[1]), parseFloat(tail[2])];
-      geoFeatureCollection.features.push(_createGeoJsonFeature('Point', [headTail[1]], 'tail'));
+    const kp = /^\(kp\)\s+(\S+)\s+(\S+)\s+(\S+)\s*$/.exec(value);
+    if (kp && Number.isFinite(Number(kp[2])) && Number.isFinite(Number(kp[3]))) {
+      geoFeatureCollection.features.push(_createGeoJsonFeature('Point', [[Number(kp[2]), Number(kp[3])]], kp[1]));
     }
 
     /* Detection Attribute */
@@ -363,7 +353,8 @@ function _parseRow(row: string[]) {
     }
   });
 
-  if (headTail[0] !== undefined && headTail[1] !== undefined) {
+  const headTail = orderedHeadTail(geoFeatureCollection.features);
+  if (headTail) {
     geoFeatureCollection.features.push(_createGeoJsonFeature('LineString', headTail, 'HeadTails'));
   }
 
@@ -773,7 +764,7 @@ async function serialize(
 
             /* Geometry */
             if (feature.geometry && feature.geometry.type === 'FeatureCollection') {
-              feature.geometry.features.forEach((geoJSONFeature) => {
+              syncHeadTail(feature.geometry.features).forEach((geoJSONFeature) => {
                 if (geoJSONFeature.geometry.type === 'Polygon') {
                   const allRings = geoJSONFeature.geometry.coordinates as number[][][];
 
@@ -793,7 +784,7 @@ async function serialize(
                     const kpname = geoJSONFeature.properties.key;
                     const { coordinates } = geoJSONFeature.geometry;
                     row.push(
-                      `${KeypointToken} ${kpname} ${coordinates.map(Math.round).join(' ')}`,
+                      `${KeypointToken} ${kpname} ${coordinates.join(' ')}`,
                     );
                   }
                 }

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -716,6 +716,11 @@ interface StereoAggregateLengthsResponse {
 }
 
 interface StereoTransferPointsRequest {
+  sourceCamera?: 'left' | 'right';
+  strict?: boolean;
+  leftImagePath?: string;
+  rightImagePath?: string;
+  frameTime?: number;
   points: [number, number][];
 }
 
@@ -726,6 +731,7 @@ interface StereoTransferPointsResponse {
   transferredPoints?: [number, number][];
   originalPoints?: [number, number][];
   disparityValues?: number[];
+  validMatches?: boolean[];
 }
 
 async function stereoEnable(

--- a/client/platform/desktop/frontend/api.ts
+++ b/client/platform/desktop/frontend/api.ts
@@ -663,6 +663,9 @@ interface StereoTransferLineRequest {
 }
 
 interface StereoMeasurement {
+  curved_length?: number;
+  straight_length?: number;
+  curvature_ratio?: number;
   length: number;
   midpoint_x: number;
   midpoint_y: number;
@@ -688,8 +691,8 @@ interface StereoTransferLineResponse {
 }
 
 interface StereoMeasureLineRequest {
-  leftLine: [[number, number], [number, number]];
-  rightLine: [[number, number], [number, number]];
+  leftLine: [number, number][];
+  rightLine: [number, number][];
 }
 
 interface StereoMeasureLineResponse {

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { headTailFeatures } from 'vue-media-annotator/headTail';
 import {
   computed, defineComponent, ref, watch, Ref, onMounted, onBeforeUnmount, nextTick,
 } from 'vue';
@@ -1018,17 +1019,17 @@ export default defineComponent({
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function getStereoLineEndpoints(track: any, frameNum: number)
-      : [[number, number], [number, number]] | null {
+      : [number, number][] | null {
       if (!track) return null;
       const [feature] = track.getFeature(frameNum);
       if (!feature || !feature.geometry) return null;
       const lineFeat = feature.geometry.features.find(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (f: any) => f.geometry.type === 'LineString' && f.geometry.coordinates.length === 2,
+        (f: any) => f.geometry.type === 'LineString' && f.geometry.coordinates.length >= 2,
       );
       if (!lineFeat) return null;
       const c = lineFeat.geometry.coordinates as [number, number][];
-      return [c[0], c[1]];
+      return c;
     }
 
     /**
@@ -1073,7 +1074,7 @@ export default defineComponent({
     }
 
     const STEREO_MEASUREMENT_ATTRS = [
-      'length', 'midpoint_x', 'midpoint_y', 'midpoint_z', 'midpoint_range', 'stereo_rms',
+      'length', 'curved_length', 'straight_length', 'curvature_ratio', 'midpoint_x', 'midpoint_y', 'midpoint_z', 'midpoint_range', 'stereo_rms',
     ];
 
     // Per-feature marker: a human (not the stereo warp) authored this camera's
@@ -1298,6 +1299,7 @@ export default defineComponent({
       // A length the user locked (length_method === 'user_set') is never
       // overwritten; the other measurements still track the shifting geometry.
       const lengthLocked = feature?.attributes?.[STEREO_LENGTH_METHOD_ATTR] === 'user_set';
+      track.setFeatureAttribute(frameNum, 'measurement_stale', false);
       const { length } = measurement;
       if (!lengthLocked && length !== undefined && Number.isFinite(length)) {
         if (feature && feature.keyframe) {
@@ -1343,7 +1345,10 @@ export default defineComponent({
       const rightLine = getStereoLineEndpoints(rightTrack, frameNum);
       if (!leftLine || !rightLine) return null;
 
+      if (leftLine.length > 2 || rightLine.length > 2) await ensureStereoFrame(frameNum);
       const response = await stereoMeasureLine({ leftLine, rightLine });
+      if (JSON.stringify(getStereoLineEndpoints(leftTrack, frameNum)) !== JSON.stringify(leftLine)
+          || JSON.stringify(getStereoLineEndpoints(rightTrack, frameNum)) !== JSON.stringify(rightLine)) return null;
       if (response.success && response.measurement) {
         ensureMeasurementAttributes();
         applyStereoMeasurement(leftTrack, frameNum, response.measurement);
@@ -1433,6 +1438,8 @@ export default defineComponent({
       // in the meantime must see this one as human-authored, not
       // machine-generated, so the warp can never overwrite it.
       if (params.type === 'line') {
+        viewerRef.value?.multiCamList.forEach((camera: string) => viewerRef.value?.cameraStore
+          ?.getPossibleTrack(params.trackId, camera)?.invalidateMeasurement(params.frameNum));
         const sourceTrack = viewerRef.value?.cameraStore
           ?.getPossibleTrack(params.trackId, params.camera);
         sourceTrack?.setFeatureAttribute(params.frameNum, STEREO_USER_LINE_ATTR, true);
@@ -1473,6 +1480,12 @@ export default defineComponent({
         || clientSettings.stereoSettings.autoComputeOtherCamera;
 
       if (params.type === 'line') {
+        // Dense point transfer is left-reference. Editing the right curve
+        // remeasures against the existing left curve instead of warping backwards.
+        if (params.line.length > 2 && params.camera !== Object.keys(stereoImagePathGetters.value)[0]) {
+          if (updateLengths && otherHasFeature) await autoUpdateStereoLength(cameraStore, params.trackId, params.frameNum);
+          return 'skipped';
+        }
         const otherIsHuman = otherHasFeature
           && otherFeature?.attributes?.[STEREO_USER_LINE_ATTR] === true;
         if (otherIsHuman || !autoCompute) {
@@ -1515,41 +1528,29 @@ export default defineComponent({
         await ensureStereoFrame(params.frameNum);
 
         if (params.type === 'line') {
-          const response = await stereoTransferLine({ line: params.line });
+          const response = params.line.length === 2
+            ? await stereoTransferLine({ line: [params.line[0], params.line[1]] })
+            : await stereoTransferPoints({ points: params.line }).then((r) => ({
+              ...r,
+              transferredLine: r.transferredPoints,
+              measurement: undefined,
+              success: r.success && !!r.disparityValues?.every((d) => Number.isFinite(d) && d > 0),
+            }));
           if (!response.success || !response.transferredLine) {
             throw new Error(response.error || 'Line transfer returned no result');
           }
 
+          const currentSource = cameraStore.getPossibleTrack(params.trackId, params.camera);
+          if (JSON.stringify(getStereoLineEndpoints(currentSource, params.frameNum)) !== JSON.stringify(params.line)) return 'skipped';
           // Get or create the track on the other camera and set the warped line
           const track = getOrCreateStereoTrack(cameraStore, params.trackId, params.camera, otherCamera, params.frameNum);
           if (track) {
-            const [p1, p2] = response.transferredLine;
-            // Preserve the source line's key and include head/tail Point markers
-            // so the warped line is a standard, line-mode-editable annotation.
-            const lineGeometry: GeoJSON.Feature[] = [
-              {
-                type: 'Feature',
-                geometry: { type: 'LineString', coordinates: response.transferredLine },
-                properties: { key: params.key },
-              },
-              {
-                type: 'Feature',
-                geometry: { type: 'Point', coordinates: [p1[0], p1[1]] },
-                properties: { key: HeadPointKey },
-              },
-              {
-                type: 'Feature',
-                geometry: { type: 'Point', coordinates: [p2[0], p2[1]] },
-                properties: { key: TailPointKey },
-              },
-            ];
-
-            // Compute bounds from the transferred line with 10% expansion to
-            // match the expansion applied on the source camera side (headtail.ts).
-            const minX = Math.min(p1[0], p2[0]);
-            const minY = Math.min(p1[1], p2[1]);
-            const maxX = Math.max(p1[0], p2[0]);
-            const maxY = Math.max(p1[1], p2[1]);
+            const points = response.transferredLine;
+            const lineGeometry = headTailFeatures(points);
+            const minX = Math.min(...points.map((p) => p[0]));
+            const minY = Math.min(...points.map((p) => p[1]));
+            const maxX = Math.max(...points.map((p) => p[0]));
+            const maxY = Math.max(...points.map((p) => p[1]));
             const width = maxX - minX;
             const height = maxY - minY;
             const padX = width * 0.10 || height * 0.10;
@@ -1584,6 +1585,9 @@ export default defineComponent({
               interpolate: false,
             }, lineGeometry);
 
+            if (params.line.length > 2 && updateLengths) {
+              await autoUpdateStereoLength(cameraStore, params.trackId, params.frameNum);
+            }
             // Report and store the full stereo measurement on both cameras
             // (length attributes are gated by the length-update feature).
             if (response.measurement && updateLengths) {
@@ -1821,7 +1825,7 @@ export default defineComponent({
             const geoFeatures = feature.geometry?.features || [];
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const line = geoFeatures.find((g: any) => g.geometry?.type === 'LineString'
-              && g.geometry.coordinates?.length === 2);
+              && g.geometry.coordinates?.length >= 2);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const poly = geoFeatures.find((g: any) => g.geometry?.type === 'Polygon');
             const base = { camera: sourceCamera, trackId: track.id, frameNum };

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -1,5 +1,8 @@
 <script lang="ts">
-import { headTailFeatures } from 'vue-media-annotator/headTail';
+import {
+  canMapPoint, pointUnchanged, applyMappedPoint, pointTargetState,
+} from 'dive-common/use/stereo/keypointTransfer';
+import { headTailFeatures, isHeadTailPoint } from 'vue-media-annotator/headTail';
 import {
   computed, defineComponent, ref, watch, Ref, onMounted, onBeforeUnmount, nextTick,
 } from 'vue';
@@ -1430,6 +1433,10 @@ export default defineComponent({
       forceAutoCompute = false,
       quiet = false,
     ): Promise<'transferred' | 'skipped' | 'failed'> {
+      if (params.type === 'point' && isHeadTailPoint(params.key)) {
+        viewerRef.value?.multiCamList.forEach((camera: string) => viewerRef.value?.cameraStore
+          ?.getPossibleTrack(params.trackId, camera)?.invalidateMeasurement(params.frameNum));
+      }
       // This handler only fires on human edits — the stereo warp writes
       // geometry directly, bypassing the annotation-complete event — so the
       // camera the user just drew/edited is now human-authored. Mark it
@@ -1437,7 +1444,7 @@ export default defineComponent({
       // can be long on a fresh launch, and a line drawn on the other camera
       // in the meantime must see this one as human-authored, not
       // machine-generated, so the warp can never overwrite it.
-      if (params.type === 'line') {
+      if (params.type === 'line' || (params.type === 'point' && isHeadTailPoint(params.key))) {
         viewerRef.value?.multiCamList.forEach((camera: string) => viewerRef.value?.cameraStore
           ?.getPossibleTrack(params.trackId, camera)?.invalidateMeasurement(params.frameNum));
         const sourceTrack = viewerRef.value?.cameraStore
@@ -1480,12 +1487,6 @@ export default defineComponent({
         || clientSettings.stereoSettings.autoComputeOtherCamera;
 
       if (params.type === 'line') {
-        // Dense point transfer is left-reference. Editing the right curve
-        // remeasures against the existing left curve instead of warping backwards.
-        if (params.line.length > 2 && params.camera !== Object.keys(stereoImagePathGetters.value)[0]) {
-          if (updateLengths && otherHasFeature) await autoUpdateStereoLength(cameraStore, params.trackId, params.frameNum);
-          return 'skipped';
-        }
         const otherIsHuman = otherHasFeature
           && otherFeature?.attributes?.[STEREO_USER_LINE_ATTR] === true;
         if (otherIsHuman || !autoCompute) {
@@ -1504,6 +1505,13 @@ export default defineComponent({
         // Otherwise (auto-compute on, other side absent or still machine-generated)
         // fall through and (re)warp source -> other so the auto-generated line
         // keeps tracking edits.
+      } else if (params.type === 'point') {
+        if (!autoCompute || (!params.insert && !canMapPoint(otherTrack, params.frameNum, params.key, params.camera))) {
+          if (isHeadTailPoint(params.key) && updateLengths && otherHasFeature) {
+            await autoUpdateStereoLength(cameraStore, params.trackId, params.frameNum);
+          }
+          return 'skipped';
+        }
       } else if (otherHasFeature) {
         // Box / polygon / segmentation: warp only once; leave existing untouched.
         return 'skipped';
@@ -1520,6 +1528,8 @@ export default defineComponent({
         stereoLoadingDialog.value = true;
       }
 
+      const pointTargetBefore = params.type === 'point'
+        ? pointTargetState(otherTrack, params.frameNum, params.key, params.insert, params.camera) : undefined;
       try {
         // Guarantee the backend has this frame's images before transferring. The
         // proactive watcher only fires on frame-number changes, so a draw on the
@@ -1527,14 +1537,49 @@ export default defineComponent({
         // deferred disparity wait.
         await ensureStereoFrame(params.frameNum);
 
-        if (params.type === 'line') {
-          const response = params.line.length === 2
+        if (params.type === 'point') {
+          const cameras = Object.keys(stereoImagePathGetters.value);
+          if (cameras.length !== 2 || !cameras.includes(params.camera)) throw new Error('Stereo camera mapping is unavailable');
+          const source = cameraStore.getPossibleTrack(params.trackId, params.camera);
+          const fps = stereoCameraFps.value[cameras[0]] || stereoDatasetFps || Object.values(stereoCameraFps.value)[0];
+          const response = await stereoTransferPoints({
+            points: [params.point],
+            strict: true,
+            sourceCamera: params.camera === cameras[0] ? 'left' : 'right',
+            leftImagePath: stereoImagePathGetters.value[cameras[0]](params.frameNum),
+            rightImagePath: stereoImagePathGetters.value[cameras[1]](params.frameNum),
+            frameTime: fps ? params.frameNum / fps : undefined,
+          });
+          const point = response.transferredPoints?.[0];
+          if (!response.success || response.validMatches?.[0] !== true || !point?.every(Number.isFinite)) {
+            throw new Error(response.error || 'No valid stereo match for this keypoint');
+          }
+          const currentTarget = cameraStore.getPossibleTrack(params.trackId, otherCamera);
+          if (!pointUnchanged(source, params.frameNum, params.key, params.point)
+              || pointTargetState(currentTarget, params.frameNum, params.key, params.insert, params.camera) !== pointTargetBefore) return 'skipped';
+          const track = getOrCreateStereoTrack(cameraStore, params.trackId, params.camera, otherCamera, params.frameNum);
+          if (track) {
+            applyMappedPoint(track, params.frameNum, params.key, point, params.camera, params.insert);
+            if (isHeadTailPoint(params.key) && updateLengths) await autoUpdateStereoLength(cameraStore, params.trackId, params.frameNum);
+          }
+        } else if (params.type === 'line') {
+          const cameras = Object.keys(stereoImagePathGetters.value);
+          const fromRight = params.camera === cameras[1];
+          const fps = stereoCameraFps.value[cameras[0]] || stereoDatasetFps || Object.values(stereoCameraFps.value)[0];
+          const response = params.line.length === 2 && !fromRight
             ? await stereoTransferLine({ line: [params.line[0], params.line[1]] })
-            : await stereoTransferPoints({ points: params.line }).then((r) => ({
+            : await stereoTransferPoints({
+              points: params.line,
+              strict: true,
+              sourceCamera: fromRight ? 'right' : 'left',
+              leftImagePath: stereoImagePathGetters.value[cameras[0]](params.frameNum),
+              rightImagePath: stereoImagePathGetters.value[cameras[1]](params.frameNum),
+              frameTime: fps ? params.frameNum / fps : undefined,
+            }).then((r) => ({
               ...r,
               transferredLine: r.transferredPoints,
               measurement: undefined,
-              success: r.success && !!r.disparityValues?.every((d) => Number.isFinite(d) && d > 0),
+              success: r.success && r.validMatches?.length === params.line.length && r.validMatches.every(Boolean),
             }));
           if (!response.success || !response.transferredLine) {
             throw new Error(response.error || 'Line transfer returned no result');
@@ -1546,7 +1591,11 @@ export default defineComponent({
           const track = getOrCreateStereoTrack(cameraStore, params.trackId, params.camera, otherCamera, params.frameNum);
           if (track) {
             const points = response.transferredLine;
-            const lineGeometry = headTailFeatures(points);
+            const lineGeometry = headTailFeatures(points).map((g) => ({
+              ...g,
+              properties: g.geometry.type === 'Point'
+                ? { ...g.properties, stereoSource: params.camera, stereoKey: g.properties?.key } : g.properties,
+            }));
             const minX = Math.min(...points.map((p) => p[0]));
             const minY = Math.min(...points.map((p) => p[1]));
             const maxX = Math.max(...points.map((p) => p[0]));
@@ -1585,7 +1634,7 @@ export default defineComponent({
               interpolate: false,
             }, lineGeometry);
 
-            if (params.line.length > 2 && updateLengths) {
+            if ((params.line.length > 2 || fromRight) && updateLengths) {
               await autoUpdateStereoLength(cameraStore, params.trackId, params.frameNum);
             }
             // Report and store the full stereo measurement on both cameras

--- a/client/src/components/layerManager/useAnnotationClickHandling.spec.ts
+++ b/client/src/components/layerManager/useAnnotationClickHandling.spec.ts
@@ -1,0 +1,53 @@
+import Vue, { ref } from 'vue';
+import useAnnotationClickHandling from './useAnnotationClickHandling';
+
+function harness(type = 'LineString') {
+  const layer = () => ({ bus: new Vue() });
+  const polygon = layer();
+  const selectedKey = ref(type === 'LineString' ? 'HeadTails' : '');
+  const selectFeatureHandle = vi.fn((_index, key) => { selectedKey.value = key; });
+  const cancelCreation = vi.fn();
+  const edit = { ...layer(), type, getMode: () => 'editing' };
+  const refresh = vi.fn();
+  useAnnotationClickHandling({
+    camera: 'left',
+    selectedCamera: ref('left'),
+    selectedTrackIdRef: ref(1),
+    selectedKeyRef: selectedKey,
+    frameNumberRef: ref(0),
+    flickNumberRef: ref(0),
+    editingModeRef: ref(type),
+    editAnnotationLayer: edit,
+    polyAnnotationLayer: polygon,
+    rectAnnotationLayer: layer(),
+    lineLayer: layer(),
+    handler: { selectFeatureHandle, cancelCreation, registerFinalizeCreation: vi.fn() },
+    refreshLayers: refresh,
+  } as never).wireHandlers();
+  return {
+    polygon, selectedKey, selectFeatureHandle, cancelCreation, edit, refresh,
+  };
+}
+
+it.each(['polygon-clicked', 'polygon-right-clicked', 'polygon-right-clicked-outside'])('keeps the saved line selected when a visible mask emits %s', (event) => {
+  const h = harness();
+  h.polygon.bus.$emit(event, 1, 'segmentation');
+  expect(h.selectedKey.value).toBe('HeadTails');
+  expect(h.selectFeatureHandle).not.toHaveBeenCalled();
+  expect(h.cancelCreation).not.toHaveBeenCalled();
+});
+
+it('still selects a mask key when the polygon editor is active', () => {
+  const h = harness('Polygon');
+  h.polygon.bus.$emit('polygon-right-clicked', 1, 'segmentation');
+  expect(h.selectedKey.value).toBe('segmentation');
+  expect(h.selectFeatureHandle).toHaveBeenCalledWith(-1, 'segmentation');
+});
+
+it('does not cancel in-progress line creation when a mask is right-clicked', () => {
+  const h = harness(); h.edit.getMode = () => 'creation';
+  h.polygon.bus.$emit('polygon-right-clicked', 1, 'segmentation');
+  h.polygon.bus.$emit('polygon-right-clicked-outside');
+  expect(h.cancelCreation).not.toHaveBeenCalled();
+  expect(h.selectedKey.value).toBe('HeadTails');
+});

--- a/client/src/components/layerManager/useAnnotationClickHandling.ts
+++ b/client/src/components/layerManager/useAnnotationClickHandling.ts
@@ -123,6 +123,9 @@ export default function useAnnotationClickHandling(options: {
     lineLayer.bus.$on('annotation-right-clicked', clicked);
 
     polyAnnotationLayer.bus.$on('polygon-right-clicked', (_trackId: number, polygonKey: string) => {
+      // Visible masks must not replace the centerline's key when editing a line.
+      if (editingModeRef.value === 'LineString'
+          || (editAnnotationLayer.type === 'LineString' && editAnnotationLayer.getMode() !== 'disabled')) return;
       if (editAnnotationLayer.getMode() === 'creation') {
         handler.cancelCreation();
       }
@@ -131,6 +134,8 @@ export default function useAnnotationClickHandling(options: {
     });
 
     polyAnnotationLayer.bus.$on('polygon-clicked', (_trackId: number, polygonKey: string) => {
+      if (editingModeRef.value === 'LineString'
+          || (editAnnotationLayer.type === 'LineString' && editAnnotationLayer.getMode() !== 'disabled')) return;
       if (editAnnotationLayer.getMode() === 'creation') {
         return;
       }
@@ -139,6 +144,8 @@ export default function useAnnotationClickHandling(options: {
     });
 
     polyAnnotationLayer.bus.$on('polygon-right-clicked-outside', () => {
+      if (editingModeRef.value === 'LineString'
+          || (editAnnotationLayer.type === 'LineString' && editAnnotationLayer.getMode() !== 'disabled')) return;
       if (editAnnotationLayer.getMode() === 'creation') {
         handler.cancelCreation();
         handler.selectFeatureHandle(-1, '');

--- a/client/src/headTail.spec.ts
+++ b/client/src/headTail.spec.ts
@@ -1,0 +1,45 @@
+import {
+  headTailFeatures, orderedHeadTail, syncHeadTail, sampleHeadTail,
+} from './headTail';
+import Track from './track';
+import HeadTail from '../dive-common/recipes/headtail';
+
+describe('editable centerlines', () => {
+  it('orders numeric names regardless of CSV column order', () => {
+    const points = ['tail', 'spine_010', 'head', 'spine_002'].map((key, i): GeoJSON.Feature<GeoJSON.Point> => ({
+      type: 'Feature', properties: { key }, geometry: { type: 'Point', coordinates: [i, 0] },
+    }));
+    expect(orderedHeadTail(points)).toEqual([[2, 0], [3, 0], [1, 0], [0, 0]]);
+  });
+  it('retains fractional vertices and unrelated geometry', () => {
+    const curve = [[1.25, 2.5], [3.125, 8.5], [9, 4]];
+    const other: GeoJSON.Feature<GeoJSON.Point> = { type: 'Feature', properties: { key: 'eye' }, geometry: { type: 'Point', coordinates: [2, 3] } };
+    const features = syncHeadTail([...headTailFeatures(curve), other]);
+    expect(orderedHeadTail(features)).toEqual(curve);
+    expect(features).toContain(other);
+  });
+  it('inserts, moves, and deletes interior vertices using the existing recipe', () => {
+    const track = new Track(0, { meta: {}, begin: 0, end: 0 });
+    track.setFeature({ frame: 0, keyframe: true, bounds: [0, 0, 100, 100] }, headTailFeatures([[10, 10], [90, 10]]));
+    track.setFeature({ frame: 0, fishLength: 42, attributes: { length: 42 } });
+    const recipe = new HeadTail();
+    const curve: GeoJSON.Feature<GeoJSON.LineString> = { type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates: [[10, 10], [40.5, 30.5], [60, 40], [90, 10]] } };
+    const update = recipe.update('editing', 0, track, [curve], 'HeadTails');
+    track.setFeature({ frame: 0 }, Object.values(update.data).flat());
+    expect(track.features[0].fishLength).toBeUndefined();
+    expect(track.features[0].attributes?.measurement_stale).toBe(true);
+    recipe.deletePoint(0, track, 1, 'HeadTails', 'LineString');
+    expect(orderedHeadTail(track.features[0].geometry!.features)).toEqual([[10, 10], [60, 40], [90, 10]]);
+    expect(track.getFeatureGeometry(0, { key: 'spine_002' })).toHaveLength(0);
+    recipe.deletePoint(0, track, 1, 'HeadTails', 'LineString');
+    expect(orderedHeadTail(track.features[0].geometry!.features)).toEqual([[10, 10], [90, 10]]);
+    expect(track.getFeatureGeometry(0, { key: 'spine_001' })).toHaveLength(0);
+    recipe.deletePoint(0, track, 0, 'HeadTails', 'LineString');
+    expect(track.getFeatureGeometry(0, { key: 'tail' })).toHaveLength(1);
+    expect(track.getFeatureGeometry(0, { key: 'HeadTails' })).toHaveLength(0);
+  });
+  it('samples a curve without dropping its endpoints', () => {
+    const sampled = sampleHeadTail([[0, 0], [0, 10], [10, 10]], 5);
+    expect(sampled).toEqual([[0, 0], [0, 5], [0, 10], [5, 10], [10, 10]]);
+  });
+});

--- a/client/src/headTail.spec.ts
+++ b/client/src/headTail.spec.ts
@@ -3,6 +3,7 @@ import {
 } from './headTail';
 import Track from './track';
 import HeadTail from '../dive-common/recipes/headtail';
+import { updateBounds } from './utils';
 
 describe('editable centerlines', () => {
   it('orders numeric names regardless of CSV column order', () => {
@@ -41,5 +42,45 @@ describe('editable centerlines', () => {
   it('samples a curve without dropping its endpoints', () => {
     const sampled = sampleHeadTail([[0, 0], [0, 10], [10, 10]], 5);
     expect(sampled).toEqual([[0, 0], [0, 5], [0, 10], [5, 10], [10, 10]]);
+  });
+});
+
+describe('centerline box preservation', () => {
+  it.each([
+    [[10, 10], [90, 20]],
+    [[20, 30], [50, 80], [80, 20]],
+    [[0, 0], [100, 100]],
+  ])('keeps an existing box for contained vertices %j', (...coordinates) => {
+    const track = new Track(0, { meta: {}, begin: 0, end: 0 });
+    track.setFeature({ frame: 0, keyframe: true, bounds: [0, 0, 100, 100] }, headTailFeatures([[10, 10], [90, 10]]));
+    const recipe = new HeadTail(); recipe.activate();
+    const change = recipe.update('editing', 0, track, [{ type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates } }], 'HeadTails');
+    expect(updateBounds(track.features[0].bounds, change.union, change.unionWithoutBounds)).toEqual([0, 0, 100, 100]);
+  });
+
+  it('expands only the necessary box edges and encloses fractional vertices', () => {
+    const track = new Track(0, { meta: {}, begin: 0, end: 0 });
+    track.setFeature({ frame: 0, keyframe: true, bounds: [0, 0, 100, 100] }, headTailFeatures([[10, 10], [90, 10]]));
+    const recipe = new HeadTail(); recipe.activate();
+    const change = recipe.update('editing', 0, track, [{ type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates: [[-0.2, 10], [50, 120.1], [90, 10]] } }], 'HeadTails');
+    const bounds = updateBounds(track.features[0].bounds, change.union, change.unionWithoutBounds);
+    track.setFeature({ frame: 0, bounds });
+    expect(track.features[0].bounds).toEqual([-1, 0, 100, 121]);
+  });
+
+  it('uses initial padding once, then preserves that box on later edits', () => {
+    const track = new Track(0, { meta: {}, begin: 0, end: 0 });
+    track.setFeature({ frame: 0, keyframe: true });
+    const recipe = new HeadTail(); recipe.activate();
+    const apply = (mode: 'in-progress' | 'editing', coordinates: number[][]) => {
+      const change = recipe.update(mode, 0, track, [{ type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates } }], 'HeadTails');
+      const bounds = updateBounds(track.features[0].bounds, change.union, change.unionWithoutBounds);
+      track.setFeature({ frame: 0, bounds }, Object.entries(change.data).flatMap(([key, geoms]) => geoms.map((g) => ({ ...g, properties: { key } }))));
+    };
+    apply('in-progress', [[10, 10]]);
+    apply('editing', [[10, 10], [90, 30]]);
+    const initialBounds = [...track.features[0].bounds!];
+    apply('editing', [[20, 15], [80, 25]]);
+    expect(track.features[0].bounds).toEqual(initialBounds);
   });
 });

--- a/client/src/headTail.ts
+++ b/client/src/headTail.ts
@@ -45,7 +45,11 @@ export function syncHeadTail(features: GeoJSON.Feature<Shape>[]): GeoJSON.Featur
   if (!coordinates || coordinates.length < 2) return features;
   const retained = features.filter((f) => !(f.geometry.type === 'Point' && isHeadTailPoint(f.properties?.key || ''))
     && !(f.geometry.type === 'LineString' && f.properties?.key === 'HeadTails'));
-  return [...retained, ...headTailFeatures(coordinates)];
+  const generated = headTailFeatures(coordinates).map((f) => {
+    const existing = features.find((old) => old.geometry.type === f.geometry.type && old.properties?.key === f.properties?.key);
+    return { ...f, properties: { ...existing?.properties, ...f.properties } };
+  });
+  return [...retained, ...generated];
 }
 
 /** Uniform arc-distance samples on the editable polyline (no index matching). */

--- a/client/src/headTail.ts
+++ b/client/src/headTail.ts
@@ -1,0 +1,78 @@
+/** Ordered editable centerlines share the existing HeadTails line/keypoint schema. */
+export const spineIndex = (key: string): number | null => {
+  const match = /^spine_([0-9]+)$/.exec(key);
+  return match && Number(match[1]) > 0 ? Number(match[1]) : null;
+};
+export const spineName = (index: number) => `spine_${String(index).padStart(3, '0')}`;
+export const isHeadTailPoint = (key: string) => key === 'head' || key === 'tail' || spineIndex(key) !== null;
+
+type Shape = GeoJSON.Point | GeoJSON.LineString | GeoJSON.Polygon;
+
+function vertexName(index: number, count: number): string {
+  if (index === 0) return 'head';
+  if (index === count - 1) return 'tail';
+  return spineName(index);
+}
+
+export function headTailFeatures(coordinates: GeoJSON.Position[]): GeoJSON.Feature<Shape>[] {
+  if (coordinates.length < 2) return [];
+  return [
+    ...coordinates.map((point, i): GeoJSON.Feature<GeoJSON.Point> => ({
+      type: 'Feature',
+      properties: { key: vertexName(i, coordinates.length) },
+      geometry: { type: 'Point', coordinates: [...point] },
+    })),
+    { type: 'Feature', properties: { key: 'HeadTails' }, geometry: { type: 'LineString', coordinates: coordinates.map((p) => [...p]) } },
+  ];
+}
+
+export function orderedHeadTail(features: GeoJSON.Feature<Shape>[]): GeoJSON.Position[] | null {
+  const points = new Map<string, GeoJSON.Position>();
+  features.forEach((f) => {
+    if (f.geometry.type === 'Point') points.set(f.properties?.key, f.geometry.coordinates);
+  });
+  const head = points.get('head'); const tail = points.get('tail');
+  if (!head || !tail) return null;
+  const spine = [...points.entries()].filter(([k]) => spineIndex(k) !== null)
+    .sort(([a], [b]) => (spineIndex(a) as number) - (spineIndex(b) as number));
+  return [head, ...spine.map(([, p]) => p), tail];
+}
+
+/** Line geometry is authoritative when present; otherwise reconstruct from points. */
+export function syncHeadTail(features: GeoJSON.Feature<Shape>[]): GeoJSON.Feature<Shape>[] {
+  const line = features.find((f) => f.properties?.key === 'HeadTails' && f.geometry.type === 'LineString');
+  const coordinates = line?.geometry.type === 'LineString' ? line.geometry.coordinates : orderedHeadTail(features);
+  if (!coordinates || coordinates.length < 2) return features;
+  const retained = features.filter((f) => !(f.geometry.type === 'Point' && isHeadTailPoint(f.properties?.key || ''))
+    && !(f.geometry.type === 'LineString' && f.properties?.key === 'HeadTails'));
+  return [...retained, ...headTailFeatures(coordinates)];
+}
+
+/** Uniform arc-distance samples on the editable polyline (no index matching). */
+export function sampleHeadTail(points: [number, number][], count = 32): [number, number][] {
+  const distances = [0];
+  for (let i = 1; i < points.length; i += 1) {
+    distances.push(distances[i - 1] + Math.hypot(points[i][0] - points[i - 1][0], points[i][1] - points[i - 1][1]));
+  }
+  const total = distances[distances.length - 1];
+  if (!(total > 0) || !Number.isFinite(total)) throw new Error('Invalid centerline');
+  const positions = [...new Set([...distances, ...Array.from({ length: count }, (_, i) => (i * total) / (count - 1))])].sort((a, b) => a - b);
+  return positions.map((d) => {
+    let j = 1;
+    while (j < distances.length - 1 && distances[j] <= d) j += 1;
+    const t = (d - distances[j - 1]) / (distances[j] - distances[j - 1] || 1);
+    return [points[j - 1][0] * (1 - t) + points[j][0] * t,
+      points[j - 1][1] * (1 - t) + points[j][1] * t];
+  });
+}
+
+export function distanceToHeadTail(point: [number, number], curve: [number, number][]): number {
+  let best = Infinity;
+  for (let i = 1; i < curve.length; i += 1) {
+    const a = curve[i - 1]; const b = curve[i];
+    const dx = b[0] - a[0]; const dy = b[1] - a[1];
+    const t = Math.max(0, Math.min(1, ((point[0] - a[0]) * dx + (point[1] - a[1]) * dy) / (dx * dx + dy * dy || 1)));
+    best = Math.min(best, Math.hypot(point[0] - a[0] - t * dx, point[1] - a[1] - t * dy));
+  }
+  return best;
+}

--- a/client/src/layers/AnnotationLayers/PointLayer.spec.ts
+++ b/client/src/layers/AnnotationLayers/PointLayer.spec.ts
@@ -1,0 +1,35 @@
+import { ref } from 'vue';
+import PointLayer from './PointLayer';
+
+function styling() {
+  const layer = Object.create(PointLayer.prototype) as PointLayer;
+  Object.assign(layer, {
+    stateStyling: { standard: { strokeWidth: 3, opacity: 0.4 }, selected: { strokeWidth: 4, color: 'yellow' } },
+    typeStyling: ref({ color: () => 'blue', strokeWidth: () => 3, opacity: () => 0.4 }),
+  });
+  return layer.createStyle() as Record<string, (data: Record<string, unknown>) => unknown>;
+}
+
+it.each([false, 'Polygon'])('renders non-line-editing interior points as smaller solid circles (%s)', (editing) => {
+  const style = styling();
+  const data = {
+    feature: 'spine_001', editing, selected: false, styleType: ['fish', 1],
+  };
+  expect(style.radius(data)).toBe(4.5);
+  expect(style.fill(data)).toBe(true);
+  expect(style.fillOpacity(data)).toBe(1);
+  expect(style.fillColor(data)).toBe(style.strokeColor(data));
+  expect(style.fillColor({ ...data, selected: true })).toBe('yellow');
+});
+
+it('preserves endpoint appearance and line-editing marker appearance', () => {
+  const style = styling();
+  const data = { editing: false, selected: false, styleType: ['fish', 1] };
+  expect(style.radius({ ...data, feature: 'head' })).toBe(6);
+  expect(style.fill({ ...data, feature: 'head' })).toBe(true);
+  expect(style.fillOpacity({ ...data, feature: 'head' })).toBe(0.4);
+  expect(style.radius({ ...data, feature: 'tail' })).toBe(6);
+  expect(style.fill({ ...data, feature: 'tail' })).toBe(false);
+  expect(style.radius({ ...data, feature: 'spine_001', editing: 'LineString' })).toBe(6);
+  expect(style.fill({ ...data, feature: 'spine_001', editing: 'LineString' })).toBe(false);
+});

--- a/client/src/layers/AnnotationLayers/PointLayer.spec.ts
+++ b/client/src/layers/AnnotationLayers/PointLayer.spec.ts
@@ -30,6 +30,26 @@ it('preserves endpoint appearance and line-editing marker appearance', () => {
   expect(style.fillOpacity({ ...data, feature: 'head' })).toBe(0.4);
   expect(style.radius({ ...data, feature: 'tail' })).toBe(6);
   expect(style.fill({ ...data, feature: 'tail' })).toBe(false);
-  expect(style.radius({ ...data, feature: 'spine_001', editing: 'LineString' })).toBe(6);
-  expect(style.fill({ ...data, feature: 'spine_001', editing: 'LineString' })).toBe(false);
+  expect(style.radius({
+    ...data, feature: 'spine_001', editing: 'LineString', selected: true,
+  })).toBe(8);
+  expect(style.fill({
+    ...data, feature: 'spine_001', editing: 'LineString', selected: true,
+  })).toBe(false);
+});
+
+it('keeps highlighted and other non-edited interior markers compact', () => {
+  const style = styling();
+  const data = {
+    feature: 'spine_001', editing: false, selected: false, styleType: ['fish', 1],
+  };
+  const highlighted = { ...data, selected: true };
+  expect(style.radius(highlighted)).toBe(style.radius(data));
+  expect(style.strokeWidth(highlighted)).toBe(1.5);
+  expect(style.fillColor(highlighted)).toBe('yellow');
+  // The tool mode is shared by every detection, but only selected lines are edited.
+  expect(style.radius({ ...data, editing: 'LineString' })).toBe(3);
+  expect(style.fill({ ...data, editing: 'LineString' })).toBe(true);
+  expect(style.radius({ ...highlighted, editing: 'LineString' })).toBe(8);
+  expect(style.strokeWidth({ ...highlighted, editing: 'LineString' })).toBe(4);
 });

--- a/client/src/layers/AnnotationLayers/PointLayer.spec.ts
+++ b/client/src/layers/AnnotationLayers/PointLayer.spec.ts
@@ -15,7 +15,7 @@ it.each([false, 'Polygon'])('renders non-line-editing interior points as smaller
   const data = {
     feature: 'spine_001', editing, selected: false, styleType: ['fish', 1],
   };
-  expect(style.radius(data)).toBe(4.5);
+  expect(style.radius(data)).toBe(3);
   expect(style.fill(data)).toBe(true);
   expect(style.fillOpacity(data)).toBe(1);
   expect(style.fillColor(data)).toBe(style.strokeColor(data));

--- a/client/src/layers/AnnotationLayers/PointLayer.ts
+++ b/client/src/layers/AnnotationLayers/PointLayer.ts
@@ -76,7 +76,7 @@ export default class PointLayer extends BaseLayer<PointGeoJSData> {
         return this.stateStyling.standard.opacity;
       },
       radius: (data: PointGeoJSData) => {
-        const scale = spineIndex(data.feature) !== null && data.editing !== 'LineString' ? 1.5 : 2;
+        const scale = spineIndex(data.feature) !== null && data.editing !== 'LineString' ? 1 : 2;
         if (data.selected) {
           return this.stateStyling.selected.strokeWidth * scale;
         }

--- a/client/src/layers/AnnotationLayers/PointLayer.ts
+++ b/client/src/layers/AnnotationLayers/PointLayer.ts
@@ -12,6 +12,9 @@ interface PointGeoJSData {
     y: number;
 }
 
+const compactInterior = (data: PointGeoJSData) => spineIndex(data.feature) !== null
+  && !(data.selected && data.editing === 'LineString');
+
 export default class PointLayer extends BaseLayer<PointGeoJSData> {
   initialize() {
     const layer = this.annotator.geoViewerRef.value.createLayer('feature', {
@@ -58,9 +61,9 @@ export default class PointLayer extends BaseLayer<PointGeoJSData> {
     return {
       ...super.createStyle(),
       fill: (data: PointGeoJSData) => data.feature === 'head'
-        || (spineIndex(data.feature) !== null && data.editing !== 'LineString'),
+        || compactInterior(data),
       fillColor: (data: PointGeoJSData) => {
-        if (spineIndex(data.feature) !== null && data.editing !== 'LineString' && data.selected) {
+        if (compactInterior(data) && data.selected) {
           return this.stateStyling.selected.color;
         }
         if (data.styleType) {
@@ -69,14 +72,19 @@ export default class PointLayer extends BaseLayer<PointGeoJSData> {
         return this.typeStyling.value.color('');
       },
       fillOpacity: (data: PointGeoJSData) => {
-        if (spineIndex(data.feature) !== null && data.editing !== 'LineString') return 1;
+        if (compactInterior(data)) return 1;
         if (data.styleType) {
           return this.typeStyling.value.opacity(data.styleType[0]);
         }
         return this.stateStyling.standard.opacity;
       },
       radius: (data: PointGeoJSData) => {
-        const scale = spineIndex(data.feature) !== null && data.editing !== 'LineString' ? 1 : 2;
+        // Selection changes color, not the size of a compact interior marker.
+        if (compactInterior(data)) {
+          return data.styleType ? this.typeStyling.value.strokeWidth(data.styleType[0])
+            : this.stateStyling.standard.strokeWidth;
+        }
+        const scale = 2;
         if (data.selected) {
           return this.stateStyling.selected.strokeWidth * scale;
         }
@@ -86,6 +94,10 @@ export default class PointLayer extends BaseLayer<PointGeoJSData> {
         return this.stateStyling.standard.strokeWidth * scale;
       },
       strokeWidth: (data: PointGeoJSData) => {
+        if (compactInterior(data)) {
+          return (data.styleType ? this.typeStyling.value.strokeWidth(data.styleType[0])
+            : this.stateStyling.standard.strokeWidth) / 2;
+        }
         if (data.selected) {
           return this.stateStyling.selected.strokeWidth;
         }

--- a/client/src/layers/AnnotationLayers/PointLayer.ts
+++ b/client/src/layers/AnnotationLayers/PointLayer.ts
@@ -1,5 +1,6 @@
 import BaseLayer, { LayerStyle } from '../BaseLayer';
 import { FrameDataTrack } from '../LayerTypes';
+import { spineIndex } from '../../headTail';
 
 interface PointGeoJSData {
     trackId: number;
@@ -56,27 +57,33 @@ export default class PointLayer extends BaseLayer<PointGeoJSData> {
   createStyle(): LayerStyle<PointGeoJSData> {
     return {
       ...super.createStyle(),
-      fill: (data: PointGeoJSData) => data.feature === 'head',
+      fill: (data: PointGeoJSData) => data.feature === 'head'
+        || (spineIndex(data.feature) !== null && data.editing !== 'LineString'),
       fillColor: (data: PointGeoJSData) => {
+        if (spineIndex(data.feature) !== null && data.editing !== 'LineString' && data.selected) {
+          return this.stateStyling.selected.color;
+        }
         if (data.styleType) {
           return this.typeStyling.value.color(data.styleType[0]);
         }
         return this.typeStyling.value.color('');
       },
       fillOpacity: (data: PointGeoJSData) => {
+        if (spineIndex(data.feature) !== null && data.editing !== 'LineString') return 1;
         if (data.styleType) {
           return this.typeStyling.value.opacity(data.styleType[0]);
         }
         return this.stateStyling.standard.opacity;
       },
       radius: (data: PointGeoJSData) => {
+        const scale = spineIndex(data.feature) !== null && data.editing !== 'LineString' ? 1.5 : 2;
         if (data.selected) {
-          return this.stateStyling.selected.strokeWidth * 2;
+          return this.stateStyling.selected.strokeWidth * scale;
         }
         if (data.styleType) {
-          return this.typeStyling.value.strokeWidth(data.styleType[0]) * 2;
+          return this.typeStyling.value.strokeWidth(data.styleType[0]) * scale;
         }
-        return this.stateStyling.standard.strokeWidth * 2;
+        return this.stateStyling.standard.strokeWidth * scale;
       },
       strokeWidth: (data: PointGeoJSData) => {
         if (data.selected) {

--- a/client/src/layers/EditAnnotationLayer.spec.ts
+++ b/client/src/layers/EditAnnotationLayer.spec.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+/* eslint-disable @typescript-eslint/no-explicit-any -- GeoJS boundary double */
+import { ref } from 'vue';
+import EditAnnotationLayer from './EditAnnotationLayer';
+import Track from '../track';
+import { headTailFeatures } from '../headTail';
+
+vi.mock('geojs', () => ({
+  default: {
+    event: {
+      mouseclick: 'mouseclick',
+      actiondown: 'actiondown',
+      actionup: 'actionup',
+      annotation: { edit_action: 'edit_action', state: 'state', select_edit_handle: 'select_edit_handle' },
+    },
+  },
+}));
+
+function harness() {
+  const handlers = new Map<string, Set<(event: any) => void>>();
+  let mode: string | null = null;
+  let annotation: any;
+  const featureLayer: any = {
+    annotations: () => (annotation ? [annotation] : []),
+    mode: (value?: string | null, edited?: any) => {
+      if (value === undefined) return mode;
+      mode = value;
+      if (edited) annotation = edited;
+      return mode;
+    },
+    _handleMouseClick: vi.fn(() => { mode = null; }),
+    geoOn: (name: string, fn: (e: any) => void) => {
+      if (!handlers.has(name)) handlers.set(name, new Set());
+      handlers.get(name)!.add(fn);
+    },
+    geoOff: (name: string, fn: (e: any) => void) => handlers.get(name)?.delete(fn),
+    removeAllAnnotations: () => { annotation = undefined; },
+    draw: vi.fn(),
+    geojson: (feature: GeoJSON.Feature<GeoJSON.LineString>) => {
+      let vertices = feature.geometry.coordinates.map(([x, y]) => ({ x, y }));
+      annotation = {
+        state: () => (mode === 'edit' ? 'edit' : 'done'),
+        options: (_key: string, value?: typeof vertices) => {
+          if (value) vertices = value;
+          return vertices;
+        },
+        geojson: () => ({ type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates: vertices.map(({ x, y }) => [x, y]) } }),
+        style: vi.fn(),
+        editHandleStyle: vi.fn(),
+        highlightStyle: vi.fn(),
+      };
+    },
+  };
+  featureLayer.geoOn('mouseclick', featureLayer._handleMouseClick);
+  const arrow: any = { style: vi.fn(), draw: vi.fn(), data: () => arrow };
+  const interactor = { mouse: () => ({ buttons: { left: false } }) };
+  const project = (p: { x: number; y: number }) => ({ x: p.x * 10, y: p.y * 10 });
+  const map = {
+    createLayer: (type: string) => (type === 'annotation' ? featureLayer : { createFeature: () => arrow }),
+    gcsToDisplay: (p: any) => (Array.isArray(p) ? p.map(project) : project(p)),
+    displayToGcs: (p: any) => ({ x: p.x / 10, y: p.y / 10 }),
+    interactor: () => interactor,
+  };
+  const layer = new EditAnnotationLayer({
+    type: 'LineString',
+    annotator: { geoViewerRef: ref(map), setCursor: vi.fn(), setImageCursor: vi.fn() },
+    stateStyling: { standard: { color: '#f00' }, selected: { color: '#f00' } },
+    typeStyling: ref({ color: () => '#f00' }),
+  } as any);
+  layer.setKey('HeadTails');
+  const track = new Track(1, { begin: 0, end: 0, meta: {} });
+  track.setFeature({ frame: 0, keyframe: true, bounds: [0, 0, 100, 30] }, headTailFeatures([[0, 10], [100, 10]]));
+  const reopen = () => layer.changeData([{ features: track.features[0], track }] as any);
+  const update = vi.fn((_mode, _done, feature, _type, key, cb) => {
+    expect(key).toBe('HeadTails');
+    track.setFeature({ frame: 0 }, headTailFeatures(feature.geometry.coordinates));
+    cb?.();
+    reopen();
+  });
+  layer.bus.$on('update:geojson', update);
+  const click = (x: number, y: number, right = false) => {
+    const event = { buttonsDown: { left: !right, right }, geo: { x, y }, handled: false };
+    handlers.get('mouseclick')!.forEach((fn) => fn(event));
+  };
+  return {
+    layer, track, reopen, update, click, featureLayer,
+  };
+}
+
+it('makes the insertion handle accessible on a two-point line', () => {
+  const { layer } = harness();
+  expect(layer.editHandleStyle().handles).toMatchObject({ edge: true, center: false });
+  layer.setType('Polygon');
+  expect(layer.editHandleStyle().handles).toMatchObject({ edge: true, center: true });
+});
+
+it('inserts a clicked segment point, selects it for deletion, and stays in edit mode', async () => {
+  const h = harness(); await h.reopen();
+  h.click(25, 10.25);
+  expect(h.track.getFeatureGeometry(0, { key: 'HeadTails' })[0].geometry.coordinates).toEqual([[0, 10], [25, 10.25], [100, 10]]);
+  expect(h.layer.selectedHandleIndex).toBe(2);
+  expect(h.layer.getMode()).toBe('editing');
+  expect(h.featureLayer._handleMouseClick).not.toHaveBeenCalled();
+  expect(h.update).toHaveBeenCalledTimes(1);
+});
+
+it('leaves vertex clicks and clicks beyond screen-space tolerance to GeoJS', async () => {
+  const h = harness(); await h.reopen();
+  h.click(0.1, 10);
+  expect(h.update).not.toHaveBeenCalled();
+  await h.reopen(); h.click(25, 12);
+  expect(h.update).not.toHaveBeenCalled();
+  expect(h.featureLayer._handleMouseClick).toHaveBeenCalledTimes(2);
+});
+
+it('synchronizes right-click exits and reopens the saved line repeatedly', async () => {
+  const h = harness();
+  const sync = vi.fn(); h.layer.bus.$on('editing-annotation-sync', sync);
+  for (let i = 0; i < 3; i += 1) {
+    // Each edit session must finish before the next right-click/reopen.
+    // eslint-disable-next-line no-await-in-loop
+    await h.reopen();
+    expect(h.layer.getMode()).toBe('editing');
+    h.click(20 + i * 10, 10);
+    expect(h.layer.getMode()).toBe('editing');
+    h.click(50, 20, true);
+    expect(h.layer.getMode()).toBe('disabled');
+    expect(sync).toHaveBeenLastCalledWith(false);
+    h.layer.disable();
+  }
+  expect(h.track.getFeatureGeometry(0, { key: 'HeadTails' })[0].geometry.coordinates).toHaveLength(5);
+});

--- a/client/src/layers/EditAnnotationLayer.ts
+++ b/client/src/layers/EditAnnotationLayer.ts
@@ -266,7 +266,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
             this.selectedHandleIndex = newIndex;
           }
           let divisor = 1;
-          if (this.type === 'Polygon' && this.selectedHandleIndex >= 0) {
+          if (['Polygon', 'LineString'].includes(this.type) && this.selectedHandleIndex >= 0) {
             divisor = 2;
           }
           window.setTimeout(() => this.redraw(), 0); //Redraw timeout to update the selected handle
@@ -417,7 +417,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
   }
 
   hoverEditHandle(e: GeoEvent) {
-    const divisor = this.type === 'LineString' ? 1 : 2; //For Polygons we skip over edge handles (midpoints)
+    const divisor = 2; // Vertex/edge handles alternate for polygons and open lines.
     if (e.enable && e.handle.handle.type === 'vertex') {
       if (e.handle.handle.selected
         && (e.handle.handle.index * divisor) !== this.hoverHandleIndex) {
@@ -426,7 +426,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
       if (!e.handle.handle.selected) {
         this.hoverHandleIndex = -1;
       }
-    } else if (e.enable && e.handle.handle.type === 'center') {
+    } else if (e.enable && ['center', 'edge'].includes(e.handle.handle.type)) {
       this.hoverHandleIndex = -1;
     }
     if (e.enable) {
@@ -1053,7 +1053,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
       return {
         handles: {
           rotate: false,
-          edge: this.type !== 'LineString',
+          edge: true,
         },
         fill: true,
         radius: (handle: EditHandleStyle): number => {

--- a/client/src/layers/EditAnnotationLayer.ts
+++ b/client/src/layers/EditAnnotationLayer.ts
@@ -201,6 +201,13 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
         finalPointProximity: 1,
         adjacentPointProximity: 1,
       });
+      // Handle segment insertion before GeoJS's default click handler, which
+      // otherwise exits edit mode when the click is not on a drag handle.
+      const defaultClick = this.featureLayer._handleMouseClick;
+      this.featureLayer.geoOff(geo.event.mouseclick, defaultClick);
+      this.featureLayer.geoOn(geo.event.mouseclick, (e: GeoEvent) => {
+        if (!this.insertLineVertex(e)) defaultClick(e);
+      });
       // For these we need to use an anonymous function to prevent geoJS from erroring
       this.featureLayer.geoOn(
         geo.event.annotation.edit_action,
@@ -216,6 +223,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
         (e: GeoEvent) => this.hoverEditHandle(e),
       );
       this.featureLayer.geoOn(geo.event.mouseclick, (e: GeoEvent) => {
+        if (this.type === 'LineString' && e.handled) return;
         // Right-click in creation mode (non-Point): cancel and fully deselect.
         // Point mode has its own right-click handler (handleContextMenu).
         if (e.buttonsDown.right && this.getMode() === 'creation' && this.type !== 'Point') {
@@ -225,7 +233,7 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
         }
         //Used to sync clicks that kick out of editing mode with application
         //This prevents that pseudo Edit state when left clicking on a object in edit mode
-        if (!this.disableModeSync && (e.buttonsDown.left)
+        if (!this.disableModeSync && (e.buttonsDown.left || e.buttonsDown.right)
           && this.getMode() === 'disabled' && this.featureLayer.annotations()[0]) {
           this.bus.$emit('editing-annotation-sync', false);
         } else if (e.buttonsDown.left) {
@@ -414,6 +422,42 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
     } else if (this.shapeInProgress) {
       this.shapeInProgress = null;
     }
+  }
+
+  /** Insert at the clicked position along an open line, in screen pixels. */
+  insertLineVertex(e: GeoEvent): boolean {
+    if (this.type !== 'LineString' || this.getMode() !== 'editing' || !e.buttonsDown.left) return false;
+    const annotation = this.featureLayer.annotations()[0];
+    if (!annotation || annotation.state() !== 'edit') return false;
+    const map = this.annotator.geoViewerRef.value;
+    const vertices: { x: number; y: number }[] = annotation.options('vertices');
+    const displayed = map.gcsToDisplay(vertices, null);
+    const click = map.gcsToDisplay(e.geo);
+    // Existing vertex clicks select handles for movement/deletion.
+    const tolerance = 8;
+    if (displayed.some((p: { x: number; y: number }) => Math.hypot(p.x - click.x, p.y - click.y) <= tolerance)) return false;
+    let segment = -1;
+    let nearest = tolerance;
+    displayed.slice(1).forEach((b: { x: number; y: number }, i: number) => {
+      const a = displayed[i];
+      const dx = b.x - a.x; const dy = b.y - a.y;
+      const t = ((click.x - a.x) * dx + (click.y - a.y) * dy) / (dx * dx + dy * dy);
+      if (t <= 0 || t >= 1) return;
+      const distance = Math.hypot(click.x - a.x - t * dx, click.y - a.y - t * dy);
+      if (distance <= nearest) { nearest = distance; segment = i; }
+    });
+    if (segment < 0) return false;
+    const coordinates = vertices.map((p) => ({ ...p }));
+    coordinates.splice(segment + 1, 0, map.displayToGcs(click, null));
+    annotation.options('vertices', coordinates);
+    this.selectedHandleIndex = (segment + 1) * 2;
+    this.hoverHandleIndex = this.selectedHandleIndex;
+    this.formattedData = [annotation.geojson()];
+    this.bus.$emit('update:geojson', 'editing', false, this.formattedData[0], this.type, this.selectedKey, this.skipNextFunc());
+    this.bus.$emit('update:selectedIndex', segment + 1, this.type, this.selectedKey);
+    e.handled = true;
+    this.redraw();
+    return true;
   }
 
   hoverEditHandle(e: GeoEvent) {
@@ -1054,6 +1098,8 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
         handles: {
           rotate: false,
           edge: true,
+          // A two-point line's center handle obscures its insertion handle.
+          center: this.type !== 'LineString',
         },
         fill: true,
         radius: (handle: EditHandleStyle): number => {

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -1,4 +1,5 @@
 import { mergePairs } from 'dive-common/typeHierarchy';
+import { syncHeadTail } from './headTail';
 import { RectBounds, polygonEqualsBounds } from './utils';
 import {
   binarySearch,
@@ -293,6 +294,8 @@ export default class Track extends BaseAnnotation {
 
   setFeature(feature: Feature, geometry: GeoJSON.Feature<TrackSupportedFeature>[] = []): Feature {
     const f = this.features[feature.frame] || {};
+    const oldLine = f.geometry?.features.find((g) => g.properties?.key === 'HeadTails' && g.geometry.type === 'LineString');
+    const oldCoordinates = JSON.stringify(oldLine?.geometry);
     this.features[feature.frame] = {
       ...f,
       ...feature,
@@ -328,6 +331,24 @@ export default class Track extends BaseAnnotation {
       }
     });
     if (fg.features.length) {
+      fg.features = syncHeadTail(fg.features);
+      const current = this.features[feature.frame];
+      const line = fg.features.find((g) => g.properties?.key === 'HeadTails' && g.geometry.type === 'LineString');
+      if (line?.geometry.type === 'LineString') {
+        current.head = [...line.geometry.coordinates[0]] as [number, number];
+        current.tail = [...line.geometry.coordinates[line.geometry.coordinates.length - 1]] as [number, number];
+      }
+      if (oldLine && oldCoordinates !== JSON.stringify(line?.geometry)) {
+        current.attributes = { ...current.attributes, measurement_stale: true };
+        delete this.attributes.avg_length;
+        // Keep explicitly user-entered lengths; derived results must be recomputed.
+        if (current.attributes.length_method !== 'user_set') {
+          current.fishLength = undefined;
+          ['length', 'curved_length', 'straight_length', 'curvature_ratio', 'avg_length',
+            'midpoint_x', 'midpoint_y', 'midpoint_z', 'midpoint_range', 'stereo_rms']
+            .forEach((key) => { delete current.attributes?.[key]; });
+        }
+      }
       this.features[feature.frame].geometry = fg;
     }
     this.maybeExpandBounds(feature.frame);
@@ -345,6 +366,20 @@ export default class Track extends BaseAnnotation {
     }
     this.notify('feature', f);
     return this.features[feature.frame];
+  }
+
+  /** Clear derived results after a geometry edit on either stereo camera. */
+  invalidateMeasurement(frame: number) {
+    const feature = this.features[frame];
+    if (!feature) return;
+    const attributes = { ...feature.attributes, measurement_stale: true } as StringKeyObject;
+    const locked = attributes.length_method === 'user_set';
+    ['curved_length', 'straight_length', 'curvature_ratio', 'avg_length',
+      'midpoint_x', 'midpoint_y', 'midpoint_z', 'midpoint_range', 'stereo_rms']
+      .forEach((key) => { delete attributes[key]; });
+    if (!locked) delete attributes.length;
+    this.setFeature({ frame, attributes, fishLength: locked ? feature.fishLength : undefined });
+    delete this.attributes.avg_length;
   }
 
   /* Get features by properties.key, geometry.type, or both */
@@ -688,6 +723,9 @@ export default class Track extends BaseAnnotation {
             ? { ...feature.geometry, features: kept }
             : undefined;
         }
+      }
+      if (feature.geometry?.features.some((g) => g.properties?.key === 'HeadTails')) {
+        feature.geometry = { ...feature.geometry, features: syncHeadTail(feature.geometry.features) };
       }
       sparseFeatures[f.frame] = feature;
     });

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -735,3 +735,24 @@ both are present.
 ```json
 { "id": 1, "name": "shark", "parents": ["fish"] }
 ```
+
+### Multi-point head/tail centerlines
+
+Centerlines reuse named keypoints and the existing `HeadTails` GeoJSON LineString.
+An example optional section in a VIAME CSV row is:
+
+```text
+(kp) head 100.25 120,(kp) spine_001 140 105.5,(kp) spine_002 180 115,(kp) tail 210 140
+```
+
+Point names are ordered `head`, numerically sorted `spine_N`, then `tail`.
+Writers preserve subpixel coordinates. The editor assigns zero-padded sequential
+names; indices may be renumbered after editing and are not cross-camera IDs.
+
+DIVE JSON stores the ordered coordinates in a feature with
+`properties.key = "HeadTails"` and `geometry.type = "LineString"`, alongside named
+Point features. When a line is present its coordinates are authoritative; its
+point markers are regenerated on import/edit/export to prevent stale vertices.
+Line-only JSON can therefore be exported to CSV without losing interior points.
+Two-point head/tail files remain valid. Older DIVE versions may drop the new
+interior points; use the updated readers and writers for round trips.

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -756,3 +756,18 @@ point markers are regenerated on import/edit/export to prevent stale vertices.
 Line-only JSON can therefore be exported to CSV without losing interior points.
 Two-point head/tail files remain valid. Older DIVE versions may drop the new
 interior points; use the updated readers and writers for round trips.
+
+COCO import/export supports these centerlines in both desktop and web DIVE.
+Exports use category `keypoints` labels (`head`, `spine_001`, …, `tail`),
+1-based `skeleton` edges, and annotation `[x, y, visibility]` triples plus
+`num_keypoints`. A shared label list covers curves with different numbers of
+vertices; absent slots are `[0, 0, 0]` and do not become vertices on import.
+Coordinates retain subpixel precision. The edited `HeadTails` LineString is
+authoritative on export, including when it has no separate point markers.
+
+DIVE also imports VIAME's KWCOCO named-point lists, resolving either
+`keypoint_category` names or `keypoint_category_id` through `keypoint_categories`.
+Both formats reconstruct the editable line from head, numerically ordered spine
+points, and tail. Without both endpoints, points are retained without creating a
+complete line. Other named keypoints are retained separately. These fields store
+the sampled polyline, not spline coefficients or physical stereo correspondences.

--- a/docs/Interactive-Annotation.md
+++ b/docs/Interactive-Annotation.md
@@ -130,8 +130,16 @@ measurement reports `curved_length`, `straight_length`, and `curvature_ratio` in
 addition to the usual length field; this ratio is a bend indicator, not local
 curvature. Computation follows the editable polyline, retaining its corners.
 
-Desktop dense stereo transfers new curved lines from the left/reference camera.
-Editing an existing curve on the right remeasures against the left curve; it does
-not overwrite the left curve with a backwards use of the left disparity map.
+Desktop dense stereo transfers points and curved lines in either direction.
+Right-camera edits use a separately computed, cached right-reference disparity map.
+The web stereo matcher also supports edits from either camera.
+
+With automatic mapping enabled, placing or moving a named keypoint maps it to
+the other camera, including when that camera already has a detection. Inserting
+an interior line vertex maps that vertex into the nearest segment of the other
+line, preserving its existing vertices. Automatically mapped points can follow
+subsequent edits; manually edited target points are protected. Failed matches
+and results that arrive after either affected annotation changes are discarded.
+These behaviors use the existing automatic mapping option in desktop and web.
 Browser ONNX matching supports transfers in either direction. Both implementations
 rematch image locations rather than pairing equally numbered intermediate points.

--- a/docs/Interactive-Annotation.md
+++ b/docs/Interactive-Annotation.md
@@ -116,7 +116,10 @@ Use the existing head/tail line tool: place the two endpoints as usual, then
 right-click the detection to edit its existing line. Click a new location on a
 line segment to insert an interior vertex, or drag its small midpoint handle. Drag vertices to adjust the centerline, or select an interior
 vertex and use the existing Delete point action to remove it. Removing the final
-interior vertex restores a two-point line. No additional annotation mode is needed.
+interior vertex restores a two-point line. Deleting a vertex keeps the remaining
+line in edit mode. An existing detection box stays unchanged while all vertices
+are inside it; moving a vertex outside expands only the necessary box edges.
+No additional annotation mode is needed.
 
 The displayed line is an open polyline, ordered head to tail. Intermediate points
 are saved as `spine_001`, `spine_002`, etc.; insertion and deletion renumber them.

--- a/docs/Interactive-Annotation.md
+++ b/docs/Interactive-Annotation.md
@@ -113,8 +113,8 @@ Confirm **Auto-compute location on other camera** is enabled, the track is linke
 ### Curved head/tail lines
 
 Use the existing head/tail line tool: place the two endpoints as usual, then
-select the line for editing. Drag a small segment midpoint handle to insert an
-interior vertex. Drag vertices to adjust the centerline, or select an interior
+right-click the detection to edit its existing line. Click a new location on a
+line segment to insert an interior vertex, or drag its small midpoint handle. Drag vertices to adjust the centerline, or select an interior
 vertex and use the existing Delete point action to remove it. Removing the final
 interior vertex restores a two-point line. No additional annotation mode is needed.
 

--- a/docs/Interactive-Annotation.md
+++ b/docs/Interactive-Annotation.md
@@ -109,3 +109,29 @@ Stereo settings appear only on stereo datasets (two cameras + calibration) in DI
 > **Stereo warp did not appear on the other camera**
 
 Confirm **Auto-compute location on other camera** is enabled, the track is linked across cameras, and the other camera has no existing detection at that frame. Human-edited lines are not overwritten.
+
+### Curved head/tail lines
+
+Use the existing head/tail line tool: place the two endpoints as usual, then
+select the line for editing. Drag a small segment midpoint handle to insert an
+interior vertex. Drag vertices to adjust the centerline, or select an interior
+vertex and use the existing Delete point action to remove it. Removing the final
+interior vertex restores a two-point line. No additional annotation mode is needed.
+
+The displayed line is an open polyline, ordered head to tail. Intermediate points
+are saved as `spine_001`, `spine_002`, etc.; insertion and deletion renumber them.
+These names describe order within a detection, not anatomical landmarks or stereo
+correspondences. Other keypoints and segmentation polygons remain separate.
+
+With stereo length updates enabled, edits clear derived measurements and trigger
+fresh correspondence along the curve. Failed matches leave the measurement stale
+instead of keeping an old length. Explicit `user_set` lengths stay locked. Curved
+measurement reports `curved_length`, `straight_length`, and `curvature_ratio` in
+addition to the usual length field; this ratio is a bend indicator, not local
+curvature. Computation follows the editable polyline, retaining its corners.
+
+Desktop dense stereo transfers new curved lines from the left/reference camera.
+Editing an existing curve on the right remeasures against the left curve; it does
+not overwrite the left curve with a backwards use of the left disparity map.
+Browser ONNX matching supports transfers in either direction. Both implementations
+rematch image locations rather than pairing equally numbered intermediate points.

--- a/server/dive_utils/serializers/kwcoco.py
+++ b/server/dive_utils/serializers/kwcoco.py
@@ -7,6 +7,7 @@ KWCOCO-compatible extensions when they are present.
 
 import functools
 import math
+import re
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from dive_utils import constants, strNumericCompare, types
@@ -369,34 +370,37 @@ def _parse_annotation(
     class_name = category.get('name') or 'unknown'
     confidence_pair = (class_name, score)
 
-    # parse keypoints
+    # Both standard COCO triples and named KWCOCO points describe the same curve.
     keypoints = annotation.get('keypoints', [])
-    head_tail = []
-    for keypoint in keypoints:
-        if isinstance(keypoint, (int, float)):  # [x1, y1, v1, ...] coco format
-            keypoint_labels = category.get('keypoints', [])
-            n = min(len(keypoint_labels), int(len(keypoints) / 3))  # stopping index
-            for i in range(n):
-                point = keypoints[3 * i : 3 * i + 2]  # extract [x, y] pair
-                label = keypoint_labels[i]
-                if label in ('head', 'tail'):  # only allow head and tail keypoints
-                    head_tail.append(point)
-                    viame.create_geoJSONFeature(features, 'Point', point, label)
-            break
-
-        # dictionary kwcoco format
-        keypoint_category_id = keypoint['keypoint_category_id']
-        label = meta.keypoint_categories[keypoint_category_id]['name']
-        point = keypoint['xy']
-        if label in ('head', 'tail'):  # only allow head and tail keypoints
-            head_tail.append(keypoint['xy'])
-            viame.create_geoJSONFeature(features, 'Point', point, label)
-
-    # create head-tail line if keypoint pair exists
-    if len(head_tail) > 2:
-        raise ValueError('Multiple head/tail keypoints per annotation not supported')
-    elif len(head_tail) == 2:
-        viame.create_geoJSONFeature(features, 'LineString', head_tail, 'HeadTails')
+    points = {}
+    if isinstance(keypoints, list) and keypoints:
+        if isinstance(keypoints[0], (int, float)):
+            for i, label in enumerate(category.get('keypoints', [])):
+                if 3 * i + 2 < len(keypoints) and keypoints[3 * i + 2] > 0:
+                    points[label] = keypoints[3 * i : 3 * i + 2]
+        else:
+            for kp in keypoints:
+                label = kp.get('keypoint_category') or meta.keypoint_categories.get(
+                    kp.get('keypoint_category_id'), {}
+                ).get('name')
+                if label and kp.get('visible', 2) > 0:
+                    points[label] = kp.get('xy')
+    points = {
+        k: p
+        for k, p in points.items()
+        if isinstance(p, list)
+        and len(p) >= 2
+        and all(isinstance(v, (int, float)) and math.isfinite(v) for v in p[:2])
+    }
+    for label, point in points.items():
+        viame.create_geoJSONFeature(features, 'Point', point[:2], label)
+    if 'head' in points and 'tail' in points:
+        spine = sorted(
+            (k for k in points if re.fullmatch(r'spine_0*[1-9][0-9]*', k)),
+            key=lambda k: int(k.split('_')[1]),
+        )
+        line = [points[k][:2] for k in ['head', *spine, 'tail']]
+        viame.create_geoJSONFeature(features, 'LineString', line, 'HeadTails')
 
     # parse polygons
     segmentation = annotation.get('segmentation', [])
@@ -619,31 +623,32 @@ def _feature_to_segmentation(feature: Feature) -> List[List[float]]:
     return segmentation
 
 
-def _feature_to_keypoints(feature: Feature) -> Tuple[List[float], int]:
-    """Extract head/tail keypoints from DIVE geometry in COCO format."""
+def _feature_points(feature: Feature) -> Dict[str, List[float]]:
+    """Use the edited centerline as authoritative, including line-only JSON geometry."""
     if not feature.geometry:
-        return [], 0
-    points: Dict[str, List[float]] = {}
-    for geo_feature in feature.geometry.features:
-        if geo_feature.geometry.type != 'Point':
-            continue
-        key = geo_feature.properties.get('key')
-        if key not in ('head', 'tail'):
-            continue
-        coords = geo_feature.geometry.coordinates
-        if not isinstance(coords, list) or len(coords) < 2:
-            continue
-        points[key] = [coords[0], coords[1], 2]
+        return {}
+    return {
+        f.properties['key']: list(f.geometry.coordinates[:2])
+        for f in viame._centerline_features(feature.geometry.features)
+        if f.geometry.type == 'Point' and f.properties.get('key')
+    }
+
+
+def _point_labels(points):
+    spine = sorted(
+        (k for k in points if re.fullmatch(r'spine_0*[1-9][0-9]*', k)),
+        key=lambda k: int(k.split('_')[1]),
+    )
+    return ['head', *spine, 'tail', *sorted(set(points) - {'head', 'tail', *spine})]
+
+
+def _feature_to_keypoints(feature: Feature, labels=None) -> Tuple[List[float], int]:
+    points = _feature_points(feature)
     if not points:
         return [], 0
-    keypoints: List[float] = []
-    count = 0
-    for label in ('head', 'tail'):
-        value = points.get(label, [0, 0, 0])
-        keypoints.extend(value)
-        if value[2] > 0:
-            count += 1
-    return keypoints, count
+    labels = labels or _point_labels(points)
+    values = [points[k] + [2] if k in points else [0, 0, 0] for k in labels]
+    return [v for triple in values for v in triple], len(points)
 
 
 def export_dive_as_coco(
@@ -688,6 +693,9 @@ def export_dive_as_coco(
         add_category_name(name)
 
     categories = {name: index + 1 for index, name in enumerate(category_names)}
+    labels = _point_labels(
+        {k for track in parsed_tracks for f in track.features for k in _feature_points(f)}
+    )
     coco_annotations: List[dict] = []
     images: Dict[int, dict] = {}
     annotation_id = 1
@@ -721,7 +729,7 @@ def export_dive_as_coco(
                 image_doc['video_id'] = 1
             images.setdefault(image_id, image_doc)
             segmentation = _feature_to_segmentation(feature)
-            keypoints, num_keypoints = _feature_to_keypoints(feature)
+            keypoints, num_keypoints = _feature_to_keypoints(feature, labels)
             annotation = {
                 'id': annotation_id,
                 'image_id': image_id,
@@ -760,7 +768,8 @@ def export_dive_as_coco(
         if parent is not None:
             category['supercategory'] = parent
         # When keypoints are exported, publish the category labels explicitly.
-        category['keypoints'] = ['head', 'tail']
+        category['keypoints'] = labels
+        category['skeleton'] = [[i, i + 1] for i in range(1, labels.index('tail') + 1)]
         categories_doc.append(category)
 
     info: Dict[str, Any] = {

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -6,12 +6,13 @@ import csv
 import datetime
 import io
 import json
+import math
 import os
 import re
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 from dive_utils import constants, types
-from dive_utils.models import Feature, Track, interpolate
+from dive_utils.models import Feature, Track, GeoJSONFeature, interpolate
 
 
 def format_timestamp(fps: int, frame: int) -> str:
@@ -173,6 +174,28 @@ def add_hole_to_polygon(features: Dict[str, Any], coords: List[Any], key=''):
             break
 
 
+def _coordinate_text(value):
+    value = float(value)
+    return str(int(value)) if value.is_integer() else repr(value)
+
+
+def _centerline_features(features):
+    """Serialize edited LineString vertices even when a JSON file has no markers."""
+    line = next((f for f in features if f.geometry.type == 'LineString'
+                 and f.properties.get('key') == 'HeadTails'), None)
+    if line is None or len(line.geometry.coordinates) < 2:
+        return features
+    points = line.geometry.coordinates
+    retained = [f for f in features if not (f.geometry.type == 'Point' and
+                (f.properties.get('key') in ('head', 'tail') or
+                 re.fullmatch(r'spine_0*[1-9][0-9]*', str(f.properties.get('key', '')))))]
+    for i, point in enumerate(points):
+        key = 'head' if i == 0 else 'tail' if i == len(points) - 1 else f'spine_{i:03d}'
+        retained.append(GeoJSONFeature(type='Feature', properties={'key': key},
+                       geometry={'type': 'Point', 'coordinates': point}))
+    return retained
+
+
 def _parse_row(row: List[str]) -> Tuple[Dict, Dict, Dict, List, List]:
     """
     Parse a single CSV line into its composite track and detection parts
@@ -191,19 +214,15 @@ def _parse_row(row: List[str]) -> Tuple[Dict, Dict, Dict, List, List]:
     start = 9 + len(sorted_confidence_pairs) * 2
 
     for j in range(start, len(row)):
-        # (kp) head x y
-        head_regex = re.match(r"^\(kp\) head (-?[0-9]+\.*-?[0-9]*) (-?[0-9]+\.*-?[0-9]*)", row[j])
-        if head_regex:
-            point = [float(head_regex[1]), float(head_regex[2])]
-            head_tail.append(point)
-            create_geoJSONFeature(features, 'Point', point, 'head')
-
-        # (kp) tail x y
-        tail_regex = re.match(r"^\(kp\) tail (-?[0-9]+\.*-?[0-9]*) (-?[0-9]+\.*-?[0-9]*)", row[j])
-        if tail_regex:
-            point = [float(tail_regex[1]), float(tail_regex[2])]
-            head_tail.append(point)
-            create_geoJSONFeature(features, 'Point', point, 'tail')
+        # Preserve every named keypoint, including ordered centerline vertices.
+        kp = re.fullmatch(r"\(kp\)\s+(\S+)\s+(\S+)\s+(\S+)\s*", row[j])
+        if kp:
+            try:
+                point = [float(kp[2]), float(kp[3])]
+                if all(math.isfinite(v) for v in point):
+                    create_geoJSONFeature(features, 'Point', point, kp[1])
+            except ValueError:
+                pass
 
         # (atr) text
         atr_regex = re.match(r"^\(atr\) (.*?)\s(.+)", row[j])
@@ -245,7 +264,13 @@ def _parse_row(row: List[str]) -> Tuple[Dict, Dict, Dict, List, List]:
         if note_regex:
             notes.append(note_regex[1])
 
-    if len(head_tail) == 2:
+    points = {f['properties']['key']: f['geometry']['coordinates']
+              for f in features.get('geometry', {}).get('features', [])
+              if f['geometry']['type'] == 'Point'}
+    if 'head' in points and 'tail' in points:
+        spine = sorted((k for k in points if re.fullmatch(r'spine_0*[1-9][0-9]*', k)),
+                       key=lambda k: int(k[6:]))
+        head_tail = [points['head']] + [points[k] for k in spine] + [points['tail']]
         create_geoJSONFeature(features, 'LineString', head_tail, 'HeadTails')
 
     return features, attributes, track_attributes, sorted_confidence_pairs, notes
@@ -704,7 +729,7 @@ def export_tracks_as_csv(
                         columns.append(f"(trk-atr) {key} {valueToString(val)}")
 
                 if feature.geometry and "FeatureCollection" == feature.geometry.type:
-                    for geoJSONFeature in feature.geometry.features:
+                    for geoJSONFeature in _centerline_features(feature.geometry.features):
                         if 'Polygon' == geoJSONFeature.geometry.type:
                             all_rings = geoJSONFeature.geometry.coordinates  # type: ignore
 
@@ -734,7 +759,7 @@ def export_tracks_as_csv(
                             coordinates = geoJSONFeature.geometry.coordinates  # type: ignore
                             columns.append(
                                 f"(kp) {geoJSONFeature.properties['key']} "
-                                f"{round(coordinates[0])} {round(coordinates[1])}"
+                                f"{_coordinate_text(coordinates[0])} {_coordinate_text(coordinates[1])}"
                             )
 
                 # Emitted last, matching the desktop TypeScript serializer's

--- a/server/dive_utils/serializers/viame.py
+++ b/server/dive_utils/serializers/viame.py
@@ -12,7 +12,7 @@ import re
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 from dive_utils import constants, types
-from dive_utils.models import Feature, Track, GeoJSONFeature, interpolate
+from dive_utils.models import Feature, GeoJSONFeature, Track, interpolate
 
 
 def format_timestamp(fps: int, frame: int) -> str:
@@ -181,18 +181,37 @@ def _coordinate_text(value):
 
 def _centerline_features(features):
     """Serialize edited LineString vertices even when a JSON file has no markers."""
-    line = next((f for f in features if f.geometry.type == 'LineString'
-                 and f.properties.get('key') == 'HeadTails'), None)
+    line = next(
+        (
+            f
+            for f in features
+            if f.geometry.type == 'LineString' and f.properties.get('key') == 'HeadTails'
+        ),
+        None,
+    )
     if line is None or len(line.geometry.coordinates) < 2:
         return features
     points = line.geometry.coordinates
-    retained = [f for f in features if not (f.geometry.type == 'Point' and
-                (f.properties.get('key') in ('head', 'tail') or
-                 re.fullmatch(r'spine_0*[1-9][0-9]*', str(f.properties.get('key', '')))))]
+    retained = [
+        f
+        for f in features
+        if not (
+            f.geometry.type == 'Point'
+            and (
+                f.properties.get('key') in ('head', 'tail')
+                or re.fullmatch(r'spine_0*[1-9][0-9]*', str(f.properties.get('key', '')))
+            )
+        )
+    ]
     for i, point in enumerate(points):
         key = 'head' if i == 0 else 'tail' if i == len(points) - 1 else f'spine_{i:03d}'
-        retained.append(GeoJSONFeature(type='Feature', properties={'key': key},
-                       geometry={'type': 'Point', 'coordinates': point}))
+        retained.append(
+            GeoJSONFeature(
+                type='Feature',
+                properties={'key': key},
+                geometry={'type': 'Point', 'coordinates': point},
+            )
+        )
     return retained
 
 
@@ -264,12 +283,15 @@ def _parse_row(row: List[str]) -> Tuple[Dict, Dict, Dict, List, List]:
         if note_regex:
             notes.append(note_regex[1])
 
-    points = {f['properties']['key']: f['geometry']['coordinates']
-              for f in features.get('geometry', {}).get('features', [])
-              if f['geometry']['type'] == 'Point'}
+    points = {
+        f['properties']['key']: f['geometry']['coordinates']
+        for f in features.get('geometry', {}).get('features', [])
+        if f['geometry']['type'] == 'Point'
+    }
     if 'head' in points and 'tail' in points:
-        spine = sorted((k for k in points if re.fullmatch(r'spine_0*[1-9][0-9]*', k)),
-                       key=lambda k: int(k[6:]))
+        spine = sorted(
+            (k for k in points if re.fullmatch(r'spine_0*[1-9][0-9]*', k)), key=lambda k: int(k[6:])
+        )
         head_tail = [points['head']] + [points[k] for k in spine] + [points['tail']]
         create_geoJSONFeature(features, 'LineString', head_tail, 'HeadTails')
 
@@ -759,7 +781,8 @@ def export_tracks_as_csv(
                             coordinates = geoJSONFeature.geometry.coordinates  # type: ignore
                             columns.append(
                                 f"(kp) {geoJSONFeature.properties['key']} "
-                                f"{_coordinate_text(coordinates[0])} {_coordinate_text(coordinates[1])}"
+                                f"{_coordinate_text(coordinates[0])} "
+                                f"{_coordinate_text(coordinates[1])}"
                             )
 
                 # Emitted last, matching the desktop TypeScript serializer's

--- a/server/tests/test_deserialize_kwcoco_json.py
+++ b/server/tests/test_deserialize_kwcoco_json.py
@@ -313,6 +313,11 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                                 },
                                 {
                                     "type": "Feature",
+                                    "geometry": {"type": "Point", "coordinates": [58.45, 262.91]},
+                                    "properties": {"key": "eye"},
+                                },
+                                {
+                                    "type": "Feature",
                                     "geometry": {
                                         "type": "LineString",
                                         "coordinates": [
@@ -358,6 +363,19 @@ test_tuple: List[Tuple[dict, dict, dict]] = [
                     {
                         "frame": 1,
                         "bounds": [73, 125, 142, 184],
+                        "geometry": {
+                            "type": "FeatureCollection",
+                            "features": [
+                                {
+                                    "type": "Feature",
+                                    "geometry": {
+                                        "type": "Point",
+                                        "coordinates": [136.825, 131.145],
+                                    },
+                                    "properties": {"key": "eye"},
+                                }
+                            ],
+                        },
                     }
                 ],
                 "confidencePairs": [["eff", 1.0]],
@@ -1321,3 +1339,107 @@ def test_repeated_category_names_are_listed_once_in_first_seen_order():
     # Nameless slots never count as repeats of each other.
     assert kwcoco.repeated_category_names({'categories': [{'id': 1}, {'id': 2}]}) == []
     assert kwcoco.repeated_category_names({'categories': [{'id': 1, 'name': 'a'}]}) == []
+
+
+@pytest.mark.parametrize('named', [False, True])
+def test_centerline_keypoints_roundtrip(named):
+    labels = ['tail', 'spine_010', 'head', 'spine_002', 'spine_003', 'eye']
+    triples = [
+        [90.5, 20.25, 2],
+        [60.1, 35.2, 2],
+        [10.25, 20.5, 2],
+        [30.75, 40.125, 1],
+        [0, 0, 0],
+        [12.5, 18.5, 2],
+    ]
+    keypoints = [v for triple in triples for v in triple]
+    if named:
+        keypoints = [
+            {'keypoint_category_id': 10 + i * 3, 'xy': p[:2], 'visible': p[2]}
+            for i, p in enumerate(triples)
+        ]
+    doc = {
+        'images': [{'id': 1, 'file_name': 'fish.png'}],
+        'categories': [{'id': 7, 'name': 'fish', 'keypoints': labels}],
+        'keypoint_categories': [{'id': 10 + i * 3, 'name': k} for i, k in enumerate(labels)],
+        'annotations': [
+            {
+                'id': 1,
+                'image_id': 1,
+                'category_id': 7,
+                'bbox': [0, 0, 100, 50],
+                'keypoints': keypoints,
+            }
+        ],
+    }
+    tracks, _, _, _ = kwcoco.load_coco_as_tracks_and_attributes(doc)
+    feature = next(iter(tracks['tracks'].values()))['features'][0]
+    geometry = feature['geometry']['features']
+    expected = [triples[i][:2] for i in [2, 3, 1, 0]]
+    assert (
+        next(g for g in geometry if g['geometry']['type'] == 'LineString')['geometry'][
+            'coordinates'
+        ]
+        == expected
+    )
+    assert not any(g['properties']['key'] == 'spine_003' for g in geometry)
+    # Test line-only geometry and stale point markers: the edited line wins.
+    feature['geometry']['features'] = [g for g in geometry if g['geometry']['type'] == 'LineString']
+    out = kwcoco.export_dive_as_coco(tracks['tracks'].values(), {0: 'fish.png'}, 'fish')
+    assert out['categories'][0]['keypoints'] == ['head', 'spine_001', 'spine_002', 'tail']
+    assert out['categories'][0]['skeleton'] == [[1, 2], [2, 3], [3, 4]]
+    assert out['annotations'][0]['num_keypoints'] == 4
+    again, _, _, _ = kwcoco.load_coco_as_tracks_and_attributes(out)
+    geo = next(iter(again['tracks'].values()))['features'][0]['geometry']['features']
+    assert (
+        next(g for g in geo if g['geometry']['type'] == 'LineString')['geometry']['coordinates']
+        == expected
+    )
+
+
+def test_centerlines_with_different_vertex_counts_share_coco_schema():
+    lines = [[[1.25, 2.5], [4.5, 6.25], [9.5, 3.25]], [[2.5, 3.5], [8.5, 4.5]]]
+    tracks = [
+        dict(
+            id=1,
+            begin=0,
+            end=1,
+            confidencePairs=[['fish', 1]],
+            features=[
+                dict(
+                    frame=i,
+                    bounds=[0, 0, 10, 10],
+                    geometry={
+                        'type': 'FeatureCollection',
+                        'features': [
+                            {
+                                'type': 'Feature',
+                                'properties': {'key': 'HeadTails'},
+                                'geometry': {'type': 'LineString', 'coordinates': line},
+                            }
+                        ],
+                    },
+                )
+                for i, line in enumerate(lines)
+            ],
+        )
+    ]
+    out = kwcoco.export_dive_as_coco(tracks, {0: 'a.png', 1: 'b.png'}, 'fish')
+    assert out['annotations'][1]['keypoints'] == [2.5, 3.5, 2, 0, 0, 0, 8.5, 4.5, 2]
+    assert out['annotations'][1]['num_keypoints'] == 2
+    result, _, _, _ = kwcoco.load_coco_as_tracks_and_attributes(out)
+    for feature, line in zip(result['tracks']['1']['features'], lines):
+        geometry = feature['geometry']['features']
+        assert (
+            next(g for g in geometry if g['geometry']['type'] == 'LineString')['geometry'][
+                'coordinates'
+            ]
+            == line
+        )
+    # No tail means no complete centerline, even with visible interior points.
+    out['annotations'][0]['keypoints'][-1] = 0
+    result, _, _, _ = kwcoco.load_coco_as_tracks_and_attributes(out)
+    assert all(
+        g['geometry']['type'] != 'LineString'
+        for g in result['tracks']['1']['features'][0]['geometry']['features']
+    )

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -44,3 +44,11 @@ def test_import_detection_length(column_length, attribute_length):
         assert 'length' not in feature['attributes']
         assert 'fishLength' not in feature
         assert 'detection_length' not in attributes
+
+
+def test_centerline_order_and_subpixel_coordinates():
+    row = '1,img.png,0,0,0,100,100,1,-1,fish,1,(kp) tail 90 10,(kp) spine_010 60.123456789 40,(kp) head 10 10,(kp) spine_002 40 30,(kp) eye 12 11'
+    features, *_ = viame._parse_row(row.split(','))
+    line = next(f for f in features['geometry']['features'] if f['geometry']['type'] == 'LineString')
+    assert line['geometry']['coordinates'] == [[10, 10], [40, 30], [60.123456789, 40], [90, 10]]
+    assert any(f['properties']['key'] == 'eye' for f in features['geometry']['features'])

--- a/server/tests/test_deserialize_viame_csv.py
+++ b/server/tests/test_deserialize_viame_csv.py
@@ -49,6 +49,8 @@ def test_import_detection_length(column_length, attribute_length):
 def test_centerline_order_and_subpixel_coordinates():
     row = '1,img.png,0,0,0,100,100,1,-1,fish,1,(kp) tail 90 10,(kp) spine_010 60.123456789 40,(kp) head 10 10,(kp) spine_002 40 30,(kp) eye 12 11'
     features, *_ = viame._parse_row(row.split(','))
-    line = next(f for f in features['geometry']['features'] if f['geometry']['type'] == 'LineString')
+    line = next(
+        f for f in features['geometry']['features'] if f['geometry']['type'] == 'LineString'
+    )
     assert line['geometry']['coordinates'] == [[10, 10], [40, 30], [60.123456789, 40], [90, 10]]
     assert any(f['properties']['key'] == 'eye' for f in features['geometry']['features'])

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -157,7 +157,7 @@ test_tuple: List[Tuple[dict, list, list]] = [
             }
         },
         [
-            "0,2.png,1,2,2,4,4,0.9,-1,bar,0.9,foo,0.2,baz,0.1,(kp) head 22 46,(kp) tail 55 22",
+            "0,2.png,1,2,2,4,4,0.9,-1,bar,0.9,foo,0.2,baz,0.1,(kp) head 22.4534 45.6564,(kp) tail 55.232 22.3445",
             "0,3.png,2,3,3,6,6,0.9,-1,bar,0.9,foo,0.2,baz,0.1",
             "0,4.png,3,4,4,8,8,0.9,-1,bar,0.9,foo,0.2,baz,0.1,(poly) 1 2 3 4 5 6 7 8 9 10",
             "",
@@ -681,3 +681,17 @@ def test_export_csv_omits_track_when_no_pairs_meet_threshold():
     )
 
     assert [line.strip() for line in lines if line.strip()] == []
+
+
+def test_centerline_json_csv_roundtrip():
+    coords = [[10.123456789, 20], [20, 30.987654321], [30, 20]]
+    track = dict(id=1, begin=0, end=0, confidencePairs=[['fish', 1]], features=[dict(
+        frame=0, bounds=[0, 0, 100, 100], keyframe=True, geometry=dict(type='FeatureCollection', features=[
+            dict(type='Feature', properties=dict(key='HeadTails'),
+                 geometry=dict(type='LineString', coordinates=coords))]))])
+    rows = list(viame.export_tracks_as_csv([track], filenames=['img.png'], header=False))
+    row = next(r for r in rows if '(kp)' in r)
+    features, *_ = viame._parse_row(next(csv.reader([row])))
+    line = next(f for f in features['geometry']['features'] if f['geometry']['type'] == 'LineString')
+    assert line['geometry']['coordinates'] == coords
+    assert '(kp) spine_001 20 30.987654321' in row

--- a/server/tests/test_serialize_viame_csv.py
+++ b/server/tests/test_serialize_viame_csv.py
@@ -685,13 +685,34 @@ def test_export_csv_omits_track_when_no_pairs_meet_threshold():
 
 def test_centerline_json_csv_roundtrip():
     coords = [[10.123456789, 20], [20, 30.987654321], [30, 20]]
-    track = dict(id=1, begin=0, end=0, confidencePairs=[['fish', 1]], features=[dict(
-        frame=0, bounds=[0, 0, 100, 100], keyframe=True, geometry=dict(type='FeatureCollection', features=[
-            dict(type='Feature', properties=dict(key='HeadTails'),
-                 geometry=dict(type='LineString', coordinates=coords))]))])
+    track = dict(
+        id=1,
+        begin=0,
+        end=0,
+        confidencePairs=[['fish', 1]],
+        features=[
+            dict(
+                frame=0,
+                bounds=[0, 0, 100, 100],
+                keyframe=True,
+                geometry=dict(
+                    type='FeatureCollection',
+                    features=[
+                        dict(
+                            type='Feature',
+                            properties=dict(key='HeadTails'),
+                            geometry=dict(type='LineString', coordinates=coords),
+                        )
+                    ],
+                ),
+            )
+        ],
+    )
     rows = list(viame.export_tracks_as_csv([track], filenames=['img.png'], header=False))
     row = next(r for r in rows if '(kp)' in r)
     features, *_ = viame._parse_row(next(csv.reader([row])))
-    line = next(f for f in features['geometry']['features'] if f['geometry']['type'] == 'LineString')
+    line = next(
+        f for f in features['geometry']['features'] if f['geometry']['type'] == 'LineString'
+    )
     assert line['geometry']['coordinates'] == coords
     assert '(kp) spine_001 20 30.987654321' in row


### PR DESCRIPTION
Fish centerlines need more than two editable endpoints. Extend the existing head/tail line tool with segment insertion and interior-vertex deletion, keeping ordered `spine_001`, `spine_002`, etc. markers synchronized with the `HeadTails` LineString. CSV, JSON, and COCO round trips retain those vertices and their subpixel coordinates. Desktop and web COCO exports publish ordered keypoint labels, skeleton edges, and absent slots for shorter curves; both import standard COCO triples and VIAME KWCOCO named points and reconstruct the editable centerline. Line-only geometry exports correctly, and visibility-zero points do not create spurious vertices.

Existing detection boxes are preserved when line vertices stay inside them and expand only as needed for outside vertices. Deleting a vertex keeps the remaining line selected for continued editing.

Line editing supports clicking along a segment to insert a vertex as well as dragging midpoint handles. The whole-line center handle no longer obscures insertion handles on two-point lines. Right-click exits synchronize the application editing state, and visible segmentation masks cannot replace the selected centerline key.

With automatic stereo mapping enabled, placing or editing named keypoints also maps them to the other camera, including existing detections. Inserting an interior vertex maps that point into the nearest segment of the target line while preserving existing vertices. Both desktop and web support either camera as the source. Desktop dense matching uses a cached right-reference disparity map for right-to-left transfers. Preserve manually edited target points, retain correspondence metadata through vertex insertion, and discard invalid or stale point matches.

Geometry edits invalidate derived measurements and trigger fresh stereo correspondence rather than treating equally numbered vertices as physical matches. Preserve locked user-entered lengths, reject incomplete curve matches, and discard measurements returned after another edit.

Outside line editing, interior spine markers are 50% smaller, opaque circles filled with their stroke color. Head/tail markers and line edit handles retain their existing appearance.

Validation: all 1,664 client tests pass on this upstream-main branch, along with TypeScript checking and lint on the stereo and editing changes. The initial centerline integration also passed 50 server CSV tests and six native VIAME reader/writer tests; the updated VIAME measurement and point-transfer suite passes all 28 tests. A headless Chrome smoke test using the real GeoJS edit layer verifies click insertion, midpoint/vertex dragging, deletion, and three repeated edit reopens. COCO validation also passes 49 server serializer tests and 25 native VIAME reader/writer tests, plus a real file round trip through server DIVE → VIAME tracks → desktop DIVE → server DIVE. Full application and stereo GPU smoke tests were not run.

Desktop curved remeasurement and checked bidirectional point transfer require the companion backend changes, now published on [VIAME main in 8c6c9a00a](https://github.com/VIAME/VIAME/commit/8c6c9a00aa7b7175030c7cd1de16c69943880084). Legacy two-endpoint requests retain their existing behavior.

This PR contains the centerline and related interactive stereo changes on upstream main. Both the centerline change and the interactive stereo follow-up are also merged into `viame/main`.



COCO category-name and visibility handling in both VIAME readers is published on [VIAME main in beee6168f](https://github.com/VIAME/VIAME/commit/beee6168f). VIAME writers already retain arbitrary named keypoints.
