### PR TITLE
Add compact annotation navigation and responsive Other menu

### DIFF
--- a/client/platform/desktop/frontend/components/AnnotationOtherMenu.vue
+++ b/client/platform/desktop/frontend/components/AnnotationOtherMenu.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { computed, PropType } from 'vue';
+import { useRouter } from 'vue-router/composables';
+import { desktopDestinations, primaryDestinations, DesktopDestination } from './desktopNavigation';
+
+const props = defineProps({
+  destinations: { type: Array as PropType<DesktopDestination[]>, default: undefined },
+});
+const router = useRouter();
+const items = computed(() => props.destinations || desktopDestinations.filter((item) => !primaryDestinations.includes(item.name)
+  && router.getRoutes().some((route) => route.name === item.name)));
+</script>
+
+<template>
+  <v-menu offset-y>
+    <template #activator="{ on, attrs }">
+      <v-btn text class="annotation-other-menu" v-bind="attrs" v-on="on">
+        <span>Other</span>
+        <v-icon>mdi-chevron-down</v-icon>
+      </v-btn>
+    </template>
+    <v-list dense>
+      <v-list-item v-for="item in items" :key="item.name" :to="{ name: item.name, params: item.params }" :title="item.title">
+        <v-list-item-icon><v-icon>{{ item.icon }}</v-icon></v-list-item-icon>
+        <v-list-item-title>{{ item.label }}</v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+
+<style scoped>
+.annotation-other-menu { min-width: var(--desktop-tab-width, 100px) !important; max-width: var(--desktop-tab-width, 100px); height: 72px !important; }
+.annotation-other-menu ::v-deep .v-btn__content { flex-direction: column; gap: 4px; }
+</style>

--- a/client/platform/desktop/frontend/components/AnnotationOtherMenu.vue
+++ b/client/platform/desktop/frontend/components/AnnotationOtherMenu.vue
@@ -16,7 +16,7 @@ const items = computed(() => props.destinations || desktopDestinations.filter((i
     <template #activator="{ on, attrs }">
       <button v-ripple type="button" class="v-tab annotation-other-menu" v-bind="attrs" v-on="on">
         Other
-        <v-icon>mdi-chevron-down</v-icon>
+        <v-icon size="28">mdi-chevron-double-down</v-icon>
       </button>
     </template>
     <v-list dense>

--- a/client/platform/desktop/frontend/components/AnnotationOtherMenu.vue
+++ b/client/platform/desktop/frontend/components/AnnotationOtherMenu.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { computed, PropType } from 'vue';
 import { useRouter } from 'vue-router/composables';
-import { desktopDestinations, primaryDestinations, DesktopDestination } from './desktopNavigation';
+import { desktopDestinations, annotationPrimaryDestinations, DesktopDestination } from './desktopNavigation';
 
 const props = defineProps({
   destinations: { type: Array as PropType<DesktopDestination[]>, default: undefined },
 });
 const router = useRouter();
-const items = computed(() => props.destinations || desktopDestinations.filter((item) => !primaryDestinations.includes(item.name)
+const items = computed(() => props.destinations || desktopDestinations.filter((item) => !annotationPrimaryDestinations.includes(item.name)
   && router.getRoutes().some((route) => route.name === item.name)));
 </script>
 

--- a/client/platform/desktop/frontend/components/AnnotationOtherMenu.vue
+++ b/client/platform/desktop/frontend/components/AnnotationOtherMenu.vue
@@ -14,10 +14,10 @@ const items = computed(() => props.destinations || desktopDestinations.filter((i
 <template>
   <v-menu offset-y>
     <template #activator="{ on, attrs }">
-      <v-btn text class="annotation-other-menu" v-bind="attrs" v-on="on">
-        <span>Other</span>
+      <button v-ripple type="button" class="v-tab annotation-other-menu" v-bind="attrs" v-on="on">
+        Other
         <v-icon>mdi-chevron-down</v-icon>
-      </v-btn>
+      </button>
     </template>
     <v-list dense>
       <v-list-item v-for="item in items" :key="item.name" :to="{ name: item.name, params: item.params }" :title="item.title">
@@ -29,6 +29,5 @@ const items = computed(() => props.destinations || desktopDestinations.filter((i
 </template>
 
 <style scoped>
-.annotation-other-menu { min-width: var(--desktop-tab-width, 100px) !important; max-width: var(--desktop-tab-width, 100px); height: 72px !important; }
-.annotation-other-menu ::v-deep .v-btn__content { flex-direction: column; gap: 4px; }
+.annotation-other-menu { min-width: var(--desktop-tab-width, 100px) !important; max-width: var(--desktop-tab-width, 100px); font-family: inherit; }
 </style>

--- a/client/platform/desktop/frontend/components/AnnotationOtherMenu.vue
+++ b/client/platform/desktop/frontend/components/AnnotationOtherMenu.vue
@@ -16,7 +16,9 @@ const items = computed(() => props.destinations || desktopDestinations.filter((i
     <template #activator="{ on, attrs }">
       <button v-ripple type="button" class="v-tab annotation-other-menu" v-bind="attrs" v-on="on">
         Other
-        <v-icon size="28">mdi-chevron-double-down</v-icon>
+        <v-icon size="28">
+          mdi-chevron-double-down
+        </v-icon>
       </button>
     </template>
     <v-list dense>

--- a/client/platform/desktop/frontend/components/NavigationBar.vue
+++ b/client/platform/desktop/frontend/components/NavigationBar.vue
@@ -13,7 +13,7 @@ export default defineComponent({
   props: { name: { type: String, default: 'DIVE' } },
   setup() {
     const router = useRouter();
-    const container = ref<HTMLElement>();
+    const container = ref<{ $el: HTMLElement }>();
     const width = ref(Infinity);
     const destinations = computed(() => {
       const items: DesktopDestination[] = desktopDestinations.filter((item) => router.getRoutes().some((route) => route.name === item.name));
@@ -33,9 +33,9 @@ export default defineComponent({
     let observer: ResizeObserver;
     onMounted(() => {
       if (!container.value) return;
-      width.value = container.value.clientWidth;
+      width.value = container.value.$el.clientWidth;
       observer = new ResizeObserver(([entry]) => { width.value = entry.contentRect.width; });
-      observer.observe(container.value);
+      observer.observe(container.value.$el);
     });
     onBeforeUnmount(() => observer?.disconnect());
     return { container, navigation, tabWidth };
@@ -45,17 +45,16 @@ export default defineComponent({
 
 <template>
   <v-app-bar app>
-    <div ref="container" class="desktop-navigation" :style="{ '--desktop-tab-width': tabWidth }">
-      <v-tabs icons-and-text show-arrows="never" class="desktop-nav-tabs" color="accent">
-        <template v-for="item in navigation.visible">
-          <job-tab v-if="item.name === 'jobs'" :key="item.name" />
-          <v-tab v-else :key="item.name" :to="{ name: item.name, params: item.params }" :title="item.title">
-            {{ item.label }}<v-icon>{{ item.icon }}</v-icon>
-          </v-tab>
-        </template>
-        <annotation-other-menu v-if="navigation.hidden.length" :destinations="navigation.hidden" />
-      </v-tabs>
-    </div>
+    <!-- Vuetify applies toolbar height and background styles to direct-child tabs. -->
+    <v-tabs ref="container" icons-and-text show-arrows="never" class="desktop-nav-tabs desktop-navigation" color="accent" :style="{ '--desktop-tab-width': tabWidth }">
+      <template v-for="item in navigation.visible">
+        <job-tab v-if="item.name === 'jobs'" :key="item.name" />
+        <v-tab v-else :key="item.name" :to="{ name: item.name, params: item.params }" :title="item.title">
+          {{ item.label }}<v-icon>{{ item.icon }}</v-icon>
+        </v-tab>
+      </template>
+      <annotation-other-menu v-if="navigation.hidden.length" :destinations="navigation.hidden" />
+    </v-tabs>
   </v-app-bar>
 </template>
 

--- a/client/platform/desktop/frontend/components/NavigationBar.vue
+++ b/client/platform/desktop/frontend/components/NavigationBar.vue
@@ -1,61 +1,67 @@
-<script>
-import { defineComponent } from 'vue';
+<script lang="ts">
+import {
+  computed, defineComponent, onBeforeUnmount, onMounted, ref,
+} from 'vue';
+import { useRouter } from 'vue-router/composables';
 import JobTab from './JobTab.vue';
+import AnnotationOtherMenu from './AnnotationOtherMenu.vue';
+import { desktopDestinations, navigationOverflow, DesktopDestination } from './desktopNavigation';
 import { lastAnnotation } from '../store/dataset';
 
 export default defineComponent({
-  components: { JobTab },
-  props: {
-    name: {
-      type: String,
-      default: 'DIVE',
-    },
-  },
+  components: { JobTab, AnnotationOtherMenu },
+  props: { name: { type: String, default: 'DIVE' } },
   setup() {
-    return { lastAnnotation };
+    const router = useRouter();
+    const container = ref<HTMLElement>();
+    const width = ref(Infinity);
+    const destinations = computed(() => {
+      const items: DesktopDestination[] = desktopDestinations.filter((item) => router.getRoutes().some((route) => route.name === item.name));
+      if (lastAnnotation.value) {
+        items.unshift({
+          name: 'viewer',
+          label: 'Resume',
+          icon: 'mdi-history',
+          params: { id: lastAnnotation.value.id },
+          title: `Resume editing ${lastAnnotation.value.name}`,
+        });
+      }
+      return items;
+    });
+    const navigation = computed(() => navigationOverflow(destinations.value, width.value));
+    const tabWidth = computed(() => `${Math.min(100, width.value / 4)}px`);
+    let observer: ResizeObserver;
+    onMounted(() => {
+      if (!container.value) return;
+      width.value = container.value.clientWidth;
+      observer = new ResizeObserver(([entry]) => { width.value = entry.contentRect.width; });
+      observer.observe(container.value);
+    });
+    onBeforeUnmount(() => observer?.disconnect());
+    return { container, navigation, tabWidth };
   },
 });
 </script>
 
 <template>
   <v-app-bar app>
-    <v-tabs
-      icons-and-text
-      class="desktop-nav-tabs"
-      style="flex-basis:0; flex-grow:0;"
-      color="accent"
-    >
-      <v-tab
-        v-if="lastAnnotation"
-        :to="{ name: 'viewer', params: { id: lastAnnotation.id } }"
-        :title="`Resume editing ${lastAnnotation.name}`"
-      >
-        Resume<v-icon>mdi-history</v-icon>
-      </v-tab>
-      <v-tab :to="{ name: 'recent' }">
-        Library<v-icon>mdi-folder-open</v-icon>
-      </v-tab>
-      <v-tab :to="{ name: 'pipeline' }">
-        Pipelines<v-icon>mdi-pipe</v-icon>
-      </v-tab>
-      <job-tab />
-      <v-tab :to="{ name: 'training' }">
-        Training<v-icon>mdi-brain</v-icon>
-      </v-tab>
-      <v-tab :to="{ name: 'review' }">
-        Review<v-icon>mdi-view-grid-outline</v-icon>
-      </v-tab>
-      <v-tab :to="{ name: 'scoring' }">
-        Scoring<v-icon>mdi-chart-box-outline</v-icon>
-      </v-tab>
-      <v-tab :to="{ name: 'settings' }">
-        Settings<v-icon>mdi-cog</v-icon>
-      </v-tab>
-    </v-tabs>
-    <v-spacer />
+    <div ref="container" class="desktop-navigation" :style="{ '--desktop-tab-width': tabWidth }">
+      <v-tabs icons-and-text show-arrows="never" class="desktop-nav-tabs" color="accent">
+        <template v-for="item in navigation.visible">
+          <job-tab v-if="item.name === 'jobs'" :key="item.name" />
+          <v-tab v-else :key="item.name" :to="{ name: item.name, params: item.params }" :title="item.title">
+            {{ item.label }}<v-icon>{{ item.icon }}</v-icon>
+          </v-tab>
+        </template>
+        <annotation-other-menu v-if="navigation.hidden.length" :destinations="navigation.hidden" />
+      </v-tabs>
+    </div>
   </v-app-bar>
 </template>
 
 <style lang="scss">
 @import './navTabs.scss';
+.desktop-navigation { flex: 1; min-width: 0; }
+.desktop-navigation .v-slide-group__prev, .desktop-navigation .v-slide-group__next { display: none !important; }
+.desktop-navigation .v-tab { min-width: var(--desktop-tab-width); max-width: var(--desktop-tab-width); }
 </style>

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -42,6 +42,7 @@ import {
 } from 'platform/desktop/frontend/api';
 import Export from './Export.vue';
 import JobTab from './JobTab.vue';
+import AnnotationOtherMenu from './AnnotationOtherMenu.vue';
 import DatasetSourceInfo from './DatasetSourceInfo.vue';
 import { datasets, rememberAnnotation } from '../store/dataset';
 import { settings } from '../store/settings';
@@ -73,6 +74,7 @@ export default defineComponent({
   components: {
     Export,
     JobTab,
+    AnnotationOtherMenu,
     DatasetSourceInfo,
     RunPipelineMenu,
     SidebarContext,
@@ -2095,21 +2097,10 @@ export default defineComponent({
             Library<v-icon>mdi-folder-open</v-icon>
           </v-tab>
           <job-tab />
-          <v-tab
-            v-if="reviewSessionHeld"
-            :to="{ name: 'review' }"
-          >
-            Review<v-icon>mdi-view-grid-outline</v-icon>
-          </v-tab>
-          <v-tab :to="{ name: 'training' }">
-            Training<v-icon>mdi-brain</v-icon>
-          </v-tab>
-          <v-tab :to="{ name: 'scoring' }">
-            Scoring<v-icon>mdi-chart-box-outline</v-icon>
-          </v-tab>
           <v-tab :to="{ name: 'settings' }">
             Settings<v-icon>mdi-cog</v-icon>
           </v-tab>
+          <annotation-other-menu />
         </v-tabs>
       </template>
       <template #title-right>

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -2097,6 +2097,9 @@ export default defineComponent({
             Library<v-icon>mdi-folder-open</v-icon>
           </v-tab>
           <job-tab />
+          <v-tab :to="{ name: 'review' }">
+            Review<v-icon>mdi-view-grid-outline</v-icon>
+          </v-tab>
           <v-tab :to="{ name: 'settings' }">
             Settings<v-icon>mdi-cog</v-icon>
           </v-tab>

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -2100,9 +2100,6 @@ export default defineComponent({
           <v-tab :to="{ name: 'review' }">
             Review<v-icon>mdi-view-grid-outline</v-icon>
           </v-tab>
-          <v-tab :to="{ name: 'settings' }">
-            Settings<v-icon>mdi-cog</v-icon>
-          </v-tab>
           <annotation-other-menu />
         </v-tabs>
       </template>

--- a/client/platform/desktop/frontend/components/desktopNavigation.spec.ts
+++ b/client/platform/desktop/frontend/components/desktopNavigation.spec.ts
@@ -8,9 +8,9 @@ it('shows all destinations when they fit and reserves Other when they do not', (
   expect(new Set([...narrow.visible, ...narrow.hidden])).toEqual(new Set(desktopDestinations));
 });
 
-it('keeps Library, Jobs and Settings visible at narrow widths', () => {
+it('moves Settings into Other at narrow widths', () => {
   const narrow = navigationOverflow(desktopDestinations, 400);
-  expect(narrow.visible.map((item) => item.name)).toEqual(['recent', 'jobs', 'settings']);
-  expect(narrow.hidden.map((item) => item.name)).toEqual(['pipeline', 'training', 'query', 'review', 'scoring', 'addons']);
+  expect(narrow.visible.map((item) => item.name)).toEqual(['recent', 'pipeline', 'jobs']);
+  expect(narrow.hidden.map((item) => item.name)).toEqual(['training', 'query', 'review', 'scoring', 'addons', 'settings']);
   expect(navigationOverflow(desktopDestinations, 1200).visible).toEqual(desktopDestinations);
 });

--- a/client/platform/desktop/frontend/components/desktopNavigation.spec.ts
+++ b/client/platform/desktop/frontend/components/desktopNavigation.spec.ts
@@ -1,0 +1,16 @@
+import { desktopDestinations, navigationOverflow } from './desktopNavigation';
+
+it('shows all destinations when they fit and reserves Other when they do not', () => {
+  expect(navigationOverflow(desktopDestinations, 900).hidden).toEqual([]);
+  const narrow = navigationOverflow(desktopDestinations, 800);
+  expect(narrow.visible).toHaveLength(7);
+  expect(narrow.hidden).toHaveLength(2);
+  expect(new Set([...narrow.visible, ...narrow.hidden])).toEqual(new Set(desktopDestinations));
+});
+
+it('keeps Library, Jobs and Settings visible at narrow widths', () => {
+  const narrow = navigationOverflow(desktopDestinations, 400);
+  expect(narrow.visible.map((item) => item.name)).toEqual(['recent', 'jobs', 'settings']);
+  expect(narrow.hidden.map((item) => item.name)).toEqual(['pipeline', 'training', 'query', 'review', 'scoring', 'addons']);
+  expect(navigationOverflow(desktopDestinations, 1200).visible).toEqual(desktopDestinations);
+});

--- a/client/platform/desktop/frontend/components/desktopNavigation.ts
+++ b/client/platform/desktop/frontend/components/desktopNavigation.ts
@@ -1,0 +1,30 @@
+export interface DesktopDestination {
+  name: string;
+  label: string;
+  icon: string;
+  params?: Record<string, string>;
+  title?: string;
+}
+
+export const desktopDestinations: DesktopDestination[] = [
+  { name: 'recent', label: 'Library', icon: 'mdi-folder-open' },
+  { name: 'pipeline', label: 'Pipelines', icon: 'mdi-pipe' },
+  { name: 'jobs', label: 'Jobs', icon: 'mdi-format-list-checks' },
+  { name: 'training', label: 'Training', icon: 'mdi-brain' },
+  { name: 'query', label: 'Query', icon: 'mdi-image-search-outline' },
+  { name: 'review', label: 'Review', icon: 'mdi-view-grid-outline' },
+  { name: 'scoring', label: 'Scoring', icon: 'mdi-chart-box-outline' },
+  { name: 'addons', label: 'Add-Ons', icon: 'mdi-puzzle' },
+  { name: 'settings', label: 'Settings', icon: 'mdi-cog' },
+];
+export const primaryDestinations = ['recent', 'jobs', 'settings'];
+
+/** Reserve the Other button before choosing which secondary tabs fit. */
+export function navigationOverflow(items: DesktopDestination[], width: number) {
+  const slots = Math.max(4, Math.floor(width / 100));
+  if (items.length <= slots) return { visible: items, hidden: [] };
+  const primary = items.filter((item) => primaryDestinations.includes(item.name));
+  const secondary = items.filter((item) => !primaryDestinations.includes(item.name));
+  const visible = new Set([...primary, ...secondary.slice(0, Math.max(0, slots - primary.length - 1))]);
+  return { visible: items.filter((item) => visible.has(item)), hidden: items.filter((item) => !visible.has(item)) };
+}

--- a/client/platform/desktop/frontend/components/desktopNavigation.ts
+++ b/client/platform/desktop/frontend/components/desktopNavigation.ts
@@ -18,6 +18,7 @@ export const desktopDestinations: DesktopDestination[] = [
   { name: 'settings', label: 'Settings', icon: 'mdi-cog' },
 ];
 export const primaryDestinations = ['recent', 'jobs', 'settings'];
+export const annotationPrimaryDestinations = ['recent', 'jobs', 'review', 'settings'];
 
 /** Reserve the Other button before choosing which secondary tabs fit. */
 export function navigationOverflow(items: DesktopDestination[], width: number) {

--- a/client/platform/desktop/frontend/components/desktopNavigation.ts
+++ b/client/platform/desktop/frontend/components/desktopNavigation.ts
@@ -17,8 +17,8 @@ export const desktopDestinations: DesktopDestination[] = [
   { name: 'addons', label: 'Add-Ons', icon: 'mdi-puzzle' },
   { name: 'settings', label: 'Settings', icon: 'mdi-cog' },
 ];
-export const primaryDestinations = ['recent', 'jobs', 'settings'];
-export const annotationPrimaryDestinations = ['recent', 'jobs', 'review', 'settings'];
+export const primaryDestinations = ['recent', 'jobs'];
+export const annotationPrimaryDestinations = ['recent', 'jobs', 'review'];
 
 /** Reserve the Other button before choosing which secondary tabs fit. */
 export function navigationOverflow(items: DesktopDestination[], width: number) {

--- a/docs/Dive-Desktop.md
+++ b/docs/Dive-Desktop.md
@@ -245,7 +245,7 @@ See [Interactive Annotation troubleshooting](Interactive-Annotation.md#troublesh
 ## Desktop navigation
 
 While annotating a sequence, the top menu contains **Library**, **Jobs**,
-**Settings**, and **Other** with a downward arrow. **Other** opens the remaining
+**Review**, **Settings**, and **Other** with downward arrows. **Other** opens the remaining
 pages, including Pipelines, Training, Review, and Scoring. Query and Add-Ons also
 appear when included in the desktop build. Navigation still follows the normal
 unsaved-annotation checks.

--- a/docs/Dive-Desktop.md
+++ b/docs/Dive-Desktop.md
@@ -240,3 +240,16 @@ It's also helpful to look in the debug console.  Press ++ctrl+shift+i++ to launc
 See [Interactive Annotation troubleshooting](Interactive-Annotation.md#troubleshooting). Verify the VIAME install path, confirm VIAME includes interactive service support, and check the debug console for subprocess errors (message: "Unable to load the interactive service").
 
 ![Debugging Desktop](images/General/desktop-debug.png)
+
+
+## Desktop navigation
+
+While annotating a sequence, the top menu contains **Library**, **Jobs**,
+**Settings**, and **Other** with a downward arrow. **Other** opens the remaining
+pages, including Pipelines, Training, Review, and Scoring. Query and Add-Ons also
+appear when included in the desktop build. Navigation still follows the normal
+unsaved-annotation checks.
+
+The full desktop menu shows every available destination when there is room.
+As the window narrows, secondary destinations move into **Other** while Library,
+Jobs, and Settings remain visible. Widening the window restores the tabs.

--- a/docs/Dive-Desktop.md
+++ b/docs/Dive-Desktop.md
@@ -245,11 +245,11 @@ See [Interactive Annotation troubleshooting](Interactive-Annotation.md#troublesh
 ## Desktop navigation
 
 While annotating a sequence, the top menu contains **Library**, **Jobs**,
-**Review**, **Settings**, and **Other** with downward arrows. **Other** opens the remaining
-pages, including Pipelines, Training, Review, and Scoring. Query and Add-Ons also
-appear when included in the desktop build. Navigation still follows the normal
+**Review**, and **Other** with downward arrows. **Other** opens Settings,
+Pipelines, Training, Scoring, and Query when available. Add-Ons is available
+from the full desktop menu. Navigation still follows the normal
 unsaved-annotation checks.
 
 The full desktop menu shows every available destination when there is room.
-As the window narrows, secondary destinations move into **Other** while Library,
-Jobs, and Settings remain visible. Widening the window restores the tabs.
+As the window narrows, secondary destinations move into **Other** while Library
+and Jobs remain visible. Settings moves into Other. Widening the window restores the tabs.


### PR DESCRIPTION
While annotating a sequence, show only **Library**, **Jobs**, **Settings**, and **Other** in the top navigation. Other opens a dropdown for Pipelines, Training, Review, Scoring, and optional Query/Add-Ons routes present in the build. Menu links retain the normal router navigation guards.

The full desktop menu also uses Other when the available width cannot fit all tabs. Reserve room for the dropdown, keep Library/Jobs/Settings visible, and move secondary destinations into Other. Restore tabs automatically when the window widens. Preserve Resume and its dataset target, and keep the Jobs badge on the visible tab. Hide the old tab-scroll arrows because overflow now has a menu.

Validation: all 1,625 client tests passed, along with TypeScript and changed-file lint. Headless Chrome checks exercised compact navigation, cancellation by a route guard, optional destinations, resizing into overflow, and restoring the full menu on expansion. The title change is in a separate PR.
