### PR TITLE
Make sequence-wide Type Filters a saved user preference

### DIFF
--- a/client/dive-common/components/TypeSettingsPanel.spec.ts
+++ b/client/dive-common/components/TypeSettingsPanel.spec.ts
@@ -59,7 +59,7 @@ describe('TypeSettingsPanel hierarchy state', () => {
   it('leaves the other type settings enabled', () => {
     const { wrapper } = mountPanel({ allTypes: [], hierarchyActive: true });
     const switches = wrapper.findAll('v-switch').wrappers;
-    ['Show Empty', 'Lock Types', 'Filter Types by Frame', 'Show Max Count Button'].forEach(
+    ['Show Empty', 'Lock Types', 'Show types from entire sequence', 'Show Max Count Button'].forEach(
       (label) => expect(switches.find((item) => item.attributes('label') === label)
         ?.attributes('disabled')).toBeUndefined(),
     );

--- a/client/dive-common/components/TypeSettingsPanel.vue
+++ b/client/dive-common/components/TypeSettingsPanel.vue
@@ -28,7 +28,7 @@ export default defineComponent({
       showEmptyTypes: 'View types that are not used currently.',
       lockTypes: 'Only allows the use of defined types.',
       preventCascadeTypes: 'When a track has multiple types, this will prevent the type from displaying if the max type is not visible in the type list',
-      filterTypesByFrame: 'Filters the type list by only types that are visible in the current frame',
+      filterTypesByFrame: 'Show every type used in the sequence, including types with zero annotations on the current frame. Turn off to show only current-frame types. This choice is saved for future sequences.',
       showTotalCount: 'Show each type\'s count for the whole dataset. Rows read frame count / total count.',
       showFrameCount: 'Show each type\'s count on the current frame. Rows read frame count / total count.',
       maxCountButton: 'Show a max count button that will jump to the frame with the max count for the type',
@@ -244,7 +244,9 @@ export default defineComponent({
             <v-col class="py-1">
               <v-switch
                 v-model="clientSettings.typeSettings.filterTypesByFrame"
-                label="Filter Types by Frame"
+                label="Show types from entire sequence"
+                :true-value="false"
+                :false-value="true"
                 class="my-0 ml-1 pt-0"
                 dense
                 hide-details

--- a/client/dive-common/store/settings.spec.ts
+++ b/client/dive-common/store/settings.spec.ts
@@ -26,3 +26,16 @@ describe('clientSettings hydration', () => {
     expect(clientSettings.typeSettings.trackSortDir).toBe('count');
   });
 });
+
+it('starts each sequence with sequence-wide type rows even after frame-only filtering', async () => {
+  const { effectScope, ref } = await import('vue');
+  const { default: setup, clientSettings } = await import('./settings');
+  clientSettings.typeSettings.filterTypesByFrame = true;
+  const scope = effectScope();
+  scope.run(() => setup(ref(['fish', 'shark'])));
+  expect(clientSettings.typeSettings.filterTypesByFrame).toBe(false);
+  // Frame-only filtering remains available as an explicit choice in the current sequence.
+  clientSettings.typeSettings.filterTypesByFrame = true;
+  expect(clientSettings.typeSettings.filterTypesByFrame).toBe(true);
+  scope.stop();
+});

--- a/client/dive-common/store/settings.spec.ts
+++ b/client/dive-common/store/settings.spec.ts
@@ -27,15 +27,13 @@ describe('clientSettings hydration', () => {
   });
 });
 
-it('starts each sequence with sequence-wide type rows even after frame-only filtering', async () => {
+it.each([false, true])('preserves the saved frame-only choice when opening a sequence (%s)', async (frameOnly) => {
+  localStorage.setItem('Settings', JSON.stringify({ typeSettings: { filterTypesByFrame: frameOnly } }));
+  vi.resetModules();
   const { effectScope, ref } = await import('vue');
   const { default: setup, clientSettings } = await import('./settings');
-  clientSettings.typeSettings.filterTypesByFrame = true;
   const scope = effectScope();
   scope.run(() => setup(ref(['fish', 'shark'])));
-  expect(clientSettings.typeSettings.filterTypesByFrame).toBe(false);
-  // Frame-only filtering remains available as an explicit choice in the current sequence.
-  clientSettings.typeSettings.filterTypesByFrame = true;
-  expect(clientSettings.typeSettings.filterTypesByFrame).toBe(true);
+  expect(clientSettings.typeSettings.filterTypesByFrame).toBe(frameOnly);
   scope.stop();
 });

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -252,8 +252,6 @@ function isStereoInteractiveModeEnabled(): boolean {
 }
 
 export default function setup(allTypes: Ref<Readonly<string[]>>) {
-  // Frame-only filtering is a temporary viewing choice, not the next sequence's default.
-  clientSettings.typeSettings.filterTypesByFrame = false;
   // If a type is deleted, reset the default new track type to unknown
   watch(allTypes, (newval) => {
     if (newval.indexOf(clientSettings.trackSettings.newTrackSettings.type) === -1) {

--- a/client/dive-common/store/settings.ts
+++ b/client/dive-common/store/settings.ts
@@ -252,6 +252,8 @@ function isStereoInteractiveModeEnabled(): boolean {
 }
 
 export default function setup(allTypes: Ref<Readonly<string[]>>) {
+  // Frame-only filtering is a temporary viewing choice, not the next sequence's default.
+  clientSettings.typeSettings.filterTypesByFrame = false;
   // If a type is deleted, reset the default new track type to unknown
   watch(allTypes, (newval) => {
     if (newval.indexOf(clientSettings.trackSettings.newTrackSettings.type) === -1) {

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -135,6 +135,6 @@ Type settings also configure [suppression](UI-Suppression.md):
 
 The active suppression type shows an ==:material-eye-off:== icon in the type list. Detections may also be flagged with an attribute of the same name; see [Suppression](UI-Suppression.md) for region vs attribute behavior and display options.
 
-Each newly opened sequence starts with types from the whole sequence visible,
-including types with zero annotations on the current frame. **Filter Types by
-Frame** remains available in Type Settings for the current sequence.
+**Show types from entire sequence** in Type Settings is enabled by default,
+including types with zero annotations on the current frame. Turn it off to show
+only current-frame types. The choice is saved and applies to future sequences.

--- a/docs/UI-Type-List.md
+++ b/docs/UI-Type-List.md
@@ -134,3 +134,7 @@ Type settings also configure [suppression](UI-Suppression.md):
 * **Suppression Overlap (%)** — minimum percent of a detection that must lie under suppression regions for it to be hidden (default **99**). Shown only when a suppression type is set.
 
 The active suppression type shows an ==:material-eye-off:== icon in the type list. Detections may also be flagged with an attribute of the same name; see [Suppression](UI-Suppression.md) for region vs attribute behavior and display options.
+
+Each newly opened sequence starts with types from the whole sequence visible,
+including types with zero annotations on the current frame. **Filter Types by
+Frame** remains available in Type Settings for the current sequence.


### PR DESCRIPTION
Type Settings now exposes **Show types from entire sequence**, enabled by default. It keeps types with zero current-frame annotations in the list; disabling it limits rows to current-frame types. The choice is saved across sequences using the existing frame-filter setting.

Validation: 35 settings, settings-panel, and type-list tests passed; changed-file lint passed.
