### PR TITLE
Switch between detection polygons with one right-click

### DIFF
--- a/client/src/components/layerManager/polygonSelection.ts
+++ b/client/src/components/layerManager/polygonSelection.ts
@@ -1,0 +1,29 @@
+import { pointInPolygon } from '../../utils';
+
+interface PolygonCandidate {
+  trackId: number;
+  polygonKey: string;
+  polygon: GeoJSON.Polygon;
+  isHole?: boolean;
+}
+
+/** Prefer polygons containing the click; resolve overlap/gaps by boundary distance. */
+export default function pickPolygon(polygons: PolygonCandidate[], trackId: number, point: number[], nearestOutside = false): PolygonCandidate | undefined {
+  const positions = (ring: GeoJSON.Position[]) => ring.map(([x, y]) => ({ x, y }));
+  const ranked = polygons.filter((p) => p.trackId === trackId && !p.isHole).map((polygon) => {
+    const [outer, ...holes] = polygon.polygon.coordinates;
+    const inside = pointInPolygon({ x: point[0], y: point[1] }, positions(outer), holes.map(positions));
+    let distance = Infinity;
+    polygon.polygon.coordinates.forEach((ring) => ring.forEach((a, i) => {
+      const b = ring[(i + 1) % ring.length];
+      const dx = b[0] - a[0]; const dy = b[1] - a[1];
+      const t = Math.max(0, Math.min(1, ((point[0] - a[0]) * dx + (point[1] - a[1]) * dy) / (dx * dx + dy * dy || 1)));
+      distance = Math.min(distance, Math.hypot(point[0] - a[0] - t * dx, point[1] - a[1] - t * dy));
+    }));
+    return { polygon, inside, distance };
+  });
+  const containing = ranked.filter((p) => p.inside);
+  let candidates = nearestOutside ? ranked : [];
+  if (containing.length) candidates = containing;
+  return candidates.sort((a, b) => a.distance - b.distance)[0]?.polygon;
+}

--- a/client/src/components/layerManager/useAnnotationClickHandling.ts
+++ b/client/src/components/layerManager/useAnnotationClickHandling.ts
@@ -98,6 +98,27 @@ export default function useAnnotationClickHandling(options: {
     }
   };
 
+  // GeoJS may finish the current edit later in the same mouse event. Apply
+  // polygon navigation after all layers have processed that click.
+  let polygonNavigationPending = false;
+  function finishPolygonClick(trackId: AnnotationId, polygonKey?: string) {
+    if (polygonNavigationPending) return;
+    polygonNavigationPending = true;
+    const frame = frameNumberRef.value;
+    const switchPolygon = polygonKey !== undefined && polygonKey !== selectedKeyRef.value;
+    window.setTimeout(() => {
+      polygonNavigationPending = false;
+      if (selectedCamera.value !== camera || frameNumberRef.value !== frame
+          || selectedTrackIdRef.value !== trackId) return;
+      editAnnotationLayer.disable();
+      if (polygonKey !== undefined) handler.selectFeatureHandle(-1, polygonKey);
+      // Select explicitly: trackEdit toggles the whole detection off when it
+      // was already being edited, requiring an unwanted second right-click.
+      handler.trackSelect(trackId, switchPolygon);
+      refreshLayers();
+    }, 0);
+  }
+
   function wireHandlers() {
     editAnnotationLayer.bus.$on('editing-annotation-sync', (editing: boolean, deselect?: boolean) => {
       if (deselect) {
@@ -106,6 +127,19 @@ export default function useAnnotationClickHandling(options: {
         handler.trackSelect(selectedTrackIdRef.value, editing);
       }
     });
+    editAnnotationLayer.bus.$on('polygon-edit-right-click', (geo: { x: number; y: number }) => {
+      const trackId = selectedTrackIdRef.value;
+      if (selectedCamera.value !== camera || trackId === null || editingModeRef.value !== 'Polygon') return;
+      const point = alignedView.mapNativePoint(geo.x, geo.y);
+      const hit = polyAnnotationLayer.formattedData.find((item) => {
+        if (item.trackId !== trackId || item.isHole) return false;
+        const [outer, ...holes] = item.polygon.coordinates;
+        const positions = (ring: GeoJSON.Position[]) => ring.map(([x, y]) => ({ x, y }));
+        return pointInPolygon({ x: point[0], y: point[1] }, positions(outer), holes.map(positions));
+      });
+      finishPolygonClick(trackId, hit?.polygonKey);
+    });
+
     editAnnotationLayer.bus.$on('confirm-annotation', () => {
       handler.confirmRecipe();
     });
@@ -122,7 +156,13 @@ export default function useAnnotationClickHandling(options: {
     lineLayer.bus.$on('annotation-clicked', clicked);
     lineLayer.bus.$on('annotation-right-clicked', clicked);
 
-    polyAnnotationLayer.bus.$on('polygon-right-clicked', (_trackId: number, polygonKey: string) => {
+    polyAnnotationLayer.bus.$on('polygon-right-clicked', (trackId: number, polygonKey: string) => {
+      if (selectedCamera.value === camera && trackId === selectedTrackIdRef.value
+          && editingModeRef.value === 'Polygon' && editAnnotationLayer.getMode() !== 'creation') {
+        // The edit-layer click resolves the actual polygon hit (including
+        // holes) and applies the switch after GeoJS finishes this mouse event.
+        return;
+      }
       if (editAnnotationLayer.getMode() === 'creation') {
         handler.cancelCreation();
       }
@@ -139,6 +179,11 @@ export default function useAnnotationClickHandling(options: {
     });
 
     polyAnnotationLayer.bus.$on('polygon-right-clicked-outside', () => {
+      if (selectedCamera.value === camera && selectedTrackIdRef.value !== null
+          && editingModeRef.value === 'Polygon' && editAnnotationLayer.getMode() !== 'creation') {
+        // The edit layer also receives clicks in gaps between polygons.
+        return;
+      }
       if (editAnnotationLayer.getMode() === 'creation') {
         handler.cancelCreation();
         handler.selectFeatureHandle(-1, '');

--- a/client/src/components/layerManager/useAnnotationClickHandling.ts
+++ b/client/src/components/layerManager/useAnnotationClickHandling.ts
@@ -11,6 +11,7 @@ import routeMulticamEditToCamera from './useMulticamEditRouting';
 import type CameraStore from '../../CameraStore';
 import type TrackStore from '../../TrackStore';
 import { pointInPolygon } from '../../utils';
+import pickPolygon from './polygonSelection';
 
 export default function useAnnotationClickHandling(options: {
   camera: string;
@@ -60,7 +61,7 @@ export default function useAnnotationClickHandling(options: {
   // it lands on overlapping features on different layers.
   let clickHandledThisTick = false;
 
-  const clicked = (trackId: number, editing: boolean, modifiers?: { ctrl: boolean }) => {
+  const clicked = (trackId: number, editing: boolean, modifiers?: { ctrl: boolean }, geo?: { x: number; y: number }) => {
     if (justFinalizedCreation) {
       return;
     }
@@ -69,6 +70,19 @@ export default function useAnnotationClickHandling(options: {
     }
     clickHandledThisTick = true;
     window.setTimeout(() => { clickHandledThisTick = false; }, 0);
+
+    if (editing && trackId !== null && geo && editAnnotationLayer.type === 'Polygon') {
+      if (selectedCamera.value !== camera) handler.selectCamera(camera, false);
+      if (selectedCamera.value !== camera) return;
+      const point = alignedView.mapNativePoint(geo.x, geo.y);
+      const polygon = pickPolygon(polyAnnotationLayer.formattedData, trackId, point, true);
+      if (polygon) {
+        editAnnotationLayer.disable();
+        handler.trackSelect(trackId, true);
+        finishPolygonClick(trackId, polygon.polygonKey, true);
+        return;
+      }
+    }
 
     if (selectedCamera.value !== camera) {
       if (editAnnotationLayer.getMode() === 'creation' && !editing) {
@@ -101,11 +115,11 @@ export default function useAnnotationClickHandling(options: {
   // GeoJS may finish the current edit later in the same mouse event. Apply
   // polygon navigation after all layers have processed that click.
   let polygonNavigationPending = false;
-  function finishPolygonClick(trackId: AnnotationId, polygonKey?: string) {
+  function finishPolygonClick(trackId: AnnotationId, polygonKey?: string, enterEditing = false) {
     if (polygonNavigationPending) return;
     polygonNavigationPending = true;
     const frame = frameNumberRef.value;
-    const switchPolygon = polygonKey !== undefined && polygonKey !== selectedKeyRef.value;
+    const switchPolygon = enterEditing || (polygonKey !== undefined && polygonKey !== selectedKeyRef.value);
     window.setTimeout(() => {
       polygonNavigationPending = false;
       if (selectedCamera.value !== camera || frameNumberRef.value !== frame
@@ -131,12 +145,7 @@ export default function useAnnotationClickHandling(options: {
       const trackId = selectedTrackIdRef.value;
       if (selectedCamera.value !== camera || trackId === null || editingModeRef.value !== 'Polygon') return;
       const point = alignedView.mapNativePoint(geo.x, geo.y);
-      const hit = polyAnnotationLayer.formattedData.find((item) => {
-        if (item.trackId !== trackId || item.isHole) return false;
-        const [outer, ...holes] = item.polygon.coordinates;
-        const positions = (ring: GeoJSON.Position[]) => ring.map(([x, y]) => ({ x, y }));
-        return pointInPolygon({ x: point[0], y: point[1] }, positions(outer), holes.map(positions));
-      });
+      const hit = pickPolygon(polyAnnotationLayer.formattedData, trackId as number, point);
       finishPolygonClick(trackId, hit?.polygonKey);
     });
 
@@ -157,6 +166,7 @@ export default function useAnnotationClickHandling(options: {
     lineLayer.bus.$on('annotation-right-clicked', clicked);
 
     polyAnnotationLayer.bus.$on('polygon-right-clicked', (trackId: number, polygonKey: string) => {
+      if (polygonNavigationPending) return;
       if (selectedCamera.value === camera && trackId === selectedTrackIdRef.value
           && editingModeRef.value === 'Polygon' && editAnnotationLayer.getMode() !== 'creation') {
         // The edit-layer click resolves the actual polygon hit (including

--- a/client/src/components/layerManager/usePolygonEditNavigation.spec.ts
+++ b/client/src/components/layerManager/usePolygonEditNavigation.spec.ts
@@ -39,6 +39,7 @@ function harness() {
     registerFinalizeCreation: vi.fn(),
     cancelCreation: vi.fn(),
   };
+  const rectangle = layer();
   const refresh = vi.fn();
   useAnnotationClickHandling({
     camera: 'left',
@@ -50,7 +51,7 @@ function harness() {
     flickNumberRef: ref(0),
     editAnnotationLayer: edit,
     polyAnnotationLayer: polygons,
-    rectAnnotationLayer: layer(),
+    rectAnnotationLayer: rectangle,
     lineLayer: layer(),
     handler,
     alignedView: { mapNativePoint: (x: number, y: number) => [x, y] },
@@ -58,7 +59,7 @@ function harness() {
   } as never).wireHandlers();
   const click = (x: number, y: number) => edit.bus.$emit('polygon-edit-right-click', { x, y });
   return {
-    selected, key, mode, frame, camera, edit, polygons, handler, refresh, click,
+    selected, key, mode, frame, camera, edit, polygons, handler, refresh, click, rectangle,
   };
 }
 
@@ -126,4 +127,31 @@ it('ignores another camera and non-polygon editing modes', () => {
   h.camera.value = 'left'; h.mode.value = 'LineString'; h.click(21, 5);
   vi.runAllTimers();
   expect(h.handler.trackSelect).not.toHaveBeenCalled();
+});
+
+it.each(['before', 'after'])('enters the clicked polygon instead of the old key (polygon event %s rectangle)', (order) => {
+  const h = harness(); h.mode.value = false; h.selected.value = null; h.key.value = 'second';
+  if (order === 'before') h.polygons.bus.$emit('polygon-right-clicked', 1, 'first');
+  h.rectangle.bus.$emit('annotation-right-clicked', 1, true, undefined, { x: 5, y: 5 });
+  if (order === 'after') h.polygons.bus.$emit('polygon-right-clicked', 1, 'second');
+  vi.runAllTimers();
+  expect(h.selected.value).toBe(1);
+  expect(h.key.value).toBe('first');
+  expect(h.mode.value).toBe('Polygon');
+});
+
+it('enters the nearest polygon when right-clicking the detection between polygons', () => {
+  const h = harness(); h.mode.value = false; h.key.value = 'first';
+  h.rectangle.bus.$emit('annotation-right-clicked', 1, true, undefined, { x: 18, y: 5 });
+  vi.runAllTimers();
+  expect(h.key.value).toBe('second');
+  expect(h.mode.value).toBe('Polygon');
+});
+
+it('chooses the closest boundary when polygons overlap, including while switching edits', () => {
+  const h = harness();
+  h.polygons.formattedData[0].polygon.coordinates = [ring(0, 0, 40, 20)];
+  h.click(21, 5); vi.runAllTimers();
+  expect(h.key.value).toBe('second');
+  expect(h.mode.value).toBe('Polygon');
 });

--- a/client/src/components/layerManager/usePolygonEditNavigation.spec.ts
+++ b/client/src/components/layerManager/usePolygonEditNavigation.spec.ts
@@ -1,0 +1,129 @@
+import Vue, { ref } from 'vue';
+import useAnnotationClickHandling from './useAnnotationClickHandling';
+import type { EditAnnotationTypes } from '../../layers/EditAnnotationLayer';
+
+const ring = (x0: number, y0: number, x1: number, y1: number) => [
+  [x0, y0], [x1, y0], [x1, y1], [x0, y1], [x0, y0],
+];
+
+function harness() {
+  const selected = ref<number | null>(1);
+  const key = ref('first');
+  const mode = ref<false | EditAnnotationTypes>('Polygon');
+  const frame = ref(0);
+  const camera = ref('left');
+  const layer = () => ({ bus: new Vue() });
+  const edit = {
+    ...layer(), type: 'Polygon', getMode: () => 'editing', disable: vi.fn(),
+  };
+  const polygons = {
+    ...layer(),
+    formattedData: [
+      {
+        trackId: 1, polygonKey: 'first', polygon: { type: 'Polygon', coordinates: [ring(0, 0, 10, 10)] }, isHole: false,
+      },
+      {
+        trackId: 1, polygonKey: 'second', polygon: { type: 'Polygon', coordinates: [ring(20, 0, 30, 10), ring(23, 3, 27, 7)] }, isHole: false,
+      },
+      {
+        trackId: 1, polygonKey: 'second', polygon: { type: 'Polygon', coordinates: [ring(23, 3, 27, 7)] }, isHole: true,
+      },
+    ],
+  };
+  const handler = {
+    trackSelect: vi.fn((id: number | null, editing: boolean) => {
+      selected.value = id;
+      mode.value = editing ? 'Polygon' : false;
+    }),
+    selectFeatureHandle: vi.fn((_index, selectedKey) => { key.value = selectedKey; }),
+    registerFinalizeCreation: vi.fn(),
+    cancelCreation: vi.fn(),
+  };
+  const refresh = vi.fn();
+  useAnnotationClickHandling({
+    camera: 'left',
+    selectedCamera: camera,
+    selectedTrackIdRef: selected,
+    selectedKeyRef: key,
+    editingModeRef: mode,
+    frameNumberRef: frame,
+    flickNumberRef: ref(0),
+    editAnnotationLayer: edit,
+    polyAnnotationLayer: polygons,
+    rectAnnotationLayer: layer(),
+    lineLayer: layer(),
+    handler,
+    alignedView: { mapNativePoint: (x: number, y: number) => [x, y] },
+    refreshLayers: refresh,
+  } as never).wireHandlers();
+  const click = (x: number, y: number) => edit.bus.$emit('polygon-edit-right-click', { x, y });
+  return {
+    selected, key, mode, frame, camera, edit, polygons, handler, refresh, click,
+  };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+
+it.each(['before', 'after'])('switches polygons with one click when the polygon layer runs %s the editor', (order) => {
+  const h = harness();
+  const saved = JSON.stringify(h.polygons.formattedData);
+  if (order === 'before') h.polygons.bus.$emit('polygon-right-clicked', 1, 'second');
+  h.click(21, 5);
+  if (order === 'after') h.polygons.bus.$emit('polygon-right-clicked', 1, 'second');
+  // GeoJS finishes the old annotation during the same mouse event.
+  h.mode.value = false;
+  vi.runAllTimers();
+  expect(h.mode.value).toBe('Polygon');
+  expect(h.key.value).toBe('second');
+  expect(h.selected.value).toBe(1);
+  expect(h.handler.trackSelect).toHaveBeenCalledExactlyOnceWith(1, true);
+  expect(h.refresh).toHaveBeenCalledTimes(1);
+  expect(JSON.stringify(h.polygons.formattedData)).toBe(saved);
+});
+
+it('finishes the current polygon when right-clicking it again', () => {
+  const h = harness(); h.click(5, 5); vi.runAllTimers();
+  expect(h.mode.value).toBe(false);
+  expect(h.selected.value).toBe(1);
+  expect(h.key.value).toBe('first');
+});
+
+it.each([[15, 5], [25, 5]])('finishes editing in a gap or hole at %j', (x, y) => {
+  const h = harness(); h.click(x, y); vi.runAllTimers();
+  expect(h.mode.value).toBe(false);
+  expect(h.selected.value).toBe(1);
+  expect(h.key.value).toBe('first');
+});
+
+it('preserves deselection when another layer handles a click outside the detection', () => {
+  const h = harness(); h.click(50, 50);
+  h.handler.trackSelect(null, false);
+  vi.runAllTimers();
+  expect(h.selected.value).toBe(null);
+  expect(h.handler.trackSelect).toHaveBeenCalledTimes(1);
+  expect(h.refresh).not.toHaveBeenCalled();
+});
+
+it.each(['frame', 'camera', 'track'])('does not apply a queued switch after the %s changes', (kind) => {
+  const h = harness(); h.click(21, 5);
+  if (kind === 'frame') h.frame.value = 1;
+  if (kind === 'camera') h.camera.value = 'right';
+  if (kind === 'track') h.selected.value = 2;
+  vi.runAllTimers();
+  expect(h.handler.trackSelect).not.toHaveBeenCalled();
+});
+
+it('allows switching to a polygon with the default empty key', () => {
+  const h = harness(); h.polygons.formattedData[1].polygonKey = '';
+  h.click(21, 5); vi.runAllTimers();
+  expect(h.key.value).toBe('');
+  expect(h.mode.value).toBe('Polygon');
+});
+
+it('ignores another camera and non-polygon editing modes', () => {
+  const h = harness(); h.camera.value = 'right'; h.click(21, 5);
+  h.camera.value = 'left'; h.mode.value = 'LineString'; h.click(21, 5);
+  vi.runAllTimers();
+  expect(h.handler.trackSelect).not.toHaveBeenCalled();
+});

--- a/client/src/layers/AnnotationLayers/PolygonLayer.ts
+++ b/client/src/layers/AnnotationLayers/PolygonLayer.ts
@@ -109,7 +109,7 @@ export default class PolygonLayer extends BaseLayer<PolyGeoJSData> {
           // Track-level events only when not drawingOther
           if (!this.drawingOther) {
             if (!e.data.editing || (e.data.editing && !e.data.selected)) {
-              this.bus.$emit('annotation-right-clicked', e.data.trackId, true);
+              this.bus.$emit('annotation-right-clicked', e.data.trackId, true, undefined, e.mouse.geo);
             }
           }
         }

--- a/client/src/layers/AnnotationLayers/RectangleLayer.ts
+++ b/client/src/layers/AnnotationLayers/RectangleLayer.ts
@@ -122,7 +122,7 @@ export default class RectangleLayer extends BaseLayer<RectGeoJSData> {
           }
         } else if (e.mouse.buttonsDown.right) {
           if (!e.data.editing || (e.data.editing && !e.data.selected)) {
-            this.bus.$emit('annotation-right-clicked', e.data.trackId, true);
+            this.bus.$emit('annotation-right-clicked', e.data.trackId, true, undefined, e.mouse.geo);
           }
         }
       });

--- a/client/src/layers/EditAnnotationLayer.ts
+++ b/client/src/layers/EditAnnotationLayer.ts
@@ -223,6 +223,9 @@ export default class EditAnnotationLayer extends BaseLayer<GeoJSON.Feature> {
           this.bus.$emit('editing-annotation-sync', false, true);
           return;
         }
+        if (e.buttonsDown.right && this.type === 'Polygon' && this.featureLayer.annotations()[0]) {
+          this.bus.$emit('polygon-edit-right-click', e.geo);
+        }
         //Used to sync clicks that kick out of editing mode with application
         //This prevents that pseudo Edit state when left clicking on a object in edit mode
         if (!this.disableModeSync && (e.buttonsDown.left)

--- a/docs/Annotation-QuickStart.md
+++ b/docs/Annotation-QuickStart.md
@@ -137,6 +137,8 @@ Every track is required to have a bounding box, but a polygon region may be adde
 
 DIVE supports multiple polygon regions on one detection and polygons with interior holes (for example, annotating a ring-shaped object). Holes are preserved in DIVE JSON and [VIAME CSV export](DataFormats.md#viame-csv-polygons-and-length) using `(poly)` and `(hole)` columns.
 
+While editing a polygon, right-click another polygon on the same detection to switch directly to editing it. Right-click the current polygon or empty space between polygons to finish polygon editing while keeping the detection selected. Right-click outside the detection to finish and deselect the detection.
+
 ## Interactive Segmentation (Desktop)
 
 [Interactive point-click segmentation](Interactive-Annotation.md#interactive-segmentation) is available in DIVE Desktop only. It helps you create polygon annotations by clicking include/exclude points instead of placing every vertex manually.


### PR DESCRIPTION
When a detection has multiple polygons, right-clicking another polygon while editing currently requires a second click to enter that polygon's editor. Handle that navigation after GeoJS finishes processing the current mouse event and explicitly retain editing on the selected detection.

Right-clicking another polygon on the same detection now finishes the current edit and opens the clicked polygon in one action. Right-clicking the current polygon or empty space between polygons finishes polygon editing while keeping the detection selected. Existing off-detection deselection is preserved. Entering polygon editing also selects the polygon under the right-click instead of restoring the previously edited polygon. Overlaps are resolved by the closest boundary; clicking within the detection but outside its polygons selects the closest polygon boundary on entry. Hit testing excludes holes, and queued changes are discarded if the camera, frame, or detection changes.

Validation: all 1,638 client tests pass, including 15 polygon-navigation regression tests; TypeScript and lint pass. A headless Chrome check with the real GeoJS edit, polygon, rectangle, and click-routing layers verified switching in both directions, preserving a vertex edit, gap finalization, reopening, off-detection deselection, initial polygon selection, and overlap/gap boundary selection. Full application dataset testing was not run.

Branched from upstream `main` at `87e7794e`. This change is separate from the centerline/stereo PR.
