### PR TITLE
Keep the VIAME launcher window title

### DIFF
--- a/client/platform/desktop/background.ts
+++ b/client/platform/desktop/background.ts
@@ -221,12 +221,13 @@ async function createWindow() {
   try {
     const size = screen.getPrimaryDisplay().workAreaSize;
     const partitionSession = session.fromPartition('persist:dive');
+    const launchedFromViame = Boolean(process.env.DIVE_VIAME_INSTALL_PATH);
     // Create the browser window.
     win = new BrowserWindow({
       width: Math.min(size.width, 1420),
       height: Math.min(size.height - 200, 960),
       autoHideMenuBar: true,
-      title: 'VIAME DIVE Desktop',
+      title: launchedFromViame ? 'VIAME - DIVE Interface' : 'DIVE Desktop',
       webPreferences: {
         nodeIntegration: false,
         contextIsolation: true,
@@ -237,6 +238,11 @@ async function createWindow() {
         session: partitionSession,
       },
     });
+
+    // desktop.html otherwise replaces the native title after every page load.
+    if (launchedFromViame) {
+      win.on('page-title-updated', (event) => event.preventDefault());
+    }
 
     listen((server) => {
       let address = server.address();

--- a/docs/Dive-Desktop.md
+++ b/docs/Dive-Desktop.md
@@ -240,3 +240,8 @@ It's also helpful to look in the debug console.  Press ++ctrl+shift+i++ to launc
 See [Interactive Annotation troubleshooting](Interactive-Annotation.md#troubleshooting). Verify the VIAME install path, confirm VIAME includes interactive service support, and check the debug console for subprocess errors (message: "Unable to load the interactive service").
 
 ![Debugging Desktop](images/General/desktop-debug.png)
+
+
+When started through the VIAME launch scripts (`DIVE_VIAME_INSTALL_PATH` is set),
+the native window title is **VIAME - DIVE Interface**. Standalone launches use
+**DIVE Desktop**.


### PR DESCRIPTION
VIAME-launched DIVE windows are renamed to **VIAME - DIVE Interface** and retain that title when desktop.html loads or updates its title. Standalone launches continue to show **DIVE Desktop**.

Use the existing `DIVE_VIAME_INSTALL_PATH` environment variable already set by the Linux and Windows VIAME launch scripts, so no companion launcher change is required.

Validation: TypeScript and lint passed; the Electron main/preload/renderer build passed. A real Electron smoke test launched both modes in isolated user-data directories and verified that an HTML title update cannot overwrite the VIAME title.
