### PR TITLE
Restore empty Review selections and group multicamera sequence rows

### DIFF
--- a/client/dive-common/components/Review/ReviewDatasetsPanel.vue
+++ b/client/dive-common/components/Review/ReviewDatasetsPanel.vue
@@ -81,7 +81,7 @@ export default defineComponent({
       :selected-ids="selectedIds"
       :picker-label="usePicker ? 'Browse…' : ''"
       :picking="picking"
-      hint="Every dataset here contributes its annotations to the grid. Multicamera datasets are added one camera at a time."
+      hint="Every dataset here contributes its annotations to the grid. Multicamera sequences appear once and include all cameras in shared review cells."
       no-data-text="No datasets in the library."
       compact
       class="mb-3"

--- a/client/dive-common/components/Review/ReviewPage.spec.ts
+++ b/client/dive-common/components/Review/ReviewPage.spec.ts
@@ -44,6 +44,7 @@ vi.mock('./ReviewCell.vue', () => ({ default: {} }));
 
 interface PageState {
   review: ReviewService;
+  view: 'results' | 'datasets';
   resolveLeave(choice: 'save' | 'discard' | 'cancel'): void;
   leaveDialog: boolean;
 }
@@ -139,4 +140,55 @@ it('disposes the active review instead of parking it on logout', async () => {
   wrapper.destroy();
   expect(dispose).toHaveBeenCalledOnce();
   expect(takeReviewSession()).toBeNull();
+});
+
+async function settlePage() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+it('opens the current sequence alone in Results on the first Review visit', async () => {
+  const wrapper = mountPage({ fallbackDatasetId: 'current' });
+  const page = wrapper.vm as unknown as PageState;
+  await settlePage();
+  expect(page.review.datasets.value.map((d) => d.id)).toEqual(['current']);
+  expect(page.view).toBe('results');
+  wrapper.destroy();
+});
+
+it.each(['untouched', 'selected', 'cleared'])('only seeds an untouched previous selection (%s)', async (selection) => {
+  const first = mountPage();
+  const original = first.vm as unknown as PageState;
+  await settlePage();
+  if (selection !== 'untouched') await original.review.addDataset('prior');
+  if (selection === 'cleared') original.review.removeDataset('prior');
+  await mocks.guard!({} as never, {} as never, vi.fn());
+  first.destroy();
+  const second = mountPage({ fallbackDatasetId: 'current' });
+  const page = second.vm as unknown as PageState;
+  await settlePage();
+  expect(page.review).toBe(original.review);
+  expect(page.review.datasets.value.map((d) => d.id)).toEqual(
+    selection === 'untouched' ? ['current'] : (selection === 'selected' ? ['prior'] : []),
+  );
+  expect(page.view).toBe(selection === 'cleared' ? 'datasets' : 'results');
+  second.destroy();
+});
+
+it('preserves explicit Library selections over the current sequence fallback', async () => {
+  const wrapper = mountPage({ initialDatasetIds: ['library'], fallbackDatasetId: 'current' });
+  const page = wrapper.vm as unknown as PageState;
+  await settlePage();
+  expect(page.review.datasets.value.map((d) => d.id)).toEqual(['library']);
+  expect(page.view).toBe('results');
+  wrapper.destroy();
+});
+
+it('keeps a plain first Review visit on Datasets', async () => {
+  const wrapper = mountPage();
+  const page = wrapper.vm as unknown as PageState;
+  await settlePage();
+  expect(page.review.datasets.value).toEqual([]);
+  expect(page.view).toBe('datasets');
+  wrapper.destroy();
 });

--- a/client/dive-common/components/Review/ReviewPage.spec.ts
+++ b/client/dive-common/components/Review/ReviewPage.spec.ts
@@ -168,9 +168,8 @@ it.each(['untouched', 'selected', 'cleared'])('only seeds an untouched previous 
   const page = second.vm as unknown as PageState;
   await settlePage();
   expect(page.review).toBe(original.review);
-  expect(page.review.datasets.value.map((d) => d.id)).toEqual(
-    selection === 'untouched' ? ['current'] : (selection === 'selected' ? ['prior'] : []),
-  );
+  const expected = { untouched: ['current'], selected: ['prior'], cleared: [] };
+  expect(page.review.datasets.value.map((d) => d.id)).toEqual(expected[selection as keyof typeof expected]);
   expect(page.view).toBe(selection === 'cleared' ? 'datasets' : 'results');
   second.destroy();
 });

--- a/client/dive-common/components/Review/ReviewPage.spec.ts
+++ b/client/dive-common/components/Review/ReviewPage.spec.ts
@@ -156,7 +156,7 @@ it('opens the current sequence alone in Results on the first Review visit', asyn
   wrapper.destroy();
 });
 
-it.each(['untouched', 'selected', 'cleared'])('only seeds an untouched previous selection (%s)', async (selection) => {
+it.each(['untouched', 'selected', 'cleared'])('seeds any empty previous selection (%s)', async (selection) => {
   const first = mountPage();
   const original = first.vm as unknown as PageState;
   await settlePage();
@@ -168,9 +168,9 @@ it.each(['untouched', 'selected', 'cleared'])('only seeds an untouched previous 
   const page = second.vm as unknown as PageState;
   await settlePage();
   expect(page.review).toBe(original.review);
-  const expected = { untouched: ['current'], selected: ['prior'], cleared: [] };
+  const expected = { untouched: ['current'], selected: ['prior'], cleared: ['current'] };
   expect(page.review.datasets.value.map((d) => d.id)).toEqual(expected[selection as keyof typeof expected]);
-  expect(page.view).toBe(selection === 'cleared' ? 'datasets' : 'results');
+  expect(page.view).toBe('results');
   second.destroy();
 });
 
@@ -190,4 +190,19 @@ it('keeps a plain first Review visit on Datasets', async () => {
   expect(page.review.datasets.value).toEqual([]);
   expect(page.view).toBe('datasets');
   wrapper.destroy();
+});
+
+it('repopulates a cleared list when returning from the same sequence that started Review', async () => {
+  const first = mountPage({ fallbackDatasetId: 'current' });
+  await settlePage();
+  const original = first.vm as unknown as PageState;
+  original.review.removeDataset('current');
+  await mocks.guard!({} as never, {} as never, vi.fn());
+  first.destroy();
+  const second = mountPage({ fallbackDatasetId: 'current' });
+  await settlePage();
+  const page = second.vm as unknown as PageState;
+  expect(page.review.datasets.value.map((dataset) => dataset.id)).toEqual(['current']);
+  expect(page.view).toBe('results');
+  second.destroy();
 });

--- a/client/dive-common/components/Review/ReviewPage.vue
+++ b/client/dive-common/components/Review/ReviewPage.vue
@@ -55,6 +55,8 @@ export default defineComponent({
   },
   props: {
     sessionOwner: { type: String, default: '' },
+    /** Current viewer dataset, used only before a Review selection has been made. */
+    fallbackDatasetId: { type: String, default: '' },
     retainSession: { type: Boolean, default: true },
     initialDatasetIds: {
       type: Array as PropType<string[]>,
@@ -69,7 +71,10 @@ export default defineComponent({
     const resumed = held && (held.owner || '') === props.sessionOwner && shouldResume(held, props.initialDatasetIds) ? held : null;
     if (held && !resumed) held.review.dispose();
     const review = resumed ? resumed.review : createReviewService({ api });
-    const datasetKey = resumed ? resumed.datasetKey : sessionKey(props.initialDatasetIds);
+    const initialIds = props.initialDatasetIds.length ? props.initialDatasetIds
+      : (!review.hasSelectedDatasets.value && review.datasets.value.length === 0 && props.fallbackDatasetId
+        ? [props.fallbackDatasetId] : []);
+    const datasetKey = resumed ? resumed.datasetKey : sessionKey(initialIds);
     provideReview(review);
     const { prompt } = usePrompt();
 
@@ -364,8 +369,8 @@ export default defineComponent({
       await review.refreshAvailable();
       // A resumed session still takes a new library selection in when the
       // held key differs (pending edits are resolved on leave nowadays).
-      if (!resumed || datasetKey !== sessionKey(props.initialDatasetIds)) {
-        await applyInitial(props.initialDatasetIds);
+      if (!resumed || datasetKey !== sessionKey(initialIds)) {
+        await applyInitial(initialIds);
       }
     });
     watch(() => props.initialDatasetIds, (ids) => { applyInitial(ids); });

--- a/client/dive-common/components/Review/ReviewPage.vue
+++ b/client/dive-common/components/Review/ReviewPage.vue
@@ -55,7 +55,7 @@ export default defineComponent({
   },
   props: {
     sessionOwner: { type: String, default: '' },
-    /** Current viewer dataset, used only before a Review selection has been made. */
+    /** Current viewer dataset, used whenever the Review selection is empty. */
     fallbackDatasetId: { type: String, default: '' },
     retainSession: { type: Boolean, default: true },
     initialDatasetIds: {
@@ -72,8 +72,7 @@ export default defineComponent({
     if (held && !resumed) held.review.dispose();
     const review = resumed ? resumed.review : createReviewService({ api });
     let initialIds = props.initialDatasetIds;
-    if (!initialIds.length && !review.hasSelectedDatasets.value
-      && review.datasets.value.length === 0 && props.fallbackDatasetId) {
+    if (!initialIds.length && review.datasets.value.length === 0 && props.fallbackDatasetId) {
       initialIds = [props.fallbackDatasetId];
     }
     const datasetKey = resumed ? resumed.datasetKey : sessionKey(initialIds);
@@ -371,7 +370,7 @@ export default defineComponent({
       await review.refreshAvailable();
       // A resumed session still takes a new library selection in when the
       // held key differs (pending edits are resolved on leave nowadays).
-      if (!resumed || datasetKey !== sessionKey(initialIds)) {
+      if (!resumed || datasetKey !== sessionKey(initialIds) || review.datasets.value.length === 0) {
         await applyInitial(initialIds);
       }
     });

--- a/client/dive-common/components/Review/ReviewPage.vue
+++ b/client/dive-common/components/Review/ReviewPage.vue
@@ -71,9 +71,11 @@ export default defineComponent({
     const resumed = held && (held.owner || '') === props.sessionOwner && shouldResume(held, props.initialDatasetIds) ? held : null;
     if (held && !resumed) held.review.dispose();
     const review = resumed ? resumed.review : createReviewService({ api });
-    const initialIds = props.initialDatasetIds.length ? props.initialDatasetIds
-      : (!review.hasSelectedDatasets.value && review.datasets.value.length === 0 && props.fallbackDatasetId
-        ? [props.fallbackDatasetId] : []);
+    let initialIds = props.initialDatasetIds;
+    if (!initialIds.length && !review.hasSelectedDatasets.value
+      && review.datasets.value.length === 0 && props.fallbackDatasetId) {
+      initialIds = [props.fallbackDatasetId];
+    }
     const datasetKey = resumed ? resumed.datasetKey : sessionKey(initialIds);
     provideReview(review);
     const { prompt } = usePrompt();

--- a/client/dive-common/use/useReview.spec.ts
+++ b/client/dive-common/use/useReview.spec.ts
@@ -115,8 +115,8 @@ describe('createReviewService', () => {
     expect(service.items.value[0].frames).toHaveLength(3);
   });
 
-  it('expands a multicamera parent into its cameras', async () => {
-    const api = makeApi({ 'm/left': [track(1, [['fish', 1]], [0])], 'm/right': [] }, {
+  it('lists a multicamera sequence once while loading, grouping, reloading, and removing its cameras', async () => {
+    const api = makeApi({ 'm/left': [track(1, [['fish', 1]], [0])], 'm/right': [track(1, [['fish', 1]], [0])] }, {
       loadConfig: vi.fn(async (id: string) => (id === 'm'
         ? config(id, {
           type: 'multi',
@@ -133,9 +133,19 @@ describe('createReviewService', () => {
     const service = createReviewService({ api });
     await service.addDataset('m', { id: 'm', name: 'Rig' });
     expect(service.datasets.value.map((d) => [d.id, d.name, d.status])).toEqual([
-      ['m/left', 'Rig (left)', 'ready'],
-      ['m/right', 'Rig (right)', 'ready'],
+      ['m', 'Rig', 'ready'],
     ]);
+    expect(service.datasets.value[0].trackCount).toBe(1);
+    expect(service.entries.value).toHaveLength(1);
+    expect(service.entries.value[0].items).toHaveLength(2);
+    await service.reloadDataset('m');
+    expect(service.entries.value[0].items).toHaveLength(2);
+    service.removeDataset('m');
+    expect(service.datasets.value).toEqual([]);
+    expect(service.entries.value).toEqual([]);
+    await service.addDataset('m', { id: 'm', name: 'Rig' });
+    expect(service.datasets.value).toHaveLength(1);
+    expect(service.entries.value[0].items).toHaveLength(2);
   });
 
   it('reassigns and accepts types, tracks pending edits, and saves them', async () => {

--- a/client/dive-common/use/useReview.ts
+++ b/client/dive-common/use/useReview.ts
@@ -68,6 +68,8 @@ export interface ReviewDataset {
 
 export interface ReviewService {
   datasets: Readonly<Ref<ReviewDataset[]>>;
+  /** Remains true after the user clears a previously selected dataset list. */
+  hasSelectedDatasets: Readonly<Ref<boolean>>;
   available: Readonly<Ref<ScoringDatasetSummary[]>>;
   query: ReviewQuery;
   grid: ReviewGridSettings;
@@ -225,6 +227,7 @@ function createScopedReviewService(deps: ReviewServiceDeps): ReviewService {
   const requests = createReviewRequestQueue();
   let disposed = false;
   const datasets = ref<ReviewDataset[]>([]);
+  const hasSelectedDatasets = ref(false);
   const available = ref<ScoringDatasetSummary[]>([]);
   const query = reactive<ReviewQuery>({ ...DEFAULT_REVIEW_QUERY });
   const grid = usePersistentGridSettings();
@@ -379,6 +382,7 @@ function createScopedReviewService(deps: ReviewServiceDeps): ReviewService {
    */
   async function addDataset(id: string, summary?: ScoringDatasetSummary, options: { defer?: boolean } = {}) {
     if (disposed || !id || entry(id)) return;
+    hasSelectedDatasets.value = true;
     datasets.value = [...datasets.value, {
       id,
       name: summary?.name || datasetName(id),
@@ -728,6 +732,7 @@ function createScopedReviewService(deps: ReviewServiceDeps): ReviewService {
 
   return {
     datasets,
+    hasSelectedDatasets,
     available,
     query,
     grid,

--- a/client/dive-common/use/useReview.ts
+++ b/client/dive-common/use/useReview.ts
@@ -68,8 +68,6 @@ export interface ReviewDataset {
 
 export interface ReviewService {
   datasets: Readonly<Ref<ReviewDataset[]>>;
-  /** Remains true after the user clears a previously selected dataset list. */
-  hasSelectedDatasets: Readonly<Ref<boolean>>;
   available: Readonly<Ref<ScoringDatasetSummary[]>>;
   query: ReviewQuery;
   grid: ReviewGridSettings;
@@ -227,7 +225,6 @@ function createScopedReviewService(deps: ReviewServiceDeps): ReviewService {
   const requests = createReviewRequestQueue();
   let disposed = false;
   const datasets = ref<ReviewDataset[]>([]);
-  const hasSelectedDatasets = ref(false);
   const available = ref<ScoringDatasetSummary[]>([]);
   const query = reactive<ReviewQuery>({ ...DEFAULT_REVIEW_QUERY });
   const grid = usePersistentGridSettings();
@@ -246,6 +243,31 @@ function createScopedReviewService(deps: ReviewServiceDeps): ReviewService {
   const styles = new StyleManager({ markChangesPending: () => undefined });
   /** Camera datasets expanded from a multicamera parent. */
   const memberships = new Map<string, CameraMembership>();
+  const parentNames = new Map<string, string>();
+  const selectedDatasets = computed<ReviewDataset[]>(() => {
+    // Keep cameras separate internally for reads, edits, and saves; present one sequence row.
+    const groups = new Map<string, ReviewDataset[]>();
+    datasets.value.forEach((dataset) => {
+      const id = memberships.get(dataset.id)?.parent ?? dataset.id;
+      if (!groups.has(id)) groups.set(id, []);
+      groups.get(id)!.push(dataset);
+    });
+    return Array.from(groups, ([id, cameras]) => {
+      if (!parentNames.has(id)) return cameras[0];
+      const status = (['loading', 'error', 'queued', 'ready'] as ReviewDatasetStatus[])
+        .find((value) => cameras.some((camera) => camera.status === value))!;
+      const trackIds = new Set(cameras.flatMap((camera) => [...(loaded.get(camera.id)?.tracks.keys() || [])]));
+      return {
+        id,
+        name: parentNames.get(id)!,
+        type: 'multi',
+        status,
+        error: cameras.filter((camera) => camera.error).map((camera) => `${camera.name}: ${camera.error}`).join('\n') || undefined,
+        trackCount: trackIds.size,
+        croppable: cameras.some((camera) => camera.croppable),
+      };
+    });
+  });
 
   // Query changes apply as soon as they settle; the grid only reshuffles
   // for those, never for edits made in it.
@@ -267,7 +289,7 @@ function createScopedReviewService(deps: ReviewServiceDeps): ReviewService {
   }
 
   function datasetName(id: string) {
-    return datasets.value.find((d) => d.id === id)?.name
+    return parentNames.get(id) || datasets.value.find((d) => d.id === id)?.name
       || available.value.find((d) => d.id === id)?.name
       || id;
   }
@@ -322,9 +344,11 @@ function createScopedReviewService(deps: ReviewServiceDeps): ReviewService {
       });
       if (!isCurrent()) return;
       if (config.type === 'multi') {
-        // Review the cameras of a multicamera dataset as separate sequences.
+        // Load each camera separately while exposing the parent as one selected sequence.
         const cameras = Object.keys(config.multiCamMedia?.cameras || {});
         const parentName = entry(id)?.name || config.name;
+        if (!cameras.length) throw new Error('This sequence has no cameras');
+        parentNames.set(id, parentName);
         datasets.value = datasets.value.filter((d) => d.id !== id);
         cameras.forEach((camera, rank) => memberships.set(`${id}/${camera}`, { parent: id, camera, rank }));
         await Promise.all(cameras.map((camera) => addDataset(`${id}/${camera}`, {
@@ -381,8 +405,7 @@ function createScopedReviewService(deps: ReviewServiceDeps): ReviewService {
    * results are actually wanted.
    */
   async function addDataset(id: string, summary?: ScoringDatasetSummary, options: { defer?: boolean } = {}) {
-    if (disposed || !id || entry(id)) return;
-    hasSelectedDatasets.value = true;
+    if (disposed || !id || entry(id) || selectedDatasets.value.some((dataset) => dataset.id === id)) return;
     datasets.value = [...datasets.value, {
       id,
       name: summary?.name || datasetName(id),
@@ -407,18 +430,29 @@ function createScopedReviewService(deps: ReviewServiceDeps): ReviewService {
     await Promise.all(unique.map((id) => addDataset(id)));
   }
 
+  function cameraIds(id: string) {
+    return datasets.value.filter((dataset) => dataset.id === id || memberships.get(dataset.id)?.parent === id)
+      .map((dataset) => dataset.id);
+  }
+
   function removeDataset(id: string) {
-    datasets.value = datasets.value.filter((d) => d.id !== id);
-    dropLoaded(id);
-    loadTokens.delete(id);
+    const ids = new Set(cameraIds(id));
+    datasets.value = datasets.value.filter((dataset) => !ids.has(dataset.id));
+    ids.forEach((cameraId) => {
+      dropLoaded(cameraId);
+      loadTokens.delete(cameraId);
+      memberships.delete(cameraId);
+    });
+    parentNames.delete(id);
     dataRevision.value += 1;
     runQuery();
   }
 
   async function reloadDataset(id: string) {
-    if (!entry(id)) return;
-    patch(id, { status: 'loading', error: undefined });
-    await load(id);
+    await Promise.all(cameraIds(id).map(async (cameraId) => {
+      patch(cameraId, { status: 'loading', error: undefined });
+      await load(cameraId);
+    }));
   }
 
   function allTracks(): TrackData[] {
@@ -731,8 +765,7 @@ function createScopedReviewService(deps: ReviewServiceDeps): ReviewService {
   }
 
   return {
-    datasets,
-    hasSelectedDatasets,
+    datasets: selectedDatasets,
     available,
     query,
     grid,

--- a/client/platform/desktop/frontend/components/ReviewPage.vue
+++ b/client/platform/desktop/frontend/components/ReviewPage.vue
@@ -15,6 +15,8 @@ const initialDatasetIds = computed(() => {
   return values.flatMap((value) => (value || '').split(',')).filter(Boolean);
 });
 
+const fallbackDatasetId = computed(() => (typeof route.query.fromDataset === 'string' ? route.query.fromDataset : ''));
+
 function openViewer(datasetId: string, focus: ViewerFocus) {
   router.push(reviewViewerLocation(datasetId, focus));
 }
@@ -25,6 +27,7 @@ function openViewer(datasetId: string, focus: ViewerFocus) {
     <navigation-bar />
     <shared-review-page
       :initial-dataset-ids="initialDatasetIds"
+      :fallback-dataset-id="fallbackDatasetId"
       @open-viewer="openViewer"
     />
   </v-main>

--- a/client/platform/desktop/frontend/components/ViewerLoader.vue
+++ b/client/platform/desktop/frontend/components/ViewerLoader.vue
@@ -4,7 +4,6 @@ import {
 } from 'vue';
 import { ANNOTATION_SOURCE_QUERY } from 'dive-common/scoring/viewerNavigation';
 import { parseViewerFocus } from 'dive-common/review/viewerNavigation';
-import { useReviewSessionHeld } from 'dive-common/review/reviewSession';
 import { useRoute, useRouter } from 'vue-router/composables';
 import Viewer from 'dive-common/components/Viewer.vue';
 import RunPipelineMenu from 'dive-common/components/RunPipelineMenu.vue';
@@ -135,8 +134,6 @@ export default defineComponent({
     const annotationSourceReturnable = computed(() => !!annotationSourceLabel.value);
     /** Frame / track deep link from the review grid. */
     const viewerFocus = computed(() => parseViewerFocus(route.query));
-    /** Jump back to Review when a session was parked by opening the viewer. */
-    const reviewSessionHeld = useReviewSessionHeld();
 
     function returnToCurrentAnnotations() {
       router.replace({ name: 'viewer', params: { id: props.id } });
@@ -2050,7 +2047,6 @@ export default defineComponent({
       annotationSourceLabel,
       annotationSourceReturnable,
       viewerFocus,
-      reviewSessionHeld,
       returnToCurrentAnnotations,
     };
   },
@@ -2096,8 +2092,7 @@ export default defineComponent({
           </v-tab>
           <job-tab />
           <v-tab
-            v-if="reviewSessionHeld"
-            :to="{ name: 'review' }"
+            :to="{ name: 'review', query: { fromDataset: id } }"
           >
             Review<v-icon>mdi-view-grid-outline</v-icon>
           </v-tab>

--- a/client/platform/web-girder/views/Review.vue
+++ b/client/platform/web-girder/views/Review.vue
@@ -21,12 +21,14 @@ export default defineComponent({
       return typeof joined === 'string' ? joined.split(',').filter((id) => id) : [];
     });
 
+    const fallbackDatasetId = computed(() => (typeof route.query.fromDataset === 'string' ? route.query.fromDataset : ''));
+
     function openViewer(datasetId: string, focus: ViewerFocus) {
       router.push(reviewViewerLocation(datasetId, focus));
     }
 
     return {
-      initialDatasetIds, openViewer, owner, retainSession,
+      initialDatasetIds, fallbackDatasetId, openViewer, owner, retainSession,
     };
   },
 });
@@ -35,6 +37,7 @@ export default defineComponent({
 <template>
   <ReviewPage
     :initial-dataset-ids="initialDatasetIds"
+    :fallback-dataset-id="fallbackDatasetId"
     :session-owner="owner"
     :retain-session="retainSession"
     @open-viewer="openViewer"

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -26,7 +26,6 @@ import { convertLargeImage } from 'platform/web-girder/api/rpc.service';
 import { useRouter, useRoute } from 'vue-router/composables';
 import { ANNOTATION_SOURCE_QUERY } from 'dive-common/scoring/viewerNavigation';
 import { parseViewerFocus } from 'dive-common/review/viewerNavigation';
-import { useReviewSessionHeld } from 'dive-common/review/reviewSession';
 import useStereoOnnxWeb from 'platform/web-girder/useStereoOnnxWeb';
 import {
   STEREO_LENGTH_METHOD_ATTR, STEREO_MEASUREMENT_ATTRS,
@@ -431,8 +430,6 @@ export default defineComponent({
     const annotationSourceReturnable = computed(() => !!annotationSourceLabel.value);
     /** Frame / track deep link from the review grid. */
     const viewerFocus = computed(() => parseViewerFocus(route.query));
-    /** Jump back to Review when a session was parked by opening the viewer. */
-    const reviewSessionHeld = useReviewSessionHeld();
 
     function returnToCurrentAnnotations() {
       router.replace({ name: 'viewer', params: { id: props.id } });
@@ -477,7 +474,6 @@ export default defineComponent({
       annotationSourceLabel,
       annotationSourceReturnable,
       viewerFocus,
-      reviewSessionHeld,
       returnToCurrentAnnotations,
     };
   },
@@ -520,8 +516,7 @@ export default defineComponent({
           </v-tab>
           <JobsTab />
           <v-tab
-            v-if="reviewSessionHeld"
-            :to="{ name: 'review' }"
+            :to="{ name: 'review', query: { fromDataset: id } }"
           >
             Review
             <v-icon>mdi-view-grid-outline</v-icon>

--- a/docs/Review.md
+++ b/docs/Review.md
@@ -98,3 +98,8 @@ Each review session limits API operations to three at a time, including loading 
 Review retains at most two decoded frames and 16 MiB of decoded pixels per dataset. Rendered chips are pruned when paging to retain 256 recent items, with the visible and prefetched pages protected. Selected annotations remain in browser memory, so the number and size of selected datasets still affect memory usage. These are per-browser limits, not a server-wide quota.
 
 A retained review session belongs to the signed-in account and is cleared on logout or account change. Saves use the existing dataset write permissions and update only changed tracks. Review does not add collaborative locking or conflict detection: coordinate assignments when multiple people edit the same tracks, since a later save can replace another person's edits.
+
+When opening **Review** from a sequence for the first time, DIVE selects that
+sequence and opens **Results** after it loads. A previous Review selection is
+retained, including a list you intentionally emptied. Visiting Review without
+selecting any datasets still allows this first selection from a sequence.

--- a/docs/Review.md
+++ b/docs/Review.md
@@ -99,7 +99,10 @@ Review retains at most two decoded frames and 16 MiB of decoded pixels per datas
 
 A retained review session belongs to the signed-in account and is cleared on logout or account change. Saves use the existing dataset write permissions and update only changed tracks. Review does not add collaborative locking or conflict detection: coordinate assignments when multiple people edit the same tracks, since a later save can replace another person's edits.
 
-When opening **Review** from a sequence for the first time, DIVE selects that
-sequence and opens **Results** after it loads. A previous Review selection is
-retained, including a list you intentionally emptied. Visiting Review without
-selecting any datasets still allows this first selection from a sequence.
+When opening **Review** from a sequence with an empty dataset list, DIVE selects
+that sequence and opens **Results** after it loads. This also applies after
+clearing a previous selection. A nonempty selection is retained.
+
+Stereo and multicamera sequences appear as one entry in the dataset list.
+Reloading or removing that entry affects all cameras. Annotations with the same
+track ID across cameras share one grid cell, showing each camera's view.


### PR DESCRIPTION
Opening Review from a sequence now selects that sequence and opens Results whenever the prior Review dataset list is empty, including after clearing the list. Nonempty selections remain unchanged, and explicit Library selections take precedence.

Stereo and multicamera sequences appear as one parent row. Reloading/removing the row affects all cameras, while matching track IDs across cameras share one grid cell. Per-camera loading and saving remain independent.

Validation: 35 targeted Review tests passed, covering cleared same-sequence return, nonempty selections, multicamera grouping, reload, removal and re-addition, as well as existing edit/save behavior. Type checking and changed-file lint passed.
